### PR TITLE
feat(configuration): add full Configuration module with encrypted private values

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -40,6 +40,12 @@ doctrine:
                         dir: '%kernel.project_dir%/src/ApiKey/Domain/Entity'
                         prefix: 'App\ApiKey\Domain\Entity'
                         alias: ApiKey
+                    Configuration:
+                        type: attribute
+                        is_bundle: false
+                        dir: '%kernel.project_dir%/src/Configuration/Domain/Entity'
+                        prefix: 'App\Configuration\Domain\Entity'
+                        alias: Configuration
                     DateDimension:
                         type: attribute
                         is_bundle: false

--- a/config/packages/event_listeners.yaml
+++ b/config/packages/event_listeners.yaml
@@ -28,3 +28,11 @@ services:
         tags:
             - { name: doctrine.event_listener, event: prePersist }
             - { name: doctrine.event_listener, event: preUpdate }
+
+    App\Configuration\Transport\EventListener\ConfigurationEntityEventListener:
+        tags:
+            - { name: doctrine.event_listener, event: prePersist }
+            - { name: doctrine.event_listener, event: postPersist }
+            - { name: doctrine.event_listener, event: preUpdate }
+            - { name: doctrine.event_listener, event: postUpdate }
+            - { name: doctrine.event_listener, event: postLoad }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -137,6 +137,9 @@ when@dev:
         App\ApiKey\Infrastructure\DataFixtures\:
             resource: '../src/ApiKey/Infrastructure/DataFixtures/*'
 
+        App\Configuration\Infrastructure\DataFixtures\:
+            resource: '../src/Configuration/Infrastructure/DataFixtures/*'
+
         App\Role\Infrastructure\DataFixtures\:
             resource: '../src/Role/Infrastructure/DataFixtures/*'
 
@@ -176,6 +179,9 @@ when@test:
 
         App\ApiKey\Infrastructure\DataFixtures\:
             resource: '../src/ApiKey/Infrastructure/DataFixtures/*'
+
+        App\Configuration\Infrastructure\DataFixtures\:
+            resource: '../src/Configuration/Infrastructure/DataFixtures/*'
 
         App\Role\Infrastructure\DataFixtures\:
             resource: '../src/Role/Infrastructure/DataFixtures/*'

--- a/migrations/Version20260306123000.php
+++ b/migrations/Version20260306123000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+/**
+ * Add configuration table.
+ */
+final class Version20260306123000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Add configuration table with unique configuration_key, JSON value, scope enum and private encryption params.';
+    }
+
+    #[Override]
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("CREATE TABLE configuration (id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', configuration_key VARCHAR(255) NOT NULL, configuration_value JSON NOT NULL, scope VARCHAR(50) NOT NULL, private TINYINT(1) NOT NULL DEFAULT 0, configuration_value_parameters JSON DEFAULT NULL COMMENT 'Configuration value decrypt parameters when encrypted', created_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime)', updated_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime)', UNIQUE INDEX uq_configuration_key (configuration_key), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('DROP TABLE configuration');
+    }
+}

