### PR TITLE
Add platform/app ownership, status, plugin relations and scoped configuration support

### DIFF
--- a/migrations/Version20260306150000.php
+++ b/migrations/Version20260306150000.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+/**
+ * Add platform status and ownership with plugin/configuration relations.
+ */
+final class Version20260306150000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Add platform status/user ownership, platform-plugin relation, and configuration links for platform/plugin scopes.';
+    }
+
+    #[Override]
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("ALTER TABLE platform ADD user_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', ADD status VARCHAR(25) NOT NULL DEFAULT 'active'");
+        $this->addSql('CREATE INDEX idx_platform_user_id ON platform (user_id)');
+        $this->addSql('ALTER TABLE platform ADD CONSTRAINT FK_PLATFORM_USER_ID FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+
+        $this->addSql("ALTER TABLE plugin ADD platform_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql('CREATE INDEX idx_plugin_platform_id ON plugin (platform_id)');
+        $this->addSql('ALTER TABLE plugin ADD CONSTRAINT FK_PLUGIN_PLATFORM_ID FOREIGN KEY (platform_id) REFERENCES platform (id) ON DELETE CASCADE');
+
+        $this->addSql("ALTER TABLE configuration ADD platform_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', ADD plugin_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql('CREATE INDEX idx_configuration_platform_id ON configuration (platform_id)');
+        $this->addSql('CREATE INDEX idx_configuration_plugin_id ON configuration (plugin_id)');
+        $this->addSql('CREATE UNIQUE INDEX uq_configuration_platform_key ON configuration (platform_id, configuration_key)');
+        $this->addSql('CREATE UNIQUE INDEX uq_configuration_plugin_key ON configuration (plugin_id, configuration_key)');
+        $this->addSql('ALTER TABLE configuration ADD CONSTRAINT FK_CONFIGURATION_PLATFORM_ID FOREIGN KEY (platform_id) REFERENCES platform (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE configuration ADD CONSTRAINT FK_CONFIGURATION_PLUGIN_ID FOREIGN KEY (plugin_id) REFERENCES plugin (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE configuration DROP FOREIGN KEY FK_CONFIGURATION_PLATFORM_ID');
+        $this->addSql('ALTER TABLE configuration DROP FOREIGN KEY FK_CONFIGURATION_PLUGIN_ID');
+        $this->addSql('DROP INDEX idx_configuration_platform_id ON configuration');
+        $this->addSql('DROP INDEX idx_configuration_plugin_id ON configuration');
+        $this->addSql('DROP INDEX uq_configuration_platform_key ON configuration');
+        $this->addSql('DROP INDEX uq_configuration_plugin_key ON configuration');
+        $this->addSql('ALTER TABLE configuration DROP platform_id, DROP plugin_id');
+
+        $this->addSql('ALTER TABLE plugin DROP FOREIGN KEY FK_PLUGIN_PLATFORM_ID');
+        $this->addSql('DROP INDEX idx_plugin_platform_id ON plugin');
+        $this->addSql('ALTER TABLE plugin DROP platform_id');
+
+        $this->addSql('ALTER TABLE platform DROP FOREIGN KEY FK_PLATFORM_USER_ID');
+        $this->addSql('DROP INDEX idx_platform_user_id ON platform');
+        $this->addSql('ALTER TABLE platform DROP user_id, DROP status');
+    }
+}

--- a/migrations/Version20260306153000.php
+++ b/migrations/Version20260306153000.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+/**
+ * Add user-owned applications with platform, plugins and scoped configurations.
+ */
+final class Version20260306153000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Create platform_application and platform_application_plugin tables and link configuration to both.';
+    }
+
+    #[Override]
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("CREATE TABLE platform_application (id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', user_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', platform_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', title VARCHAR(255) NOT NULL, status VARCHAR(25) NOT NULL DEFAULT 'active', created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP, INDEX idx_platform_application_user_id (user_id), INDEX idx_platform_application_platform_id (platform_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+        $this->addSql('ALTER TABLE platform_application ADD CONSTRAINT FK_PLATFORM_APPLICATION_USER_ID FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE platform_application ADD CONSTRAINT FK_PLATFORM_APPLICATION_PLATFORM_ID FOREIGN KEY (platform_id) REFERENCES platform (id) ON DELETE RESTRICT');
+
+        $this->addSql("CREATE TABLE platform_application_plugin (id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', application_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', plugin_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', created_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP, INDEX idx_platform_application_plugin_application_id (application_id), INDEX idx_platform_application_plugin_plugin_id (plugin_id), UNIQUE INDEX uq_application_plugin (application_id, plugin_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+        $this->addSql('ALTER TABLE platform_application_plugin ADD CONSTRAINT FK_PLATFORM_APPLICATION_PLUGIN_APPLICATION_ID FOREIGN KEY (application_id) REFERENCES platform_application (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE platform_application_plugin ADD CONSTRAINT FK_PLATFORM_APPLICATION_PLUGIN_PLUGIN_ID FOREIGN KEY (plugin_id) REFERENCES plugin (id) ON DELETE RESTRICT');
+
+        $this->addSql("ALTER TABLE configuration ADD application_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', ADD application_plugin_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql('CREATE INDEX idx_configuration_application_id ON configuration (application_id)');
+        $this->addSql('CREATE INDEX idx_configuration_application_plugin_id ON configuration (application_plugin_id)');
+        $this->addSql('CREATE UNIQUE INDEX uq_configuration_application_key ON configuration (application_id, configuration_key)');
+        $this->addSql('CREATE UNIQUE INDEX uq_configuration_application_plugin_key ON configuration (application_plugin_id, configuration_key)');
+        $this->addSql('ALTER TABLE configuration ADD CONSTRAINT FK_CONFIGURATION_APPLICATION_ID FOREIGN KEY (application_id) REFERENCES platform_application (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE configuration ADD CONSTRAINT FK_CONFIGURATION_APPLICATION_PLUGIN_ID FOREIGN KEY (application_plugin_id) REFERENCES platform_application_plugin (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE configuration DROP FOREIGN KEY FK_CONFIGURATION_APPLICATION_ID');
+        $this->addSql('ALTER TABLE configuration DROP FOREIGN KEY FK_CONFIGURATION_APPLICATION_PLUGIN_ID');
+        $this->addSql('DROP INDEX idx_configuration_application_id ON configuration');
+        $this->addSql('DROP INDEX idx_configuration_application_plugin_id ON configuration');
+        $this->addSql('DROP INDEX uq_configuration_application_key ON configuration');
+        $this->addSql('DROP INDEX uq_configuration_application_plugin_key ON configuration');
+        $this->addSql('ALTER TABLE configuration DROP application_id, DROP application_plugin_id');
+
+        $this->addSql('ALTER TABLE platform_application_plugin DROP FOREIGN KEY FK_PLATFORM_APPLICATION_PLUGIN_APPLICATION_ID');
+        $this->addSql('ALTER TABLE platform_application_plugin DROP FOREIGN KEY FK_PLATFORM_APPLICATION_PLUGIN_PLUGIN_ID');
+        $this->addSql('DROP TABLE platform_application_plugin');
+
+        $this->addSql('ALTER TABLE platform_application DROP FOREIGN KEY FK_PLATFORM_APPLICATION_USER_ID');
+        $this->addSql('ALTER TABLE platform_application DROP FOREIGN KEY FK_PLATFORM_APPLICATION_PLATFORM_ID');
+        $this->addSql('DROP TABLE platform_application');
+    }
+}

--- a/src/Configuration/Domain/Entity/Configuration.php
+++ b/src/Configuration/Domain/Entity/Configuration.php
@@ -8,6 +8,10 @@ use App\Configuration\Domain\Enum\ConfigurationScope;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\ApplicationPlugin;
+use App\Platform\Domain\Entity\Platform;
+use App\Platform\Domain\Entity\Plugin;
 use App\User\Domain\Entity\User;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
@@ -25,8 +29,16 @@ use Throwable;
 #[ORM\Entity]
 #[ORM\Table(name: 'configuration')]
 #[ORM\UniqueConstraint(name: 'uq_configuration_user_key', columns: ['user_id', 'configuration_key'])]
+#[ORM\UniqueConstraint(name: 'uq_configuration_platform_key', columns: ['platform_id', 'configuration_key'])]
+#[ORM\UniqueConstraint(name: 'uq_configuration_plugin_key', columns: ['plugin_id', 'configuration_key'])]
+#[ORM\UniqueConstraint(name: 'uq_configuration_application_key', columns: ['application_id', 'configuration_key'])]
+#[ORM\UniqueConstraint(name: 'uq_configuration_application_plugin_key', columns: ['application_plugin_id', 'configuration_key'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 #[AssertCollection\UniqueEntity(fields: ['user', 'configurationKey'])]
+#[AssertCollection\UniqueEntity(fields: ['platform', 'configurationKey'])]
+#[AssertCollection\UniqueEntity(fields: ['plugin', 'configurationKey'])]
+#[AssertCollection\UniqueEntity(fields: ['application', 'configurationKey'])]
+#[AssertCollection\UniqueEntity(fields: ['applicationPlugin', 'configurationKey'])]
 class Configuration implements EntityInterface
 {
     use Timestampable;
@@ -41,6 +53,22 @@ class Configuration implements EntityInterface
     #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'configurations')]
     #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
     private ?User $user = null;
+
+    #[ORM\ManyToOne(targetEntity: Platform::class, inversedBy: 'configurations')]
+    #[ORM\JoinColumn(name: 'platform_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    private ?Platform $platform = null;
+
+    #[ORM\ManyToOne(targetEntity: Plugin::class, inversedBy: 'configurations')]
+    #[ORM\JoinColumn(name: 'plugin_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    private ?Plugin $plugin = null;
+
+    #[ORM\ManyToOne(targetEntity: Application::class, inversedBy: 'configurations')]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    private ?Application $application = null;
+
+    #[ORM\ManyToOne(targetEntity: ApplicationPlugin::class, inversedBy: 'configurations')]
+    #[ORM\JoinColumn(name: 'application_plugin_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    private ?ApplicationPlugin $applicationPlugin = null;
 
     #[ORM\Column(name: 'configuration_key', type: Types::STRING, length: 255)]
     #[Groups(['Configuration', 'Configuration.configurationKey'])]
@@ -97,6 +125,54 @@ class Configuration implements EntityInterface
     public function setUser(?User $user): self
     {
         $this->user = $user;
+
+        return $this;
+    }
+
+    public function getPlatform(): ?Platform
+    {
+        return $this->platform;
+    }
+
+    public function setPlatform(?Platform $platform): self
+    {
+        $this->platform = $platform;
+
+        return $this;
+    }
+
+    public function getPlugin(): ?Plugin
+    {
+        return $this->plugin;
+    }
+
+    public function setPlugin(?Plugin $plugin): self
+    {
+        $this->plugin = $plugin;
+
+        return $this;
+    }
+
+    public function getApplication(): ?Application
+    {
+        return $this->application;
+    }
+
+    public function setApplication(?Application $application): self
+    {
+        $this->application = $application;
+
+        return $this;
+    }
+
+    public function getApplicationPlugin(): ?ApplicationPlugin
+    {
+        return $this->applicationPlugin;
+    }
+
+    public function setApplicationPlugin(?ApplicationPlugin $applicationPlugin): self
+    {
+        $this->applicationPlugin = $applicationPlugin;
 
         return $this;
     }

--- a/src/Platform/Application/DTO/Platform/Platform.php
+++ b/src/Platform/Application/DTO/Platform/Platform.php
@@ -7,6 +7,7 @@ namespace App\Platform\Application\DTO\Platform;
 use App\General\Application\DTO\Interfaces\RestDtoInterface;
 use App\General\Application\DTO\RestDto;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Platform\Domain\Enum\PlatformStatus;
 use App\Platform\Domain\Entity\Platform as Entity;
 use Override;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -35,6 +36,14 @@ class Platform extends RestDto
 
     #[Assert\NotNull]
     protected bool $enabled = true;
+
+    #[Assert\NotNull]
+    #[Assert\Choice(choices: [
+        PlatformStatus::ACTIVE->value,
+        PlatformStatus::MAINTENANCE->value,
+        PlatformStatus::DISABLED->value,
+    ])]
+    protected string $status = PlatformStatus::ACTIVE->value;
 
     public function getName(): string
     {
@@ -101,6 +110,19 @@ class Platform extends RestDto
         return $this;
     }
 
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->setVisited('status');
+        $this->status = $status;
+
+        return $this;
+    }
+
     /**
      * {@inheritdoc}
      *
@@ -116,6 +138,7 @@ class Platform extends RestDto
             $this->private = $entity->isPrivate();
             $this->photo = $entity->getPhoto();
             $this->enabled = $entity->isEnabled();
+            $this->status = $entity->getStatusValue();
         }
 
         return $this;

--- a/src/Platform/Domain/Entity/Application.php
+++ b/src/Platform/Domain/Entity/Application.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Domain\Entity;
+
+use App\Configuration\Domain\Entity\Configuration;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Platform\Domain\Enum\PlatformStatus;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Throwable;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'platform_application')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Application implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull]
+    private ?User $user = null;
+
+    #[ORM\ManyToOne(targetEntity: Platform::class)]
+    #[ORM\JoinColumn(name: 'platform_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
+    #[Assert\NotNull]
+    private ?Platform $platform = null;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Length(min: 2, max: 255)]
+    private string $title = '';
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 25, enumType: PlatformStatus::class, options: ['default' => PlatformStatus::ACTIVE->value])]
+    #[Assert\NotNull]
+    private PlatformStatus $status = PlatformStatus::ACTIVE;
+
+    /**
+     * @var Collection<int, Configuration>|ArrayCollection<int, Configuration>
+     */
+    #[ORM\OneToMany(targetEntity: Configuration::class, mappedBy: 'application', cascade: ['persist', 'remove'])]
+    private Collection | ArrayCollection $configurations;
+
+    /**
+     * @var Collection<int, ApplicationPlugin>|ArrayCollection<int, ApplicationPlugin>
+     */
+    #[ORM\OneToMany(targetEntity: ApplicationPlugin::class, mappedBy: 'application', cascade: ['persist', 'remove'])]
+    private Collection | ArrayCollection $applicationPlugins;
+
+    /** @throws Throwable */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->configurations = new ArrayCollection();
+        $this->applicationPlugins = new ArrayCollection();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getPlatform(): ?Platform
+    {
+        return $this->platform;
+    }
+
+    public function setPlatform(?Platform $platform): self
+    {
+        $this->platform = $platform;
+
+        return $this;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getStatus(): PlatformStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(PlatformStatus|string $status): self
+    {
+        $this->status = $status instanceof PlatformStatus ? $status : PlatformStatus::from($status);
+
+        return $this;
+    }
+
+    /** @return Collection<int, Configuration>|ArrayCollection<int, Configuration> */
+    public function getConfigurations(): Collection | ArrayCollection
+    {
+        return $this->configurations;
+    }
+
+    public function addConfiguration(Configuration $configuration): self
+    {
+        if ($this->configurations->contains($configuration) === false) {
+            $this->configurations->add($configuration);
+            $configuration->setApplication($this);
+        }
+
+        return $this;
+    }
+
+    /** @return Collection<int, ApplicationPlugin>|ArrayCollection<int, ApplicationPlugin> */
+    public function getApplicationPlugins(): Collection | ArrayCollection
+    {
+        return $this->applicationPlugins;
+    }
+
+    public function addApplicationPlugin(ApplicationPlugin $applicationPlugin): self
+    {
+        if ($this->applicationPlugins->contains($applicationPlugin) === false) {
+            $this->applicationPlugins->add($applicationPlugin);
+            $applicationPlugin->setApplication($this);
+        }
+
+        return $this;
+    }
+}

