### PR TITLE
Add per-user configuration with default notification prefs and profile endpoints

### DIFF
--- a/migrations/Version20260306140000.php
+++ b/migrations/Version20260306140000.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+/**
+ * Add user relation to configuration and switch uniqueness to (user_id, configuration_key).
+ */
+final class Version20260306140000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Add nullable user_id to configuration with FK and unique index on (user_id, configuration_key).';
+    }
+
+    #[Override]
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("ALTER TABLE configuration ADD user_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql('ALTER TABLE configuration DROP INDEX uq_configuration_key');
+        $this->addSql('CREATE INDEX idx_configuration_user_id ON configuration (user_id)');
+        $this->addSql('ALTER TABLE configuration ADD CONSTRAINT FK_CONFIGURATION_USER_ID FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+        $this->addSql('CREATE UNIQUE INDEX uq_configuration_user_key ON configuration (user_id, configuration_key)');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE configuration DROP FOREIGN KEY FK_CONFIGURATION_USER_ID');
+        $this->addSql('DROP INDEX uq_configuration_user_key ON configuration');
+        $this->addSql('DROP INDEX idx_configuration_user_id ON configuration');
+        $this->addSql('CREATE UNIQUE INDEX uq_configuration_key ON configuration (configuration_key)');
+        $this->addSql('ALTER TABLE configuration DROP user_id');
+    }
+}

--- a/src/Configuration/Domain/Entity/Configuration.php
+++ b/src/Configuration/Domain/Entity/Configuration.php
@@ -8,6 +8,7 @@ use App\Configuration\Domain\Enum\ConfigurationScope;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
@@ -23,9 +24,9 @@ use Throwable;
  */
 #[ORM\Entity]
 #[ORM\Table(name: 'configuration')]
-#[ORM\UniqueConstraint(name: 'uq_configuration_key', columns: ['configuration_key'])]
+#[ORM\UniqueConstraint(name: 'uq_configuration_user_key', columns: ['user_id', 'configuration_key'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
-#[AssertCollection\UniqueEntity('configurationKey')]
+#[AssertCollection\UniqueEntity(fields: ['user', 'configurationKey'])]
 class Configuration implements EntityInterface
 {
     use Timestampable;
@@ -35,6 +36,11 @@ class Configuration implements EntityInterface
     #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
     #[Groups(['Configuration', 'Configuration.id'])]
     private UuidInterface $id;
+
+
+    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'configurations')]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    private ?User $user = null;
 
     #[ORM\Column(name: 'configuration_key', type: Types::STRING, length: 255)]
     #[Groups(['Configuration', 'Configuration.configurationKey'])]
@@ -80,6 +86,19 @@ class Configuration implements EntityInterface
     public function getId(): string
     {
         return $this->id->toString();
+    }
+
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
     }
 
     public function getConfigurationKey(): string

--- a/src/User/Domain/Entity/Traits/UserRelations.php
+++ b/src/User/Domain/Entity/Traits/UserRelations.php
@@ -6,6 +6,7 @@ namespace App\User\Domain\Entity\Traits;
 
 use App\Log\Domain\Entity\LogLogin;
 use App\Log\Domain\Entity\LogLoginFailure;
+use App\Configuration\Domain\Entity\Configuration;
 use App\Log\Domain\Entity\LogRequest;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Entity\UserGroup;
@@ -68,6 +69,19 @@ trait UserRelations
     ])]
     protected Collection | ArrayCollection $logsLoginFailure;
 
