### PR TITLE
Add enum-based platform_key and plugin_key and expose them in API responses

### DIFF
--- a/migrations/Version20260306190000.php
+++ b/migrations/Version20260306190000.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+/**
+ * Add platform_key and plugin_key columns.
+ */
+final class Version20260306190000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Add platform_key to platform and plugin_key to plugin with default enum values.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("ALTER TABLE platform ADD platform_key VARCHAR(25) NOT NULL DEFAULT 'crm'");
+        $this->addSql("ALTER TABLE plugin ADD plugin_key VARCHAR(25) NOT NULL DEFAULT 'chat'");
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE platform DROP platform_key');
+        $this->addSql('ALTER TABLE plugin DROP plugin_key');
+    }
+}

--- a/src/Platform/Application/DTO/Platform/Platform.php
+++ b/src/Platform/Application/DTO/Platform/Platform.php
@@ -7,6 +7,7 @@ namespace App\Platform\Application\DTO\Platform;
 use App\General\Application\DTO\Interfaces\RestDtoInterface;
 use App\General\Application\DTO\RestDto;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Platform\Domain\Enum\PlatformKey;
 use App\Platform\Domain\Enum\PlatformStatus;
 use App\Platform\Domain\Entity\Platform as Entity;
 use Override;
@@ -28,6 +29,16 @@ class Platform extends RestDto
 
     #[Assert\NotNull]
     protected string $description = '';
+
+
+    #[Assert\NotNull]
+    #[Assert\Choice(choices: [
+        PlatformKey::CRM->value,
+        PlatformKey::SCHOOL->value,
+        PlatformKey::SHOP->value,
+        PlatformKey::RECRUIT->value,
+    ])]
+    protected string $platformKey = PlatformKey::CRM->value;
 
     #[Assert\NotNull]
     protected bool $private = false;
@@ -67,6 +78,20 @@ class Platform extends RestDto
     {
         $this->setVisited('description');
         $this->description = $description;
+
+        return $this;
+    }
+
+
+    public function getPlatformKey(): string
+    {
+        return $this->platformKey;
+    }
+
+    public function setPlatformKey(string $platformKey): self
+    {
+        $this->setVisited('platformKey');
+        $this->platformKey = $platformKey;
 
         return $this;
     }
@@ -135,6 +160,7 @@ class Platform extends RestDto
             $this->id = $entity->getId();
             $this->name = $entity->getName();
             $this->description = $entity->getDescription();
+            $this->platformKey = $entity->getPlatformKeyValue();
             $this->private = $entity->isPrivate();
             $this->photo = $entity->getPhoto();
             $this->enabled = $entity->isEnabled();

--- a/src/Platform/Application/DTO/Plugin/Plugin.php
+++ b/src/Platform/Application/DTO/Plugin/Plugin.php
@@ -7,6 +7,7 @@ namespace App\Platform\Application\DTO\Plugin;
 use App\General\Application\DTO\Interfaces\RestDtoInterface;
 use App\General\Application\DTO\RestDto;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Platform\Domain\Enum\PluginKey;
 use App\Platform\Domain\Entity\Plugin as Entity;
 use Override;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -27,6 +28,16 @@ class Plugin extends RestDto
 
     #[Assert\NotNull]
     protected string $description = '';
+
+
+    #[Assert\NotNull]
+    #[Assert\Choice(choices: [
+        PluginKey::CALENDAR->value,
+        PluginKey::CHAT->value,
+        PluginKey::BLOG->value,
+        PluginKey::LANGUAGE->value,
+    ])]
+    protected string $pluginKey = PluginKey::CHAT->value;
 
     #[Assert\NotNull]
     protected bool $private = false;
@@ -58,6 +69,20 @@ class Plugin extends RestDto
     {
         $this->setVisited('description');
         $this->description = $description;
+
+        return $this;
+    }
+
+
+    public function getPluginKey(): string
+    {
+        return $this->pluginKey;
+    }
+
+    public function setPluginKey(string $pluginKey): self
+    {
+        $this->setVisited('pluginKey');
+        $this->pluginKey = $pluginKey;
 
         return $this;
     }
@@ -113,6 +138,7 @@ class Plugin extends RestDto
             $this->id = $entity->getId();
             $this->name = $entity->getName();
             $this->description = $entity->getDescription();
+            $this->pluginKey = $entity->getPluginKeyValue();
             $this->private = $entity->isPrivate();
             $this->photo = $entity->getPhoto();
             $this->enabled = $entity->isEnabled();

