### PR TITLE
Add deterministic Plugin fixtures and API V1 tests

### DIFF
--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Infrastructure\DataFixtures\ORM;
+
+use App\General\Domain\Rest\UuidHelper;
+use App\Platform\Domain\Entity\Plugin;
+use App\Tests\Utils\PhpUnitUtil;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+use Throwable;
+
+/**
+ * @package App\Platform
+ */
+final class LoadPluginData extends Fixture implements OrderedFixtureInterface
+{
+    /**
+     * @var array<non-empty-string, non-empty-string>
+     */
+    public static array $uuids = [
+        'CRM Assistant' => '50000000-0000-1000-8000-000000000001',
+        'Analytics Booster' => '50000000-0000-1000-8000-000000000002',
+        'Private Beta Plugin' => '50000000-0000-1000-8000-000000000003',
+        'Disabled Public Plugin' => '50000000-0000-1000-8000-000000000004',
+        'Knowledge Base Connector' => '50000000-0000-1000-8000-000000000005',
+    ];
+
+    /**
+     * @var array<int, array{uuid: non-empty-string, key: non-empty-string, name: non-empty-string, enabled: bool, private: bool, description: non-empty-string}>
+     */
+    private const array DATA = [
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000001',
+            'key' => 'CRM-Assistant',
+            'name' => 'CRM Assistant',
+            'enabled' => true,
+            'private' => false,
+            'description' => 'AI assistant to summarize conversations, suggest follow-ups, and improve CRM workflows.',
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000002',
+            'key' => 'Analytics-Booster',
+            'name' => 'Analytics Booster',
+            'enabled' => true,
+            'private' => false,
+            'description' => 'Advanced analytics plugin with dashboards, KPIs, and custom reporting blocks.',
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000003',
+            'key' => 'Private-Beta-Plugin',
+            'name' => 'Private Beta Plugin',
+            'enabled' => true,
+            'private' => true,
+            'description' => 'Experimental plugin available only for selected internal beta users.',
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000004',
+            'key' => 'Disabled-Public-Plugin',
+            'name' => 'Disabled Public Plugin',
+            'enabled' => false,
+            'private' => false,
+            'description' => 'Legacy plugin currently disabled during migration and performance checks.',
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000005',
+            'key' => 'Knowledge-Base-Connector',
+            'name' => 'Knowledge Base Connector',
+            'enabled' => true,
+            'private' => false,
+            'description' => 'Connector to sync articles and FAQs from external knowledge base systems.',
+        ],
+    ];
+
+    /**
+     * @throws Throwable
+     */
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        foreach (self::DATA as $item) {
+            $entity = new Plugin()
+                ->setName($item['name'])
+                ->setDescription($item['description'])
+                ->setEnabled($item['enabled'])
+                ->setPrivate($item['private'])
+                ->ensureGeneratedPhoto();
+
+            PhpUnitUtil::setProperty('id', UuidHelper::fromString($item['uuid']), $entity);
+
+            $manager->persist($entity);
+            $this->addReference('Plugin-' . $item['key'], $entity);
+        }
+
+        $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 6;
+    }
+
+    public static function getUuidByKey(string $key): string
+    {
+        return self::$uuids[$key];
+    }
+}