--- a/src/Configuration/Application/DTO/Configuration/Configuration.php
+++ b/src/Configuration/Application/DTO/Configuration/Configuration.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Application\DTO\Configuration;
+
+use App\Configuration\Domain\Entity\Configuration as Entity;
+use App\Configuration\Domain\Enum\ConfigurationScope;
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use Override;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @package App\Configuration
+ *
+ * @method self|RestDtoInterface get(string $id)
+ * @method self|RestDtoInterface patch(RestDtoInterface $dto)
+ * @method Entity|EntityInterface update(EntityInterface $entity)
+ */
+class Configuration extends RestDto
+{
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 2, max: 255)]
+    protected string $configurationKey = '';
+
+    /**
+     * @var array<string, mixed>
+     */
+    #[Assert\NotNull]
+    protected array $configurationValue = [];
+
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Choice(callback: [self::class, 'getScopeValues'])]
+    protected string $scope = ConfigurationScope::SYSTEM->value;
+
+    #[Assert\NotNull]
+    protected bool $private = false;
+
+    public function getConfigurationKey(): string
+    {
+        return $this->configurationKey;
+    }
+
+    public function setConfigurationKey(string $configurationKey): self
+    {
+        $this->setVisited('configurationKey');
+        $this->configurationKey = $configurationKey;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfigurationValue(): array
+    {
+        return $this->configurationValue;
+    }
+
+    /**
+     * @param array<string, mixed> $configurationValue
+     */
+    public function setConfigurationValue(array $configurationValue): self
+    {
+        $this->setVisited('configurationValue');
+        $this->configurationValue = $configurationValue;
+
+        return $this;
+    }
+
+    public function getScope(): string
+    {
+        return $this->scope;
+    }
+
+    public function setScope(string $scope): self
+    {
+        $this->setVisited('scope');
+        $this->scope = $scope;
+
+        return $this;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->private;
+    }
+
+    public function setPrivate(bool $private): self
+    {
+        $this->setVisited('private');
+        $this->private = $private;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param EntityInterface|Entity $entity
+     */
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->configurationKey = $entity->getConfigurationKey();
+            $this->configurationValue = $entity->getConfigurationValue();
+            $this->scope = $entity->getScopeValue();
+            $this->private = $entity->isPrivate();
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public static function getScopeValues(): array
+    {
+        return array_map(
+            static fn (ConfigurationScope $scope): string => $scope->value,
+            ConfigurationScope::cases(),
+        );
+    }
+}

--- a/src/Configuration/Application/DTO/Configuration/ConfigurationCreate.php
+++ b/src/Configuration/Application/DTO/Configuration/ConfigurationCreate.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Application\DTO\Configuration;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @package App\Configuration
+ */
+class ConfigurationCreate extends Configuration
+{
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 2, max: 255)]
+    protected string $configurationKey = '';
+
+    /**
+     * @var array<string, mixed>
+     */
+    #[Assert\NotNull]
+    protected array $configurationValue = [];
+
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Choice(callback: [self::class, 'getScopeValues'])]
+    protected string $scope = 'system';
+
+    #[Assert\NotNull]
+    protected bool $private = false;
+}

--- a/src/Configuration/Application/DTO/Configuration/ConfigurationPatch.php
+++ b/src/Configuration/Application/DTO/Configuration/ConfigurationPatch.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Application\DTO\Configuration;
+
+/**
+ * @package App\Configuration
+ */
+class ConfigurationPatch extends Configuration
+{
+}

--- a/src/Configuration/Application/DTO/Configuration/ConfigurationUpdate.php
+++ b/src/Configuration/Application/DTO/Configuration/ConfigurationUpdate.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Application\DTO\Configuration;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @package App\Configuration
+ */
+class ConfigurationUpdate extends Configuration
+{
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 2, max: 255)]
+    protected string $configurationKey = '';
+
+    /**
+     * @var array<string, mixed>
+     */
+    #[Assert\NotNull]
+    protected array $configurationValue = [];
+
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Choice(callback: [self::class, 'getScopeValues'])]
+    protected string $scope = 'system';
+
+    #[Assert\NotNull]
+    protected bool $private = false;
+}

--- a/src/Configuration/Application/Resource/ConfigurationResource.php
+++ b/src/Configuration/Application/Resource/ConfigurationResource.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Application\Resource;
+
+use App\Configuration\Domain\Entity\Configuration as Entity;
+use App\Configuration\Domain\Repository\Interfaces\ConfigurationRepositoryInterface as Repository;
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\Rest\RestResource;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+
+/**
+ * @package App\Configuration
+ *
+ * @psalm-suppress LessSpecificImplementedReturnType
+ * @codingStandardsIgnoreStart
+ *
+ * @method Entity getReference(string $id, ?string $entityManagerName = null)
+ * @method \App\Configuration\Infrastructure\Repository\ConfigurationRepository getRepository()
+ * @method Entity[] find(?array $criteria = null, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?array $search = null, ?string $entityManagerName = null)
+ * @method Entity|null findOne(string $id, ?bool $throwExceptionIfNotFound = null, ?string $entityManagerName = null)
+ * @method Entity|null findOneBy(array $criteria, ?array $orderBy = null, ?bool $throwExceptionIfNotFound = null, ?string $entityManagerName = null)
+ * @method Entity create(RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity update(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity patch(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity delete(string $id, ?bool $flush = null, ?string $entityManagerName = null)
+ * @method Entity save(EntityInterface $entity, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ *
+ * @codingStandardsIgnoreEnd
+ */
+class ConfigurationResource extends RestResource
+{
+    /**
+     * @param \App\Configuration\Infrastructure\Repository\ConfigurationRepository $repository
+     */
+    public function __construct(
+        Repository $repository,
+    ) {
+        parent::__construct($repository);
+    }
+}

