### PR TITLE
Add Plugin entity and create plugin table migration

### DIFF
--- a/migrations/Version20260306100000.php
+++ b/migrations/Version20260306100000.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+/**
+ * Create plugin table.
+ */
+final class Version20260306100000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Create plugin table.';
+    }
+
+    #[Override]
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql(<<<'SQL'
+CREATE TABLE plugin (
+    id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)',
+    name VARCHAR(255) NOT NULL,
+    description LONGTEXT NOT NULL,
+    private TINYINT(1) NOT NULL DEFAULT '0',
+    photo VARCHAR(255) NOT NULL COMMENT 'Plugin photo URL',
+    enabled TINYINT(1) NOT NULL DEFAULT '1',
+    created_at DATETIME DEFAULT NULL,
+    updated_at DATETIME DEFAULT NULL,
+    PRIMARY KEY(id)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB
+SQL
+        );
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('DROP TABLE plugin');
+    }
+}

--- a/src/Platform/Domain/Entity/Plugin.php
+++ b/src/Platform/Domain/Entity/Plugin.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+use Throwable;
+
+use function rawurlencode;
+use function str_replace;
+
+/**
+ * @package App\Platform
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'plugin')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Plugin implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(
+        name: 'id',
+        type: UuidBinaryOrderedTimeType::NAME,
+        unique: true,
+    )]
+    #[Groups([
+        'Plugin',
+        'Plugin.id',
+    ])]
+    private UuidInterface $id;
+
+    #[ORM\Column(
+        name: 'name',
+        type: Types::STRING,
+        length: 255,
+    )]
+    #[Groups([
+        'Plugin',
+        'Plugin.name',
+    ])]
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(
+        min: 2,
+        max: 255,
+    )]
+    private string $name = '';
+
+    #[ORM\Column(
+        name: 'description',
+        type: Types::TEXT,
+    )]
+    #[Groups([
+        'Plugin',
+        'Plugin.description',
+    ])]
+    #[Assert\NotNull]
+    private string $description = '';
+
+    #[ORM\Column(
+        name: 'private',
+        type: Types::BOOLEAN,
+        options: [
+            'default' => false,
+        ],
+    )]
+    #[Groups([
+        'Plugin',
+        'Plugin.private',
+    ])]
+    #[Assert\NotNull]
+    private bool $private = false;
+
+    #[ORM\Column(
+        name: 'photo',
+        type: Types::STRING,
+        length: 255,
+        options: [
+            'comment' => 'Plugin photo URL',
+        ],
+    )]
+    #[Groups([
+        'Plugin',
+        'Plugin.photo',
+    ])]
+    private string $photo = '';
+
+    #[ORM\Column(
+        name: 'enabled',
+        type: Types::BOOLEAN,
+        options: [
+            'default' => true,
+        ],
+    )]
+    #[Groups([
+        'Plugin',
+        'Plugin.enabled',
+    ])]
+    #[Assert\NotNull]
+    private bool $enabled = true;
+
+    /**
+     * @throws Throwable
+     */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->private;
+    }
+
+    public function setPrivate(bool $private): self
+    {
+        $this->private = $private;
+
+        return $this;
+    }
+
+    public function getPhoto(): string
+    {
+        return $this->photo;
+    }
+
+    public function setPhoto(string $photo): self
+    {
+        $this->photo = $photo;
+
+        return $this;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function setEnabled(bool $enabled): self
+    {
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    public function ensureGeneratedPhoto(): self
+    {
+        if ($this->photo === '') {
+            $name = rawurlencode($this->name);
+            $this->photo = 'https://ui-avatars.com/api/?name=' . str_replace('%20', '+', $name);
+        }
+
+        return $this;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a new `Plugin` domain entity that mirrors `Platform` so plugins can be managed and exposed by the API with the same validation, serialization and lifecycle behavior. 
- Persist plugin data in a dedicated SQL table with the same column types and defaults as `platform` so DB schema and API contract remain consistent.

### Description

- Add `src/Platform/Domain/Entity/Plugin.php` implementing the same fields as `Platform` (`id`, `name`, `description`, `private`, `photo`, `enabled`) and using the `Uuid` and `Timestampable` traits. 
- Map the entity to the SQL table with `#[ORM/Table(name: 'plugin')]` and matching column types/lengths/constraints and expose serializer groups `Plugin`, `Plugin.id`, `Plugin.name`, `Plugin.description`, `Plugin.private`, `Plugin.photo`, and `Plugin.enabled`. 
- Implement `ensureGeneratedPhoto()` in `Plugin` with the same avatar-generation logic as `Platform::ensureGeneratedPhoto()` to auto-generate `photo` when empty. 
- Add Doctrine migration `migrations/Version20260306100000.php` to create the `plugin` table with UUID binary primary key, name, description, boolean defaults, `photo` column with comment, and nullable `created_at`/`updated_at` timestamp columns.

### Testing

- Ran `php -l src/Platform/Domain/Entity/Plugin.php` and it reported no syntax errors. 
- Ran `php -l migrations/Version20260306100000.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aadb510b9c832bb9279d36e2a7e0d4)