--- a/src/Platform/Domain/Entity/ApplicationPlugin.php
+++ b/src/Platform/Domain/Entity/ApplicationPlugin.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Domain\Entity;
+
+use App\Configuration\Domain\Entity\Configuration;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Throwable;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'platform_application_plugin')]
+#[ORM\UniqueConstraint(name: 'uq_application_plugin', columns: ['application_id', 'plugin_id'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class ApplicationPlugin implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Application::class, inversedBy: 'applicationPlugins')]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull]
+    private ?Application $application = null;
+
+    #[ORM\ManyToOne(targetEntity: Plugin::class)]
+    #[ORM\JoinColumn(name: 'plugin_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
+    #[Assert\NotNull]
+    private ?Plugin $plugin = null;
+
+    /**
+     * @var Collection<int, Configuration>|ArrayCollection<int, Configuration>
+     */
+    #[ORM\OneToMany(targetEntity: Configuration::class, mappedBy: 'applicationPlugin', cascade: ['persist', 'remove'])]
+    private Collection | ArrayCollection $configurations;
+
+    /** @throws Throwable */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->configurations = new ArrayCollection();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getApplication(): ?Application
+    {
+        return $this->application;
+    }
+
+    public function setApplication(?Application $application): self
+    {
+        $this->application = $application;
+
+        return $this;
+    }
+
+    public function getPlugin(): ?Plugin
+    {
+        return $this->plugin;
+    }
+
+    public function setPlugin(?Plugin $plugin): self
+    {
+        $this->plugin = $plugin;
+
+        return $this;
+    }
+
+    /** @return Collection<int, Configuration>|ArrayCollection<int, Configuration> */
+    public function getConfigurations(): Collection | ArrayCollection
+    {
+        return $this->configurations;
+    }
+
+    public function addConfiguration(Configuration $configuration): self
+    {
+        if ($this->configurations->contains($configuration) === false) {
+            $this->configurations->add($configuration);
+            $configuration->setApplicationPlugin($this);
+        }
+
+        return $this;
+    }
+}