--- a/src/Configuration/Application/Service/Crypt/ConfigurationValueCryptService.php
+++ b/src/Configuration/Application/Service/Crypt/ConfigurationValueCryptService.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Application\Service\Crypt;
+
+use App\Configuration\Application\Service\Crypt\Interfaces\ConfigurationValueCryptServiceInterface;
+use App\Configuration\Domain\Entity\Configuration;
+use App\Tool\Domain\Service\Crypt\Interfaces\OpenSslCryptServiceInterface;
+
+use function is_array;
+
+/**
+ * @package App\Configuration
+ */
+class ConfigurationValueCryptService implements ConfigurationValueCryptServiceInterface
+{
+    public function __construct(
+        private readonly OpenSslCryptServiceInterface $openSslCryptService,
+    ) {
+    }
+
+    public function encryptValue(Configuration $configuration): void
+    {
+        if (!$configuration->isPrivate() || $configuration->getConfigurationValueParameters() !== null) {
+            return;
+        }
+
+        $value = $configuration->getConfigurationValue();
+        $data = $this->openSslCryptService->encrypt(json_encode($value, JSON_THROW_ON_ERROR));
+
+        $configuration
+            ->setConfigurationValue([
+                'data' => $data['data'],
+            ])
+            ->setConfigurationValueParameters($data['params']);
+    }
+
+    public function decryptValue(Configuration $configuration): void
+    {
+        $params = $configuration->getConfigurationValueParameters();
+
+        if (!$configuration->isPrivate() || $params === null) {
+            return;
+        }
+
+        $value = $configuration->getConfigurationValue();
+        $encryptedData = $value['data'] ?? null;
+
+        if (!is_string($encryptedData) || $encryptedData === '') {
+            return;
+        }
+
+        $decrypted = $this->openSslCryptService->decrypt([
+            'data' => $encryptedData,
+            'params' => $params,
+        ]);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($decrypted, true, 512, JSON_THROW_ON_ERROR);
+
+        $configuration->setConfigurationValue($decoded);
+    }
+}

--- a/src/Configuration/Application/Service/Crypt/Interfaces/ConfigurationValueCryptServiceInterface.php
+++ b/src/Configuration/Application/Service/Crypt/Interfaces/ConfigurationValueCryptServiceInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Application\Service\Crypt\Interfaces;
+
+use App\Configuration\Domain\Entity\Configuration;
+
+/**
+ * @package App\Configuration
+ */
+interface ConfigurationValueCryptServiceInterface
+{
+    public function encryptValue(Configuration $configuration): void;
+
+    public function decryptValue(Configuration $configuration): void;
+}

