### PR TITLE
Add Plugin DTOs and AutoMapper request mapping

### DIFF
--- a/src/Platform/Application/DTO/Plugin/Plugin.php
+++ b/src/Platform/Application/DTO/Plugin/Plugin.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\DTO\Plugin;
+
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Platform\Domain\Entity\Plugin as Entity;
+use Override;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @package App\Platform
+ *
+ * @method self|RestDtoInterface get(string $id)
+ * @method self|RestDtoInterface patch(RestDtoInterface $dto)
+ * @method Entity|EntityInterface update(EntityInterface $entity)
+ */
+class Plugin extends RestDto
+{
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 2, max: 255)]
+    protected string $name = '';
+
+    #[Assert\NotNull]
+    protected string $description = '';
+
+    #[Assert\NotNull]
+    protected bool $private = false;
+
+    protected string $photo = '';
+
+    #[Assert\NotNull]
+    protected bool $enabled = true;
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->setVisited('name');
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->setVisited('description');
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->private;
+    }
+
+    public function setPrivate(bool $private): self
+    {
+        $this->setVisited('private');
+        $this->private = $private;
+
+        return $this;
+    }
+
+    public function getPhoto(): string
+    {
+        return $this->photo;
+    }
+
+    public function setPhoto(string $photo): self
+    {
+        $this->setVisited('photo');
+        $this->photo = $photo;
+
+        return $this;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+
+    public function setEnabled(bool $enabled): self
+    {
+        $this->setVisited('enabled');
+        $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param EntityInterface|Entity $entity
+     */
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->name = $entity->getName();
+            $this->description = $entity->getDescription();
+            $this->private = $entity->isPrivate();
+            $this->photo = $entity->getPhoto();
+            $this->enabled = $entity->isEnabled();
+        }
+
+        return $this;
+    }
+}

--- a/src/Platform/Application/DTO/Plugin/PluginCreate.php
+++ b/src/Platform/Application/DTO/Plugin/PluginCreate.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\DTO\Plugin;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @package App\Platform
+ */
+class PluginCreate extends Plugin
+{
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 2, max: 255)]
+    protected string $name = '';
+
+    #[Assert\NotNull]
+    protected string $description = '';
+
+    #[Assert\NotNull]
+    protected bool $private = false;
+
+    #[Assert\NotNull]
+    protected bool $enabled = true;
+}

--- a/src/Platform/Application/DTO/Plugin/PluginPatch.php
+++ b/src/Platform/Application/DTO/Plugin/PluginPatch.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\DTO\Plugin;
+
+/**
+ * @package App\Platform
+ */
+class PluginPatch extends Plugin
+{
+}

--- a/src/Platform/Application/DTO/Plugin/PluginUpdate.php
+++ b/src/Platform/Application/DTO/Plugin/PluginUpdate.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\DTO\Plugin;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @package App\Platform
+ */
+class PluginUpdate extends Plugin
+{
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 2, max: 255)]
+    protected string $name = '';
+
+    #[Assert\NotNull]
+    protected string $description = '';
+
+    #[Assert\NotNull]
+    protected bool $private = false;
+
+    #[Assert\NotNull]
+    protected bool $enabled = true;
+}

--- a/src/Platform/Transport/AutoMapper/Plugin/AutoMapperConfiguration.php
+++ b/src/Platform/Transport/AutoMapper/Plugin/AutoMapperConfiguration.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Transport\AutoMapper\Plugin;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Platform\Application\DTO\Plugin\PluginCreate;
+use App\Platform\Application\DTO\Plugin\PluginPatch;
+use App\Platform\Application\DTO\Plugin\PluginUpdate;
+
+/**
+ * @package App\Platform
+ */
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    /**
+     * Classes to use specified request mapper.
+     *
+     * @var array<int, class-string>
+     */
+    protected static array $requestMapperClasses = [
+        PluginCreate::class,
+        PluginUpdate::class,
+        PluginPatch::class,
+    ];
+
+    public function __construct(
+        RequestMapper $requestMapper,
+    ) {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Platform/Transport/AutoMapper/Plugin/RequestMapper.php
+++ b/src/Platform/Transport/AutoMapper/Plugin/RequestMapper.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Transport\AutoMapper\Plugin;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+/**
+ * @package App\Platform
+ */
+class RequestMapper extends RestRequestMapper
+{
+    /**
+     * @var array<int, non-empty-string>
+     */
+    protected static array $properties = [
+        'name',
+        'description',
+        'private',
+        'photo',
+        'enabled',
+    ];
+}


### PR DESCRIPTION
### Motivation
- Provide REST DTOs for the `Plugin` entity to support create/update/patch API flows similar to existing `Platform` DTOs.
- Ensure input validation for `Plugin` requests matches the `Platform` constraints on `name`, `description`, `private`, and `enabled`.
- Wire request-to-DTO mapping for plugin endpoints so request payloads are translated into the new DTO classes.

### Description
- Added DTO classes under `src/Platform/Application/DTO/Plugin/`: `Plugin`, `PluginCreate`, `PluginUpdate`, and `PluginPatch`, where `Plugin` extends `RestDto` and implements `load()` to populate `id`, `name`, `description`, `private`, `photo`, and `enabled` from the entity.
- Reproduced validation annotations (`NotBlank`, `NotNull`, `Length`) on `name`, `description`, `private`, and `enabled` for the create and update DTOs.
- Added `src/Platform/Transport/AutoMapper/Plugin/RequestMapper.php` that maps request properties `name`, `description`, `private`, `photo`, and `enabled`.
- Added `src/Platform/Transport/AutoMapper/Plugin/AutoMapperConfiguration.php` registering `PluginCreate`, `PluginUpdate`, and `PluginPatch` to use the above request mapper.

### Testing
- Ran `php -l` on the new files under `src/Platform/Application/DTO/Plugin/` and `src/Platform/Transport/AutoMapper/Plugin/`, and all files reported no syntax errors.
- No additional automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aadce7473c832b8e8050f98221d762)