### PR TITLE
Add Plugin repository, interface and resource to expose findPublicEnabled

### DIFF
--- a/src/Platform/Application/Resource/PluginResource.php
+++ b/src/Platform/Application/Resource/PluginResource.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Resource;
+
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\Rest\RestResource;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Platform\Domain\Entity\Plugin as Entity;
+use App\Platform\Domain\Repository\Interfaces\PluginRepositoryInterface as Repository;
+
+/**
+ * @package App\Platform
+ *
+ * @psalm-suppress LessSpecificImplementedReturnType
+ * @codingStandardsIgnoreStart
+ *
+ * @method Entity getReference(string $id, ?string $entityManagerName = null)
+ * @method \App\Platform\Infrastructure\Repository\PluginRepository getRepository()
+ * @method Entity[] find(?array $criteria = null, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?array $search = null, ?string $entityManagerName = null)
+ * @method Entity|null findOne(string $id, ?bool $throwExceptionIfNotFound = null, ?string $entityManagerName = null)
+ * @method Entity|null findOneBy(array $criteria, ?array $orderBy = null, ?bool $throwExceptionIfNotFound = null, ?string $entityManagerName = null)
+ * @method Entity create(RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity update(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity patch(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity delete(string $id, ?bool $flush = null, ?string $entityManagerName = null)
+ * @method Entity save(EntityInterface $entity, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ *
+ * @codingStandardsIgnoreEnd
+ */
+class PluginResource extends RestResource
+{
+    /**
+     * @param \App\Platform\Infrastructure\Repository\PluginRepository $repository
+     */
+    public function __construct(
+        Repository $repository,
+    ) {
+        parent::__construct($repository);
+    }
+
+    /**
+     * @return array<int, Entity>
+     */
+    public function findPublicEnabled(): array
+    {
+        return $this->getRepository()->findPublicEnabled();
+    }
+}

--- a/src/Platform/Domain/Repository/Interfaces/PluginRepositoryInterface.php
+++ b/src/Platform/Domain/Repository/Interfaces/PluginRepositoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Domain\Repository\Interfaces;
+
+/**
+ * @package App\Platform
+ */
+interface PluginRepositoryInterface
+{
+    /**
+     * @return array<int, \App\Platform\Domain\Entity\Plugin>
+     */
+    public function findPublicEnabled(): array;
+}

--- a/src/Platform/Infrastructure/Repository/PluginRepository.php
+++ b/src/Platform/Infrastructure/Repository/PluginRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Platform\Domain\Entity\Plugin as Entity;
+use App\Platform\Domain\Repository\Interfaces\PluginRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @package App\Platform
+ *
+ * @psalm-suppress LessSpecificImplementedReturnType
+ * @codingStandardsIgnoreStart
+ *
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity|null findAdvanced(string $id, string|int|null $hydrationMode = null, string|null $entityManagerName = null)
+ * @method Entity|null findOneBy(array $criteria, ?array $orderBy = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ * @method Entity[] findByAdvanced(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?array $search = null, ?string $entityManagerName = null)
+ * @method Entity[] findAll(?string $entityManagerName = null)
+ *
+ * @codingStandardsIgnoreEnd
+ */
+class PluginRepository extends BaseRepository implements PluginRepositoryInterface
+{
+    /**
+     * @psalm-var class-string
+     */
+    protected static string $entityName = Entity::class;
+
+    /**
+     * @var array<int, string>
+     */
+    protected static array $searchColumns = [
+        'name',
+        'description',
+        'enabled',
+        'private',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+
+    /**
+     * @return array<int, Entity>
+     */
+    public function findPublicEnabled(): array
+    {
+        return $this->findBy(
+            criteria: [
+                'enabled' => true,
+                'private' => false,
+            ],
+            orderBy: [
+                'name' => 'ASC',
+                'id' => 'ASC',
+            ],
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a repository contract and resource to list public, enabled `Plugin` entities consistently with existing `Platform` patterns.
- Allow application code to fetch publicly visible plugins ordered by `name` then `id` for API usage and listing views.

### Description
- Add `src/Platform/Domain/Repository/Interfaces/PluginRepositoryInterface.php` declaring `findPublicEnabled(): array` returning `Plugin[]`.
- Add `src/Platform/Infrastructure/Repository/PluginRepository.php` extending `BaseRepository` with `protected static string $entityName = Entity::class` and `protected static array $searchColumns` mirroring `PlatformRepository`.
- Implement `findPublicEnabled()` in the repository to filter `enabled = true` and `private = false` and order by `name ASC` then `id ASC`.
- Add `src/Platform/Application/Resource/PluginResource.php` extending `RestResource` and exposing `findPublicEnabled()` that delegates to the repository; docblocks include the same `@method` annotations convention used by other resources.

### Testing
- Ran `php -l` on the three new files and all syntax checks passed.
- Inspected `config/services.yaml` to confirm the `App\:` autowiring covers these classes and no service config changes were required.
- No unit or integration tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aadc00a108832bb8391267957f0ca3)