--- a/src/Configuration/Domain/Entity/Configuration.php
+++ b/src/Configuration/Domain/Entity/Configuration.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Domain\Entity;
+
+use App\Configuration\Domain\Enum\ConfigurationScope;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Bridge\Doctrine\Validator\Constraints as AssertCollection;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+use Throwable;
+
+/**
+ * @package App\Configuration
+ */
+#[ORM\Entity]
+#[ORM\Table(name: 'configuration')]
+#[ORM\UniqueConstraint(name: 'uq_configuration_key', columns: ['configuration_key'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+#[AssertCollection\UniqueEntity('configurationKey')]
+class Configuration implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['Configuration', 'Configuration.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'configuration_key', type: Types::STRING, length: 255)]
+    #[Groups(['Configuration', 'Configuration.configurationKey'])]
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 2, max: 255)]
+    private string $configurationKey = '';
+
+    /**
+     * @var array<string, mixed>
+     */
+    #[ORM\Column(name: 'configuration_value', type: Types::JSON)]
+    #[Groups(['Configuration', 'Configuration.configurationValue'])]
+    #[Assert\NotNull]
+    private array $configurationValue = [];
+
+    #[ORM\Column(name: 'scope', type: Types::STRING, length: 50, enumType: ConfigurationScope::class)]
+    #[Groups(['Configuration', 'Configuration.scope'])]
+    #[Assert\NotNull]
+    private ConfigurationScope $scope = ConfigurationScope::SYSTEM;
+
+    #[ORM\Column(name: 'private', type: Types::BOOLEAN, options: ['default' => false])]
+    #[Groups(['Configuration', 'Configuration.private'])]
+    #[Assert\NotNull]
+    private bool $private = false;
+
+    /**
+     * @var array<string, string>|null
+     */
+    #[ORM\Column(name: 'configuration_value_parameters', type: Types::JSON, nullable: true, options: ['comment' => 'Configuration value decrypt parameters when encrypted'])]
+    #[Groups(['Configuration.configurationValueParameters'])]
+    private ?array $configurationValueParameters = null;
+
+    /**
+     * @throws Throwable
+     */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getConfigurationKey(): string
+    {
+        return $this->configurationKey;
+    }
+
+    public function setConfigurationKey(string $configurationKey): self
+    {
+        $this->configurationKey = $configurationKey;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfigurationValue(): array
+    {
+        return $this->configurationValue;
+    }
+
+    /**
+     * @param array<string, mixed> $configurationValue
+     */
+    public function setConfigurationValue(array $configurationValue): self
+    {
+        $this->configurationValue = $configurationValue;
+
+        return $this;
+    }
+
+    public function getScope(): ConfigurationScope
+    {
+        return $this->scope;
+    }
+
+    public function getScopeValue(): string
+    {
+        return $this->scope->value;
+    }
+
+    public function setScope(ConfigurationScope|string $scope): self
+    {
+        $this->scope = $scope instanceof ConfigurationScope ? $scope : ConfigurationScope::from($scope);
+
+        return $this;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->private;
+    }
+
+    public function setPrivate(bool $private): self
+    {
+        $this->private = $private;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    public function getConfigurationValueParameters(): ?array
+    {
+        return $this->configurationValueParameters;
+    }
+
+    /**
+     * @param array<string, string>|null $configurationValueParameters
+     */
+    public function setConfigurationValueParameters(?array $configurationValueParameters): self
+    {
+        $this->configurationValueParameters = $configurationValueParameters;
+
+        return $this;
+    }
+}

--- a/src/Configuration/Domain/Enum/ConfigurationScope.php
+++ b/src/Configuration/Domain/Enum/ConfigurationScope.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Domain\Enum;
+
+/**
+ * @package App\Configuration
+ */
+enum ConfigurationScope: string
+{
+    case SYSTEM = 'system';
+    case USER = 'user';
+    case PLATFORM = 'platform';
+    case PLUGIN = 'plugin';
+    case PUBLIC = 'public';
+}

--- a/src/Configuration/Domain/Repository/Interfaces/ConfigurationRepositoryInterface.php
+++ b/src/Configuration/Domain/Repository/Interfaces/ConfigurationRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Domain\Repository\Interfaces;
+
+/**
+ * @package App\Configuration
+ */
+interface ConfigurationRepositoryInterface
+{
+}

--- a/src/Configuration/Infrastructure/DataFixtures/ORM/LoadConfigurationData.php
+++ b/src/Configuration/Infrastructure/DataFixtures/ORM/LoadConfigurationData.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Infrastructure\DataFixtures\ORM;
+
+use App\Configuration\Domain\Entity\Configuration;
+use App\Configuration\Domain\Enum\ConfigurationScope;
+use App\General\Domain\Rest\UuidHelper;
+use App\Tests\Utils\PhpUnitUtil;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+use Throwable;
+
+/**
+ * @package App\Configuration
+ */
+final class LoadConfigurationData extends Fixture implements OrderedFixtureInterface
+{
+    /**
+     * @var array<non-empty-string, non-empty-string>
+     */
+    public static array $uuids = [
+        'system-default-locale' => '50000000-0000-1000-8000-000000000001',
+        'public-branding' => '50000000-0000-1000-8000-000000000002',
+        'plugin-crm-toggles' => '50000000-0000-1000-8000-000000000003',
+        'user-dashboard-preferences' => '50000000-0000-1000-8000-000000000004',
+        'platform-secrets' => '50000000-0000-1000-8000-000000000005',
+    ];
+
+    /**
+     * @var array<int, array{uuid: non-empty-string, key: non-empty-string, value: array<string, mixed>, scope: ConfigurationScope, private: bool}>
+     */
+    private const array DATA = [
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000001',
+            'key' => 'system.default.locale',
+            'value' => ['locale' => 'en'],
+            'scope' => ConfigurationScope::SYSTEM,
+            'private' => false,
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000002',
+            'key' => 'public.branding',
+            'value' => ['title' => 'BRO World', 'theme' => 'dark'],
+            'scope' => ConfigurationScope::PUBLIC,
+            'private' => false,
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000003',
+            'key' => 'plugin.crm.toggles',
+            'value' => ['featureA' => true, 'featureB' => false],
+            'scope' => ConfigurationScope::PLUGIN,
+            'private' => false,
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000004',
+            'key' => 'user.dashboard.preferences',
+            'value' => ['layout' => 'compact', 'cards' => ['sales', 'tasks']],
+            'scope' => ConfigurationScope::USER,
+            'private' => false,
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000005',
+            'key' => 'platform.secrets',
+            'value' => ['apiSecret' => 'secret-value', 'rotation' => 30],
+            'scope' => ConfigurationScope::PLATFORM,
+            'private' => true,
+        ],
+    ];
+
+    /**
+     * @throws Throwable
+     */
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        foreach (self::DATA as $item) {
+            $entity = new Configuration();
+            $entity
+                ->setConfigurationKey($item['key'])
+                ->setConfigurationValue($item['value'])
+                ->setScope($item['scope'])
+                ->setPrivate($item['private']);
+
+            PhpUnitUtil::setProperty('id', UuidHelper::fromString($item['uuid']), $entity);
+
+            $manager->persist($entity);
+            $this->addReference('Configuration-' . $item['key'], $entity);
+        }
+
+        $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 6;
+    }
+
+    public static function getUuidByKey(string $key): string
+    {
+        return self::$uuids[$key];
+    }
+}

