### PR TITLE
Add Plugin API v1 controllers for admin CRUD and public listing

### DIFF
--- a/src/Platform/Transport/Controller/Api/V1/Plugin/PluginController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Plugin/PluginController.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Transport\Controller\Api\V1\Plugin;
+
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\ResponseHandler;
+use App\General\Transport\Rest\Traits\Actions;
+use App\Platform\Application\DTO\Plugin\PluginCreate;
+use App\Platform\Application\DTO\Plugin\PluginPatch;
+use App\Platform\Application\DTO\Plugin\PluginUpdate;
+use App\Platform\Application\Resource\PluginResource;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * @package App\Platform
+ *
+ * @method PluginResource getResource()
+ * @method ResponseHandler getResponseHandler()
+ */
+#[AsController]
+#[Route(
+    path: '/v1/plugin',
+)]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Plugin Management')]
+class PluginController extends Controller
+{
+    use Actions\Admin\CountAction;
+    use Actions\Admin\FindAction;
+    use Actions\Admin\FindOneAction;
+    use Actions\Admin\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    /**
+     * @var array<string, string>
+     */
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => PluginCreate::class,
+        Controller::METHOD_UPDATE => PluginUpdate::class,
+        Controller::METHOD_PATCH => PluginPatch::class,
+    ];
+
+    public function __construct(
+        PluginResource $resource,
+    ) {
+        parent::__construct($resource);
+    }
+}

--- a/src/Platform/Transport/Controller/Api/V1/Plugin/PublicPluginListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Plugin/PublicPluginListController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Transport\Controller\Api\V1\Plugin;
+
+use App\General\Transport\Rest\ResponseHandler;
+use App\Platform\Application\Resource\PluginResource;
+use App\Platform\Domain\Entity\Plugin;
+use Nelmio\ApiDocBundle\Attribute\Model;
+use OpenApi\Attributes as OA;
+use OpenApi\Attributes\JsonContent;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Throwable;
+
+/**
+ * @package App\Platform
+ */
+#[AsController]
+#[OA\Tag(name: 'Plugin')]
+class PublicPluginListController
+{
+    public function __construct(
+        private readonly PluginResource $pluginResource,
+        private readonly ResponseHandler $responseHandler,
+    ) {
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Route(
+        path: '/v1/plugin/public',
+        methods: [Request::METHOD_GET],
+    )]
+    #[OA\Get(
+        security: [],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'List of enabled public plugins.',
+                content: new JsonContent(
+                    type: 'array',
+                    items: new OA\Items(
+                        ref: new Model(
+                            type: Plugin::class,
+                            groups: ['Plugin.id', 'Plugin.name', 'Plugin.description', 'Plugin.photo'],
+                        ),
+                    ),
+                ),
+            ),
+        ],
+    )]
+    public function __invoke(Request $request): Response
+    {
+        return $this->responseHandler->createResponse(
+            request: $request,
+            data: $this->pluginResource->findPublicEnabled(),
+            restResource: $this->pluginResource,
+            context: [
+                'groups' => ['Plugin.id', 'Plugin.name', 'Plugin.description', 'Plugin.photo'],
+            ],
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an admin REST endpoint for `Plugin` resources matching the existing `PlatformController` pattern to support CRUD operations for plugins.
- Expose a public, unauthenticated list endpoint for enabled plugins that only returns public-facing fields.
- Ensure OpenAPI documentation and serialization groups are consistent with other API resources and that the global `/api` prefix is preserved.

### Description
- Add `src/Platform/Transport/Controller/Api/V1/Plugin/PluginController.php` with base route `/v1/plugin`, `#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]`, admin/root REST action traits, and `$dtoClasses` mapped to `PluginCreate`, `PluginUpdate`, and `PluginPatch`.
- Add `src/Platform/Transport/Controller/Api/V1/Plugin/PublicPluginListController.php` with route `GET /v1/plugin/public`, an empty `security` section in the OpenAPI `OA\nGet`, Nelmio `Model` reference, and serialization groups `Plugin.id`, `Plugin.name`, `Plugin.description`, `Plugin.photo` sourcing data from `PluginResource::findPublicEnabled()`.
- Add coherent OpenAPI tags (`Plugin`, `Plugin Management`) and use `Nelmio\ApiDocBundle\Attribute\Model` for response models, aligning documentation with existing controllers.
- Preserve global API route prefix by relying on the existing `/api` prefix defined in `config/routes.yaml`, resulting in final endpoints under `/api/v1/plugin`.

### Testing
- Ran PHP syntax checks with `php -l src/Platform/Transport/Controller/Api/V1/Plugin/PluginController.php` and `php -l src/Platform/Transport/Controller/Api/V1/Plugin/PublicPluginListController.php`, both reported no syntax errors.
- Verified the global API prefix exists by inspecting `config/routes.yaml` (search for `/api`) to ensure endpoints will be served under `/api/v1/plugin`.
- No automated unit/integration tests were modified or added in this change; only static validation commands above were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaddbd32c0832b87bbd79bc11ea829)