### PR TITLE
Add application description and include author/platform metadata in application lists

### DIFF
--- a/migrations/Version20260306170000.php
+++ b/migrations/Version20260306170000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+/**
+ * Add description column to platform_application.
+ */
+final class Version20260306170000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Add description text column to platform_application.';
+    }
+
+    #[Override]
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("ALTER TABLE platform_application ADD description LONGTEXT NOT NULL");
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE platform_application DROP description');
+    }
+}

--- a/src/Platform/Domain/Entity/Application.php
+++ b/src/Platform/Domain/Entity/Application.php
@@ -48,6 +48,10 @@ class Application implements EntityInterface
     #[Assert\Length(min: 2, max: 255)]
     private string $title = '';
 
+    #[ORM\Column(name: 'description', type: Types::TEXT, options: ['default' => ''])]
+    #[Assert\NotNull]
+    private string $description = '';
+
     #[ORM\Column(name: 'status', type: Types::STRING, length: 25, enumType: PlatformStatus::class, options: ['default' => PlatformStatus::ACTIVE->value])]
     #[Assert\NotNull]
     private PlatformStatus $status = PlatformStatus::ACTIVE;
@@ -126,6 +130,18 @@ class Application implements EntityInterface
     public function setStatus(PlatformStatus|string $status): self
     {
         $this->status = $status instanceof PlatformStatus ? $status : PlatformStatus::from($status);
+
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
 
         return $this;
     }

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
@@ -30,6 +30,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
      *     uuid: non-empty-string,
      *     key: non-empty-string,
      *     title: non-empty-string,
+     *     description: non-empty-string,
      *     status: PlatformStatus,
      *     private: bool,
      *     platformReference: non-empty-string,
@@ -42,6 +43,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'uuid' => '60000000-0000-1000-8000-000000000001',
             'key' => 'crm-growth-app',
             'title' => 'CRM Growth App',
+            'description' => 'Application CRM pour la croissance commerciale.',
             'status' => PlatformStatus::ACTIVE,
             'private' => false,
             'platformReference' => 'Platform-CR-CRM 1',
@@ -86,6 +88,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'uuid' => '60000000-0000-1000-8000-000000000002',
             'key' => 'shop-ops-app',
             'title' => 'Shop Ops App',
+            'description' => 'Application de gestion des operations e-commerce.',
             'status' => PlatformStatus::MAINTENANCE,
             'private' => false,
             'platformReference' => 'Platform-SH-Shop Principal',
@@ -114,6 +117,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'uuid' => '60000000-0000-1000-8000-000000000003',
             'key' => 'recruit-lite-app',
             'title' => 'Recruit Lite App',
+            'description' => 'Application privee pour le recrutement interne.',
             'status' => PlatformStatus::DISABLED,
             'private' => true,
             'platformReference' => 'Platform-RE-Recruit Principal',
@@ -157,6 +161,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                 ->setUser($owner)
                 ->setPlatform($platform)
                 ->setTitle($item['title'])
+                ->setDescription($item['description'])
                 ->setStatus($item['status'])
                 ->setPrivate($item['private']);
 

--- a/src/Platform/Transport/Controller/Api/V1/Application/PrivateApplicationListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Application/PrivateApplicationListController.php
@@ -45,11 +45,22 @@ class PrivateApplicationListController
                         properties: [
                             new Property(property: 'id', type: 'string'),
                             new Property(property: 'title', type: 'string'),
+                            new Property(property: 'description', type: 'string'),
                             new Property(property: 'status', type: 'string'),
                             new Property(property: 'private', type: 'boolean'),
                             new Property(property: 'platformId', type: 'string'),
                             new Property(property: 'platformName', type: 'string'),
-                            new Property(property: 'ownerId', type: 'string', nullable: true),
+                            new Property(
+                                property: 'author',
+                                properties: [
+                                    new Property(property: 'id', type: 'string', nullable: true),
+                                    new Property(property: 'firstName', type: 'string'),
+                                    new Property(property: 'lastName', type: 'string'),
+                                    new Property(property: 'photo', type: 'string'),
+                                ],
+                                type: 'object',
+                            ),
+                            new Property(property: 'createdAt', type: 'string', nullable: true),
                             new Property(property: 'isOwner', type: 'boolean'),
                         ],
                         type: 'object',
@@ -71,7 +82,9 @@ class PrivateApplicationListController
             ->getRepository(Application::class)
             ->createQueryBuilder('application')
             ->leftJoin('application.platform', 'platform')
+            ->leftJoin('application.user', 'user')
             ->addSelect('platform')
+            ->addSelect('user')
             ->where('application.private = :publicApplication')
             ->orWhere('application.user = :loggedInUser')
             ->setParameter('publicApplication', false)
