### PR TITLE
feat(application): add filtered, paginated, cached application listing with Elasticsearch support

### DIFF
--- a/src/Platform/Application/Service/ApplicationListService.php
+++ b/src/Platform/Application/Service/ApplicationListService.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Service;
+
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\Platform\Domain\Entity\Application;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Throwable;
+
+class ApplicationListService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly CacheInterface $cache,
+        private readonly ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+    }
+
+    /** @return array<string, mixed> */
+    public function getPublicList(Request $request): array
+    {
+        return $this->getList($request, null);
+    }
+
+    /** @return array<string, mixed> */
+    public function getPrivateList(Request $request, User $loggedInUser): array
+    {
+        return $this->getList($request, $loggedInUser);
+    }
+
+    /** @return array<string, mixed> */
+    private function getList(Request $request, ?User $loggedInUser): array
+    {
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+
+        $filters = [
+            'title' => trim((string) $request->query->get('title', '')),
+            'description' => trim((string) $request->query->get('description', '')),
+            'platformName' => trim((string) $request->query->get('platformName', '')),
+            'platformKey' => trim((string) $request->query->get('platformKey', '')),
+        ];
+
+        $cacheKey = 'application_list_' . md5((string) json_encode([
+            'userId' => $loggedInUser?->getId(),
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ]));
+
+        /** @var array<string, mixed> $result */
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($loggedInUser, $filters, $page, $limit): array {
+            $item->expiresAfter(120);
+
+            $qb = $this->entityManager
+                ->getRepository(Application::class)
+                ->createQueryBuilder('application')
+                ->leftJoin('application.platform', 'platform')
+                ->leftJoin('application.user', 'user')
+                ->leftJoin('application.applicationPlugins', 'applicationPlugin')
+                ->leftJoin('applicationPlugin.plugin', 'plugin')
+                ->addSelect('platform')
+                ->addSelect('user')
+                ->addSelect('applicationPlugin')
+                ->addSelect('plugin');
+
+            if ($loggedInUser === null) {
+                $qb->where('application.private = :publicApplication')
+                    ->setParameter('publicApplication', false);
+            } else {
+                $qb->where('application.private = :publicApplication')
+                    ->orWhere('application.user = :loggedInUser')
+                    ->setParameter('publicApplication', false)
+                    ->setParameter('loggedInUser', $loggedInUser);
+            }
+
+            if ($filters['platformKey'] !== '') {
+                $qb->andWhere('LOWER(platform.platformKey) = :platformKey')
+                    ->setParameter('platformKey', mb_strtolower($filters['platformKey']));
+            }
+
+            $esIds = $this->searchIdsFromElastic($filters);
+            if ($esIds !== null) {
+                if ($esIds === []) {
+                    return [
+                        'items' => [],
+                        'pagination' => [
+                            'page' => $page,
+                            'limit' => $limit,
+                            'totalItems' => 0,
+                            'totalPages' => 0,
+                        ],
+                    ];
+                }
+
+                $qb->andWhere('application.id IN (:esIds)')
+                    ->setParameter('esIds', $esIds);
+            }
+
+            if ($filters['title'] !== '') {
+                $qb->andWhere('LOWER(application.title) LIKE :title')
+                    ->setParameter('title', '%' . mb_strtolower($filters['title']) . '%');
+            }
+
+            if ($filters['description'] !== '') {
+                $qb->andWhere('LOWER(application.description) LIKE :description')
+                    ->setParameter('description', '%' . mb_strtolower($filters['description']) . '%');
+            }
+
+            if ($filters['platformName'] !== '') {
+                $qb->andWhere('LOWER(platform.name) LIKE :platformName')
+                    ->setParameter('platformName', '%' . mb_strtolower($filters['platformName']) . '%');
+            }
+
+            $qb->orderBy('application.title', 'ASC')
+                ->addOrderBy('application.id', 'ASC');
+
+            $query = $qb
+                ->setFirstResult(($page - 1) * $limit)
+                ->setMaxResults($limit)
+                ->getQuery();
+
+            $paginator = new Paginator($query, true);
+            $totalItems = $paginator->count();
+
+            $items = [];
+            /** @var Application $application */
+            foreach ($paginator as $application) {
+                $pluginKeys = [];
+                foreach ($application->getApplicationPlugins() as $applicationPlugin) {
+                    $pluginKey = $applicationPlugin->getPlugin()?->getPluginKeyValue();
+                    if ($pluginKey !== null) {
+                        $pluginKeys[$pluginKey] = true;
+                    }
+                }
+
+                $items[] = [
+                    'id' => $application->getId(),
+                    'title' => $application->getTitle(),
+                    'slug' => $application->getSlug(),
+                    'description' => $application->getDescription(),
+                    'photo' => $application->getPhoto(),
+                    'status' => $application->getStatus()->value,
+                    'private' => $application->isPrivate(),
+                    'platformId' => $application->getPlatform()?->getId(),
+                    'platformName' => $application->getPlatform()?->getName(),
+                    'platformKey' => $application->getPlatform()?->getPlatformKeyValue(),
+                    'pluginKeys' => array_keys($pluginKeys),
+                    'author' => [
+                        'id' => $application->getUser()?->getId(),
+                        'firstName' => $application->getUser()?->getFirstName() ?? '',
+                        'lastName' => $application->getUser()?->getLastName() ?? '',
+                        'photo' => $application->getUser()?->getPhoto() ?? '',
+                    ],
+                    'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
+                    'isOwner' => $loggedInUser !== null && $application->getUser()?->getId() === $loggedInUser->getId(),
+                ];
+            }
+
+            return [
+                'items' => $items,
+                'pagination' => [
+                    'page' => $page,
+                    'limit' => $limit,
+                    'totalItems' => $totalItems,
+                    'totalPages' => $totalItems > 0 ? (int) ceil($totalItems / $limit) : 0,
+                ],
+            ];
+        });
+
+        $result['filters'] = array_filter($filters, static fn (string $value): bool => $value !== '');
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, string> $filters
+     *
+     * @return array<int, string>|null
+     */
+    private function searchIdsFromElastic(array $filters): ?array
+    {
+        if ($filters['title'] === '' && $filters['description'] === '' && $filters['platformName'] === '') {
+            return null;
+        }
+
+        try {
+            $must = [];
+
+            if ($filters['title'] !== '') {
+                $must[] = ['match_phrase_prefix' => ['title' => $filters['title']]];
+            }
+            if ($filters['description'] !== '') {
+                $must[] = ['match_phrase_prefix' => ['description' => $filters['description']]];
+            }
+            if ($filters['platformName'] !== '') {
+                $must[] = ['match_phrase_prefix' => ['platformName' => $filters['platformName']]];
+            }
+
+            $response = $this->elasticsearchService->search(
+                ElasticsearchServiceInterface::INDEX_PREFIX . '_*',
+                [
+                    'query' => ['bool' => ['must' => $must]],
+                    '_source' => ['id'],
+                ],
+                0,
+                1000,
+            );
+
+            if (!is_array($response) || !isset($response['hits']['hits']) || !is_array($response['hits']['hits'])) {
+                return null;
+            }
+
+            $ids = [];
+            foreach ($response['hits']['hits'] as $hit) {
+                if (is_array($hit) && isset($hit['_source']['id']) && is_string($hit['_source']['id'])) {
+                    $ids[] = $hit['_source']['id'];
+                }
+            }
+
+            return array_values(array_unique($ids));
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/Platform/Transport/Controller/Api/V1/Application/PrivateApplicationListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Application/PrivateApplicationListController.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Platform\Transport\Controller\Api\V1\Application;
 
-use App\Platform\Domain\Entity\Application;
+use App\Platform\Application\Service\ApplicationListService;
 use App\User\Domain\Entity\User;
-use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use OpenApi\Attributes\JsonContent;
 use OpenApi\Attributes\Property;
@@ -17,122 +16,35 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Throwable;
 
-/**
- * @package App\Platform
- */
 #[AsController]
 #[OA\Tag(name: 'Application')]
 class PrivateApplicationListController
 {
-    public function __construct(
-        private readonly EntityManagerInterface $entityManager,
-    ) {
+    public function __construct(private readonly ApplicationListService $applicationListService)
+    {
     }
 
-    #[Route(
-        path: '/v1/application/private',
-        methods: [Request::METHOD_GET],
-    )]
+    #[Route(path: '/v1/application/private', methods: [Request::METHOD_GET])]
     #[OA\Get(
         responses: [
             new OA\Response(
                 response: 200,
-                description: 'List all public applications and authenticated user applications (public or private).',
+                description: 'List all public applications and authenticated user applications with filters and pagination.',
                 content: new JsonContent(
-                    type: 'array',
-                    items: new OA\Items(
-                        properties: [
-                            new Property(property: 'id', type: 'string'),
-                            new Property(property: 'title', type: 'string'),
-                            new Property(property: 'slug', type: 'string'),
-                            new Property(property: 'description', type: 'string'),
-                            new Property(property: 'photo', type: 'string'),
-                            new Property(property: 'status', type: 'string'),
-                            new Property(property: 'private', type: 'boolean'),
-                            new Property(property: 'platformId', type: 'string'),
-                            new Property(property: 'platformName', type: 'string'),
-                            new Property(property: 'platformKey', type: 'string', nullable: true),
-                            new Property(property: 'pluginKeys', type: 'array', items: new OA\Items(type: 'string')),
-                            new Property(
-                                property: 'author',
-                                properties: [
-                                    new Property(property: 'id', type: 'string', nullable: true),
-                                    new Property(property: 'firstName', type: 'string'),
-                                    new Property(property: 'lastName', type: 'string'),
-                                    new Property(property: 'photo', type: 'string'),
-                                ],
-                                type: 'object',
-                            ),
-                            new Property(property: 'createdAt', type: 'string', nullable: true),
-                            new Property(property: 'isOwner', type: 'boolean'),
-                        ],
-                        type: 'object',
-                    ),
+                    properties: [
+                        new Property(property: 'items', type: 'array', items: new OA\Items(type: 'object')),
+                        new Property(property: 'pagination', type: 'object'),
+                        new Property(property: 'filters', type: 'object'),
+                    ],
+                    type: 'object',
                 ),
             ),
         ],
     )]
     #[IsGranted('IS_AUTHENTICATED_FULLY')]