--- a/src/Platform/Domain/Entity/Platform.php
+++ b/src/Platform/Domain/Entity/Platform.php
@@ -8,6 +8,7 @@ use App\Configuration\Domain\Entity\Configuration;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\Platform\Domain\Enum\PlatformKey;
 use App\Platform\Domain\Enum\PlatformStatus;
 use App\User\Domain\Entity\User;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -75,6 +76,20 @@ class Platform implements EntityInterface
     ])]
     #[Assert\NotNull]
     private string $description = '';
+
+
+    #[ORM\Column(
+        name: 'platform_key',
+        type: Types::STRING,
+        length: 25,
+        enumType: PlatformKey::class,
+    )]
+    #[Groups([
+        'Platform',
+        'Platform.platformKey',
+    ])]
+    #[Assert\NotNull]
+    private PlatformKey $platformKey = PlatformKey::CRM;
 
     #[ORM\Column(
         name: 'private',
@@ -196,6 +211,24 @@ class Platform implements EntityInterface
     public function setDescription(string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+
+
+    public function getPlatformKey(): PlatformKey
+    {
+        return $this->platformKey;
+    }
+
+    public function getPlatformKeyValue(): string
+    {
+        return $this->platformKey->value;
+    }
+
+    public function setPlatformKey(PlatformKey|string $platformKey): self
+    {
+        $this->platformKey = $platformKey instanceof PlatformKey ? $platformKey : PlatformKey::from($platformKey);
 
         return $this;
     }

--- a/src/Platform/Domain/Entity/Plugin.php
+++ b/src/Platform/Domain/Entity/Plugin.php
@@ -6,6 +6,7 @@ namespace App\Platform\Domain\Entity;
 
 use App\Configuration\Domain\Entity\Configuration;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Platform\Domain\Enum\PluginKey;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -73,6 +74,20 @@ class Plugin implements EntityInterface
     ])]
     #[Assert\NotNull]
     private string $description = '';
+
+
+    #[ORM\Column(
+        name: 'plugin_key',
+        type: Types::STRING,
+        length: 25,
+        enumType: PluginKey::class,
+    )]
+    #[Groups([
+        'Plugin',
+        'Plugin.pluginKey',
+    ])]
+    #[Assert\NotNull]
+    private PluginKey $pluginKey = PluginKey::CHAT;
 
     #[ORM\Column(
         name: 'private',