+
+    /**
+     * @var Collection<int, Configuration>|ArrayCollection<int, Configuration>
+     */
+    #[ORM\OneToMany(
+        targetEntity: Configuration::class,
+        mappedBy: 'user',
+    )]
+    #[Groups([
+        'User.configurations',
+    ])]
+    protected Collection | ArrayCollection $configurations;
+
     /**
      * Getter for roles.
      *
@@ -129,6 +143,36 @@ trait UserRelations
     public function getLogsLoginFailure(): Collection | ArrayCollection
     {
         return $this->logsLoginFailure;
+    }
+
+
+    /**
+     * Getter for user configurations collection.
+     *
+     * @return Collection<int, Configuration>|ArrayCollection<int, Configuration>
+     */
+    public function getConfigurations(): Collection | ArrayCollection
+    {
+        return $this->configurations;
+    }
+
+    public function addConfiguration(Configuration $configuration): self
+    {
+        if ($this->configurations->contains($configuration) === false) {
+            $this->configurations->add($configuration);
+            $configuration->setUser($this);
+        }
+
+        return $this;
+    }
+
+    public function removeConfiguration(Configuration $configuration): self
+    {
+        if ($this->configurations->removeElement($configuration) && $configuration->getUser() === $this) {
+            $configuration->setUser(null);
+        }
+
+        return $this;
     }
 
     /**

--- a/src/User/Domain/Entity/User.php
+++ b/src/User/Domain/Entity/User.php
@@ -267,6 +267,7 @@ class User implements EntityInterface, UserInterface, UserGroupAwareInterface
         $this->logsRequest = new ArrayCollection();
         $this->logsLogin = new ArrayCollection();
         $this->logsLoginFailure = new ArrayCollection();
+        $this->configurations = new ArrayCollection();
     }
 
     /**

--- a/src/User/Transport/Controller/Api/V1/Profile/ConfigurationController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ConfigurationController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Transport\Controller\Api\V1\Profile;
+
+use App\Configuration\Application\Resource\ConfigurationResource;
+use App\Configuration\Domain\Entity\Configuration;
+use App\Configuration\Domain\Enum\ConfigurationScope;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Property;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * @package App\User
+ */
+#[AsController]
+#[OA\Tag(name: 'Profile')]
+class ConfigurationController
+{
+    public function __construct(
+        private readonly ConfigurationResource $configurationResource,
+    ) {
+    }
+
+    #[Route(
+        path: '/v1/profile/configuration/{configurationKey}',
+        methods: [Request::METHOD_GET],
+    )]
+    #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+    #[OA\Response(
+        response: 200,
+        description: 'Logged in user configuration by key',
+        content: new JsonContent(
+            properties: [
+                new Property(property: 'configurationKey', type: 'string', example: 'user.notifications.preferences'),
+                new Property(property: 'configurationValue', type: 'array', items: new OA\Items(type: 'object')),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[OA\Response(response: 404, description: 'Configuration not found')]
+    public function __invoke(User $loggedInUser, string $configurationKey): JsonResponse
+    {
+        $configuration = $this->findUserConfiguration($loggedInUser, $configurationKey);
+
+        return new JsonResponse([
+            'configurationKey' => $configurationKey,
+            'configurationValue' => $configuration->getConfigurationValue(),
+        ]);
+    }
+
+    private function findUserConfiguration(User $loggedInUser, string $configurationKey): Configuration
+    {
+        $configuration = $this->configurationResource->findOneBy(
+            criteria: [
+                'configurationKey' => $configurationKey,
+                'user' => $loggedInUser,
+                'scope' => ConfigurationScope::USER,
+                'private' => true,
+            ],
+            throwExceptionIfNotFound: true,
+        );
+
+        return $configuration instanceof Configuration
+            ? $configuration
+            : throw new \RuntimeException('User configuration not found.');
+    }
+}

--- a/src/User/Transport/Controller/Api/V1/Profile/ConfigurationPatchController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ConfigurationPatchController.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Transport\Controller\Api\V1\Profile;
+
+use App\Configuration\Application\Resource\ConfigurationResource;
+use App\Configuration\Domain\Entity\Configuration;
+use App\Configuration\Domain\Enum\ConfigurationScope;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Property;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_array;
+
+/**
+ * @package App\User
+ */
+#[AsController]
+#[OA\Tag(name: 'Profile')]
+class ConfigurationPatchController
+{
+    public function __construct(
+        private readonly ConfigurationResource $configurationResource,
+    ) {
+    }
+
+    #[Route(
+        path: '/v1/profile/configuration/{configurationKey}',
+        methods: [Request::METHOD_PATCH],
+    )]
+    #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+    #[OA\RequestBody(
+        required: true,
+        content: new JsonContent(
+            type: 'object',
+            example: [
+                'configurationValue' => [
+                    [
+                        'switchState' => false,
+                        'text' => 'Email me when someone follows me',
+                    ],
+                ],
+            ],
+        ),
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Updated logged in user configuration',
+        content: new JsonContent(
+            properties: [
+                new Property(property: 'configurationKey', type: 'string', example: 'user.notifications.preferences'),
+                new Property(property: 'configurationValue', type: 'array', items: new OA\Items(type: 'object')),
+            ],
+            type: 'object',
+        ),
+    )]
+    public function __invoke(Request $request, User $loggedInUser, string $configurationKey): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+        $configurationValue = $payload['configurationValue'] ?? null;
+
+        if (!is_array($configurationValue)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "configurationValue" must be an array.');
+        }
+
+        $configuration = $this->findUserConfiguration($loggedInUser, $configurationKey);
+        $configuration->setConfigurationValue($configurationValue);
+        $this->configurationResource->save($configuration);
+
+        return new JsonResponse([
+            'configurationKey' => $configurationKey,
+            'configurationValue' => $configuration->getConfigurationValue(),
+        ]);
+    }
+
+    private function findUserConfiguration(User $loggedInUser, string $configurationKey): Configuration
+    {
+        $configuration = $this->configurationResource->findOneBy(
+            criteria: [
+                'configurationKey' => $configurationKey,
+                'user' => $loggedInUser,
+                'scope' => ConfigurationScope::USER,
+                'private' => true,
+            ],
+            throwExceptionIfNotFound: true,
+        );
+
+        return $configuration instanceof Configuration
+            ? $configuration
+            : throw new \RuntimeException('User configuration not found.');
+    }
+}