-    /**
-     * @throws Throwable
-     */
-    public function __invoke(User $loggedInUser): JsonResponse
+    /** @throws Throwable */
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {
-        /** @var array<int, Application> $applications */
-        $applications = $this->entityManager
-            ->getRepository(Application::class)
-            ->createQueryBuilder('application')
-            ->leftJoin('application.platform', 'platform')
-            ->leftJoin('application.user', 'user')
-            ->leftJoin('application.applicationPlugins', 'applicationPlugin')
-            ->leftJoin('applicationPlugin.plugin', 'plugin')
-            ->addSelect('platform')
-            ->addSelect('user')
-            ->addSelect('applicationPlugin')
-            ->addSelect('plugin')
-            ->where('application.private = :publicApplication')
-            ->orWhere('application.user = :loggedInUser')
-            ->setParameter('publicApplication', false)
-            ->setParameter('loggedInUser', $loggedInUser)
-            ->orderBy('application.title', 'ASC')
-            ->addOrderBy('application.id', 'ASC')
-            ->getQuery()
-            ->getResult();
-
-        $output = [];
-
-        foreach ($applications as $application) {
-            $pluginKeys = [];
-            foreach ($application->getApplicationPlugins() as $applicationPlugin) {
-                $pluginKey = $applicationPlugin->getPlugin()?->getPluginKeyValue();
-                if ($pluginKey !== null) {
-                    $pluginKeys[$pluginKey] = true;
-                }
-            }
-
-            $output[] = [
-                'id' => $application->getId(),
-                'title' => $application->getTitle(),
-                'slug' => $application->getSlug(),
-                'description' => $application->getDescription(),
-                'photo' => $application->getPhoto(),
-                'status' => $application->getStatus()->value,
-                'private' => $application->isPrivate(),
-                'platformId' => $application->getPlatform()?->getId(),
-                'platformName' => $application->getPlatform()?->getName(),
-                'platformKey' => $application->getPlatform()?->getPlatformKeyValue(),
-                'pluginKeys' => array_keys($pluginKeys),
-                'author' => [
-                    'id' => $application->getUser()?->getId(),
-                    'firstName' => $application->getUser()?->getFirstName() ?? '',
-                    'lastName' => $application->getUser()?->getLastName() ?? '',
-                    'photo' => $application->getUser()?->getPhoto() ?? '',
-                ],
-                'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
-                'isOwner' => $application->getUser()?->getId() === $loggedInUser?->getId(),
-            ];
-        }
-
-        return new JsonResponse($output);
+        return new JsonResponse($this->applicationListService->getPrivateList($request, $loggedInUser));
     }
 }

