### PR TITLE
Add Platform data fixtures and register them for dev/test environments

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -140,6 +140,9 @@ when@dev:
         App\Role\Infrastructure\DataFixtures\:
             resource: '../src/Role/Infrastructure/DataFixtures/*'
 
+        App\Platform\Infrastructure\DataFixtures\:
+            resource: '../src/Platform/Infrastructure/DataFixtures/*'
+
         App\User\Infrastructure\DataFixtures\:
             resource: '../src/User/Infrastructure/DataFixtures/*'
 
@@ -176,6 +179,9 @@ when@test:
 
         App\Role\Infrastructure\DataFixtures\:
             resource: '../src/Role/Infrastructure/DataFixtures/*'
+
+        App\Platform\Infrastructure\DataFixtures\:
+            resource: '../src/Platform/Infrastructure/DataFixtures/*'
 
         App\User\Infrastructure\DataFixtures\:
             resource: '../src/User/Infrastructure/DataFixtures/*'

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadPlatformData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadPlatformData.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Infrastructure\DataFixtures\ORM;
+
+use App\General\Domain\Rest\UuidHelper;
+use App\Platform\Domain\Entity\Platform;
+use App\Tests\Utils\PhpUnitUtil;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+use Throwable;
+
+/**
+ * @package App\Platform
+ */
+final class LoadPlatformData extends Fixture implements OrderedFixtureInterface
+{
+    /**
+     * @var array<int, array{uuid: non-empty-string, code: non-empty-string, name: non-empty-string, enabled: bool, description: non-empty-string}>
+     */
+    private const array DATA = [
+        [
+            'uuid' => '40000000-0000-1000-8000-000000000001',
+            'code' => 'CR',
+            'name' => 'CRM 1',
+            'enabled' => true,
+            'description' => 'Complete CRM module to centralize customer relationships, track opportunities, and structure commercial activity.',
+        ],
+        [
+            'uuid' => '40000000-0000-1000-8000-000000000002',
+            'code' => 'CR',
+            'name' => 'CRM 2',
+            'enabled' => true,
+            'description' => 'Complete CRM module to centralize customer relationships, track opportunities, and structure commercial activity.',
+        ],
+        [
+            'uuid' => '40000000-0000-1000-8000-000000000003',
+            'code' => 'SH',
+            'name' => 'Shop Principal',
+            'enabled' => true,
+            'description' => 'E-commerce suite to manage product catalogs, orders, payments, and sales performance.',
+        ],
+        [
+            'uuid' => '40000000-0000-1000-8000-000000000004',
+            'code' => 'RE',
+            'name' => 'Recruit Principal',
+            'enabled' => true,
+            'description' => 'Recruitment workspace to publish job offers, qualify applications, and manage interviews efficiently.',
+        ],
+        [
+            'uuid' => '40000000-0000-1000-8000-000000000005',
+            'code' => 'SC',
+            'name' => 'School Principal',
+            'enabled' => true,
+            'description' => 'School module to organize classes, plan lessons, and monitor learner progress.',
+        ],
+    ];
+
+    /**
+     * @throws Throwable
+     */
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        foreach (self::DATA as $item) {
+            $entity = new Platform()
+                ->setName($item['name'])
+                ->setDescription($item['description'])
+                ->setEnabled($item['enabled'])
+                ->setPrivate(false)
+                ->ensureGeneratedPhoto();
+
+            PhpUnitUtil::setProperty('id', UuidHelper::fromString($item['uuid']), $entity);
+
+            $manager->persist($entity);
+            $this->addReference('Platform-' . $item['code'] . '-' . $item['name'], $entity);
+        }
+
+        $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 5;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a set of seeded `Platform` entities for development and testing so platform-related features have deterministic sample data.
- Make the new fixtures discoverable by Symfony in `dev` and `test` environments so they are loaded with other project fixtures.

### Description
- Add `LoadPlatformData` fixture at `src/Platform/Infrastructure/DataFixtures/ORM/LoadPlatformData.php` which defines a `DATA` array of platforms and creates `Platform` entities, sets properties, assigns deterministic UUIDs using `UuidHelper::fromString`, persists them, and registers references.
- Use `PhpUnitUtil::setProperty` to set the entity `id` for deterministic IDs in tests, and implement `getOrder()` returning `5` to control fixture ordering.
- Update `config/services.yaml` to include `App\Platform\Infrastructure\DataFixtures\` as a resource in the `when@dev` and `when@test` service sections so the fixtures are autowired/autoconfigured in those environments.

### Testing
- Ran the project test suite via `php bin/phpunit` and the tests completed successfully.
- Verified that instantiating the fixture class does not throw and that references are created by executing the fixture class in a test context, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa6ffb8260832ba7442b0a1640f647)