### PR TITLE
feat(user): add photo URL with generated avatar fallback

### DIFF
--- a/migrations/Version20260305110000.php
+++ b/migrations/Version20260305110000.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+/**
+ * Add photo field to user table.
+ */
+final class Version20260305110000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Add photo field to user table and generate default avatar URL from first and last name.';
+    }
+
+    #[Override]
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("ALTER TABLE user ADD photo VARCHAR(255) DEFAULT NULL COMMENT 'User profile photo URL' AFTER timezone");
+        $this->addSql("UPDATE user SET photo = CONCAT('https://ui-avatars.com/api/?name=', REPLACE(CONCAT(first_name, ' ', last_name), ' ', '+')) WHERE photo IS NULL OR photo = ''");
+        $this->addSql("ALTER TABLE user CHANGE photo photo VARCHAR(255) NOT NULL COMMENT 'User profile photo URL'");
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE user DROP photo');
+    }
+}

--- a/src/User/Application/DTO/User/User.php
+++ b/src/User/Application/DTO/User/User.php
@@ -73,6 +73,8 @@ class User extends RestDto
     #[ToolAppAssert\Timezone]
     protected string $timezone = LocalizationServiceInterface::DEFAULT_TIMEZONE;
 
+    protected string $photo = '';
+
     /**
      * @var UserGroupEntity[]|array<int, UserGroupEntity>
      */
@@ -183,6 +185,20 @@ class User extends RestDto
         return $this;
     }
 
+    public function getPhoto(): string
+    {
+        return $this->photo;
+    }
+
+    public function setPhoto(string $photo): self
+    {
+        $this->setVisited('photo');
+
+        $this->photo = $photo;
+
+        return $this;
+    }
+
     /**
      * @return array<int, UserGroupEntity>
      */
@@ -234,6 +250,7 @@ class User extends RestDto
             $this->language = $entity->getLanguage();
             $this->locale = $entity->getLocale();
             $this->timezone = $entity->getTimezone();
+            $this->photo = $entity->getPhoto();
             /** @var array<int, UserGroupEntity> $groups */
             $groups = $entity->getUserGroups()->toArray();
             $this->userGroups = $groups;

--- a/src/User/Domain/Entity/User.php
+++ b/src/User/Domain/Entity/User.php
@@ -26,6 +26,9 @@ use Symfony\Component\Serializer\Attribute\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 use Throwable;
 
+use function rawurlencode;
+use function str_replace;
+
 /**
  * @package App\User
  */
@@ -217,6 +220,24 @@ class User implements EntityInterface, UserInterface, UserGroupAwareInterface
     private string $timezone = LocalizationServiceInterface::DEFAULT_TIMEZONE;
 
     #[ORM\Column(
+        name: 'photo',
+        type: Types::STRING,
+        length: 255,
+        nullable: false,
+        options: [
+            'comment' => 'User profile photo URL',
+        ],
+    )]
+    #[Groups([
+        'User',
+        'User.photo',
+
+        self::SET_USER_PROFILE,
+        self::SET_USER_BASIC,
+    ])]
+    private string $photo = '';
+
+    #[ORM\Column(
         name: 'password',
         type: Types::STRING,
         length: 255,
@@ -339,6 +360,28 @@ class User implements EntityInterface, UserInterface, UserGroupAwareInterface
     public function setTimezone(string $timezone): self
     {
         $this->timezone = $timezone;
+
+        return $this;
+    }
+
+    public function getPhoto(): string
+    {
+        return $this->photo;
+    }
+
+    public function setPhoto(string $photo): self
+    {
+        $this->photo = $photo;
+
+        return $this;
+    }
+
+    public function ensureGeneratedPhoto(): self
+    {
+        if ($this->photo === '') {
+            $name = rawurlencode($this->firstName . ' ' . $this->lastName);
+            $this->photo = 'https://ui-avatars.com/api/?name=' . str_replace('%20', '+', $name);
+        }
 
         return $this;
     }

--- a/src/User/Transport/EventListener/UserEntityEventListener.php
+++ b/src/User/Transport/EventListener/UserEntityEventListener.php
@@ -48,6 +48,7 @@ class UserEntityEventListener
 
         // Valid user so lets change password
         if ($user instanceof User) {
+            $user->ensureGeneratedPhoto();
             $this->changePassword($user);
         }
     }

--- a/tests/Application/User/Transport/Controller/Api/V1/Profile/IndexControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/Profile/IndexControllerTest.php
@@ -57,6 +57,8 @@ class IndexControllerTest extends WebTestCase
         self::assertEquals($userEntity->getLocale()->value, $responseData['locale']);
         self::assertArrayHasKey('timezone', $responseData);
         self::assertEquals($userEntity->getTimezone(), $responseData['timezone']);
+        self::assertArrayHasKey('photo', $responseData);
+        self::assertEquals($userEntity->getPhoto(), $responseData['photo']);
         self::assertArrayHasKey('roles', $responseData);
         self::assertIsArray($responseData['roles']);
         self::assertCount(count($roleService->getInheritedRoles($userEntity->getRoles())), $responseData['roles']);