--- a/src/Platform/Domain/Entity/Platform.php
+++ b/src/Platform/Domain/Entity/Platform.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace App\Platform\Domain\Entity;
 
+use App\Configuration\Domain\Entity\Configuration;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\Platform\Domain\Enum\PlatformStatus;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
@@ -112,12 +117,56 @@ class Platform implements EntityInterface
     #[Assert\NotNull]
     private bool $enabled = true;
 
+    #[ORM\Column(
+        name: 'status',
+        type: Types::STRING,
+        length: 25,
+        enumType: PlatformStatus::class,
+        options: [
+            'default' => PlatformStatus::ACTIVE->value,
+        ],
+    )]
+    #[Groups([
+        'Platform',
+        'Platform.status',
+    ])]
+    #[Assert\NotNull]
+    private PlatformStatus $status = PlatformStatus::ACTIVE;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    #[Groups([
+        'Platform',
+        'Platform.user',
+    ])]
+    private ?User $user = null;
+
+    /**
+     * @var Collection<int, Configuration>|ArrayCollection<int, Configuration>
+     */
+    #[ORM\OneToMany(targetEntity: Configuration::class, mappedBy: 'platform')]
+    #[Groups([
+        'Platform.configurations',
+    ])]
+    private Collection | ArrayCollection $configurations;
+
+    /**
+     * @var Collection<int, Plugin>|ArrayCollection<int, Plugin>
+     */
+    #[ORM\OneToMany(targetEntity: Plugin::class, mappedBy: 'platform')]
+    #[Groups([
+        'Platform.plugins',
+    ])]
+    private Collection | ArrayCollection $plugins;
+
     /**
      * @throws Throwable
      */
     public function __construct()
     {
         $this->id = $this->createUuid();
+        $this->configurations = new ArrayCollection();
+        $this->plugins = new ArrayCollection();
     }
 
     #[Override]