@@ -87,11 +100,18 @@ class PrivateApplicationListController
             $output[] = [
                 'id' => $application->getId(),
                 'title' => $application->getTitle(),
+                'description' => $application->getDescription(),
                 'status' => $application->getStatus()->value,
                 'private' => $application->isPrivate(),
                 'platformId' => $application->getPlatform()?->getId(),
                 'platformName' => $application->getPlatform()?->getName(),
-                'ownerId' => $application->getUser()?->getId(),
+                'author' => [
+                    'id' => $application->getUser()?->getId(),
+                    'firstName' => $application->getUser()?->getFirstName() ?? '',
+                    'lastName' => $application->getUser()?->getLastName() ?? '',
+                    'photo' => $application->getUser()?->getPhoto() ?? '',
+                ],
+                'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
                 'isOwner' => $application->getUser()?->getId() === $loggedInUser?->getId(),
             ];
         }

--- a/src/Platform/Transport/Controller/Api/V1/Application/PublicApplicationListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Application/PublicApplicationListController.php
@@ -43,11 +43,22 @@ class PublicApplicationListController
                         properties: [
                             new Property(property: 'id', type: 'string'),
                             new Property(property: 'title', type: 'string'),
+                            new Property(property: 'description', type: 'string'),
                             new Property(property: 'status', type: 'string'),
                             new Property(property: 'private', type: 'boolean'),
                             new Property(property: 'platformId', type: 'string'),
                             new Property(property: 'platformName', type: 'string'),
-                            new Property(property: 'ownerId', type: 'string', nullable: true),
+                            new Property(
+                                property: 'author',
+                                properties: [
+                                    new Property(property: 'id', type: 'string', nullable: true),
+                                    new Property(property: 'firstName', type: 'string'),
+                                    new Property(property: 'lastName', type: 'string'),
+                                    new Property(property: 'photo', type: 'string'),
+                                ],
+                                type: 'object',
+                            ),
+                            new Property(property: 'createdAt', type: 'string', nullable: true),
                         ],
                         type: 'object',
                     ),
@@ -65,7 +76,9 @@ class PublicApplicationListController
             ->getRepository(Application::class)
             ->createQueryBuilder('application')
             ->leftJoin('application.platform', 'platform')
+            ->leftJoin('application.user', 'user')
             ->addSelect('platform')
+            ->addSelect('user')
             ->where('application.private = :publicApplication')
             ->setParameter('publicApplication', false)
             ->orderBy('application.title', 'ASC')
@@ -79,11 +92,18 @@ class PublicApplicationListController
             $output[] = [
                 'id' => $application->getId(),
                 'title' => $application->getTitle(),
+                'description' => $application->getDescription(),
                 'status' => $application->getStatus()->value,
                 'private' => $application->isPrivate(),
                 'platformId' => $application->getPlatform()?->getId(),
                 'platformName' => $application->getPlatform()?->getName(),
-                'ownerId' => $application->getUser()?->getId(),
+                'author' => [
+                    'id' => $application->getUser()?->getId(),
+                    'firstName' => $application->getUser()?->getFirstName() ?? '',
+                    'lastName' => $application->getUser()?->getLastName() ?? '',
+                    'photo' => $application->getUser()?->getPhoto() ?? '',
+                ],
+                'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
             ];
         }
 

--- a/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
@@ -28,6 +28,7 @@ use Throwable;
 use function is_array;
 use function is_bool;
 use function is_string;
+use function trim;
 
 #[AsController]
 #[OA\Tag(name: 'Profile')]