--- a/src/Configuration/Infrastructure/Repository/ConfigurationRepository.php
+++ b/src/Configuration/Infrastructure/Repository/ConfigurationRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Infrastructure\Repository;
+
+use App\Configuration\Domain\Entity\Configuration as Entity;
+use App\Configuration\Domain\Repository\Interfaces\ConfigurationRepositoryInterface;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @package App\Configuration
+ *
+ * @psalm-suppress LessSpecificImplementedReturnType
+ * @codingStandardsIgnoreStart
+ *
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity|null findAdvanced(string $id, string|int|null $hydrationMode = null, string|null $entityManagerName = null)
+ * @method Entity|null findOneBy(array $criteria, ?array $orderBy = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ * @method Entity[] findByAdvanced(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?array $search = null, ?string $entityManagerName = null)
+ * @method Entity[] findAll(?string $entityManagerName = null)
+ *
+ * @codingStandardsIgnoreEnd
+ */
+class ConfigurationRepository extends BaseRepository implements ConfigurationRepositoryInterface
+{
+    /**
+     * @psalm-var class-string
+     */
+    protected static string $entityName = Entity::class;
+
+    /**
+     * @var array<int, string>
+     */
+    protected static array $searchColumns = [
+        'configurationKey',
+        'scope',
+        'private',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+}

--- a/src/Configuration/Transport/AutoMapper/Configuration/AutoMapperConfiguration.php
+++ b/src/Configuration/Transport/AutoMapper/Configuration/AutoMapperConfiguration.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Transport\AutoMapper\Configuration;
+
+use App\Configuration\Application\DTO\Configuration\ConfigurationCreate;
+use App\Configuration\Application\DTO\Configuration\ConfigurationPatch;
+use App\Configuration\Application\DTO\Configuration\ConfigurationUpdate;
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+
+/**
+ * @package App\Configuration
+ */
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    /**
+     * Classes to use specified request mapper.
+     *
+     * @var array<int, class-string>
+     */
+    protected static array $requestMapperClasses = [
+        ConfigurationCreate::class,
+        ConfigurationUpdate::class,
+        ConfigurationPatch::class,
+    ];
+
+    public function __construct(
+        RequestMapper $requestMapper,
+    ) {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Configuration/Transport/AutoMapper/Configuration/RequestMapper.php
+++ b/src/Configuration/Transport/AutoMapper/Configuration/RequestMapper.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Transport\AutoMapper\Configuration;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+/**
+ * @package App\Configuration
+ */
+class RequestMapper extends RestRequestMapper
+{
+    /**
+     * @var array<int, non-empty-string>
+     */
+    protected static array $properties = [
+        'configurationKey',
+        'configurationValue',
+        'scope',
+        'private',
+    ];
+}

--- a/src/Configuration/Transport/Controller/Api/V1/Configuration/ConfigurationController.php
+++ b/src/Configuration/Transport/Controller/Api/V1/Configuration/ConfigurationController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Transport\Controller\Api\V1\Configuration;
+
+use App\Configuration\Application\DTO\Configuration\ConfigurationCreate;
+use App\Configuration\Application\DTO\Configuration\ConfigurationPatch;
+use App\Configuration\Application\DTO\Configuration\ConfigurationUpdate;
+use App\Configuration\Application\Resource\ConfigurationResource;
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\ResponseHandler;
+use App\General\Transport\Rest\Traits\Actions;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * @package App\Configuration
+ *
+ * @method ConfigurationResource getResource()
+ * @method ResponseHandler getResponseHandler()
+ */
+#[AsController]
+#[Route(path: '/v1/configuration')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Configuration Management')]
+class ConfigurationController extends Controller
+{
+    use Actions\Admin\CountAction;
+    use Actions\Admin\FindAction;
+    use Actions\Admin\FindOneAction;
+    use Actions\Admin\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    /**
+     * @var array<string, string>
+     */
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => ConfigurationCreate::class,
+        Controller::METHOD_UPDATE => ConfigurationUpdate::class,
+        Controller::METHOD_PATCH => ConfigurationPatch::class,
+    ];
+
+    public function __construct(
+        ConfigurationResource $resource,
+    ) {
+        parent::__construct($resource);
+    }
+}

--- a/src/Configuration/Transport/EventListener/ConfigurationEntityEventListener.php
+++ b/src/Configuration/Transport/EventListener/ConfigurationEntityEventListener.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Configuration\Transport\EventListener;
+
+use App\Configuration\Application\Service\Crypt\Interfaces\ConfigurationValueCryptServiceInterface;
+use App\Configuration\Domain\Entity\Configuration;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+
+/**
+ * @package App\Configuration
+ */
+class ConfigurationEntityEventListener
+{
+    public function __construct(
+        private readonly ConfigurationValueCryptServiceInterface $configurationValueCryptService,
+    ) {
+    }
+
+    public function prePersist(LifecycleEventArgs $event): void
+    {
+        $this->process($event, 'encrypt');
+    }
+
+    public function postPersist(LifecycleEventArgs $event): void
+    {
+        $this->process($event, 'decrypt');
+    }
+
+    public function preUpdate(LifecycleEventArgs $event): void
+    {
+        $this->process($event, 'encrypt');
+    }
+
+    public function postUpdate(LifecycleEventArgs $event): void
+    {
+        $this->process($event, 'decrypt');
+    }
+
+    public function postLoad(LifecycleEventArgs $event): void
+    {
+        $this->process($event, 'decrypt');
+    }
+
+    private function process(LifecycleEventArgs $event, string $action): void
+    {
+        $configuration = $event->getObject();
+
+        if (!$configuration instanceof Configuration) {
+            return;
+        }
+
+        $action === 'encrypt'
+            ? $this->configurationValueCryptService->encryptValue($configuration)
+            : $this->configurationValueCryptService->decryptValue($configuration);
+    }
+}

--- a/tests/Application/Configuration/Transport/Controller/Api/V1/Configuration/ConfigurationControllerTest.php
+++ b/tests/Application/Configuration/Transport/Controller/Api/V1/Configuration/ConfigurationControllerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Configuration\Transport\Controller\Api\V1\Configuration;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class ConfigurationControllerTest extends WebTestCase
+{
+    protected static string $baseUrl = self::API_URL_PREFIX . '/v1/configuration';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /api/v1/configuration` request returns `401` for non-logged user.')]
+    public function testThatGetBaseRouteReturn401(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', static::$baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[DataProvider('dataProviderGetActions')]
+    #[TestDox('Test that `$method $action` returns forbidden error for non-admin user.')]
+    public function testThatGetActionsForbiddenForNonAdminUser(string $method, string $action): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request($method, $action);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /api/v1/configuration/count` for admin returns success response.')]
+    public function testThatCountActionForAdminUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $client->request(method: 'GET', uri: static::$baseUrl . '/count');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('count', $responseData);
+        self::assertGreaterThan(0, $responseData['count']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /api/v1/configuration` for admin returns success response.')]
+    public function testThatFindActionForAdminUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $client->request('GET', static::$baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertGreaterThanOrEqual(5, count($responseData));
+        self::assertArrayHasKey('id', $responseData[0]);
+        self::assertArrayHasKey('configurationKey', $responseData[0]);
+        self::assertArrayHasKey('configurationValue', $responseData[0]);
+        self::assertArrayHasKey('scope', $responseData[0]);
+        self::assertArrayHasKey('private', $responseData[0]);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /api/v1/configuration/ids` for admin returns success response.')]
+    public function testThatIdsActionForAdminUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $client->request('GET', static::$baseUrl . '/ids');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertGreaterThan(0, count($responseData));
+        self::assertIsString($responseData[0]);
+    }
+
+    /**
+     * @return Generator<array{0: string, 1: string}>
+     */
+    public static function dataProviderGetActions(): Generator
+    {
+        yield ['GET', static::$baseUrl . '/count'];
+        yield ['GET', static::$baseUrl];
+        yield ['GET', static::$baseUrl . '/ids'];
+    }
+}

--- a/tests/Application/Configuration/Transport/Controller/Api/V1/Configuration/ConfigurationCreateControllerTest.php
+++ b/tests/Application/Configuration/Transport/Controller/Api/V1/Configuration/ConfigurationCreateControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Configuration\Transport\Controller\Api\V1\Configuration;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class ConfigurationCreateControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/configuration';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `POST /api/v1/configuration` returns forbidden for non-root user.')]
+    public function testThatCreateActionForNonRootUserReturnsForbiddenResponse(): void
+    {
+        $client = $this->getTestClient('john-admin', 'password-admin');
+
+        $client->request(method: 'POST', uri: $this->baseUrl, content: JSON::encode($this->getValidPayload()));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_FORBIDDEN, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @param array<string, mixed> $requestData
+     *
+     * @throws Throwable
+     */
+    #[DataProvider('dataProviderWithIncorrectData')]
+    #[TestDox('Test that `POST /api/v1/configuration` with wrong data returns validation error.')]
+    public function testThatCreateActionForRootUserWithWrongDataReturnsValidationErrorResponse(
+        array $requestData,
+        string $error
+    ): void {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(method: 'POST', uri: $this->baseUrl, content: JSON::encode($requestData));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('message', $responseData);
+        self::assertStringContainsString($error, $responseData['message']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `POST /api/v1/configuration` for root returns success and decrypted private value.')]
+    public function testThatCreateActionForRootUserReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $requestData = $this->getValidPayload();
+        $requestData['private'] = true;
+        $requestData['configurationKey'] = 'system.private.created';
+        $client->request(method: 'POST', uri: $this->baseUrl, content: JSON::encode($requestData));
+        $response = $client->getResponse();
+        $responseContent = $response->getContent();
+        self::assertNotFalse($responseContent);
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($responseContent, true);
+        self::assertArrayHasKey('id', $responseData);
+        self::assertArrayHasKey('configurationKey', $responseData);
+        self::assertArrayHasKey('configurationValue', $responseData);
+        self::assertArrayHasKey('scope', $responseData);
+        self::assertArrayHasKey('private', $responseData);
+        self::assertSame($requestData['configurationValue'], $responseData['configurationValue']);
+    }
+
+    /**
+     * @return Generator<array{0: array<string, mixed>, 1: string}>
+     */
+    public static function dataProviderWithIncorrectData(): Generator
+    {
+        yield [[
+            'configurationKey' => '',
+            'configurationValue' => ['enabled' => true],
+            'scope' => 'system',
+            'private' => false,
+        ], 'This value should not be blank.'];
+
+        yield [[
+            'configurationKey' => 'test.invalid.scope',
+            'configurationValue' => ['enabled' => true],
+            'scope' => 'invalid',
+            'private' => false,
+        ], 'The value you selected is not a valid choice.'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getValidPayload(): array
+    {
+        return [
+            'configurationKey' => 'system.feature.flags',
+            'configurationValue' => ['featureX' => true, 'featureY' => false],
+            'scope' => 'system',
+            'private' => false,
+        ];
+    }
+}

--- a/tests/Application/Configuration/Transport/Controller/Api/V1/Configuration/ConfigurationModifyControllerTest.php
+++ b/tests/Application/Configuration/Transport/Controller/Api/V1/Configuration/ConfigurationModifyControllerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Configuration\Transport\Controller\Api\V1\Configuration;
+
+use App\Configuration\Infrastructure\DataFixtures\ORM\LoadConfigurationData;
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class ConfigurationModifyControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/configuration';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that view/update/patch/delete configuration actions work as expected.')]
+    public function testThatCrudActionsWorkAsExpected(): void
+    {
+        $configurationId = LoadConfigurationData::getUuidByKey('platform-secrets');
+
+        $adminClient = $this->getTestClient('john-admin', 'password-admin');
+        $adminClient->request('GET', $this->baseUrl . '/' . $configurationId);
+        $viewResponse = $adminClient->getResponse();
+        $viewContent = $viewResponse->getContent();
+        self::assertNotFalse($viewContent);
+        self::assertSame(Response::HTTP_OK, $viewResponse->getStatusCode(), "Response:\n" . $viewResponse);
+        $viewData = JSON::decode($viewContent, true);
+        self::assertSame('platform.secrets', $viewData['configurationKey']);
+        self::assertIsArray($viewData['configurationValue']);
+        self::assertArrayHasKey('apiSecret', $viewData['configurationValue']);
+
+        $rootClient = $this->getTestClient('john-root', 'password-root');
+        $updateData = [
+            'configurationKey' => 'platform.secrets.updated',
+            'configurationValue' => ['apiSecret' => 'updated-secret', 'rotation' => 90],
+            'scope' => 'platform',
+            'private' => true,
+        ];
+        $rootClient->request('PUT', $this->baseUrl . '/' . $configurationId, content: JSON::encode($updateData));
+        $updateResponse = $rootClient->getResponse();
+        $updateContent = $updateResponse->getContent();
+        self::assertNotFalse($updateContent);
+        self::assertSame(Response::HTTP_OK, $updateResponse->getStatusCode(), "Response:\n" . $updateResponse);
+        $updated = JSON::decode($updateContent, true);
+        self::assertSame('platform.secrets.updated', $updated['configurationKey']);
+        self::assertSame('updated-secret', $updated['configurationValue']['apiSecret']);
+
+        $patchData = ['configurationValue' => ['apiSecret' => 'patched-secret', 'rotation' => 15]];
+        $rootClient->request('PATCH', $this->baseUrl . '/' . $configurationId, content: JSON::encode($patchData));
+        $patchResponse = $rootClient->getResponse();
+        $patchContent = $patchResponse->getContent();
+        self::assertNotFalse($patchContent);
+        self::assertSame(Response::HTTP_OK, $patchResponse->getStatusCode(), "Response:\n" . $patchResponse);
+        $patched = JSON::decode($patchContent, true);
+        self::assertSame('patched-secret', $patched['configurationValue']['apiSecret']);
+
+        $rootClient->request('DELETE', $this->baseUrl . '/' . $configurationId);
+        $deleteResponse = $rootClient->getResponse();
+        $deleteContent = $deleteResponse->getContent();
+        self::assertNotFalse($deleteContent);
+        self::assertSame(Response::HTTP_NO_CONTENT, $deleteResponse->getStatusCode(), "Response:\n" . $deleteResponse);
+    }
+}