@@ -182,6 +231,89 @@ class Platform implements EntityInterface
     public function setEnabled(bool $enabled): self
     {
         $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    public function getStatus(): PlatformStatus
+    {
+        return $this->status;
+    }
+
+    public function getStatusValue(): string
+    {
+        return $this->status->value;
+    }
+
+    public function setStatus(PlatformStatus|string $status): self
+    {
+        $this->status = $status instanceof PlatformStatus ? $status : PlatformStatus::from($status);
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Configuration>|ArrayCollection<int, Configuration>
+     */
+    public function getConfigurations(): Collection | ArrayCollection
+    {
+        return $this->configurations;
+    }
+
+    public function addConfiguration(Configuration $configuration): self
+    {
+        if ($this->configurations->contains($configuration) === false) {
+            $this->configurations->add($configuration);
+            $configuration->setPlatform($this);
+        }
+
+        return $this;
+    }
+
+    public function removeConfiguration(Configuration $configuration): self
+    {
+        if ($this->configurations->removeElement($configuration) && $configuration->getPlatform() === $this) {
+            $configuration->setPlatform(null);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Plugin>|ArrayCollection<int, Plugin>
+     */
+    public function getPlugins(): Collection | ArrayCollection
+    {
+        return $this->plugins;
+    }
+
+    public function addPlugin(Plugin $plugin): self
+    {
+        if ($this->plugins->contains($plugin) === false) {
+            $this->plugins->add($plugin);
+            $plugin->setPlatform($this);
+        }
+
+        return $this;
+    }
+
+    public function removePlugin(Plugin $plugin): self
+    {
+        if ($this->plugins->removeElement($plugin) && $plugin->getPlatform() === $this) {
+            $plugin->setPlatform(null);
+        }
 
         return $this;
     }

--- a/src/Platform/Domain/Entity/Plugin.php
+++ b/src/Platform/Domain/Entity/Plugin.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Platform\Domain\Entity;
 
+use App\Configuration\Domain\Entity\Configuration;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
@@ -112,12 +115,30 @@ class Plugin implements EntityInterface
     #[Assert\NotNull]
     private bool $enabled = true;
 
+    #[ORM\ManyToOne(targetEntity: Platform::class, inversedBy: 'plugins')]
+    #[ORM\JoinColumn(name: 'platform_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    #[Groups([
+        'Plugin',
+        'Plugin.platform',
+    ])]
+    private ?Platform $platform = null;
+
+    /**
+     * @var Collection<int, Configuration>|ArrayCollection<int, Configuration>
+     */
+    #[ORM\OneToMany(targetEntity: Configuration::class, mappedBy: 'plugin')]
+    #[Groups([
+        'Plugin.configurations',
+    ])]
+    private Collection | ArrayCollection $configurations;
+
     /**
      * @throws Throwable
      */
     public function __construct()
     {
         $this->id = $this->createUuid();
+        $this->configurations = new ArrayCollection();
     }
 
     #[Override]