@@ -55,6 +56,7 @@ class ApplicationCreateController
             example: [
                 'platformId' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e70',
                 'title' => 'My Ecommerce App',
+                'description' => 'Application description',
                 'status' => 'active',
                 'private' => false,
                 'configurations' => [
@@ -85,6 +87,7 @@ class ApplicationCreateController
                 new Property(property: 'id', type: 'string'),
                 new Property(property: 'platformId', type: 'string'),
                 new Property(property: 'title', type: 'string'),
+                new Property(property: 'description', type: 'string'),
                 new Property(property: 'status', type: 'string'),
                 new Property(property: 'private', type: 'boolean'),
             ],
@@ -98,6 +101,7 @@ class ApplicationCreateController
 
         $platformId = $payload['platformId'] ?? null;
         $title = $payload['title'] ?? null;
+        $description = $payload['description'] ?? '';
         $status = $payload['status'] ?? PlatformStatus::ACTIVE->value;
         $private = $payload['private'] ?? false;
 
@@ -107,6 +111,10 @@ class ApplicationCreateController
 
         if (!is_string($title) || $title === '') {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "title" is required.');
+        }
+
+        if (!is_string($description)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "description" must be a string.');
         }
 
         if (!is_string($status)) {
@@ -123,6 +131,7 @@ class ApplicationCreateController
             ->setUser($loggedInUser)
             ->setPlatform($platform)
             ->setTitle($title)
+            ->setDescription(trim($description))
             ->setStatus($status)
             ->setPrivate($private);
 
@@ -187,6 +196,7 @@ class ApplicationCreateController
             'id' => $application->getId(),
             'platformId' => $application->getPlatform()?->getId(),
             'title' => $application->getTitle(),
+            'description' => $application->getDescription(),
             'status' => $application->getStatus()->value,
             'private' => $application->isPrivate(),
         ], JsonResponse::HTTP_CREATED);

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PrivateApplicationListControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PrivateApplicationListControllerTest.php
@@ -60,6 +60,16 @@ class PrivateApplicationListControllerTest extends WebTestCase
         );
 
         foreach ($responseData as $application) {
+            self::assertArrayHasKey('description', $application);
+            self::assertArrayHasKey('platformName', $application);
+            self::assertArrayHasKey('author', $application);
+            self::assertArrayHasKey('createdAt', $application);
+
+            self::assertIsArray($application['author']);
+            self::assertArrayHasKey('id', $application['author']);
+            self::assertArrayHasKey('firstName', $application['author']);
+            self::assertArrayHasKey('lastName', $application['author']);
+            self::assertArrayHasKey('photo', $application['author']);
             self::assertArrayHasKey('isOwner', $application);
             self::assertTrue($application['isOwner']);
         }
@@ -84,6 +94,16 @@ class PrivateApplicationListControllerTest extends WebTestCase
         self::assertCount(2, $responseData);
 
         foreach ($responseData as $application) {
+            self::assertArrayHasKey('description', $application);
+            self::assertArrayHasKey('platformName', $application);
+            self::assertArrayHasKey('author', $application);
+            self::assertArrayHasKey('createdAt', $application);
+
+            self::assertIsArray($application['author']);
+            self::assertArrayHasKey('id', $application['author']);
+            self::assertArrayHasKey('firstName', $application['author']);
+            self::assertArrayHasKey('lastName', $application['author']);
+            self::assertArrayHasKey('photo', $application['author']);
             self::assertArrayHasKey('isOwner', $application);
             self::assertFalse($application['isOwner']);
         }

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PublicApplicationListControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PublicApplicationListControllerTest.php
@@ -48,11 +48,19 @@ class PublicApplicationListControllerTest extends WebTestCase
             self::assertIsArray($application);
             self::assertArrayHasKey('id', $application);
             self::assertArrayHasKey('title', $application);
+            self::assertArrayHasKey('description', $application);
             self::assertArrayHasKey('status', $application);
             self::assertArrayHasKey('private', $application);
             self::assertArrayHasKey('platformId', $application);
             self::assertArrayHasKey('platformName', $application);
-            self::assertArrayHasKey('ownerId', $application);
+            self::assertArrayHasKey('author', $application);
+            self::assertArrayHasKey('createdAt', $application);
+
+            self::assertIsArray($application['author']);
+            self::assertArrayHasKey('id', $application['author']);
+            self::assertArrayHasKey('firstName', $application['author']);
+            self::assertArrayHasKey('lastName', $application['author']);
+            self::assertArrayHasKey('photo', $application['author']);
             self::assertFalse($application['private']);
         }
     }


### PR DESCRIPTION
### Motivation
- Add a human-readable `description` to the `Application` entity so applications can expose textual details. 
- Return richer payloads for public and private application list endpoints so consumers receive author info, platform name and creation date. 

### Description
- Add `description` field to `App\Platform\Domain\Entity\Application` with Doctrine mapping, getter and setter. 
- Add a Doctrine migration `Version20260306170000` to add the `description` column to the `platform_application` table (and drop it on rollback). 
- Accept and validate `description` in `POST /v1/profile/applications` (`ApplicationCreateController`) and include it in the creation response. 
- Enrich `GET /v1/application/public` and `GET /v1/application/private` responses to include `description`, `author` object (`id`, `firstName`, `lastName`, `photo`), `platformName` and `createdAt`, and add joins to preload the user to avoid lazy loads. 
- Update fixtures (`LoadApplicationData.php`) to seed application descriptions and update the public/private list tests to assert the new payload shape. 

### Testing
- Checked PHP syntax for all changed files with `php -l` and all reported files had no syntax errors. 
- Attempted to run targeted PHPUnit tests for the modified controllers, but the local PHPUnit binary was not available in this environment (`vendor/bin/phpunit: No such file or directory`). 
- Performed static/syntax validation on controllers, entity, fixtures, migrations and updated tests which all passed `php -l` checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0f63ff28832bb5237684e24f840a)