@@ -168,6 +183,24 @@ class Plugin implements EntityInterface
     public function setDescription(string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+
+
+    public function getPluginKey(): PluginKey
+    {
+        return $this->pluginKey;
+    }
+
+    public function getPluginKeyValue(): string
+    {
+        return $this->pluginKey->value;
+    }
+
+    public function setPluginKey(PluginKey|string $pluginKey): self
+    {
+        $this->pluginKey = $pluginKey instanceof PluginKey ? $pluginKey : PluginKey::from($pluginKey);
 
         return $this;
     }

--- a/src/Platform/Domain/Enum/PlatformKey.php
+++ b/src/Platform/Domain/Enum/PlatformKey.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Domain\Enum;
+
+/**
+ * @package App\Platform
+ */
+enum PlatformKey: string
+{
+    case CRM = 'crm';
+    case SCHOOL = 'school';
+    case SHOP = 'shop';
+    case RECRUIT = 'recruit';
+}
+

--- a/src/Platform/Domain/Enum/PluginKey.php
+++ b/src/Platform/Domain/Enum/PluginKey.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Domain\Enum;
+
+/**
+ * @package App\Platform
+ */
+enum PluginKey: string
+{
+    case CALENDAR = 'calendar';
+    case CHAT = 'chat';
+    case BLOG = 'blog';
+    case LANGUAGE = 'language';
+}

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadPlatformData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadPlatformData.php
@@ -19,12 +19,13 @@ use Throwable;
 final class LoadPlatformData extends Fixture implements OrderedFixtureInterface
 {
     /**
-     * @var array<int, array{uuid: non-empty-string, code: non-empty-string, name: non-empty-string, enabled: bool, description: non-empty-string}>
+     * @var array<int, array{uuid: non-empty-string, code: non-empty-string, platformKey: non-empty-string, name: non-empty-string, enabled: bool, description: non-empty-string}>
      */
     private const array DATA = [
         [
             'uuid' => '40000000-0000-1000-8000-000000000001',
             'code' => 'CR',
+            'platformKey' => 'crm',
             'name' => 'CRM 1',
             'enabled' => true,
             'description' => 'Complete CRM module to centralize customer relationships, track opportunities, and structure commercial activity.',
@@ -32,6 +33,7 @@ final class LoadPlatformData extends Fixture implements OrderedFixtureInterface
         [
             'uuid' => '40000000-0000-1000-8000-000000000002',
             'code' => 'CR',
+            'platformKey' => 'crm',
             'name' => 'CRM 2',
             'enabled' => true,
             'description' => 'Complete CRM module to centralize customer relationships, track opportunities, and structure commercial activity.',
@@ -39,6 +41,7 @@ final class LoadPlatformData extends Fixture implements OrderedFixtureInterface
         [
             'uuid' => '40000000-0000-1000-8000-000000000003',
             'code' => 'SH',
+            'platformKey' => 'shop',
             'name' => 'Shop Principal',
             'enabled' => true,
             'description' => 'E-commerce suite to manage product catalogs, orders, payments, and sales performance.',
@@ -46,6 +49,7 @@ final class LoadPlatformData extends Fixture implements OrderedFixtureInterface
         [
             'uuid' => '40000000-0000-1000-8000-000000000004',
             'code' => 'RE',
+            'platformKey' => 'recruit',
             'name' => 'Recruit Principal',
             'enabled' => true,
             'description' => 'Recruitment workspace to publish job offers, qualify applications, and manage interviews efficiently.',
@@ -53,6 +57,7 @@ final class LoadPlatformData extends Fixture implements OrderedFixtureInterface
         [
             'uuid' => '40000000-0000-1000-8000-000000000005',
             'code' => 'SC',
+            'platformKey' => 'school',
             'name' => 'School Principal',
             'enabled' => true,
             'description' => 'School module to organize classes, plan lessons, and monitor learner progress.',
@@ -69,6 +74,7 @@ final class LoadPlatformData extends Fixture implements OrderedFixtureInterface
             $entity = new Platform()
                 ->setName($item['name'])
                 ->setDescription($item['description'])
+                ->setPlatformKey($item['platformKey'])
                 ->setEnabled($item['enabled'])
                 ->setPrivate(false)
                 ->ensureGeneratedPhoto();

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php
@@ -30,12 +30,13 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
     ];
 
     /**
-     * @var array<int, array{uuid: non-empty-string, key: non-empty-string, name: non-empty-string, enabled: bool, private: bool, description: non-empty-string}>
+     * @var array<int, array{uuid: non-empty-string, key: non-empty-string, pluginKey: non-empty-string, name: non-empty-string, enabled: bool, private: bool, description: non-empty-string}>
      */
     private const array DATA = [
         [
             'uuid' => '50000000-0000-1000-8000-000000000001',
             'key' => 'CRM-Assistant',
+            'pluginKey' => 'chat',
             'name' => 'CRM Assistant',
             'enabled' => true,
             'private' => false,
@@ -44,6 +45,7 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
         [
             'uuid' => '50000000-0000-1000-8000-000000000002',
             'key' => 'Analytics-Booster',
+            'pluginKey' => 'calendar',
             'name' => 'Analytics Booster',
             'enabled' => true,
             'private' => false,
@@ -52,6 +54,7 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
         [
             'uuid' => '50000000-0000-1000-8000-000000000003',
             'key' => 'Private-Beta-Plugin',
+            'pluginKey' => 'blog',
             'name' => 'Private Beta Plugin',
             'enabled' => true,
             'private' => true,
@@ -60,6 +63,7 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
         [
             'uuid' => '50000000-0000-1000-8000-000000000004',
             'key' => 'Disabled-Public-Plugin',
+            'pluginKey' => 'language',
             'name' => 'Disabled Public Plugin',
             'enabled' => false,
             'private' => false,
@@ -68,6 +72,7 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
         [
             'uuid' => '50000000-0000-1000-8000-000000000005',
             'key' => 'Knowledge-Base-Connector',
+            'pluginKey' => 'blog',
             'name' => 'Knowledge Base Connector',
             'enabled' => true,
             'private' => false,
@@ -85,6 +90,7 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
             $entity = new Plugin()
                 ->setName($item['name'])
                 ->setDescription($item['description'])
+                ->setPluginKey($item['pluginKey'])
                 ->setEnabled($item['enabled'])
                 ->setPrivate($item['private'])
                 ->ensureGeneratedPhoto();

--- a/src/Platform/Transport/Controller/Api/V1/Application/PrivateApplicationListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Application/PrivateApplicationListController.php
@@ -51,6 +51,8 @@ class PrivateApplicationListController
                             new Property(property: 'private', type: 'boolean'),
                             new Property(property: 'platformId', type: 'string'),
                             new Property(property: 'platformName', type: 'string'),
+                            new Property(property: 'platformKey', type: 'string', nullable: true),
+                            new Property(property: 'pluginKeys', type: 'array', items: new OA\Items(type: 'string')),
                             new Property(
                                 property: 'author',
                                 properties: [
@@ -82,8 +84,12 @@ class PrivateApplicationListController
             ->createQueryBuilder('application')
             ->leftJoin('application.platform', 'platform')
             ->leftJoin('application.user', 'user')
+            ->leftJoin('application.applicationPlugins', 'applicationPlugin')
+            ->leftJoin('applicationPlugin.plugin', 'plugin')
             ->addSelect('platform')
             ->addSelect('user')
+            ->addSelect('applicationPlugin')
+            ->addSelect('plugin')
             ->where('application.private = :publicApplication')
             ->orWhere('application.user = :loggedInUser')
             ->setParameter('publicApplication', false)
@@ -96,6 +102,14 @@ class PrivateApplicationListController
         $output = [];
 
         foreach ($applications as $application) {
+            $pluginKeys = [];
+            foreach ($application->getApplicationPlugins() as $applicationPlugin) {
+                $pluginKey = $applicationPlugin->getPlugin()?->getPluginKeyValue();
+                if ($pluginKey !== null) {
+                    $pluginKeys[$pluginKey] = true;
+                }
+            }
+
             $output[] = [
                 'id' => $application->getId(),
                 'title' => $application->getTitle(),
@@ -106,6 +120,8 @@ class PrivateApplicationListController
                 'private' => $application->isPrivate(),
                 'platformId' => $application->getPlatform()?->getId(),
                 'platformName' => $application->getPlatform()?->getName(),
+                'platformKey' => $application->getPlatform()?->getPlatformKeyValue(),
+                'pluginKeys' => array_keys($pluginKeys),
                 'author' => [
                     'id' => $application->getUser()?->getId(),
                     'firstName' => $application->getUser()?->getFirstName() ?? '',

--- a/src/Platform/Transport/Controller/Api/V1/Application/PublicApplicationListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Application/PublicApplicationListController.php
@@ -50,6 +50,8 @@ class PublicApplicationListController
                             new Property(property: 'private', type: 'boolean'),
                             new Property(property: 'platformId', type: 'string'),
                             new Property(property: 'platformName', type: 'string'),
+                            new Property(property: 'platformKey', type: 'string', nullable: true),
+                            new Property(property: 'pluginKeys', type: 'array', items: new OA\Items(type: 'string')),
                             new Property(
                                 property: 'author',
                                 properties: [
@@ -79,8 +81,12 @@ class PublicApplicationListController
             ->createQueryBuilder('application')
             ->leftJoin('application.platform', 'platform')
             ->leftJoin('application.user', 'user')
+            ->leftJoin('application.applicationPlugins', 'applicationPlugin')
+            ->leftJoin('applicationPlugin.plugin', 'plugin')
             ->addSelect('platform')
             ->addSelect('user')
+            ->addSelect('applicationPlugin')
+            ->addSelect('plugin')
             ->where('application.private = :publicApplication')
             ->setParameter('publicApplication', false)
             ->orderBy('application.title', 'ASC')
@@ -91,6 +97,14 @@ class PublicApplicationListController
         $output = [];
 
         foreach ($applications as $application) {
+            $pluginKeys = [];
+            foreach ($application->getApplicationPlugins() as $applicationPlugin) {
+                $pluginKey = $applicationPlugin->getPlugin()?->getPluginKeyValue();
+                if ($pluginKey !== null) {
+                    $pluginKeys[$pluginKey] = true;
+                }
+            }
+
             $output[] = [
                 'id' => $application->getId(),
                 'title' => $application->getTitle(),
@@ -101,6 +115,8 @@ class PublicApplicationListController
                 'private' => $application->isPrivate(),
                 'platformId' => $application->getPlatform()?->getId(),
                 'platformName' => $application->getPlatform()?->getName(),
+                'platformKey' => $application->getPlatform()?->getPlatformKeyValue(),
+                'pluginKeys' => array_keys($pluginKeys),
                 'author' => [
                     'id' => $application->getUser()?->getId(),
                     'firstName' => $application->getUser()?->getFirstName() ?? '',

--- a/src/Platform/Transport/Controller/Api/V1/Platform/PublicPlatformListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Platform/PublicPlatformListController.php
@@ -47,7 +47,7 @@ class PublicPlatformListController
                     items: new OA\Items(
                         ref: new Model(
                             type: Platform::class,
-                            groups: ['Platform.id', 'Platform.name', 'Platform.description', 'Platform.photo'],
+                            groups: ['Platform.id', 'Platform.name', 'Platform.description', 'Platform.platformKey', 'Platform.photo'],
                         ),
                     ),
                 ),
@@ -61,7 +61,7 @@ class PublicPlatformListController
             data: $this->platformResource->findPublicEnabled(),
             restResource: $this->platformResource,
             context: [
-                'groups' => ['Platform.id', 'Platform.name', 'Platform.description', 'Platform.photo'],
+                'groups' => ['Platform.id', 'Platform.name', 'Platform.description', 'Platform.platformKey', 'Platform.photo'],
             ],
         );
     }

--- a/src/Platform/Transport/Controller/Api/V1/Plugin/PublicPluginListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Plugin/PublicPluginListController.php
@@ -47,7 +47,7 @@ class PublicPluginListController
                     items: new OA\Items(
                         ref: new Model(
                             type: Plugin::class,
-                            groups: ['Plugin.id', 'Plugin.name', 'Plugin.description', 'Plugin.photo'],
+                            groups: ['Plugin.id', 'Plugin.name', 'Plugin.description', 'Plugin.pluginKey', 'Plugin.photo'],
                         ),
                     ),
                 ),
@@ -61,7 +61,7 @@ class PublicPluginListController
             data: $this->pluginResource->findPublicEnabled(),
             restResource: $this->pluginResource,
             context: [
-                'groups' => ['Plugin.id', 'Plugin.name', 'Plugin.description', 'Plugin.photo'],
+                'groups' => ['Plugin.id', 'Plugin.name', 'Plugin.description', 'Plugin.pluginKey', 'Plugin.photo'],
             ],
         );
     }

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginCreateControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginCreateControllerTest.php
@@ -32,6 +32,7 @@ class PluginCreateControllerTest extends WebTestCase
             'description' => 'A plugin for tests',
             'enabled' => true,
             'private' => false,
+            'pluginKey' => 'chat',
         ];
 
         $client->request(method: 'POST', uri: $this->baseUrl, content: JSON::encode($requestData));
@@ -77,6 +78,7 @@ class PluginCreateControllerTest extends WebTestCase
             'description' => 'Plugin created without photo payload',
             'enabled' => true,
             'private' => false,
+            'pluginKey' => 'chat',
         ];
 
         $client->request(method: 'POST', uri: $this->baseUrl, content: JSON::encode($requestData));
@@ -91,9 +93,11 @@ class PluginCreateControllerTest extends WebTestCase
         self::assertArrayHasKey('enabled', $responseData);
         self::assertArrayHasKey('private', $responseData);
         self::assertArrayHasKey('photo', $responseData);
+        self::assertArrayHasKey('pluginKey', $responseData);
         self::assertSame($requestData['name'], $responseData['name']);
         self::assertSame($requestData['description'], $responseData['description']);
         self::assertStringStartsWith('https://ui-avatars.com/api/?name=', $responseData['photo']);
+        self::assertSame($requestData['pluginKey'], $responseData['pluginKey']);
     }
 
     /**
@@ -107,6 +111,7 @@ class PluginCreateControllerTest extends WebTestCase
                 'description' => 'Plugin description',
                 'enabled' => true,
                 'private' => false,
+            'pluginKey' => 'chat',
             ],
             'This value should not be blank.',
         ];
@@ -116,6 +121,7 @@ class PluginCreateControllerTest extends WebTestCase
                 'description' => 'Plugin description',
                 'enabled' => true,
                 'private' => false,
+            'pluginKey' => 'chat',
             ],
             'This value is too short.',
         ];

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginListControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginListControllerTest.php
@@ -55,5 +55,6 @@ class PluginListControllerTest extends WebTestCase
         self::assertArrayHasKey('enabled', $responseData[0]);
         self::assertArrayHasKey('private', $responseData[0]);
         self::assertArrayHasKey('photo', $responseData[0]);
+        self::assertArrayHasKey('pluginKey', $responseData[0]);
     }
 }

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginPatchControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginPatchControllerTest.php
@@ -98,6 +98,7 @@ class PluginPatchControllerTest extends WebTestCase
         $requestData = [
             'description' => 'Patched description for knowledge base connector',
             'enabled' => false,
+            'pluginKey' => 'calendar',
         ];
 
         $client->request(
@@ -113,8 +114,10 @@ class PluginPatchControllerTest extends WebTestCase
         self::assertArrayHasKey('id', $responseData);
         self::assertArrayHasKey('description', $responseData);
         self::assertArrayHasKey('enabled', $responseData);
+        self::assertArrayHasKey('pluginKey', $responseData);
         self::assertSame($requestData['description'], $responseData['description']);
         self::assertSame($requestData['enabled'], $responseData['enabled']);
+        self::assertSame($requestData['pluginKey'], $responseData['pluginKey']);
     }
 
     /**

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginUpdateControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginUpdateControllerTest.php
@@ -50,6 +50,7 @@ class PluginUpdateControllerTest extends WebTestCase
             'description' => 'Updated plugin description',
             'enabled' => true,
             'private' => false,
+            'pluginKey' => 'calendar',
         ];
 
         $client->request(
@@ -103,6 +104,7 @@ class PluginUpdateControllerTest extends WebTestCase
             'description' => 'Updated analytics plugin description',
             'enabled' => false,
             'private' => true,
+            'pluginKey' => 'language',
         ];
 
         $client->request(
@@ -122,6 +124,7 @@ class PluginUpdateControllerTest extends WebTestCase
         self::assertSame($requestData['description'], $responseData['description']);
         self::assertSame($requestData['enabled'], $responseData['enabled']);
         self::assertSame($requestData['private'], $responseData['private']);
+        self::assertSame($requestData['pluginKey'], $responseData['pluginKey']);
     }
 
     /**

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PluginViewControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PluginViewControllerTest.php
@@ -51,7 +51,9 @@ class PluginViewControllerTest extends WebTestCase
         self::assertArrayHasKey('name', $responseData);
         self::assertArrayHasKey('description', $responseData);
         self::assertArrayHasKey('photo', $responseData);
+        self::assertArrayHasKey('pluginKey', $responseData);
         self::assertSame(LoadPluginData::getUuidByKey('CRM Assistant'), $responseData['id']);
         self::assertStringStartsWith('https://ui-avatars.com/api/?name=', $responseData['photo']);
+        self::assertContains($responseData['pluginKey'], ['calendar', 'chat', 'blog', 'language']);
     }
 }

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PrivateApplicationListControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PrivateApplicationListControllerTest.php
@@ -63,6 +63,8 @@ class PrivateApplicationListControllerTest extends WebTestCase
             self::assertArrayHasKey('description', $application);
             self::assertArrayHasKey('photo', $application);
             self::assertArrayHasKey('platformName', $application);
+            self::assertArrayHasKey('platformKey', $application);
+            self::assertArrayHasKey('pluginKeys', $application);
             self::assertArrayHasKey('author', $application);
             self::assertArrayHasKey('createdAt', $application);
 
@@ -72,6 +74,8 @@ class PrivateApplicationListControllerTest extends WebTestCase
             self::assertArrayHasKey('lastName', $application['author']);
             self::assertArrayHasKey('photo', $application['author']);
             self::assertArrayHasKey('isOwner', $application);
+            self::assertIsString($application['platformKey']);
+            self::assertIsArray($application['pluginKeys']);
             self::assertTrue($application['isOwner']);
         }
     }
@@ -108,6 +112,8 @@ class PrivateApplicationListControllerTest extends WebTestCase
             self::assertArrayHasKey('description', $application);
             self::assertArrayHasKey('photo', $application);
             self::assertArrayHasKey('platformName', $application);
+            self::assertArrayHasKey('platformKey', $application);
+            self::assertArrayHasKey('pluginKeys', $application);
             self::assertArrayHasKey('author', $application);
             self::assertArrayHasKey('createdAt', $application);
 
@@ -117,6 +123,8 @@ class PrivateApplicationListControllerTest extends WebTestCase
             self::assertArrayHasKey('lastName', $application['author']);
             self::assertArrayHasKey('photo', $application['author']);
             self::assertArrayHasKey('isOwner', $application);
+            self::assertIsString($application['platformKey']);
+            self::assertIsArray($application['pluginKeys']);
 
             if ($application['title'] === 'John User Private App') {
                 self::assertTrue($application['isOwner']);

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PublicApplicationListControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PublicApplicationListControllerTest.php
@@ -54,6 +54,8 @@ class PublicApplicationListControllerTest extends WebTestCase
             self::assertArrayHasKey('private', $application);
             self::assertArrayHasKey('platformId', $application);
             self::assertArrayHasKey('platformName', $application);
+            self::assertArrayHasKey('platformKey', $application);
+            self::assertArrayHasKey('pluginKeys', $application);
             self::assertArrayHasKey('author', $application);
             self::assertArrayHasKey('createdAt', $application);
 
@@ -63,6 +65,8 @@ class PublicApplicationListControllerTest extends WebTestCase
             self::assertArrayHasKey('lastName', $application['author']);
             self::assertArrayHasKey('photo', $application['author']);
             self::assertFalse($application['private']);
+            self::assertIsString($application['platformKey']);
+            self::assertIsArray($application['pluginKeys']);
         }
     }
 }

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PublicPluginListControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PublicPluginListControllerTest.php
@@ -41,9 +41,11 @@ class PublicPluginListControllerTest extends WebTestCase
             self::assertArrayHasKey('name', $plugin);
             self::assertArrayHasKey('description', $plugin);
             self::assertArrayHasKey('photo', $plugin);
+            self::assertArrayHasKey('pluginKey', $plugin);
             self::assertArrayNotHasKey('private', $plugin);
             self::assertArrayNotHasKey('enabled', $plugin);
             self::assertStringStartsWith('https://ui-avatars.com/api/?name=', $plugin['photo']);
+            self::assertContains($plugin['pluginKey'], ['calendar', 'chat', 'blog', 'language']);
         }
 
         $names = array_column($responseData, 'name');


### PR DESCRIPTION
### Motivation
- Introduire des clés énumérées pour `Platform` et `Plugin` (`platform_key` et `plugin_key`) afin de catégoriser les plateformes et plugins de façon standardisée et sûre. 
- Renvoyer ces clés dans les endpoints publics/privés pour que les clients puissent filtrer/afficher les types de platform/plugin sans charger les entités complètes. 

### Description
- Ajout des enums `PlatformKey` (`crm|school|shop|recruit`) et `PluginKey` (`calendar|chat|blog|language`) dans `src/Platform/Domain/Enum` et utilisation comme types d'entité Doctrine. 
- Extension des entités `Platform` et `Plugin` pour inclure les champs `platform_key` et `plugin_key` (enum-backed), avec getters/setters et méthodes utilitaires pour récupérer la valeur string. 
- Mise à jour des DTOs `Platform` et `Plugin` pour valider et exposer `platformKey` / `pluginKey` via `Assert\u005CChoice` et `load(...)` pour peupler depuis l'entité. 
- Mise à jour des fixtures (`LoadPlatformData`, `LoadPluginData`) pour seed des valeurs `platformKey`/`pluginKey`. 
- Modification des controllers d'API pour exposer `platformKey` et `pluginKey` : les listes publiques/privées d'applications retournent `platformKey` et `pluginKeys` (array), et les listes publiques `Platform` / `Plugin` incluent respectivement `platformKey` / `pluginKey` dans les groupes de sérialisation et la doc OpenAPI. 
- Ajout d'une migration Doctrine `Version20260306190000` pour créer les colonnes SQL `platform_key` et `plugin_key` avec valeurs par défaut compatibles. 
- Mise à jour des tests d'intégration pertinents pour vérifier la présence et le format des nouveaux champs (`platformKey`, `pluginKeys`, `pluginKey`). 

### Testing
- Lint PHP: `php -l` a été exécuté sur les fichiers modifiés et a réussi pour toutes les cibles (vérification syntaxique passée). 
- Tests PHPUnit: les tests d'API pertinents ont été adaptés pour valider les nouveaux champs mais l'exécution complète de `phpunit` n'a pas pu être lancée ici car `bin/phpunit` est absent dans cet environnement. 
- Migration: une migration Doctrine a été ajoutée pour créer les colonnes avec des valeurs par défaut afin d'assurer une montée de version sûre en base de données.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab5fcac11c832ba71208b601832a2b)