@@ -182,6 +203,45 @@ class Plugin implements EntityInterface
     public function setEnabled(bool $enabled): self
     {
         $this->enabled = $enabled;
+
+        return $this;
+    }
+
+    public function getPlatform(): ?Platform
+    {
+        return $this->platform;
+    }
+
+    public function setPlatform(?Platform $platform): self
+    {
+        $this->platform = $platform;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Configuration>|ArrayCollection<int, Configuration>
+     */
+    public function getConfigurations(): Collection | ArrayCollection
+    {
+        return $this->configurations;
+    }
+
+    public function addConfiguration(Configuration $configuration): self
+    {
+        if ($this->configurations->contains($configuration) === false) {
+            $this->configurations->add($configuration);
+            $configuration->setPlugin($this);
+        }
+
+        return $this;
+    }
+
+    public function removeConfiguration(Configuration $configuration): self
+    {
+        if ($this->configurations->removeElement($configuration) && $configuration->getPlugin() === $this) {
+            $configuration->setPlugin(null);
+        }
 
         return $this;
     }

--- a/src/Platform/Domain/Enum/PlatformStatus.php
+++ b/src/Platform/Domain/Enum/PlatformStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Domain\Enum;
+
+/**
+ * @package App\Platform
+ */
+enum PlatformStatus: string
+{
+    case ACTIVE = 'active';
+    case MAINTENANCE = 'maintenance';
+    case DISABLED = 'disabled';
+}

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Infrastructure\DataFixtures\ORM;
+
+use App\Configuration\Domain\Entity\Configuration;
+use App\Configuration\Domain\Enum\ConfigurationScope;
+use App\General\Domain\Rest\UuidHelper;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\ApplicationPlugin;
+use App\Platform\Domain\Entity\Platform;
+use App\Platform\Domain\Entity\Plugin;
+use App\Platform\Domain\Enum\PlatformStatus;
+use App\Tests\Utils\PhpUnitUtil;
+use App\User\Domain\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+use Throwable;
+
+/**
+ * @package App\Platform
+ */
+final class LoadApplicationData extends Fixture implements OrderedFixtureInterface
+{
+    /**
+     * @var array<int, array{
+     *     uuid: non-empty-string,
+     *     key: non-empty-string,
+     *     title: non-empty-string,
+     *     status: PlatformStatus,
+     *     platformReference: non-empty-string,
+     *     appConfigurations: array<int, array{uuid: non-empty-string, key: non-empty-string, value: array<string, mixed>}>,
+     *     plugins: array<int, array{uuid: non-empty-string, reference: non-empty-string, configurations: array<int, array{uuid: non-empty-string, key: non-empty-string, value: array<string, mixed>}>}>
+     * }
+     */
+    private const array DATA = [
+        [
+            'uuid' => '60000000-0000-1000-8000-000000000001',
+            'key' => 'crm-growth-app',
+            'title' => 'CRM Growth App',
+            'status' => PlatformStatus::ACTIVE,
+            'platformReference' => 'Platform-CR-CRM 1',
+            'appConfigurations' => [
+                [
+                    'uuid' => '60000000-0000-1000-8000-000000000101',
+                    'key' => 'application.crm.theme',
+                    'value' => ['theme' => 'dark', 'density' => 'compact'],
+                ],
+                [
+                    'uuid' => '60000000-0000-1000-8000-000000000102',
+                    'key' => 'application.crm.access',
+                    'value' => ['regions' => ['eu', 'us'], 'strictMode' => true],
+                ],
+            ],
+            'plugins' => [
+                [
+                    'uuid' => '60000000-0000-1000-8000-000000000201',
+                    'reference' => 'Plugin-CRM-Assistant',
+                    'configurations' => [
+                        [
+                            'uuid' => '60000000-0000-1000-8000-000000000301',
+                            'key' => 'plugin.crm-assistant.prompts',
+                            'value' => ['autoSummary' => true, 'language' => 'en'],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '60000000-0000-1000-8000-000000000202',
+                    'reference' => 'Plugin-Analytics-Booster',
+                    'configurations' => [
+                        [
+                            'uuid' => '60000000-0000-1000-8000-000000000302',
+                            'key' => 'plugin.analytics.widgets',
+                            'value' => ['enabled' => ['pipeline', 'conversion']],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        [
+            'uuid' => '60000000-0000-1000-8000-000000000002',
+            'key' => 'shop-ops-app',
+            'title' => 'Shop Ops App',
+            'status' => PlatformStatus::MAINTENANCE,
+            'platformReference' => 'Platform-SH-Shop Principal',
+            'appConfigurations' => [
+                [
+                    'uuid' => '60000000-0000-1000-8000-000000000103',
+                    'key' => 'application.shop.checkout',
+                    'value' => ['retryPayment' => true, 'guestCheckout' => false],
+                ],
+            ],
+            'plugins' => [
+                [
+                    'uuid' => '60000000-0000-1000-8000-000000000203',
+                    'reference' => 'Plugin-Knowledge-Base-Connector',
+                    'configurations' => [
+                        [
+                            'uuid' => '60000000-0000-1000-8000-000000000303',
+                            'key' => 'plugin.kb.sync',
+                            'value' => ['intervalMinutes' => 15, 'categories' => ['faq', 'refund']],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+        [
+            'uuid' => '60000000-0000-1000-8000-000000000003',
+            'key' => 'recruit-lite-app',
+            'title' => 'Recruit Lite App',
+            'status' => PlatformStatus::DISABLED,
+            'platformReference' => 'Platform-RE-Recruit Principal',
+            'appConfigurations' => [
+                [
+                    'uuid' => '60000000-0000-1000-8000-000000000104',
+                    'key' => 'application.recruit.visibility',
+                    'value' => ['publicJobs' => false, 'teamOnly' => true],
+                ],
+            ],
+            'plugins' => [
+                [
+                    'uuid' => '60000000-0000-1000-8000-000000000204',
+                    'reference' => 'Plugin-Private-Beta-Plugin',
+                    'configurations' => [
+                        [
+                            'uuid' => '60000000-0000-1000-8000-000000000304',
+                            'key' => 'plugin.beta.flags',
+                            'value' => ['aiRanking' => false, 'cvParsingV2' => true],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+    /**
+     * @throws Throwable
+     */
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        /** @var User $owner */
+        $owner = $this->getReference('User-john-root', User::class);
+
+        foreach (self::DATA as $item) {
+            /** @var Platform $platform */
+            $platform = $this->getReference($item['platformReference'], Platform::class);
+
+            $application = (new Application())
+                ->setUser($owner)
+                ->setPlatform($platform)
+                ->setTitle($item['title'])
+                ->setStatus($item['status']);
+
+            PhpUnitUtil::setProperty('id', UuidHelper::fromString($item['uuid']), $application);
+
+            foreach ($item['appConfigurations'] as $appConfigurationData) {
+                $configuration = (new Configuration())
+                    ->setConfigurationKey($appConfigurationData['key'])
+                    ->setConfigurationValue($appConfigurationData['value'])
+                    ->setScope(ConfigurationScope::PLATFORM)
+                    ->setPrivate(true)
+                    ->setApplication($application);
+
+                PhpUnitUtil::setProperty('id', UuidHelper::fromString($appConfigurationData['uuid']), $configuration);
+
+                $application->addConfiguration($configuration);
+                $manager->persist($configuration);
+            }
+
+            foreach ($item['plugins'] as $pluginData) {
+                /** @var Plugin $plugin */
+                $plugin = $this->getReference($pluginData['reference'], Plugin::class);
+
+                $applicationPlugin = (new ApplicationPlugin())
+                    ->setApplication($application)
+                    ->setPlugin($plugin);
+
+                PhpUnitUtil::setProperty('id', UuidHelper::fromString($pluginData['uuid']), $applicationPlugin);
+
+                foreach ($pluginData['configurations'] as $pluginConfigurationData) {
+                    $pluginConfiguration = (new Configuration())
+                        ->setConfigurationKey($pluginConfigurationData['key'])
+                        ->setConfigurationValue($pluginConfigurationData['value'])
+                        ->setScope(ConfigurationScope::PLUGIN)
+                        ->setPrivate(true)
+                        ->setApplicationPlugin($applicationPlugin);
+
+                    PhpUnitUtil::setProperty('id', UuidHelper::fromString($pluginConfigurationData['uuid']), $pluginConfiguration);
+
+                    $applicationPlugin->addConfiguration($pluginConfiguration);
+                    $manager->persist($pluginConfiguration);
+                }
+
+                $application->addApplicationPlugin($applicationPlugin);
+                $manager->persist($applicationPlugin);
+            }
+
+            $manager->persist($application);
+            $this->addReference('Application-' . $item['key'], $application);
+        }
+
+        $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 7;
+    }
+}

--- a/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Transport\Controller\Api\V1\Profile;
+
+use App\Configuration\Domain\Entity\Configuration;
+use App\Configuration\Domain\Enum\ConfigurationScope;
+use App\Platform\Application\Resource\PlatformResource;
+use App\Platform\Application\Resource\PluginResource;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\ApplicationPlugin;
+use App\Platform\Domain\Enum\PlatformStatus;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Property;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Throwable;
+
+use function is_array;
+use function is_string;
+
+#[AsController]
+#[OA\Tag(name: 'Profile')]
+class ApplicationCreateController
+{
+    public function __construct(
+        private readonly PlatformResource $platformResource,
+        private readonly PluginResource $pluginResource,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Route(
+        path: '/v1/profile/applications',
+        methods: [Request::METHOD_POST],
+    )]
+    #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+    #[OA\RequestBody(
+        required: true,
+        content: new JsonContent(
+            type: 'object',
+            example: [
+                'platformId' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e70',
+                'title' => 'My Ecommerce App',
+                'status' => 'active',
+                'configurations' => [
+                    [
+                        'configurationKey' => 'app.theme',
+                        'configurationValue' => ['name' => 'dark'],
+                    ],
+                ],
+                'plugins' => [
+                    [
+                        'pluginId' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e71',
+                        'configurations' => [
+                            [
+                                'configurationKey' => 'plugin.cache.ttl',
+                                'configurationValue' => ['seconds' => 120],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ),
+    )]
+    #[OA\Response(
+        response: 201,
+        description: 'Application created for logged in user',
+        content: new JsonContent(
+            properties: [
+                new Property(property: 'id', type: 'string'),
+                new Property(property: 'platformId', type: 'string'),
+                new Property(property: 'title', type: 'string'),
+                new Property(property: 'status', type: 'string'),
+            ],
+            type: 'object',
+        ),
+    )]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+
+        $platformId = $payload['platformId'] ?? null;
+        $title = $payload['title'] ?? null;
+        $status = $payload['status'] ?? PlatformStatus::ACTIVE->value;
+
+        if (!is_string($platformId) || $platformId === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "platformId" is required.');
+        }
+
+        if (!is_string($title) || $title === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "title" is required.');
+        }
+
+        if (!is_string($status)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" must be a string.');
+        }
+
+        $platform = $this->platformResource->findOne($platformId, true);
+
+        $application = (new Application())
+            ->setUser($loggedInUser)
+            ->setPlatform($platform)
+            ->setTitle($title)
+            ->setStatus($status);
+
+        $configurations = $payload['configurations'] ?? [];
+        if (!is_array($configurations)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "configurations" must be an array.');
+        }
+
+        foreach ($configurations as $configurationData) {
+            if (!is_array($configurationData)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Each item in "configurations" must be an object.');
+            }
+
+            $configuration = $this->buildConfiguration($configurationData, ConfigurationScope::PLATFORM);
+            $configuration->setApplication($application);
+            $application->addConfiguration($configuration);
+        }
+
+        $plugins = $payload['plugins'] ?? [];
+        if (!is_array($plugins)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "plugins" must be an array.');
+        }
+
+        foreach ($plugins as $pluginData) {
+            if (!is_array($pluginData)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Each item in "plugins" must be an object.');
+            }
+
+            $pluginId = $pluginData['pluginId'] ?? null;
+            if (!is_string($pluginId) || $pluginId === '') {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Each plugin item must contain "pluginId".');
+            }
+
+            $plugin = $this->pluginResource->findOne($pluginId, true);
+
+            $applicationPlugin = (new ApplicationPlugin())
+                ->setApplication($application)
+                ->setPlugin($plugin);
+
+            $pluginConfigurations = $pluginData['configurations'] ?? [];
+            if (!is_array($pluginConfigurations)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "plugins[].configurations" must be an array.');
+            }
+
+            foreach ($pluginConfigurations as $pluginConfigurationData) {
+                if (!is_array($pluginConfigurationData)) {
+                    throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Each item in "plugins[].configurations" must be an object.');
+                }
+
+                $pluginConfiguration = $this->buildConfiguration($pluginConfigurationData, ConfigurationScope::PLUGIN);
+                $pluginConfiguration->setApplicationPlugin($applicationPlugin);
+                $applicationPlugin->addConfiguration($pluginConfiguration);
+            }
+
+            $application->addApplicationPlugin($applicationPlugin);
+        }
+
+        $this->entityManager->persist($application);
+        $this->entityManager->flush();
+
+        return new JsonResponse([
+            'id' => $application->getId(),
+            'platformId' => $application->getPlatform()?->getId(),
+            'title' => $application->getTitle(),
+            'status' => $application->getStatus()->value,
+        ], JsonResponse::HTTP_CREATED);
+    }
+
+    /**
+     * @param array<string, mixed> $configurationData
+     */
+    private function buildConfiguration(array $configurationData, ConfigurationScope $scope): Configuration
+    {
+        $configurationKey = $configurationData['configurationKey'] ?? null;
+        $configurationValue = $configurationData['configurationValue'] ?? null;
+
+        if (!is_string($configurationKey) || $configurationKey === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "configurationKey" is required for each configuration.');
+        }
+
+        if (!is_array($configurationValue)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "configurationValue" must be an array for each configuration.');
+        }
+
+        return (new Configuration())
+            ->setConfigurationKey($configurationKey)
+            ->setConfigurationValue($configurationValue)
+            ->setScope($scope)
+            ->setPrivate(true);
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce user-owned applications and application-plugin relations so configurations can be scoped to platforms, plugins, applications and application-plugins.
- Add platform `status` and ownership to support lifecycle states and per-user platform ownership.
- Enforce unique configuration keys per scope (platform/plugin/application/application_plugin) to prevent cross-scope collisions.
- Provide API and fixtures to create and seed user applications with scoped configurations for end-to-end usage.

### Description
- Added two Doctrine migrations `Version20260306150000` and `Version20260306153000` to add `user_id` and `status` on `platform`, link `plugin.platform_id`, extend `configuration` with `platform_id`/`plugin_id` and add `platform_application` and `platform_application_plugin` tables with FK constraints and unique indexes.
- Extended `Configuration` entity to reference `Platform`, `Plugin`, `Application`, and `ApplicationPlugin` and added corresponding unique constraints and `UniqueEntity` validators for scope uniqueness.
- Implemented new domain entities `Application` and `ApplicationPlugin` with relations to `User`, `Platform`, `Plugin`, and `Configuration` and added management methods for collections.
- Updated `Platform` and `Plugin` entities to support `status`, owner `user`, and `configurations`/`plugins` associations, and added `PlatformStatus` enum in `App\Platform\Domain\Enum\PlatformStatus`.
- Updated DTO `Platform` to expose `status`, and added a controller `ApplicationCreateController` to create user applications and associated scoped configurations and application plugins via API; also added fixture `LoadApplicationData` to seed example applications, plugins and configurations.

### Testing
- Ran the automated test suite via `composer test` (which runs `phpunit`) and all tests passed.
- Executed migration-related checks by running the test suite against the development database schema to ensure migrations and entity metadata are compatible and no migration assertions failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaed89b0a0832b9255fcf00d0ee9e0)