### PR TITLE
Normalize platform/plugin/application photo values when persisting entities

### DIFF
--- a/src/Platform/Domain/Entity/Application.php
+++ b/src/Platform/Domain/Entity/Application.php
@@ -22,6 +22,7 @@ use Throwable;
 
 use function rawurlencode;
 use function str_replace;
+use function str_starts_with;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'platform_application')]
@@ -176,6 +177,12 @@ class Application implements EntityInterface
         if ($this->photo === '') {
             $title = rawurlencode($this->title);
             $this->photo = 'https://ui-avatars.com/api/?name=' . str_replace('%20', '+', $title);
+
+            return $this;
+        }
+
+        if (!str_starts_with($this->photo, 'http://') && !str_starts_with($this->photo, 'https://')) {
+            $this->photo = '/uploads/applications/' . ltrim($this->photo, '/');
         }
 
         return $this;

--- a/src/Platform/Domain/Entity/Platform.php
+++ b/src/Platform/Domain/Entity/Platform.php
@@ -23,6 +23,7 @@ use Throwable;
 
 use function rawurlencode;
 use function str_replace;
+use function str_starts_with;
 
 /**
  * @package App\Platform
@@ -323,6 +324,12 @@ class Platform implements EntityInterface
         if ($this->photo === '') {
             $name = rawurlencode($this->name);
             $this->photo = 'https://ui-avatars.com/api/?name=' . str_replace('%20', '+', $name);
+
+            return $this;
+        }
+
+        if (!str_starts_with($this->photo, 'http://') && !str_starts_with($this->photo, 'https://')) {
+            $this->photo = '/uploads/platforms/' . ltrim($this->photo, '/');
         }
 
         return $this;

--- a/src/Platform/Domain/Entity/Plugin.php
+++ b/src/Platform/Domain/Entity/Plugin.php
@@ -21,6 +21,7 @@ use Throwable;
 
 use function rawurlencode;
 use function str_replace;
+use function str_starts_with;
 
 /**
  * @package App\Platform
@@ -251,6 +252,12 @@ class Plugin implements EntityInterface
         if ($this->photo === '') {
             $name = rawurlencode($this->name);
             $this->photo = 'https://ui-avatars.com/api/?name=' . str_replace('%20', '+', $name);
+
+            return $this;
+        }
+
+        if (!str_starts_with($this->photo, 'http://') && !str_starts_with($this->photo, 'https://')) {
+            $this->photo = '/uploads/plugins/' . ltrim($this->photo, '/');
         }
 
         return $this;

--- a/tests/Unit/Platform/Domain/Entity/PhotoGenerationTest.php
+++ b/tests/Unit/Platform/Domain/Entity/PhotoGenerationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Platform\Domain\Entity;
+
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\Platform;
+use App\Platform\Domain\Entity\Plugin;
+use PHPUnit\Framework\Attributes\TestDox;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+class PhotoGenerationTest extends TestCase
+{
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('It generates avatar URL when plugin photo is not provided.')]
+    public function testPluginPhotoDefaultsToAvatarUrl(): void
+    {
+        $plugin = (new Plugin())
+            ->setName('Payment Plugin')
+            ->setPhoto('')
+            ->ensureGeneratedPhoto();
+
+        self::assertStringStartsWith('https://ui-avatars.com/api/?name=Payment+Plugin', $plugin->getPhoto());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('It normalizes plugin photo into uploads URL when a file name is provided.')]
+    public function testPluginPhotoNormalizesToUploadsPath(): void
+    {
+        $plugin = (new Plugin())
+            ->setPhoto('plugin-photo.png')
+            ->ensureGeneratedPhoto();
+
+        self::assertSame('/uploads/plugins/plugin-photo.png', $plugin->getPhoto());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('It normalizes platform photo into uploads URL when a file name is provided.')]
+    public function testPlatformPhotoNormalizesToUploadsPath(): void
+    {
+        $platform = (new Platform())
+            ->setPhoto('platform-photo.png')
+            ->ensureGeneratedPhoto();
+
+        self::assertSame('/uploads/platforms/platform-photo.png', $platform->getPhoto());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('It normalizes application photo into uploads URL when a file name is provided.')]
+    public function testApplicationPhotoNormalizesToUploadsPath(): void
+    {
+        $application = (new Application())
+            ->setPhoto('application-photo.png')
+            ->ensureGeneratedPhoto();
+
+        self::assertSame('/uploads/applications/application-photo.png', $application->getPhoto());
+    }
+}


### PR DESCRIPTION
### Motivation
- Aligner le comportement du listener/entité avec le contrôleur d'upload en injectant un fallback avatar si `photo` est vide et en convertissant les valeurs locales en URL d'upload cohérente lorsqu'une valeur non-absolute est fournie.

### Description
- Mise à jour de la méthode `ensureGeneratedPhoto()` dans `Application`, `Platform` et `Plugin` pour conserver la génération d'avatar `ui-avatars` lorsque `photo` est vide et pour normaliser les valeurs non absolues vers `/uploads/applications/...`, `/uploads/platforms/...` ou `/uploads/plugins/...`.
- Ajout de l'import `use function str_starts_with;` dans les trois entités et ajustement de la logique de retour pour appliquer la normalisation uniquement quand `photo` n'est pas une URL absolue.
- Ajout d'un test unitaire `tests/Unit/Platform/Domain/Entity/PhotoGenerationTest.php` qui vérifie la génération d'avatar par défaut et la normalisation des chemins pour `Plugin`, `Platform` et `Application`.
- Fichiers modifiés : `src/Platform/Domain/Entity/Application.php`, `src/Platform/Domain/Entity/Platform.php`, `src/Platform/Domain/Entity/Plugin.php` et `tests/Unit/Platform/Domain/Entity/PhotoGenerationTest.php`.

### Testing
- Vérification de syntaxe PHP via `php -l` sur les fichiers modifiés (aucune erreur détectée). 
- Tentative d'exécution du test avec `./vendor/bin/phpunit tests/Unit/Platform/Domain/Entity/PhotoGenerationTest.php` qui n'a pas pu être lancée car `vendor/bin/phpunit` n'est pas disponible dans cet environnement (dépendances non installées).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab2d3fa388832b9febb3c769601e10)