--- a/tests/Application/User/Transport/Controller/Api/V1/User/DeleteUserControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/User/DeleteUserControllerTest.php
@@ -82,6 +82,7 @@ class DeleteUserControllerTest extends WebTestCase
         self::assertArrayHasKey('language', $responseData);
         self::assertArrayHasKey('locale', $responseData);
         self::assertArrayHasKey('timezone', $responseData);
+        self::assertArrayHasKey('photo', $responseData);
         self::assertEquals($this->user->getId(), $responseData['id']);
 
         // let's check that row deleted inside db.

--- a/tests/Application/User/Transport/Controller/Api/V1/User/UserControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/User/UserControllerTest.php
@@ -175,6 +175,7 @@ class UserControllerTest extends WebTestCase
         self::assertEquals($userEntity->getLanguage()->value, $responseData['language']);
         self::assertEquals($userEntity->getLocale()->value, $responseData['locale']);
         self::assertEquals($userEntity->getTimezone(), $responseData['timezone']);
+        self::assertEquals($userEntity->getPhoto(), $responseData['photo']);
     }
 
     /**
@@ -215,6 +216,7 @@ class UserControllerTest extends WebTestCase
         $responseData = JSON::decode($content, true);
         $this->checkBasicFieldsInResponse($responseData);
         $this->checkThatRequestEqualsResponseData($requestData, $responseData);
+        self::assertStringContainsString('https://ui-avatars.com/api/?name=Name+Last+name', $responseData['photo']);
     }
 
     /**
@@ -357,6 +359,7 @@ class UserControllerTest extends WebTestCase
         self::assertArrayHasKey('language', $responseData);
         self::assertArrayHasKey('locale', $responseData);
         self::assertArrayHasKey('timezone', $responseData);
+        self::assertArrayHasKey('photo', $responseData);
     }
 
     /**

--- a/tests/Application/User/Transport/Controller/Api/V1/UserGroup/AttachUserControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/UserGroup/AttachUserControllerTest.php
@@ -80,6 +80,7 @@ class AttachUserControllerTest extends WebTestCase
             self::assertArrayHasKey('language', $user);
             self::assertArrayHasKey('locale', $user);
             self::assertArrayHasKey('timezone', $user);
+            self::assertArrayHasKey('photo', $user);
         }
 
         // let's check that inside database we have the same data as in response above

--- a/tests/Application/User/Transport/Controller/Api/V1/UserGroup/DetachUserControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/UserGroup/DetachUserControllerTest.php
@@ -106,6 +106,7 @@ class DetachUserControllerTest extends WebTestCase
             self::assertArrayHasKey('language', $user);
             self::assertArrayHasKey('locale', $user);
             self::assertArrayHasKey('timezone', $user);
+            self::assertArrayHasKey('photo', $user);
         }
 
         // let's check that inside database we have the same data as in response above

--- a/tests/Application/User/Transport/Controller/Api/V1/UserGroup/UsersControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/UserGroup/UsersControllerTest.php
@@ -91,5 +91,6 @@ class UsersControllerTest extends WebTestCase
         self::assertArrayHasKey('language', $responseData);
         self::assertArrayHasKey('locale', $responseData);
         self::assertArrayHasKey('timezone', $responseData);
+        self::assertArrayHasKey('photo', $responseData);
     }
 }


### PR DESCRIPTION
### Motivation

- Add a `photo` string URL to `User` so the API can return a user avatar URL.  
- Provide a sensible default avatar when no photo is uploaded by generating a UI-avatars URL from the user's `firstName` and `lastName` at creation/update.

### Description

- Added a `photo` ORM column and serialization `Groups` to `User` and exposed it via `getPhoto()`/`setPhoto()` on the entity.  
- Implemented `ensureGeneratedPhoto()` on the entity to generate `https://ui-avatars.com/api/?name=First+Last` (URL-encoded) when `photo` is empty.  
- Call `ensureGeneratedPhoto()` from the Doctrine lifecycle handling in `UserEntityEventListener` during `prePersist` and `preUpdate` to guarantee a value.  
- Updated the user DTO `User` to support `photo` (getter/setter and loading from entity) and added a Doctrine migration `migrations/Version20260305110000.php` that adds the `photo` column, backfills existing rows with generated avatar URLs, and makes the column `NOT NULL`.  
- Updated user/profile-related API tests to assert presence of `photo` and added an assertion for generated avatar URL on create.

### Testing

- Ran syntax checks: `php -l src/User/Domain/Entity/User.php`, `php -l src/User/Application/DTO/User/User.php`, `php -l src/User/Transport/EventListener/UserEntityEventListener.php`, `php -l migrations/Version20260305110000.php` and the updated tests; all reported no syntax errors.  
- Updated PHPUnit assertions in multiple tests under `tests/Application/User/...` to cover `photo`.  
- Attempted to run `./vendor/bin/phpunit tests/Application/User/Transport/Controller/Api/V1/User/UserControllerTest.php` but it could not run in this environment because `vendor/bin/phpunit` is not available (CI/local runner should run full test suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b7e9de04832b9048a805ea4e8536)