--- a/src/Platform/Transport/Controller/Api/V1/Application/PublicApplicationListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Application/PublicApplicationListController.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Platform\Transport\Controller\Api\V1\Application;
 
-use App\Platform\Domain\Entity\Application;
-use Doctrine\ORM\EntityManagerInterface;
+use App\Platform\Application\Service\ApplicationListService;
 use OpenApi\Attributes as OA;
 use OpenApi\Attributes\JsonContent;
 use OpenApi\Attributes\Property;
@@ -15,118 +14,35 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Throwable;
 
-/**
- * @package App\Platform
- */
 #[AsController]
 #[OA\Tag(name: 'Application')]
 class PublicApplicationListController
 {
-    public function __construct(
-        private readonly EntityManagerInterface $entityManager,
-    ) {
+    public function __construct(private readonly ApplicationListService $applicationListService)
+    {
     }
 
-    #[Route(
-        path: '/v1/application/public',
-        methods: [Request::METHOD_GET],
-    )]
+    #[Route(path: '/v1/application/public', methods: [Request::METHOD_GET])]
     #[OA\Get(
         security: [],
         responses: [
             new OA\Response(
                 response: 200,
-                description: 'List public applications.',
+                description: 'List public applications with filters and pagination.',
                 content: new JsonContent(
-                    type: 'array',
-                    items: new OA\Items(
-                        properties: [
-                            new Property(property: 'id', type: 'string'),
-                            new Property(property: 'title', type: 'string'),
-                            new Property(property: 'slug', type: 'string'),
-                            new Property(property: 'description', type: 'string'),
-                            new Property(property: 'photo', type: 'string'),
-                            new Property(property: 'status', type: 'string'),
-                            new Property(property: 'private', type: 'boolean'),
-                            new Property(property: 'platformId', type: 'string'),
-                            new Property(property: 'platformName', type: 'string'),
-                            new Property(property: 'platformKey', type: 'string', nullable: true),
-                            new Property(property: 'pluginKeys', type: 'array', items: new OA\Items(type: 'string')),
-                            new Property(
-                                property: 'author',
-                                properties: [
-                                    new Property(property: 'id', type: 'string', nullable: true),
-                                    new Property(property: 'firstName', type: 'string'),
-                                    new Property(property: 'lastName', type: 'string'),
-                                    new Property(property: 'photo', type: 'string'),
-                                ],
-                                type: 'object',
-                            ),
-                            new Property(property: 'createdAt', type: 'string', nullable: true),
-                        ],
-                        type: 'object',
-                    ),
+                    properties: [
+                        new Property(property: 'items', type: 'array', items: new OA\Items(type: 'object')),
+                        new Property(property: 'pagination', type: 'object'),
+                        new Property(property: 'filters', type: 'object'),
+                    ],
+                    type: 'object',
                 ),
             ),
         ],
     )]