### PR DESCRIPTION
## Summary
- added a new `Configuration` module with full REST CRUD support (private/admin/root actions pattern aligned with existing modules)
- introduced `Configuration` entity with:
  - `configurationKey` (unique)
  - `configurationValue` (JSON)
  - `scope` (enum: `system`, `user`, `platform`, `plugin`, `public`)
  - `private` (boolean)
  - `configurationValueParameters` for encrypted payload metadata
- implemented private value encryption/decryption workflow:
  - `ConfigurationValueCryptService`
  - `ConfigurationEntityEventListener` (`prePersist`, `postPersist`, `preUpdate`, `postUpdate`, `postLoad`)
  - values are encrypted before persistence and transparently decrypted when loaded/returned
- added DTOs, AutoMapper mapping, repository, and resource for the new module
- added Doctrine mapping registration and event listener wiring
- added fixtures `LoadConfigurationData` including scoped examples and private config sample
- added migration `Version20260306123000` for the new `configuration` table and constraints
- added integration-style controller tests for list/count/ids, create validations/permissions, and view/update/patch/delete flows

## Files of interest
- `src/Configuration/**`
- `migrations/Version20260306123000.php`
- `config/packages/doctrine.yaml`
- `config/packages/event_listeners.yaml`
- `config/services.yaml`
- `tests/Application/Configuration/**`

## Validation
- syntax checked all new PHP files with `php -l`
- phpunit execution was not possible in this environment because PHPUnit binaries are not installed (`bin/phpunit` and `vendor/bin/phpunit` missing)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aada610ba0832baa89b33346adc00d)