--- a/src/Platform/Transport/Controller/Api/V1/Plugin/PluginController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Plugin/PluginController.php
@@ -31,10 +31,10 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[OA\Tag(name: 'Plugin Management')]
 class PluginController extends Controller
 {
-    use Actions\Admin\CountAction;
-    use Actions\Admin\FindAction;
-    use Actions\Admin\FindOneAction;
-    use Actions\Admin\IdsAction;
+    use Actions\Root\CountAction;
+    use Actions\Root\FindAction;
+    use Actions\Root\FindOneAction;
+    use Actions\Root\IdsAction;
     use Actions\Root\CreateAction;
     use Actions\Root\DeleteAction;
     use Actions\Root\PatchAction;

--- a/src/Platform/Transport/EventListener/PlatformEntityEventListener.php
+++ b/src/Platform/Transport/EventListener/PlatformEntityEventListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Platform\Transport\EventListener;
 
 use App\Platform\Domain\Entity\Platform;
+use App\Platform\Domain\Entity\Plugin;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 
 /**
@@ -24,10 +25,10 @@ class PlatformEntityEventListener
 
     private function process(LifecycleEventArgs $event): void
     {
-        $platform = $event->getObject();
+        $entity = $event->getObject();
 
-        if ($platform instanceof Platform) {
-            $platform->ensureGeneratedPhoto();
+        if ($entity instanceof Platform || $entity instanceof Plugin) {
+            $entity->ensureGeneratedPhoto();
         }
     }
 }

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginCountControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginCountControllerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Platform\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class PluginCountControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/plugin/count';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/plugin/count` returns forbidden error for non-root user.')]
+    public function testThatCountActionForNonRootUserReturnsForbiddenResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $client->request('GET', $this->baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/plugin/count` for the Root user returns success response.')]
+    public function testThatCountActionForRootUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(method: 'GET', uri: $this->baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('count', $responseData);
+        self::assertGreaterThanOrEqual(5, $responseData['count']);
+    }
+}

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginCreateControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginCreateControllerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Platform\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class PluginCreateControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/plugin';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `POST /v1/plugin` returns forbidden error for non-root user.')]
+    public function testThatCreateActionForNonRootUserReturnsForbiddenResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $requestData = [
+            'name' => 'New plugin',
+            'description' => 'A plugin for tests',
+            'enabled' => true,
+            'private' => false,
+        ];
+
+        $client->request(method: 'POST', uri: $this->baseUrl, content: JSON::encode($requestData));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @param array<string, bool|string> $requestData
+     *
+     * @throws Throwable
+     */
+    #[DataProvider('dataProviderWithIncorrectData')]
+    #[TestDox('Test that `POST /v1/plugin` with wrong data returns validation error.')]
+    public function testThatCreateActionForRootUserWithWrongDataReturnsValidationErrorResponse(
+        array $requestData,
+        string $error
+    ): void {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(method: 'POST', uri: $this->baseUrl, content: JSON::encode($requestData));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('message', $responseData);
+        self::assertStringContainsString($error, $responseData['message']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `POST /v1/plugin` for the Root user returns success response and auto-generates photo.')]
+    public function testThatCreateActionForRootUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $requestData = [
+            'name' => 'Plugin sans photo',
+            'description' => 'Plugin created without photo payload',
+            'enabled' => true,
+            'private' => false,
+        ];
+
+        $client->request(method: 'POST', uri: $this->baseUrl, content: JSON::encode($requestData));
+        $response = $client->getResponse();
+        $responseContent = $response->getContent();
+        self::assertNotFalse($responseContent);
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($responseContent, true);
+        self::assertArrayHasKey('id', $responseData);
+        self::assertArrayHasKey('name', $responseData);
+        self::assertArrayHasKey('description', $responseData);
+        self::assertArrayHasKey('enabled', $responseData);
+        self::assertArrayHasKey('private', $responseData);
+        self::assertArrayHasKey('photo', $responseData);
+        self::assertSame($requestData['name'], $responseData['name']);
+        self::assertSame($requestData['description'], $responseData['description']);
+        self::assertStringStartsWith('https://ui-avatars.com/api/?name=', $responseData['photo']);
+    }
+
+    /**
+     * @return Generator<array{0: array<string, bool|string>, 1: string}>
+     */
+    public static function dataProviderWithIncorrectData(): Generator
+    {
+        yield [
+            [
+                'name' => '',
+                'description' => 'Plugin description',
+                'enabled' => true,
+                'private' => false,
+            ],
+            'This value should not be blank.',
+        ];
+        yield [
+            [
+                'name' => 'A',
+                'description' => 'Plugin description',
+                'enabled' => true,
+                'private' => false,
+            ],
+            'This value is too short.',
+        ];
+    }
+}

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginDeleteControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginDeleteControllerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Platform\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Platform\Application\Resource\PluginResource;
+use App\Platform\Domain\Entity\Plugin;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class PluginDeleteControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/plugin';
+    private PluginResource $pluginResource;
+    private Plugin $plugin;
+
+    /**
+     * @throws Throwable
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pluginResource = static::getContainer()->get(PluginResource::class);
+        $plugin = $this->pluginResource->findOneBy(
+            criteria: [
+                'name' => 'Private Beta Plugin',
+            ],
+            throwExceptionIfNotFound: true,
+        );
+        self::assertInstanceOf(Plugin::class, $plugin);
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `DELETE /v1/plugin/{id}` returns forbidden error for non-root user.')]
+    public function testThatDeleteActionForNonRootUserReturnsForbiddenResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $client->request(method: 'DELETE', uri: $this->baseUrl . '/' . $this->plugin->getId());
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), "Response:\n" . $response);
+
+        /** @var Plugin|null $plugin */
+        $plugin = $this->pluginResource->findOne($this->plugin->getId());
+        self::assertInstanceOf(Plugin::class, $plugin);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `DELETE /v1/plugin/{id}` for the Root user returns success response.')]
+    public function testThatDeleteActionForRootUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('DELETE', $this->baseUrl . '/' . $this->plugin->getId());
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('id', $responseData);
+        self::assertArrayHasKey('name', $responseData);
+        self::assertArrayHasKey('description', $responseData);
+        self::assertSame($this->plugin->getId(), $responseData['id']);
+
+        /** @var Plugin|null $plugin */
+        $plugin = $this->pluginResource->findOne($this->plugin->getId());
+        self::assertNull($plugin);
+    }
+}

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginIdsControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginIdsControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Platform\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class PluginIdsControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/plugin/ids';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/plugin/ids` returns forbidden error for non-root user.')]
+    public function testThatIdsActionForNonRootUserReturnsForbiddenResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $client->request('GET', $this->baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/plugin/ids` for the Root user returns success response.')]
+    public function testThatIdsActionForRootUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(method: 'GET', uri: $this->baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertGreaterThanOrEqual(5, count($responseData));
+        self::assertIsString($responseData[0]);
+    }
+}

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginListControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginListControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Platform\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class PluginListControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/plugin';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/plugin` returns forbidden error for non-root user.')]
+    public function testThatFindActionForNonRootUserReturnsForbiddenResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $client->request('GET', $this->baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/plugin` for the Root user returns success response.')]
+    public function testThatFindActionForRootUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(method: 'GET', uri: $this->baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertGreaterThanOrEqual(5, count($responseData));
+        self::assertIsArray($responseData[0]);
+        self::assertArrayHasKey('id', $responseData[0]);
+        self::assertArrayHasKey('name', $responseData[0]);
+        self::assertArrayHasKey('description', $responseData[0]);
+        self::assertArrayHasKey('enabled', $responseData[0]);
+        self::assertArrayHasKey('private', $responseData[0]);
+        self::assertArrayHasKey('photo', $responseData[0]);
+    }
+}

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginPatchControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginPatchControllerTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Platform\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Platform\Application\Resource\PluginResource;
+use App\Platform\Domain\Entity\Plugin;
+use App\Platform\Infrastructure\DataFixtures\ORM\LoadPluginData;
+use App\Tests\TestCase\WebTestCase;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class PluginPatchControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/plugin';
+    private PluginResource $pluginResource;
+    private Plugin $plugin;
+
+    /**
+     * @throws Throwable
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pluginResource = static::getContainer()->get(PluginResource::class);
+        $plugin = $this->pluginResource->findOne(LoadPluginData::getUuidByKey('Knowledge Base Connector'));
+        self::assertInstanceOf(Plugin::class, $plugin);
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `PATCH /v1/plugin/{id}` returns forbidden error for non-root user.')]
+    public function testThatPatchActionForNonRootUserReturnsForbiddenResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $requestData = [
+            'name' => 'Patched plugin name',
+        ];
+
+        $client->request(
+            method: 'PATCH',
+            uri: $this->baseUrl . '/' . $this->plugin->getId(),
+            content: JSON::encode($requestData)
+        );
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @param array<string, string> $requestData
+     *
+     * @throws Throwable
+     */
+    #[DataProvider('dataProviderWithIncorrectData')]
+    #[TestDox('Test that `PATCH /v1/plugin/{id}` with wrong data returns validation error.')]
+    public function testThatPatchActionForRootUserWithWrongDataReturnsValidationErrorResponse(
+        array $requestData,
+        string $error
+    ): void {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(
+            method: 'PATCH',
+            uri: $this->baseUrl . '/' . $this->plugin->getId(),
+            content: JSON::encode($requestData)
+        );
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('message', $responseData);
+        self::assertStringContainsString($error, $responseData['message']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `PATCH /v1/plugin/{id}` for the Root user returns success response.')]
+    public function testThatPatchActionForRootUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $requestData = [
+            'description' => 'Patched description for knowledge base connector',
+            'enabled' => false,
+        ];
+
+        $client->request(
+            method: 'PATCH',
+            uri: $this->baseUrl . '/' . $this->plugin->getId(),
+            content: JSON::encode($requestData)
+        );
+        $response = $client->getResponse();
+        $responseContent = $response->getContent();
+        self::assertNotFalse($responseContent);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($responseContent, true);
+        self::assertArrayHasKey('id', $responseData);
+        self::assertArrayHasKey('description', $responseData);
+        self::assertArrayHasKey('enabled', $responseData);
+        self::assertSame($requestData['description'], $responseData['description']);
+        self::assertSame($requestData['enabled'], $responseData['enabled']);
+    }
+
+    /**
+     * @return Generator<array{0: array<string, string>, 1: string}>
+     */
+    public static function dataProviderWithIncorrectData(): Generator
+    {
+        yield [
+            [
+                'name' => '',
+            ],
+            'This value should not be blank.',
+        ];
+    }
+}

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginUpdateControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginUpdateControllerTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Platform\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Platform\Application\Resource\PluginResource;
+use App\Platform\Domain\Entity\Plugin;
+use App\Platform\Infrastructure\DataFixtures\ORM\LoadPluginData;
+use App\Tests\TestCase\WebTestCase;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class PluginUpdateControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/plugin';
+    private PluginResource $pluginResource;
+    private Plugin $plugin;
+
+    /**
+     * @throws Throwable
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pluginResource = static::getContainer()->get(PluginResource::class);
+        $plugin = $this->pluginResource->findOne(LoadPluginData::getUuidByKey('Analytics Booster'));
+        self::assertInstanceOf(Plugin::class, $plugin);
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `PUT /v1/plugin/{id}` returns forbidden error for non-root user.')]
+    public function testThatUpdateActionForNonRootUserReturnsForbiddenResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $requestData = [
+            'name' => 'Updated plugin name',
+            'description' => 'Updated plugin description',
+            'enabled' => true,
+            'private' => false,
+        ];
+
+        $client->request(
+            method: 'PUT',
+            uri: $this->baseUrl . '/' . $this->plugin->getId(),
+            content: JSON::encode($requestData)
+        );
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @param array<string, bool|string> $requestData
+     *
+     * @throws Throwable
+     */
+    #[DataProvider('dataProviderWithIncorrectData')]
+    #[TestDox('Test that `PUT /v1/plugin/{id}` with wrong data returns validation error.')]
+    public function testThatUpdateActionForRootUserWithWrongDataReturnsValidationErrorResponse(
+        array $requestData,
+        string $error
+    ): void {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(
+            method: 'PUT',
+            uri: $this->baseUrl . '/' . $this->plugin->getId(),
+            content: JSON::encode($requestData)
+        );
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('message', $responseData);
+        self::assertStringContainsString($error, $responseData['message']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `PUT /v1/plugin/{id}` for the Root user returns success response.')]
+    public function testThatUpdateActionForRootUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $requestData = [
+            'name' => 'Updated analytics plugin',
+            'description' => 'Updated analytics plugin description',
+            'enabled' => false,
+            'private' => true,
+        ];
+
+        $client->request(
+            method: 'PUT',
+            uri: $this->baseUrl . '/' . $this->plugin->getId(),
+            content: JSON::encode($requestData)
+        );
+        $response = $client->getResponse();
+        $responseContent = $response->getContent();
+        self::assertNotFalse($responseContent);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($responseContent, true);
+        self::assertArrayHasKey('id', $responseData);
+        self::assertArrayHasKey('name', $responseData);
+        self::assertArrayHasKey('description', $responseData);
+        self::assertSame($requestData['name'], $responseData['name']);
+        self::assertSame($requestData['description'], $responseData['description']);
+        self::assertSame($requestData['enabled'], $responseData['enabled']);
+        self::assertSame($requestData['private'], $responseData['private']);
+    }
+
+    /**
+     * @return Generator<array{0: array<string, bool|string>, 1: string}>
+     */
+    public static function dataProviderWithIncorrectData(): Generator
+    {
+        yield [
+            [
+                'name' => '',
+                'description' => 'Updated plugin description',
+                'enabled' => true,
+                'private' => false,
+            ],
+            'This value should not be blank.',
+        ];
+    }
+}

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginViewControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginViewControllerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Platform\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Platform\Infrastructure\DataFixtures\ORM\LoadPluginData;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class PluginViewControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/plugin';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/plugin/{id}` returns forbidden error for non-root user.')]
+    public function testThatFindOneActionForNonRootUserReturnsForbiddenResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $client->request('GET', $this->baseUrl . '/' . LoadPluginData::getUuidByKey('CRM Assistant'));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/plugin/{id}` for the Root user returns success response.')]
+    public function testThatFindOneActionForRootUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', $this->baseUrl . '/' . LoadPluginData::getUuidByKey('CRM Assistant'));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('id', $responseData);
+        self::assertArrayHasKey('name', $responseData);
+        self::assertArrayHasKey('description', $responseData);
+        self::assertArrayHasKey('photo', $responseData);
+        self::assertSame(LoadPluginData::getUuidByKey('CRM Assistant'), $responseData['id']);
+        self::assertStringStartsWith('https://ui-avatars.com/api/?name=', $responseData['photo']);
+    }
+}

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PublicPluginListControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PublicPluginListControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Platform\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class PublicPluginListControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/plugin/public';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/plugin/public` without authentication returns enabled and non-private plugins only.')]
+    public function testThatPublicListWorksWithoutAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', $this->baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertCount(3, $responseData);
+
+        foreach ($responseData as $plugin) {
+            self::assertIsArray($plugin);
+            self::assertArrayHasKey('id', $plugin);
+            self::assertArrayHasKey('name', $plugin);
+            self::assertArrayHasKey('description', $plugin);
+            self::assertArrayHasKey('photo', $plugin);
+            self::assertArrayNotHasKey('private', $plugin);
+            self::assertArrayNotHasKey('enabled', $plugin);
+            self::assertStringStartsWith('https://ui-avatars.com/api/?name=', $plugin['photo']);
+        }
+
+        $names = array_column($responseData, 'name');
+        self::assertSame(
+            [
+                'Analytics Booster',
+                'CRM Assistant',
+                'Knowledge Base Connector',
+            ],
+            $names,
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide deterministic Plugin fixtures (stable UUIDs and references) so tests can target known IDs and verify photo auto-generation. 
- Cover API V1 behavior for Plugin endpoints (private admin/root operations and public listing) with end-to-end tests following existing test patterns. 
- Ensure `Plugin` entities get an auto-generated photo on persist/update so create flows without `photo` still produce a photo URL. 

### Description
- Added fixture `src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php` with deterministic UUIDs, `setName`/`setDescription`/`setEnabled`/`setPrivate`, `ensureGeneratedPhoto()`, `addReference('Plugin-...')`, `getOrder(): 6` and a static `getUuidByKey()` helper. 
- Switched private management actions in `src/Platform/Transport/Controller/Api/V1/Plugin/PluginController.php` from `Actions\Admin\*` to `Actions\Root\*` to match requirement “root OK / non-root forbidden”. 
- Updated `src/Platform/Transport/EventListener/PlatformEntityEventListener.php` to also handle `Plugin` entities so `ensureGeneratedPhoto()` runs on `prePersist`/`preUpdate`. 
- Added API tests under `tests/Application/Platform/Transport/Controller/Api/V1/` exercising list/ids/count/findOne (root vs non-root), create/update/patch/delete (success + validation), and public list `/api/v1/plugin/public` (no auth, filters `enabled && !private`), and checks that photo URLs are generated when absent. 

### Testing
- Ran PHP syntax checks with `php -l` for all touched PHP files and the new tests, which returned no syntax errors. 
- Attempted to run the test suite with `vendor/bin/phpunit` and `bin/phpunit` for `tests/Application/Platform/Transport/Controller/Api/V1`, but the PHPUnit binary is not available in this environment so tests could not be executed here. 
- All added files pass static syntax validation performed in the change-set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aade5bda94832b83b3a27ed6024580)