-    /**
-     * @throws Throwable
-     */
-    public function __invoke(): JsonResponse
+    /** @throws Throwable */
+    public function __invoke(Request $request): JsonResponse
     {
-        /** @var array<int, Application> $applications */
-        $applications = $this->entityManager
-            ->getRepository(Application::class)
-            ->createQueryBuilder('application')
-            ->leftJoin('application.platform', 'platform')
-            ->leftJoin('application.user', 'user')
-            ->leftJoin('application.applicationPlugins', 'applicationPlugin')
-            ->leftJoin('applicationPlugin.plugin', 'plugin')
-            ->addSelect('platform')
-            ->addSelect('user')
-            ->addSelect('applicationPlugin')
-            ->addSelect('plugin')
-            ->where('application.private = :publicApplication')
-            ->setParameter('publicApplication', false)
-            ->orderBy('application.title', 'ASC')
-            ->addOrderBy('application.id', 'ASC')
-            ->getQuery()
-            ->getResult();
-
-        $output = [];
-
-        foreach ($applications as $application) {
-            $pluginKeys = [];
-            foreach ($application->getApplicationPlugins() as $applicationPlugin) {
-                $pluginKey = $applicationPlugin->getPlugin()?->getPluginKeyValue();
-                if ($pluginKey !== null) {
-                    $pluginKeys[$pluginKey] = true;
-                }
-            }
-
-            $output[] = [
-                'id' => $application->getId(),
-                'title' => $application->getTitle(),
-                'slug' => $application->getSlug(),
-                'description' => $application->getDescription(),
-                'photo' => $application->getPhoto(),
-                'status' => $application->getStatus()->value,
-                'private' => $application->isPrivate(),
-                'platformId' => $application->getPlatform()?->getId(),
-                'platformName' => $application->getPlatform()?->getName(),
-                'platformKey' => $application->getPlatform()?->getPlatformKeyValue(),
-                'pluginKeys' => array_keys($pluginKeys),
-                'author' => [
-                    'id' => $application->getUser()?->getId(),
-                    'firstName' => $application->getUser()?->getFirstName() ?? '',
-                    'lastName' => $application->getUser()?->getLastName() ?? '',
-                    'photo' => $application->getUser()?->getPhoto() ?? '',
-                ],
-                'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
-            ];
-        }
-
-        return new JsonResponse($output);
+        return new JsonResponse($this->applicationListService->getPublicList($request));
     }
 }

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PrivateApplicationListControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PrivateApplicationListControllerTest.php
@@ -10,16 +10,11 @@ use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
-/**
- * @package App\Tests
- */
 class PrivateApplicationListControllerTest extends WebTestCase
 {
     private string $baseUrl = self::API_URL_PREFIX . '/v1/application/private';
 
-    /**
-     * @throws Throwable
-     */
+    /** @throws Throwable */
     #[TestDox('Test that `GET /v1/application/private` requires authentication.')]
     public function testThatPrivateListRequiresAuthentication(): void
     {
@@ -31,10 +26,8 @@ class PrivateApplicationListControllerTest extends WebTestCase
         self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode(), "Response:\n" . $response);
     }
 
