### PR TITLE
Add unauthenticated public platform list API endpoint

### DIFF
--- a/src/Platform/Application/Resource/PlatformResource.php
+++ b/src/Platform/Application/Resource/PlatformResource.php
@@ -39,4 +39,12 @@ class PlatformResource extends RestResource
     ) {
         parent::__construct($repository);
     }
+
+    /**
+     * @return array<int, Entity>
+     */
+    public function findPublicEnabled(): array
+    {
+        return $this->getRepository()->findPublicEnabled();
+    }
 }

--- a/src/Platform/Domain/Repository/Interfaces/PlatformRepositoryInterface.php
+++ b/src/Platform/Domain/Repository/Interfaces/PlatformRepositoryInterface.php
@@ -9,4 +9,8 @@ namespace App\Platform\Domain\Repository\Interfaces;
  */
 interface PlatformRepositoryInterface
 {
+    /**
+     * @return array<int, \App\Platform\Domain\Entity\Platform>
+     */
+    public function findPublicEnabled(): array;
 }

--- a/src/Platform/Infrastructure/Repository/PlatformRepository.php
+++ b/src/Platform/Infrastructure/Repository/PlatformRepository.php
@@ -46,4 +46,21 @@ class PlatformRepository extends BaseRepository implements PlatformRepositoryInt
         protected ManagerRegistry $managerRegistry,
     ) {
     }
+
+    /**
+     * @return array<int, Entity>
+     */
+    public function findPublicEnabled(): array
+    {
+        return $this->findBy(
+            criteria: [
+                'enabled' => true,
+                'private' => false,
+            ],
+            orderBy: [
+                'name' => 'ASC',
+                'id' => 'ASC',
+            ],
+        );
+    }
 }

--- a/src/Platform/Transport/Controller/Api/V1/Platform/PublicPlatformListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Platform/PublicPlatformListController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Transport\Controller\Api\V1\Platform;
+
+use App\General\Transport\Rest\ResponseHandler;
+use App\Platform\Application\Resource\PlatformResource;
+use App\Platform\Domain\Entity\Platform;
+use Nelmio\ApiDocBundle\Attribute\Model;
+use OpenApi\Attributes as OA;
+use OpenApi\Attributes\JsonContent;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Throwable;
+
+/**
+ * @package App\Platform
+ */
+#[AsController]
+#[OA\Tag(name: 'Platform')]
+class PublicPlatformListController
+{
+    public function __construct(
+        private readonly PlatformResource $platformResource,
+        private readonly ResponseHandler $responseHandler,
+    ) {
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Route(
+        path: '/v1/platform/public',
+        methods: [Request::METHOD_GET],
+    )]
+    #[OA\Get(
+        security: [],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'List of enabled public platforms.',
+                content: new JsonContent(
+                    type: 'array',
+                    items: new OA\Items(
+                        ref: new Model(
+                            type: Platform::class,
+                            groups: ['Platform.id', 'Platform.name', 'Platform.description', 'Platform.photo'],
+                        ),
+                    ),
+                ),
+            ),
+        ],
+    )]
+    public function __invoke(Request $request): Response
+    {
+        return $this->responseHandler->createResponse(
+            request: $request,
+            data: $this->platformResource->findPublicEnabled(),
+            restResource: $this->platformResource,
+            context: [
+                'groups' => ['Platform.id', 'Platform.name', 'Platform.description', 'Platform.photo'],
+            ],
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose a simple public endpoint to list platforms that are both `enabled` and not `private` for public-facing clients. 
- Ensure a stable, predictable ordering and avoid returning sensitive fields by using limited serializer groups. 

### Description
- Add `findPublicEnabled()` to `PlatformRepositoryInterface` to declare a repository-level query for public enabled platforms. 
- Implement `findPublicEnabled()` in `PlatformRepository` to filter by `enabled = true` and `private = false` and sort by `name ASC` then `id ASC`. 
- Expose the repository method via `PlatformResource::findPublicEnabled()` as a thin proxy. 
- Add `PublicPlatformListController` at `GET /api/v1/platform/public` with no `IsGranted` and OpenAPI annotation `security: []`, returning results through `ResponseHandler` with serializer groups `Platform.id`, `Platform.name`, `Platform.description`, and `Platform.photo`.

### Testing
- Ran PHP lint on modified files with `php -l` which reported no syntax errors for `PlatformRepositoryInterface`, `PlatformRepository`, `PlatformResource`, and `PublicPlatformListController`. 
- Attempted route inspection with `php bin/console debug:router` but it failed due to missing environment dependencies (`composer install` required) so runtime routing verification was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa72bea810832bbac589b9417dd8b7)