### PR TITLE
feat(platform): scaffold Platform CRUD module

### DIFF
--- a/config/packages/event_listeners.yaml
+++ b/config/packages/event_listeners.yaml
@@ -23,3 +23,8 @@ services:
             - { name: doctrine.event_listener, event: preUpdate }
             - { name: doctrine.event_listener, event: postUpdate }
             - { name: doctrine.event_listener, event: postLoad }
+
+    App\Platform\Transport\EventListener\PlatformEntityEventListener:
+        tags:
+            - { name: doctrine.event_listener, event: prePersist }
+            - { name: doctrine.event_listener, event: preUpdate }

--- a/src/Platform/Application/DTO/Platform/Platform.php
+++ b/src/Platform/Application/DTO/Platform/Platform.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\DTO\Platform;
+
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Platform\Domain\Entity\Platform as Entity;
+use Override;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @package App\Platform
+ *
+ * @method self|RestDtoInterface get(string $id)
+ * @method self|RestDtoInterface patch(RestDtoInterface $dto)
+ * @method Entity|EntityInterface update(EntityInterface $entity)
+ */
+class Platform extends RestDto
+{
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 2, max: 255)]
+    protected string $name = '';
+
+    #[Assert\NotNull]
+    protected string $description = '';
+
+    #[Assert\NotNull]
+    protected bool $private = false;
+
+    protected string $photo = '';
+
+    #[Assert\NotNull]
+    protected bool $enabled = true;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->setVisited('name');
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->setVisited('description');
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->private;
+    }
+
+    public function setPrivate(bool $private): self
+    {
+        $this->setVisited('private');
+        $this->private = $private;
+
+        return $this;
+    }
+
+    public function getPhoto(): string
+    {
+        return $this->photo;
+    }
+
+    public function setPhoto(string $photo): self
+    {
+        $this->setVisited('photo');
+        $this->photo = $photo;
+
+        return $this;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function setEnabled(bool $enabled): self
+    {
+        $this->setVisited('enabled');
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param EntityInterface|Entity $entity
+     */
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->name = $entity->getName();
+            $this->description = $entity->getDescription();
+            $this->private = $entity->isPrivate();
+            $this->photo = $entity->getPhoto();
+            $this->enabled = $entity->isEnabled();
+        }
+
+        return $this;
+    }
+}

--- a/src/Platform/Application/DTO/Platform/PlatformCreate.php
+++ b/src/Platform/Application/DTO/Platform/PlatformCreate.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\DTO\Platform;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @package App\Platform
+ */
+class PlatformCreate extends Platform
+{
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 2, max: 255)]
+    protected string $name = '';
+
+    #[Assert\NotNull]
+    protected string $description = '';
+
+    #[Assert\NotNull]
+    protected bool $private = false;
+
+    #[Assert\NotNull]
+    protected bool $enabled = true;
+}

--- a/src/Platform/Application/DTO/Platform/PlatformPatch.php
+++ b/src/Platform/Application/DTO/Platform/PlatformPatch.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\DTO\Platform;
+
+/**
+ * @package App\Platform
+ */
+class PlatformPatch extends Platform
+{
+}

--- a/src/Platform/Application/DTO/Platform/PlatformUpdate.php
+++ b/src/Platform/Application/DTO/Platform/PlatformUpdate.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\DTO\Platform;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @package App\Platform
+ */
+class PlatformUpdate extends Platform
+{
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 2, max: 255)]
+    protected string $name = '';
+
+    #[Assert\NotNull]
+    protected string $description = '';
+
+    #[Assert\NotNull]
+    protected bool $private = false;
+
+    #[Assert\NotNull]
+    protected bool $enabled = true;
+}

--- a/src/Platform/Application/Resource/PlatformResource.php
+++ b/src/Platform/Application/Resource/PlatformResource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Resource;
+
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\Rest\RestResource;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Platform\Domain\Entity\Platform as Entity;
+use App\Platform\Domain\Repository\Interfaces\PlatformRepositoryInterface as Repository;
+
+/**
+ * @package App\Platform
+ *
+ * @psalm-suppress LessSpecificImplementedReturnType
+ * @codingStandardsIgnoreStart
+ *
+ * @method Entity getReference(string $id, ?string $entityManagerName = null)
+ * @method \App\Platform\Infrastructure\Repository\PlatformRepository getRepository()
+ * @method Entity[] find(?array $criteria = null, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?array $search = null, ?string $entityManagerName = null)
+ * @method Entity|null findOne(string $id, ?bool $throwExceptionIfNotFound = null, ?string $entityManagerName = null)
+ * @method Entity|null findOneBy(array $criteria, ?array $orderBy = null, ?bool $throwExceptionIfNotFound = null, ?string $entityManagerName = null)
+ * @method Entity create(RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity update(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity patch(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity delete(string $id, ?bool $flush = null, ?string $entityManagerName = null)
+ * @method Entity save(EntityInterface $entity, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ *
+ * @codingStandardsIgnoreEnd
+ */
+class PlatformResource extends RestResource
+{
+    /**
+     * @param \App\Platform\Infrastructure\Repository\PlatformRepository $repository
+     */
+    public function __construct(
+        Repository $repository,
+    ) {
+        parent::__construct($repository);
+    }
+}