--- a/src/User/Transport/EventListener/UserEntityEventListener.php
+++ b/src/User/Transport/EventListener/UserEntityEventListener.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\User\Transport\EventListener;
 
+use App\Configuration\Domain\Entity\Configuration;
+use App\Configuration\Domain\Enum\ConfigurationScope;
 use App\User\Application\Security\SecurityUser;
 use App\User\Domain\Entity\User;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
@@ -17,6 +19,38 @@ use function strlen;
  */
 class UserEntityEventListener
 {
+    private const string USER_NOTIFICATION_PREFERENCES_KEY = 'user.notifications.preferences';
+
+    /**
+     * @var array<int, array{switchState: bool, text: string}>
+     */
+    private const array DEFAULT_USER_NOTIFICATION_PREFERENCES = [
+        [
+            'switchState' => true,
+            'text' => 'Email me when someone follows me',
+        ],
+        [
+            'switchState' => false,
+            'text' => 'Email me when someone answers on...',
+        ],
+        [
+            'switchState' => true,
+            'text' => 'Email me when someone mentions me...',
+        ],
+        [
+            'switchState' => false,
+            'text' => 'New launches and projects',
+        ],
+        [
+            'switchState' => true,
+            'text' => 'Monthly product updates',
+        ],
+        [
+            'switchState' => false,
+            'text' => 'Subscribe to newsletter',
+        ],
+    ];
+
     public function __construct(
         private readonly UserPasswordHasherInterface $userPasswordHasher,
     ) {
@@ -28,6 +62,12 @@ class UserEntityEventListener
     public function prePersist(LifecycleEventArgs $event): void
     {
         $this->process($event);
+
+        $user = $event->getObject();
+
+        if ($user instanceof User) {
+            $this->createDefaultUserConfigurations($event, $user);
+        }
     }
 
     /**
@@ -51,6 +91,19 @@ class UserEntityEventListener
             $user->ensureGeneratedPhoto();
             $this->changePassword($user);
         }
+    }
+
+    private function createDefaultUserConfigurations(LifecycleEventArgs $event, User $user): void
+    {
+        $configuration = new Configuration();
+        $configuration
+            ->setConfigurationKey(self::USER_NOTIFICATION_PREFERENCES_KEY)
+            ->setUser($user)
+            ->setConfigurationValue(self::DEFAULT_USER_NOTIFICATION_PREFERENCES)
+            ->setScope(ConfigurationScope::USER)
+            ->setPrivate(true);
+
+        $event->getObjectManager()->persist($configuration);
     }
 
     /**

--- a/tests/Application/User/Transport/Controller/Api/V1/Profile/ConfigurationControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/Profile/ConfigurationControllerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\Profile;
+
+use App\Configuration\Application\Resource\ConfigurationResource;
+use App\Configuration\Domain\Entity\Configuration;
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Application\Resource\UserResource;
+use App\User\Infrastructure\DataFixtures\ORM\LoadUserGroupData;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class ConfigurationControllerTest extends WebTestCase
+{
+    private const string CONFIGURATION_KEY = 'user.notifications.preferences';
+
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/profile/configuration/' . self::CONFIGURATION_KEY;
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that profile configuration endpoint returns configuration of logged in user.')]
+    public function testThatGetProfileConfigurationReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request(method: 'GET', uri: $this->baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertSame(self::CONFIGURATION_KEY, $responseData['configurationKey']);
+        self::assertIsArray($responseData['configurationValue']);
+        self::assertCount(6, $responseData['configurationValue']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that profile configuration endpoint patches logged in user configuration value.')]
+    public function testThatPatchProfileConfigurationReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+        $payload = [
+            'configurationValue' => [
+                [
+                    'switchState' => false,
+                    'text' => 'Email me when someone follows me',
+                ],
+            ],
+        ];
+
+        $client->request(method: 'PATCH', uri: $this->baseUrl, content: JSON::encode($payload));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertSame(self::CONFIGURATION_KEY, $responseData['configurationKey']);
+        self::assertCount(1, $responseData['configurationValue']);
+        self::assertFalse($responseData['configurationValue'][0]['switchState']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that user creation creates default private user notification preferences configuration.')]
+    public function testThatCreatingUserCreatesDefaultNotificationConfiguration(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $requestData = [
+            'username' => 'test-config-user',
+            'firstName' => 'Config',
+            'lastName' => 'User',
+            'email' => 'test-config-user@test.com',
+            'userGroups' => [
+                LoadUserGroupData::getUuidByKey('Role-logged'),
+            ],
+            'password' => 'test12345',
+            'language' => 'en',
+            'locale' => 'en',
+            'timezone' => 'UTC',
+        ];
+
+        $client->request(method: 'POST', uri: self::API_URL_PREFIX . '/v1/user', content: JSON::encode($requestData));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), "Response:\n" . $response);
+
+        $userResource = static::getContainer()->get(UserResource::class);
+        $configurationResource = static::getContainer()->get(ConfigurationResource::class);
+        $user = $userResource->findOneBy(['username' => 'test-config-user']);
+        self::assertInstanceOf(User::class, $user);
+        $configuration = $configurationResource->findOneBy([
+            'configurationKey' => self::CONFIGURATION_KEY,
+            'user' => $user,
+            'private' => true,
+        ]);
+
+        self::assertInstanceOf(Configuration::class, $configuration);
+        self::assertCount(6, $configuration->getConfigurationValue());
+    }
+}


### PR DESCRIPTION
### Motivation

- Allow storing configuration per user by adding a nullable `user_id` relation to `configuration` and switching uniqueness to `(user_id, configuration_key)` so multiple users can have the same key. 
- Provide API endpoints for logged-in users to read and patch their own private configurations. 
- Create a default private notification preferences configuration automatically when a new user is created.

### Description

- Added migration `Version20260306140000` to add `user_id` (UUID binary), FK to `user(id)`, an index on `user_id`, and replace the unique constraint with `uq_configuration_user_key` on `(user_id, configuration_key)`.
- Updated `Configuration` entity to add a `ManyToOne` relation to `User`, adjusted the ORM unique constraint to `['user_id', 'configuration_key']` and the `UniqueEntity` validator to `fields: ['user', 'configurationKey']`.
- Extended `User` relations (trait `UserRelations`) to include a `configurations` `OneToMany` collection with `get`, `add`, and `remove` helpers, and initialized the collection in `User::__construct`.
- Added profile controllers `ConfigurationController` (GET) and `ConfigurationPatchController` (PATCH) to fetch and update the logged-in user configuration by key using `ConfigurationResource`.
- Added `UserEntityEventListener` behavior to create default notification preferences (`user.notifications.preferences`) for new users on `prePersist` using `ConfigurationScope::USER` and mark it as private.
- Added integration tests `tests/Application/User/Transport/Controller/Api/V1/Profile/ConfigurationControllerTest.php` covering GET, PATCH and verifying default configuration creation on user registration.

### Testing

- Executed the new PHPUnit integration test file `tests/Application/User/Transport/Controller/Api/V1/Profile/ConfigurationControllerTest.php` and it passed.
- Ran the project test suite with `phpunit` focusing on the affected areas and the test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaea658b4c832b977839b282c40227)