### PR TITLE
feat(fixtures): add 150 bulk private application fixtures

### DIFF
--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
@@ -20,11 +20,16 @@ use Doctrine\Persistence\ObjectManager;
 use Override;
 use Throwable;
 
+use function sprintf;
+use function str_pad;
+
 /**
  * @package App\Platform
  */
 final class LoadApplicationData extends Fixture implements OrderedFixtureInterface
 {
+    private const int BULK_APPLICATION_COUNT = 150;
+
     /**
      * @var array<int, array{
      *     uuid: non-empty-string,
@@ -247,7 +252,63 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             $this->addReference('Application-' . $item['key'], $application);
         }
 
+        $this->loadBulkPrivateApplications($manager);
+
         $manager->flush();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function loadBulkPrivateApplications(ObjectManager $manager): void
+    {
+        $ownerReferences = [
+            'User-john',
+            'User-john-logged',
+            'User-john-api',
+            'User-john-admin',
+            'User-john-user',
+        ];
+        $platformReferences = [
+            'Platform-SH-Shop Principal',
+            'Platform-RE-Recruit Principal',
+            'Platform-SC-School Principal',
+        ];
+        $statuses = [
+            PlatformStatus::ACTIVE,
+            PlatformStatus::MAINTENANCE,
+            PlatformStatus::DISABLED,
+        ];
+
+        for ($index = 1; $index <= self::BULK_APPLICATION_COUNT; ++$index) {
+            $ownerReference = $ownerReferences[($index - 1) % count($ownerReferences)];
+            $platformReference = $platformReferences[($index - 1) % count($platformReferences)];
+            $status = $statuses[($index - 1) % count($statuses)];
+
+            /** @var User $owner */
+            $owner = $this->getReference($ownerReference, User::class);
+
+            /** @var Platform $platform */
+            $platform = $this->getReference($platformReference, Platform::class);
+
+            $application = (new Application())
+                ->setUser($owner)
+                ->setPlatform($platform)
+                ->setTitle(sprintf('Bulk Private App %03d', $index))
+                ->setDescription(sprintf('Application de fixture volumique %03d pour %s.', $index, $owner->getUsername()))
+                ->setStatus($status)
+                ->setPrivate(true);
+
+            PhpUnitUtil::setProperty('id', UuidHelper::fromString($this->buildBulkUuid($index)), $application);
+
+            $manager->persist($application);
+            $this->addReference(sprintf('Application-bulk-private-%03d', $index), $application);
+        }
+    }
+
+    private function buildBulkUuid(int $index): string
+    {
+        return '70000000-0000-1000-8000-' . str_pad((string) $index, 12, '0', STR_PAD_LEFT);
     }
 
     #[Override]


### PR DESCRIPTION
### Motivation

- Ajouter un grand nombre de fixtures d'`Application` (100–200) réparties entre plusieurs users pour tester pagination/performances et scénarios multi-utilisateurs.

### Description

- Modifié `src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php` pour conserver les fixtures existantes et ajouter une génération volumique déterministe.;
- Introduit la constante `BULK_APPLICATION_COUNT = 150` et la méthode `loadBulkPrivateApplications()` qui crée 150 applications privées réparties sur plusieurs owners et plateformes.;
- Les applications bulk utilisent des titres/descritions formatés (`Bulk Private App %03d`) et des UUIDs déterministes générés par `buildBulkUuid()` pour garantir la reproductibilité des fixtures.;
- Chaque application bulk est persistée et une référence `Application-bulk-private-XXX` est ajoutée pour réutilisation dans d'autres fixtures/tests.

### Testing

- Vérification de syntaxe PHP avec `php -l src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php` qui a réussi.;
- Tentative d'exécution de tests PHPUnit avec `./vendor/bin/phpunit ...` échouée car le binaire PHPUnit n'est pas présent dans cet environnement (`./vendor/bin/phpunit: No such file or directory`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab6d37378c832bad9bf2d5ebc929f0)