--- a/src/Platform/Domain/Entity/Platform.php
+++ b/src/Platform/Domain/Entity/Platform.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+use Throwable;
+
+use function rawurlencode;
+use function str_replace;
+
+/**
+ * @package App\Platform
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'platform')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Platform implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(
+        name: 'id',
+        type: UuidBinaryOrderedTimeType::NAME,
+        unique: true,
+    )]
+    #[Groups([
+        'Platform',
+        'Platform.id',
+    ])]
+    private UuidInterface $id;
+
+    #[ORM\Column(
+        name: 'name',
+        type: Types::STRING,
+        length: 255,
+    )]
+    #[Groups([
+        'Platform',
+        'Platform.name',
+    ])]
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(
+        min: 2,
+        max: 255,
+    )]
+    private string $name = '';
+
+    #[ORM\Column(
+        name: 'description',
+        type: Types::TEXT,
+    )]
+    #[Groups([
+        'Platform',
+        'Platform.description',
+    ])]
+    #[Assert\NotNull]
+    private string $description = '';
+
+    #[ORM\Column(
+        name: 'private',
+        type: Types::BOOLEAN,
+        options: [
+            'default' => false,
+        ],
+    )]
+    #[Groups([
+        'Platform',
+        'Platform.private',
+    ])]
+    #[Assert\NotNull]
+    private bool $private = false;
+
+    #[ORM\Column(
+        name: 'photo',
+        type: Types::STRING,
+        length: 255,
+        options: [
+            'comment' => 'Platform photo URL',
+        ],
+    )]
+    #[Groups([
+        'Platform',
+        'Platform.photo',
+    ])]
+    private string $photo = '';
+
+    #[ORM\Column(
+        name: 'enabled',
+        type: Types::BOOLEAN,
+        options: [
+            'default' => true,
+        ],
+    )]
+    #[Groups([
+        'Platform',
+        'Platform.enabled',
+    ])]
+    #[Assert\NotNull]
+    private bool $enabled = true;
+
+    /**
+     * @throws Throwable
+     */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->private;
+    }
+
+    public function setPrivate(bool $private): self
+    {
+        $this->private = $private;
+
+        return $this;
+    }
+
+    public function getPhoto(): string
+    {
+        return $this->photo;
+    }
+
+    public function setPhoto(string $photo): self
+    {
+        $this->photo = $photo;
+
+        return $this;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function setEnabled(bool $enabled): self
+    {
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    public function ensureGeneratedPhoto(): self
+    {
+        if ($this->photo === '') {
+            $name = rawurlencode($this->name);
+            $this->photo = 'https://ui-avatars.com/api/?name=' . str_replace('%20', '+', $name);
+        }
+
+        return $this;
+    }
+}

--- a/src/Platform/Domain/Repository/Interfaces/PlatformRepositoryInterface.php
+++ b/src/Platform/Domain/Repository/Interfaces/PlatformRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Domain\Repository\Interfaces;
+
+/**
+ * @package App\Platform
+ */
+interface PlatformRepositoryInterface
+{
+}

--- a/src/Platform/Infrastructure/Repository/PlatformRepository.php
+++ b/src/Platform/Infrastructure/Repository/PlatformRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Platform\Domain\Entity\Platform as Entity;
+use App\Platform\Domain\Repository\Interfaces\PlatformRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @package App\Platform
+ *
+ * @psalm-suppress LessSpecificImplementedReturnType
+ * @codingStandardsIgnoreStart
+ *
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity|null findAdvanced(string $id, string|int|null $hydrationMode = null, string|null $entityManagerName = null)
+ * @method Entity|null findOneBy(array $criteria, ?array $orderBy = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ * @method Entity[] findByAdvanced(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?array $search = null, ?string $entityManagerName = null)
+ * @method Entity[] findAll(?string $entityManagerName = null)
+ *
+ * @codingStandardsIgnoreEnd
+ */
+class PlatformRepository extends BaseRepository implements PlatformRepositoryInterface
+{
+    /**
+     * @psalm-var class-string
+     */
+    protected static string $entityName = Entity::class;
+
+    /**
+     * @var array<int, string>
+     */
+    protected static array $searchColumns = [
+        'name',
+        'description',
+        'enabled',
+        'private',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+}

--- a/src/Platform/Transport/AutoMapper/Platform/AutoMapperConfiguration.php
+++ b/src/Platform/Transport/AutoMapper/Platform/AutoMapperConfiguration.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Transport\AutoMapper\Platform;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Platform\Application\DTO\Platform\PlatformCreate;
+use App\Platform\Application\DTO\Platform\PlatformPatch;
+use App\Platform\Application\DTO\Platform\PlatformUpdate;
+
+/**
+ * @package App\Platform
+ */
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    /**
+     * Classes to use specified request mapper.
+     *
+     * @var array<int, class-string>
+     */
+    protected static array $requestMapperClasses = [
+        PlatformCreate::class,
+        PlatformUpdate::class,
+        PlatformPatch::class,
+    ];
+
+    public function __construct(
+        RequestMapper $requestMapper,
+    ) {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Platform/Transport/AutoMapper/Platform/RequestMapper.php
+++ b/src/Platform/Transport/AutoMapper/Platform/RequestMapper.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Transport\AutoMapper\Platform;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+/**
+ * @package App\Platform
+ */
+class RequestMapper extends RestRequestMapper
+{
+    /**
+     * @var array<int, non-empty-string>
+     */
+    protected static array $properties = [
+        'name',
+        'description',
+        'private',
+        'photo',
+        'enabled',
+    ];
+}

--- a/src/Platform/Transport/Controller/Api/V1/Platform/PlatformController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Platform/PlatformController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Transport\Controller\Api\V1\Platform;
+
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\ResponseHandler;
+use App\General\Transport\Rest\Traits\Actions;
+use App\Platform\Application\DTO\Platform\PlatformCreate;
+use App\Platform\Application\DTO\Platform\PlatformPatch;
+use App\Platform\Application\DTO\Platform\PlatformUpdate;
+use App\Platform\Application\Resource\PlatformResource;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * @package App\Platform
+ *
+ * @method PlatformResource getResource()
+ * @method ResponseHandler getResponseHandler()
+ */
+#[AsController]
+#[Route(
+    path: '/v1/platform',
+)]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Platform Management')]
+class PlatformController extends Controller
+{
+    use Actions\Admin\CountAction;
+    use Actions\Admin\FindAction;
+    use Actions\Admin\FindOneAction;
+    use Actions\Admin\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    /**
+     * @var array<string, string>
+     */
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => PlatformCreate::class,
+        Controller::METHOD_UPDATE => PlatformUpdate::class,
+        Controller::METHOD_PATCH => PlatformPatch::class,
+    ];
+
+    public function __construct(
+        PlatformResource $resource,
+    ) {
+        parent::__construct($resource);
+    }
+}

--- a/src/Platform/Transport/EventListener/PlatformEntityEventListener.php
+++ b/src/Platform/Transport/EventListener/PlatformEntityEventListener.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Transport\EventListener;
+
+use App\Platform\Domain\Entity\Platform;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+
+/**
+ * @package App\Platform
+ */
+class PlatformEntityEventListener
+{
+    public function prePersist(LifecycleEventArgs $event): void
+    {
+        $this->process($event);
+    }
+
+    public function preUpdate(LifecycleEventArgs $event): void
+    {
+        $this->process($event);
+    }
+
+    private function process(LifecycleEventArgs $event): void
+    {
+        $platform = $event->getObject();
+
+        if ($platform instanceof Platform) {
+            $platform->ensureGeneratedPhoto();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Ajouter un module `Platform` complet suivant le même modèle que les modules CRUD existants pour gérer des plateformes avec UUID, DTOs, mapping et contrôleur sécurisé.
- Générer automatiquement une photo par défaut pour les plateformes vides et la persister via un listener Doctrine.

### Description

- Création de l'entité `App\Platform\Domain\Entity\Platform` implémentant `EntityInterface`, utilisant le trait `Uuid`, avec champs Doctrine `id` (type `UuidBinaryOrderedTimeType::NAME`), `name`, `description`, `private`, `photo`, `enabled`, groupes serializer `Platform.*` et la méthode `ensureGeneratedPhoto()` qui génère une URL `https://ui-avatars.com/api/?name=...` lorsque `photo` est vide.
- Ajout du listener `App\Platform\Transport\EventListener\PlatformEntityEventListener` (pré-persist / pré-update) qui appelle `ensureGeneratedPhoto()` et enregistrement dans `config/packages/event_listeners.yaml`.
- Ajout de l'interface `App\Platform\Domain\Repository\Interfaces\PlatformRepositoryInterface` et de l'implémentation `App\Platform\Infrastructure\Repository\PlatformRepository` héritant de `BaseRepository` avec `protected static string $entityName = Entity::class;` et `protected static array $searchColumns = ['name','description','enabled','private']`.
- Ajout des DTOs `Platform`, `PlatformCreate`, `PlatformUpdate`, `PlatformPatch` dans `App\Platform\Application\DTO\Platform` (héritage de `RestDto`, contraintes `NotBlank/NotNull` où demandées et implémentation de `load()` pour hydrater depuis l'entité).
- Ajout de l'automapper `RequestMapper` et `AutoMapperConfiguration` pour mapper `PlatformCreate/Update/Patch`, de la ressource `PlatformResource` et du contrôleur sécurisé `App\Platform\Transport\Controller\Api\V1\Platform\PlatformController` exposant les actions CRUD sur la route `'/v1/platform'` et mappant les DTOs.

### Testing

- Exécution de `find src/Platform -name '*.php' -print0 | xargs -0 -n1 php -l` a réussi et a retourné "No syntax errors detected" pour tous les fichiers créés.
- Exécution de `php bin/console lint:yaml config/packages/event_listeners.yaml` a échoué dans cet environnement à cause de dépendances manquantes (message indiquant `Try running "composer install"`), donc la validation YAML n'a pas pu être réalisée ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa70a02a30832b852b3b3b340ca3ac)