-    /**
-     * @throws Throwable
-     */
-    #[TestDox('Test that `GET /v1/application/private` returns public applications and authenticated user applications.')]
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/application/private` returns public and current user applications with pagination.')]
     public function testThatPrivateListReturnsPublicAndCurrentUserApplications(): void
     {
         $client = $this->getTestClient('john-root', 'password-root');
@@ -47,48 +40,24 @@ class PrivateApplicationListControllerTest extends WebTestCase
 
         $responseData = JSON::decode($content, true);
         self::assertIsArray($responseData);
-        self::assertCount(3, $responseData);
+        self::assertCount(3, $responseData['items']);
 
-        $titles = array_column($responseData, 'title');
-        self::assertSame(
-            [
-                'CRM Growth App',
-                'Recruit Lite App',
-                'Shop Ops App',
-            ],
-            $titles,
-        );
+        $titles = array_column($responseData['items'], 'title');
+        self::assertSame(['CRM Growth App', 'Recruit Lite App', 'Shop Ops App'], $titles);
 
-        foreach ($responseData as $application) {
-            self::assertArrayHasKey('description', $application);
-            self::assertArrayHasKey('photo', $application);
-            self::assertArrayHasKey('platformName', $application);
-            self::assertArrayHasKey('platformKey', $application);
-            self::assertArrayHasKey('pluginKeys', $application);
-            self::assertArrayHasKey('author', $application);
-            self::assertArrayHasKey('createdAt', $application);
-
-            self::assertIsArray($application['author']);
-            self::assertArrayHasKey('id', $application['author']);
-            self::assertArrayHasKey('firstName', $application['author']);
-            self::assertArrayHasKey('lastName', $application['author']);
-            self::assertArrayHasKey('photo', $application['author']);
+        foreach ($responseData['items'] as $application) {
             self::assertArrayHasKey('isOwner', $application);
-            self::assertIsString($application['platformKey']);
-            self::assertIsArray($application['pluginKeys']);
             self::assertTrue($application['isOwner']);
         }
     }
 
-    /**
-     * @throws Throwable
-     */
-    #[TestDox('Test that `GET /v1/application/private` indicates ownership for non owner authenticated users.')]
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/application/private` supports ownership and filtering.')]
     public function testThatPrivateListOwnershipIsFalseForNonOwner(): void
     {
         $client = $this->getTestClient('john-user', 'password-user');
 
-        $client->request('GET', $this->baseUrl);
+        $client->request('GET', $this->baseUrl . '?platformKey=crm&limit=10');
         $response = $client->getResponse();
         $content = $response->getContent();
         self::assertNotFalse($content);
@@ -96,35 +65,10 @@ class PrivateApplicationListControllerTest extends WebTestCase
 
         $responseData = JSON::decode($content, true);
         self::assertIsArray($responseData);
-        self::assertCount(3, $responseData);
+        self::assertSame('crm', $responseData['filters']['platformKey']);
 
-        $titles = array_column($responseData, 'title');
-        self::assertSame(
-            [
-                'CRM Growth App',
-                'John User Private App',
-                'Shop Ops App',
-            ],
-            $titles,
-        );
-
-        foreach ($responseData as $application) {
-            self::assertArrayHasKey('description', $application);
-            self::assertArrayHasKey('photo', $application);
-            self::assertArrayHasKey('platformName', $application);
-            self::assertArrayHasKey('platformKey', $application);
-            self::assertArrayHasKey('pluginKeys', $application);
-            self::assertArrayHasKey('author', $application);
-            self::assertArrayHasKey('createdAt', $application);
-
-            self::assertIsArray($application['author']);
-            self::assertArrayHasKey('id', $application['author']);
-            self::assertArrayHasKey('firstName', $application['author']);
-            self::assertArrayHasKey('lastName', $application['author']);
-            self::assertArrayHasKey('photo', $application['author']);
-            self::assertArrayHasKey('isOwner', $application);
-            self::assertIsString($application['platformKey']);
-            self::assertIsArray($application['pluginKeys']);
+        foreach ($responseData['items'] as $application) {
+            self::assertSame('crm', $application['platformKey']);
 
             if ($application['title'] === 'John User Private App') {
                 self::assertTrue($application['isOwner']);

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PublicApplicationListControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PublicApplicationListControllerTest.php
@@ -10,17 +10,12 @@ use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
-/**
- * @package App\Tests
- */
 class PublicApplicationListControllerTest extends WebTestCase
 {
     private string $baseUrl = self::API_URL_PREFIX . '/v1/application/public';
 
-    /**
-     * @throws Throwable
-     */
-    #[TestDox('Test that `GET /v1/application/public` without authentication returns all public applications only.')]
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/application/public` without authentication returns paginated public applications only.')]
     public function testThatPublicListWorksWithoutAuthentication(): void
     {
         $client = $this->getTestClient();
@@ -33,40 +28,46 @@ class PublicApplicationListControllerTest extends WebTestCase
 
         $responseData = JSON::decode($content, true);
         self::assertIsArray($responseData);
-        self::assertCount(2, $responseData);
+        self::assertArrayHasKey('items', $responseData);
+        self::assertArrayHasKey('pagination', $responseData);
+        self::assertArrayHasKey('filters', $responseData);
 
-        $titles = array_column($responseData, 'title');
-        self::assertSame(
-            [
-                'CRM Growth App',
-                'Shop Ops App',
-            ],
-            $titles,
-        );
+        self::assertCount(2, $responseData['items']);
+        self::assertSame(2, $responseData['pagination']['totalItems']);
 
-        foreach ($responseData as $application) {
+        $titles = array_column($responseData['items'], 'title');
+        self::assertSame(['CRM Growth App', 'Shop Ops App'], $titles);
+
+        foreach ($responseData['items'] as $application) {
             self::assertIsArray($application);
-            self::assertArrayHasKey('id', $application);
             self::assertArrayHasKey('title', $application);
             self::assertArrayHasKey('description', $application);
-            self::assertArrayHasKey('photo', $application);
-            self::assertArrayHasKey('status', $application);
-            self::assertArrayHasKey('private', $application);
-            self::assertArrayHasKey('platformId', $application);
             self::assertArrayHasKey('platformName', $application);
             self::assertArrayHasKey('platformKey', $application);
-            self::assertArrayHasKey('pluginKeys', $application);
-            self::assertArrayHasKey('author', $application);
-            self::assertArrayHasKey('createdAt', $application);
-
-            self::assertIsArray($application['author']);
-            self::assertArrayHasKey('id', $application['author']);
-            self::assertArrayHasKey('firstName', $application['author']);
-            self::assertArrayHasKey('lastName', $application['author']);
-            self::assertArrayHasKey('photo', $application['author']);
+            self::assertArrayHasKey('isOwner', $application);
             self::assertFalse($application['private']);
-            self::assertIsString($application['platformKey']);
-            self::assertIsArray($application['pluginKeys']);
         }
+    }
+
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/application/public` supports filters and pagination.')]
+    public function testThatPublicListSupportsFiltersAndPagination(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', $this->baseUrl . '?title=shop&platformKey=shop&page=1&limit=1');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertCount(1, $responseData['items']);
+        self::assertSame('Shop Ops App', $responseData['items'][0]['title']);
+        self::assertSame('shop', $responseData['filters']['platformKey']);
+        self::assertSame(1, $responseData['pagination']['page']);
+        self::assertSame(1, $responseData['pagination']['limit']);
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a single orchestrated implementation for application listing supporting text filters (`title`, `description`, `platformName`), exact platform filtering (`platformKey`), and performant pagination.
- Improve read performance and stability by adding a short TTL cache for repeated list queries.
- Allow more relevant text filtering by leveraging Elasticsearch for ID preselection while keeping a graceful fallback to Doctrine when ES is unavailable.

### Description
- Introduced `ApplicationListService` which centralizes listing logic, handles query parameters (`page`, `limit`, `title`, `description`, `platformName`, `platformKey`), pagination calculation, caching (TTL 120s) and optional Elasticsearch-assisted ID preselection (`src/Platform/Application/Service/ApplicationListService.php`).
- Refactored `PublicApplicationListController` and `PrivateApplicationListController` to delegate to `ApplicationListService` and changed endpoints to accept `Request` and return a unified envelope `{ items, pagination, filters }` (`src/Platform/Transport/Controller/Api/V1/Application/PublicApplicationListController.php`, `src/Platform/Transport/Controller/Api/V1/Application/PrivateApplicationListController.php`).
- Updated integration tests to assert the new response envelope, pagination and filter behavior (`tests/Application/Platform/Transport/Controller/Api/V1/PublicApplicationListControllerTest.php`, `tests/Application/Platform/Transport/Controller/Api/V1/PrivateApplicationListControllerTest.php`).

### Testing
- Ran PHP syntax checks with `php -l` on the new and modified PHP files and they all reported `No syntax errors detected`.
- Attempted to run PHPUnit via `vendor/bin/phpunit` but the binary is not present in this environment so tests could not be executed end-to-end.
- Attempted `composer test` with filter but the project does not define that command in this environment, so only static checks were performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab6714a23c832b8740c2e857522453)