### PR TITLE
Profile photo upload: add image detection fallback and tests

### DIFF
--- a/src/User/Transport/Controller/Api/V1/Profile/UploadPhotoController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/UploadPhotoController.php
@@ -21,6 +21,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 use function bin2hex;
+use function exif_imagetype;
+use function function_exists;
 use function random_bytes;
 use function str_starts_with;
 
@@ -86,7 +88,7 @@ class UploadPhotoController
             throw new HttpException(Response::HTTP_BAD_REQUEST, 'Invalid uploaded file.');
         }
 
-        if (!str_starts_with((string)$photo->getMimeType(), 'image/')) {
+        if (!$this->isImageFile($photo)) {
             throw new HttpException(Response::HTTP_BAD_REQUEST, 'Uploaded file must be an image.');
         }
 
@@ -105,5 +107,22 @@ class UploadPhotoController
         return new JsonResponse([
             'photo' => $photoUrl,
         ]);
+    }
+
+    private function isImageFile(UploadedFile $photo): bool
+    {
+        if (str_starts_with((string) $photo->getMimeType(), 'image/')) {
+            return true;
+        }
+
+        if (str_starts_with((string) $photo->getClientMimeType(), 'image/')) {
+            return true;
+        }
+
+        if (function_exists('exif_imagetype')) {
+            return false !== exif_imagetype($photo->getPathname());
+        }
+
+        return false;
     }
 }

--- a/tests/Application/User/Transport/Controller/Api/V1/Profile/UploadPhotoControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/Profile/UploadPhotoControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\Profile;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+use function file_exists;
+use function file_put_contents;
+use function parse_url;
+use function random_bytes;
+use function sys_get_temp_dir;
+use function unlink;
+
+/**
+ * @package App\Tests
+ */
+class UploadPhotoControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/profile/photo';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `POST /v1/profile/photo` requires authentication.')]
+    public function testThatUploadPhotoRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('POST', $this->baseUrl);
+        $response = $client->getResponse();
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that user can upload profile photo when MIME detection fallback is needed.')]
+    public function testThatUserCanUploadProfilePhotoWhenMimeTypeFallbackIsNeeded(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root', null, ['CONTENT_TYPE' => 'multipart/form-data']);
+
+        $tmpImage = sys_get_temp_dir() . '/profile_upload_' . bin2hex(random_bytes(8)) . '.png';
+        file_put_contents($tmpImage, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO6p8b8AAAAASUVORK5CYII=', true));
+
+        $photoFile = new UploadedFile(
+            $tmpImage,
+            'profile.png',
+            'application/octet-stream',
+            null,
+            true
+        );
+
+        $client->request(
+            'POST',
+            $this->baseUrl,
+            [],
+            [
+                'photo' => $photoFile,
+            ],
+        );
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertArrayHasKey('photo', $responseData);
+        self::assertIsString($responseData['photo']);
+        self::assertStringContainsString('/uploads/profile/', $responseData['photo']);
+
+        $photoPath = parse_url($responseData['photo'], PHP_URL_PATH);
+        self::assertIsString($photoPath);
+
+        $projectDir = (string) static::getContainer()->getParameter('kernel.project_dir');
+        $absolutePhotoPath = $projectDir . '/public' . $photoPath;
+
+        self::assertFileExists($absolutePhotoPath);
+
+        if (file_exists($absolutePhotoPath)) {
+            unlink($absolutePhotoPath);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent valid image uploads from being rejected when the client or server MIME detection is not reported as `image/*`.
- Provide a robust fallback to detect image binaries on the server side to avoid 400 responses for real images.
- Add coverage for the fallback behavior to ensure uploads work when the client MIME is `application/octet-stream`.

### Description
- Replace the simple `str_starts_with(... 'image/')` check with a dedicated `isImageFile()` method in `UploadPhotoController` that accepts server MIME, client MIME, or a positive `exif_imagetype()` check as an image detection fallback.
- Update the upload validation to call `isImageFile()` and keep existing checks for missing or invalid uploads and the existing file save logic in `src/User/Transport/Controller/Api/V1/Profile/UploadPhotoController.php`.
- Add `tests/Application/User/Transport/Controller/Api/V1/Profile/UploadPhotoControllerTest.php` which covers authentication and a successful upload where the client MIME is `application/octet-stream` but the payload is a valid image, and removes the uploaded file after the test.

### Testing
- Ran PHP syntax checks with `php -l src/User/Transport/Controller/Api/V1/Profile/UploadPhotoController.php` and `php -l tests/Application/User/Transport/Controller/Api/V1/Profile/UploadPhotoControllerTest.php`, both returned no syntax errors.
- Attempted to run the new test with `vendor/bin/phpunit tests/Application/User/Transport/Controller/Api/V1/Profile/UploadPhotoControllerTest.php`, but `vendor/bin/phpunit` is not present in this environment so PHPUnit could not be executed.
- Verified the modified PHP source compiles (syntax checks) and the new test file is syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab48b9cdcc832bb5a4ebef63e24d99)