### PR TITLE
feat: add Recruit module with full CRUD and public jobs listing endpoint

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -70,6 +70,12 @@ doctrine:
                         dir: '%kernel.project_dir%/src/Platform/Domain/Entity'
                         prefix: 'App\Platform\Domain\Entity'
                         alias: Platform
+                    Recruit:
+                        type: attribute
+                        is_bundle: false
+                        dir: '%kernel.project_dir%/src/Recruit/Domain/Entity'
+                        prefix: 'App\Recruit\Domain\Entity'
+                        alias: Recruit
                     Role:
                         type: attribute
                         is_bundle: false

--- a/config/packages/event_listeners.yaml
+++ b/config/packages/event_listeners.yaml
@@ -36,3 +36,9 @@ services:
             - { name: doctrine.event_listener, event: preUpdate }
             - { name: doctrine.event_listener, event: postUpdate }
             - { name: doctrine.event_listener, event: postLoad }
+
+    App\Recruit\Transport\EventListener\RecruitEntityEventListener:
+        tags:
+            - { name: doctrine.event_listener, event: prePersist }
+            - { name: doctrine.event_listener, event: preUpdate }
+

--- a/migrations/Version20260307110000.php
+++ b/migrations/Version20260307110000.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260307110000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Create recruit module tables for jobs, companies, badges, tags and salaries';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('CREATE TABLE recruit_company (id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", name VARCHAR(255) NOT NULL, logo VARCHAR(25) NOT NULL, sector VARCHAR(100) NOT NULL, size VARCHAR(100) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \"(DC2Type:datetime)\", updated_at DATETIME DEFAULT NULL COMMENT \"(DC2Type:datetime)\", PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_badge (id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", label VARCHAR(255) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \"(DC2Type:datetime)\", updated_at DATETIME DEFAULT NULL COMMENT \"(DC2Type:datetime)\", PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_tag (id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", label VARCHAR(100) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \"(DC2Type:datetime)\", updated_at DATETIME DEFAULT NULL COMMENT \"(DC2Type:datetime)\", PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_salary (id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", min_salary INT NOT NULL, max_salary INT NOT NULL, currency VARCHAR(5) NOT NULL, period VARCHAR(20) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \"(DC2Type:datetime)\", updated_at DATETIME DEFAULT NULL COMMENT \"(DC2Type:datetime)\", PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_job (id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", company_id BINARY(16) DEFAULT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", salary_id BINARY(16) DEFAULT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", slug VARCHAR(255) NOT NULL, title VARCHAR(255) NOT NULL, location VARCHAR(255) NOT NULL, contract_type VARCHAR(25) NOT NULL, work_mode VARCHAR(25) NOT NULL, schedule VARCHAR(25) NOT NULL, summary LONGTEXT NOT NULL, match_score SMALLINT NOT NULL, mission_title VARCHAR(255) NOT NULL, mission_description LONGTEXT NOT NULL, responsibilities JSON NOT NULL, profile JSON NOT NULL, benefits JSON NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \"(DC2Type:datetime)\", updated_at DATETIME DEFAULT NULL COMMENT \"(DC2Type:datetime)\", INDEX IDX_D8F53A99979B1AD6 (company_id), UNIQUE INDEX UNIQ_D8F53A99A4594665 (salary_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_job_badge (job_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", badge_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", INDEX IDX_DCD31C48BE04EA9 (job_id), INDEX IDX_DCD31C4F7B2C80C (badge_id), PRIMARY KEY(job_id, badge_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_job_tag (job_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", tag_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", INDEX IDX_7E0C1F02BE04EA9 (job_id), INDEX IDX_7E0C1F02BAD26311 (tag_id), PRIMARY KEY(job_id, tag_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE recruit_job ADD CONSTRAINT FK_D8F53A99979B1AD6 FOREIGN KEY (company_id) REFERENCES recruit_company (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE recruit_job ADD CONSTRAINT FK_D8F53A99A4594665 FOREIGN KEY (salary_id) REFERENCES recruit_salary (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE recruit_job_badge ADD CONSTRAINT FK_DCD31C48BE04EA9 FOREIGN KEY (job_id) REFERENCES recruit_job (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_job_badge ADD CONSTRAINT FK_DCD31C4F7B2C80C FOREIGN KEY (badge_id) REFERENCES recruit_badge (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_job_tag ADD CONSTRAINT FK_7E0C1F02BE04EA9 FOREIGN KEY (job_id) REFERENCES recruit_job (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_job_tag ADD CONSTRAINT FK_7E0C1F02BAD26311 FOREIGN KEY (tag_id) REFERENCES recruit_tag (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE recruit_job_badge DROP FOREIGN KEY FK_DCD31C48BE04EA9');
+        $this->addSql('ALTER TABLE recruit_job_badge DROP FOREIGN KEY FK_DCD31C4F7B2C80C');
+        $this->addSql('ALTER TABLE recruit_job_tag DROP FOREIGN KEY FK_7E0C1F02BE04EA9');
+        $this->addSql('ALTER TABLE recruit_job_tag DROP FOREIGN KEY FK_7E0C1F02BAD26311');
+        $this->addSql('ALTER TABLE recruit_job DROP FOREIGN KEY FK_D8F53A99979B1AD6');
+        $this->addSql('ALTER TABLE recruit_job DROP FOREIGN KEY FK_D8F53A99A4594665');
+
+        $this->addSql('DROP TABLE recruit_job_badge');
+        $this->addSql('DROP TABLE recruit_job_tag');
+        $this->addSql('DROP TABLE recruit_job');
+        $this->addSql('DROP TABLE recruit_company');
+        $this->addSql('DROP TABLE recruit_badge');
+        $this->addSql('DROP TABLE recruit_tag');
+        $this->addSql('DROP TABLE recruit_salary');
+    }
+}

--- a/src/Recruit/Application/DTO/Badge/Badge.php
+++ b/src/Recruit/Application/DTO/Badge/Badge.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Badge;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Recruit\Domain\Entity\Badge as Entity;
+use Override;
+
+class Badge extends RestDto
+{
+    protected string $label = '';
+    public function getLabel(): string { return $this->label; }
+    public function setLabel(string $label): self { $this->setVisited('label'); $this->label = $label; return $this; }
+    #[Override]
+    public function load(EntityInterface $entity): self { if ($entity instanceof Entity) { $this->id=$entity->getId(); $this->label=$entity->getLabel(); } return $this; }
+}

--- a/src/Recruit/Application/DTO/Badge/BadgeCreate.php
+++ b/src/Recruit/Application/DTO/Badge/BadgeCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Badge;
+
+class BadgeCreate extends Badge
+{
+}

--- a/src/Recruit/Application/DTO/Badge/BadgePatch.php
+++ b/src/Recruit/Application/DTO/Badge/BadgePatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Badge;
+
+class BadgePatch extends Badge
+{
+}

--- a/src/Recruit/Application/DTO/Badge/BadgeUpdate.php
+++ b/src/Recruit/Application/DTO/Badge/BadgeUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Badge;
+
+class BadgeUpdate extends Badge
+{
+}

--- a/src/Recruit/Application/DTO/Company/Company.php
+++ b/src/Recruit/Application/DTO/Company/Company.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Company;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Recruit\Domain\Entity\Company as Entity;
+use Override;
+
+class Company extends RestDto
+{
+    protected string $name = '';
+    protected string $logo = '';
+    protected string $sector = '';
+    protected string $size = '';
+
+    public function getName(): string { return $this->name; }
+    public function setName(string $name): self { $this->setVisited('name'); $this->name = $name; return $this; }
+    public function getLogo(): string { return $this->logo; }
+    public function setLogo(string $logo): self { $this->setVisited('logo'); $this->logo = $logo; return $this; }
+    public function getSector(): string { return $this->sector; }
+    public function setSector(string $sector): self { $this->setVisited('sector'); $this->sector = $sector; return $this; }
+    public function getSize(): string { return $this->size; }
+    public function setSize(string $size): self { $this->setVisited('size'); $this->size = $size; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->name = $entity->getName();
+            $this->logo = $entity->getLogo();
+            $this->sector = $entity->getSector();
+            $this->size = $entity->getSize();
+        }
+
+        return $this;
+    }
+}

--- a/src/Recruit/Application/DTO/Company/CompanyCreate.php
+++ b/src/Recruit/Application/DTO/Company/CompanyCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Company;
+
+class CompanyCreate extends Company
+{
+}

--- a/src/Recruit/Application/DTO/Company/CompanyPatch.php
+++ b/src/Recruit/Application/DTO/Company/CompanyPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Company;
+
+class CompanyPatch extends Company
+{
+}

--- a/src/Recruit/Application/DTO/Company/CompanyUpdate.php
+++ b/src/Recruit/Application/DTO/Company/CompanyUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Company;
+
+class CompanyUpdate extends Company
+{
+}

--- a/src/Recruit/Application/DTO/Job/Job.php
+++ b/src/Recruit/Application/DTO/Job/Job.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Job;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Recruit\Domain\Entity\Job as Entity;
+use App\Recruit\Domain\Enum\ContractType;
+use App\Recruit\Domain\Enum\Schedule;
+use App\Recruit\Domain\Enum\WorkMode;
+use Override;
+
+class Job extends RestDto
+{
+    protected string $title = '';
+    protected string $location = '';
+    protected string $contractType = ContractType::CDI->value;
+    protected string $workMode = WorkMode::HYBRID->value;
+    protected string $schedule = Schedule::FULL_TIME->value;
+    protected string $summary = '';
+    protected int $matchScore = 0;
+    protected string $missionTitle = '';
+    protected string $missionDescription = '';
+    protected array $responsibilities = [];
+    protected array $profile = [];
+    protected array $benefits = [];
+
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->setVisited('title'); $this->title = $title; return $this; }
+    public function getLocation(): string { return $this->location; }
+    public function setLocation(string $location): self { $this->setVisited('location'); $this->location = $location; return $this; }
+    public function getContractType(): string { return $this->contractType; }
+    public function setContractType(string $contractType): self { $this->setVisited('contractType'); $this->contractType = $contractType; return $this; }
+    public function getWorkMode(): string { return $this->workMode; }
+    public function setWorkMode(string $workMode): self { $this->setVisited('workMode'); $this->workMode = $workMode; return $this; }
+    public function getSchedule(): string { return $this->schedule; }
+    public function setSchedule(string $schedule): self { $this->setVisited('schedule'); $this->schedule = $schedule; return $this; }
+    public function getSummary(): string { return $this->summary; }
+    public function setSummary(string $summary): self { $this->setVisited('summary'); $this->summary = $summary; return $this; }
+    public function getMatchScore(): int { return $this->matchScore; }
+    public function setMatchScore(int $matchScore): self { $this->setVisited('matchScore'); $this->matchScore = $matchScore; return $this; }
+    public function getMissionTitle(): string { return $this->missionTitle; }
+    public function setMissionTitle(string $missionTitle): self { $this->setVisited('missionTitle'); $this->missionTitle = $missionTitle; return $this; }
+    public function getMissionDescription(): string { return $this->missionDescription; }
+    public function setMissionDescription(string $missionDescription): self { $this->setVisited('missionDescription'); $this->missionDescription = $missionDescription; return $this; }
+    public function getResponsibilities(): array { return $this->responsibilities; }
+    public function setResponsibilities(array $responsibilities): self { $this->setVisited('responsibilities'); $this->responsibilities = $responsibilities; return $this; }
+    public function getProfile(): array { return $this->profile; }
+    public function setProfile(array $profile): self { $this->setVisited('profile'); $this->profile = $profile; return $this; }
+    public function getBenefits(): array { return $this->benefits; }
+    public function setBenefits(array $benefits): self { $this->setVisited('benefits'); $this->benefits = $benefits; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->title = $entity->getTitle();
+            $this->location = $entity->getLocation();
+            $this->contractType = $entity->getContractTypeValue();
+            $this->workMode = $entity->getWorkModeValue();
+            $this->schedule = $entity->getScheduleValue();
+            $this->summary = $entity->getSummary();
+            $this->matchScore = $entity->getMatchScore();
+            $this->missionTitle = $entity->getMissionTitle();
+            $this->missionDescription = $entity->getMissionDescription();
+            $this->responsibilities = $entity->getResponsibilities();
+            $this->profile = $entity->getProfile();
+            $this->benefits = $entity->getBenefits();
+        }
+
+        return $this;
+    }
+}

--- a/src/Recruit/Application/DTO/Job/JobCreate.php
+++ b/src/Recruit/Application/DTO/Job/JobCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Job;
+
+class JobCreate extends Job
+{
+}

--- a/src/Recruit/Application/DTO/Job/JobPatch.php
+++ b/src/Recruit/Application/DTO/Job/JobPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Job;
+
+class JobPatch extends Job
+{
+}

--- a/src/Recruit/Application/DTO/Job/JobUpdate.php
+++ b/src/Recruit/Application/DTO/Job/JobUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Job;
+
+class JobUpdate extends Job
+{
+}

--- a/src/Recruit/Application/DTO/Salary/Salary.php
+++ b/src/Recruit/Application/DTO/Salary/Salary.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Salary;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Recruit\Domain\Entity\Salary as Entity;
+use Override;
+
+class Salary extends RestDto
+{
+    protected int $min = 0;
+    protected int $max = 0;
+    protected string $currency = 'EUR';
+    protected string $period = 'year';
+
+    public function getMin(): int { return $this->min; }
+    public function setMin(int $min): self { $this->setVisited('min'); $this->min = $min; return $this; }
+    public function getMax(): int { return $this->max; }
+    public function setMax(int $max): self { $this->setVisited('max'); $this->max = $max; return $this; }
+    public function getCurrency(): string { return $this->currency; }
+    public function setCurrency(string $currency): self { $this->setVisited('currency'); $this->currency = $currency; return $this; }
+    public function getPeriod(): string { return $this->period; }
+    public function setPeriod(string $period): self { $this->setVisited('period'); $this->period = $period; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->min = $entity->getMin();
+            $this->max = $entity->getMax();
+            $this->currency = $entity->getCurrency();
+            $this->period = $entity->getPeriod();
+        }
+
+        return $this;
+    }
+}

--- a/src/Recruit/Application/DTO/Salary/SalaryCreate.php
+++ b/src/Recruit/Application/DTO/Salary/SalaryCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Salary;
+
+class SalaryCreate extends Salary
+{
+}

--- a/src/Recruit/Application/DTO/Salary/SalaryPatch.php
+++ b/src/Recruit/Application/DTO/Salary/SalaryPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Salary;
+
+class SalaryPatch extends Salary
+{
+}

--- a/src/Recruit/Application/DTO/Salary/SalaryUpdate.php
+++ b/src/Recruit/Application/DTO/Salary/SalaryUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Salary;
+
+class SalaryUpdate extends Salary
+{
+}

--- a/src/Recruit/Application/DTO/Tag/Tag.php
+++ b/src/Recruit/Application/DTO/Tag/Tag.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Tag;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Recruit\Domain\Entity\Tag as Entity;
+use Override;
+
+class Tag extends RestDto
+{
+    protected string $label = '';
+    public function getLabel(): string { return $this->label; }
+    public function setLabel(string $label): self { $this->setVisited('label'); $this->label = $label; return $this; }
+    #[Override]
+    public function load(EntityInterface $entity): self { if ($entity instanceof Entity) { $this->id=$entity->getId(); $this->label=$entity->getLabel(); } return $this; }
+}

--- a/src/Recruit/Application/DTO/Tag/TagCreate.php
+++ b/src/Recruit/Application/DTO/Tag/TagCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Tag;
+
+class TagCreate extends Tag
+{
+}

--- a/src/Recruit/Application/DTO/Tag/TagPatch.php
+++ b/src/Recruit/Application/DTO/Tag/TagPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Tag;
+
+class TagPatch extends Tag
+{
+}

--- a/src/Recruit/Application/DTO/Tag/TagUpdate.php
+++ b/src/Recruit/Application/DTO/Tag/TagUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Tag;
+
+class TagUpdate extends Tag
+{
+}

--- a/src/Recruit/Application/Resource/BadgeResource.php
+++ b/src/Recruit/Application/Resource/BadgeResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Recruit\Domain\Repository\Interfaces\BadgeRepositoryInterface as Repository;
+
+class BadgeResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Recruit/Application/Resource/CompanyResource.php
+++ b/src/Recruit/Application/Resource/CompanyResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Recruit\Domain\Repository\Interfaces\CompanyRepositoryInterface as Repository;
+
+class CompanyResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Recruit/Application/Resource/JobResource.php
+++ b/src/Recruit/Application/Resource/JobResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Recruit\Domain\Repository\Interfaces\JobRepositoryInterface as Repository;
+
+class JobResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Recruit/Application/Resource/SalaryResource.php
+++ b/src/Recruit/Application/Resource/SalaryResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Recruit\Domain\Repository\Interfaces\SalaryRepositoryInterface as Repository;
+
+class SalaryResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Recruit/Application/Resource/TagResource.php
+++ b/src/Recruit/Application/Resource/TagResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Recruit\Domain\Repository\Interfaces\TagRepositoryInterface as Repository;
+
+class TagResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Recruit/Application/Service/JobPublicListService.php
+++ b/src/Recruit/Application/Service/JobPublicListService.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Domain\Entity\Job;
+use DateInterval;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Symfony\Component\HttpFoundation\Request;
+
+class JobPublicListService
+{
+    public function __construct(private readonly EntityManagerInterface $entityManager)
+    {
+    }
+
+    /** @return array<string, mixed> */
+    public function getList(Request $request): array
+    {
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+
+        $filters = [
+            'company' => trim((string) $request->query->get('company', '')),
+            'salaryMin' => $request->query->getInt('salaryMin', 0),
+            'salaryMax' => $request->query->getInt('salaryMax', 0),
+            'contractType' => trim((string) $request->query->get('contractType', '')),
+            'workMode' => trim((string) $request->query->get('workMode', '')),
+            'schedule' => trim((string) $request->query->get('schedule', '')),
+            'postedAtLabel' => trim((string) $request->query->get('postedAtLabel', '')),
+            'location' => trim((string) $request->query->get('location', '')),
+        ];
+
+        $qb = $this->entityManager->getRepository(Job::class)
+            ->createQueryBuilder('job')
+            ->leftJoin('job.company', 'company')->addSelect('company')
+            ->leftJoin('job.salary', 'salary')->addSelect('salary')
+            ->leftJoin('job.badges', 'badge')->addSelect('badge')
+            ->leftJoin('job.tags', 'tag')->addSelect('tag')
+            ->orderBy('job.createdAt', 'DESC');
+
+        if ($filters['company'] !== '') {
+            $qb->andWhere('LOWER(company.name) LIKE :company')->setParameter('company', '%' . mb_strtolower($filters['company']) . '%');
+        }
+        if ($filters['contractType'] !== '') {
+            $qb->andWhere('job.contractType = :contractType')->setParameter('contractType', $filters['contractType']);
+        }
+        if ($filters['workMode'] !== '') {
+            $qb->andWhere('job.workMode = :workMode')->setParameter('workMode', $filters['workMode']);
+        }
+        if ($filters['schedule'] !== '') {
+            $qb->andWhere('job.schedule = :schedule')->setParameter('schedule', $filters['schedule']);
+        }
+        if ($filters['location'] !== '') {
+            $qb->andWhere('LOWER(job.location) LIKE :location')->setParameter('location', '%' . mb_strtolower($filters['location']) . '%');
+        }
+        if ($filters['salaryMin'] > 0) {
+            $qb->andWhere('salary.max >= :salaryMin')->setParameter('salaryMin', $filters['salaryMin']);
+        }
+        if ($filters['salaryMax'] > 0) {
+            $qb->andWhere('salary.min <= :salaryMax')->setParameter('salaryMax', $filters['salaryMax']);
+        }
+
+        $query = $qb->setFirstResult(($page - 1) * $limit)->setMaxResults($limit)->getQuery();
+        $paginator = new Paginator($query, true);
+
+        $items = [];
+        foreach ($paginator as $job) {
+            if (!$job instanceof Job) {
+                continue;
+            }
+
+            $postedAtLabel = $this->buildPostedAtLabel($job->getCreatedAt());
+            if ($filters['postedAtLabel'] !== '' && mb_strtolower($filters['postedAtLabel']) !== mb_strtolower($postedAtLabel)) {
+                continue;
+            }
+
+            $items[] = [
+                'id' => $job->getId(),
+                'slug' => $job->getSlug(),
+                'title' => $job->getTitle(),
+                'company' => [
+                    'name' => $job->getCompany()?->getName() ?? '',
+                    'logo' => $job->getCompany()?->getLogo() ?? '',
+                    'sector' => $job->getCompany()?->getSector() ?? '',
+                    'size' => $job->getCompany()?->getSize() ?? '',
+                ],
+                'location' => $job->getLocation(),
+                'contractType' => $job->getContractTypeValue(),
+                'workMode' => $job->getWorkModeValue(),
+                'schedule' => $job->getScheduleValue(),
+                'salary' => [
+                    'min' => $job->getSalary()?->getMin() ?? 0,
+                    'max' => $job->getSalary()?->getMax() ?? 0,
+                    'currency' => $job->getSalary()?->getCurrency() ?? 'EUR',
+                    'period' => $job->getSalary()?->getPeriod() ?? 'year',
+                ],
+                'postedAtLabel' => $postedAtLabel,
+                'summary' => $job->getSummary(),
+                'matchScore' => $job->getMatchScore(),
+                'badges' => array_map(static fn ($badge): string => $badge->getLabel(), $job->getBadges()->toArray()),
+                'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $job->getTags()->toArray()),
+                'missionTitle' => $job->getMissionTitle(),
+                'missionDescription' => $job->getMissionDescription(),
+                'responsibilities' => $job->getResponsibilities(),
+                'profile' => $job->getProfile(),
+                'benefits' => $job->getBenefits(),
+            ];
+        }
+
+        $totalItems = $paginator->count();
+
+        return [
+            'jobs' => $items,
+            'pagination' => [
+                'page' => $page,
+                'limit' => $limit,
+                'totalItems' => $totalItems,
+                'totalPages' => $totalItems > 0 ? (int) ceil($totalItems / $limit) : 0,
+            ],
+            'filters' => array_filter($filters, static fn (string|int $value): bool => $value !== '' && $value !== 0),
+        ];
+    }
+
+    private function buildPostedAtLabel(?DateTimeImmutable $createdAt): string
+    {
+        if ($createdAt === null) {
+            return 'vor kurzem';
+        }
+
+        $now = new DateTimeImmutable();
+        $diff = $createdAt->diff($now);
+
+        if ($diff->y > 0) {
+            return 'vor ' . $diff->y . ' Jahr' . ($diff->y > 1 ? 'en' : '');
+        }
+        if ($diff->m > 0) {
+            return 'vor ' . $diff->m . ' Monat' . ($diff->m > 1 ? 'en' : '');
+        }
+        if ($diff->days !== false && $diff->days >= 7) {
+            $weeks = (int) floor($diff->days / 7);
+            return 'vor ' . $weeks . ' Woche' . ($weeks > 1 ? 'n' : '');
+        }
+        if ($diff->d > 0) {
+            return 'vor ' . $diff->d . ' Tag' . ($diff->d > 1 ? 'en' : '');
+        }
+
+        return 'vor kurzem';
+    }
+}

--- a/src/Recruit/Domain/Entity/Badge.php
+++ b/src/Recruit/Domain/Entity/Badge.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_badge')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Badge implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['Badge', 'Badge.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'label', type: Types::STRING, length: 255)]
+    #[Groups(['Badge', 'Badge.label'])]
+    private string $label = '';
+
+    public function __construct() { $this->id = $this->createUuid(); }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getLabel(): string { return $this->label; }
+    public function setLabel(string $label): self { $this->label = $label; return $this; }
+}

--- a/src/Recruit/Domain/Entity/Company.php
+++ b/src/Recruit/Domain/Entity/Company.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_company')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Company implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['Company', 'Company.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
+    #[Groups(['Company', 'Company.name'])]
+    private string $name = '';
+
+    #[ORM\Column(name: 'logo', type: Types::STRING, length: 25, options: ['default' => ''])]
+    #[Groups(['Company', 'Company.logo'])]
+    private string $logo = '';
+
+    #[ORM\Column(name: 'sector', type: Types::STRING, length: 100, options: ['default' => ''])]
+    #[Groups(['Company', 'Company.sector'])]
+    private string $sector = '';
+
+    #[ORM\Column(name: 'size', type: Types::STRING, length: 100, options: ['default' => ''])]
+    #[Groups(['Company', 'Company.size'])]
+    private string $size = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getName(): string { return $this->name; }
+    public function setName(string $name): self { $this->name = $name; return $this; }
+    public function getLogo(): string { return $this->logo; }
+    public function setLogo(string $logo): self { $this->logo = $logo; return $this; }
+    public function getSector(): string { return $this->sector; }
+    public function setSector(string $sector): self { $this->sector = $sector; return $this; }
+    public function getSize(): string { return $this->size; }
+    public function setSize(string $size): self { $this->size = $size; return $this; }
+}

--- a/src/Recruit/Domain/Entity/Job.php
+++ b/src/Recruit/Domain/Entity/Job.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Recruit\Domain\Enum\ContractType;
+use App\Recruit\Domain\Enum\Schedule;
+use App\Recruit\Domain\Enum\WorkMode;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+use function iconv;
+use function is_string;
+use function preg_replace;
+use function strtolower;
+use function substr;
+use function trim;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_job')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Job implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['Job', 'Job.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, options: ['default' => ''])]
+    #[Groups(['Job', 'Job.slug'])]
+    private string $slug = '';
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
+    #[Groups(['Job', 'Job.title'])]
+    private string $title = '';
+
+    #[ORM\ManyToOne(targetEntity: Company::class)]
+    #[ORM\JoinColumn(name: 'company_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['Job', 'Job.company'])]
+    private ?Company $company = null;
+
+    #[ORM\OneToOne(targetEntity: Salary::class)]
+    #[ORM\JoinColumn(name: 'salary_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['Job', 'Job.salary'])]
+    private ?Salary $salary = null;
+
+    #[ORM\Column(name: 'location', type: Types::STRING, length: 255, options: ['default' => ''])]
+    #[Groups(['Job', 'Job.location'])]
+    private string $location = '';
+
+    #[ORM\Column(name: 'contract_type', type: Types::STRING, length: 25, enumType: ContractType::class)]
+    #[Groups(['Job', 'Job.contractType'])]
+    private ContractType $contractType = ContractType::CDI;
+
+    #[ORM\Column(name: 'work_mode', type: Types::STRING, length: 25, enumType: WorkMode::class)]
+    #[Groups(['Job', 'Job.workMode'])]
+    private WorkMode $workMode = WorkMode::HYBRID;
+
+    #[ORM\Column(name: 'schedule', type: Types::STRING, length: 25, enumType: Schedule::class)]
+    #[Groups(['Job', 'Job.schedule'])]
+    private Schedule $schedule = Schedule::FULL_TIME;
+
+    #[ORM\Column(name: 'summary', type: Types::TEXT, options: ['default' => ''])]
+    #[Groups(['Job', 'Job.summary'])]
+    private string $summary = '';
+
+    #[ORM\Column(name: 'match_score', type: Types::SMALLINT, options: ['default' => 0])]
+    #[Groups(['Job', 'Job.matchScore'])]
+    private int $matchScore = 0;
+
+    #[ORM\Column(name: 'mission_title', type: Types::STRING, length: 255, options: ['default' => ''])]
+    #[Groups(['Job', 'Job.missionTitle'])]
+    private string $missionTitle = '';
+
+    #[ORM\Column(name: 'mission_description', type: Types::TEXT, options: ['default' => ''])]
+    #[Groups(['Job', 'Job.missionDescription'])]
+    private string $missionDescription = '';
+
+    #[ORM\Column(name: 'responsibilities', type: Types::JSON)]
+    #[Groups(['Job', 'Job.responsibilities'])]
+    private array $responsibilities = [];
+
+    #[ORM\Column(name: 'profile', type: Types::JSON)]
+    #[Groups(['Job', 'Job.profile'])]
+    private array $profile = [];
+
+    #[ORM\Column(name: 'benefits', type: Types::JSON)]
+    #[Groups(['Job', 'Job.benefits'])]
+    private array $benefits = [];
+
+    /** @var Collection<int, Badge>|ArrayCollection<int, Badge> */
+    #[ORM\ManyToMany(targetEntity: Badge::class)]
+    #[ORM\JoinTable(name: 'recruit_job_badge')]
+    private Collection|ArrayCollection $badges;
+
+    /** @var Collection<int, Tag>|ArrayCollection<int, Tag> */
+    #[ORM\ManyToMany(targetEntity: Tag::class)]
+    #[ORM\JoinTable(name: 'recruit_job_tag')]
+    private Collection|ArrayCollection $tags;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->badges = new ArrayCollection();
+        $this->tags = new ArrayCollection();
+    }
+
+    public function ensureGeneratedSlug(): self
+    {
+        $normalizedTitle = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $this->title);
+        $base = is_string($normalizedTitle) ? $normalizedTitle : $this->title;
+        $slug = preg_replace('/[^a-z0-9]+/i', '-', strtolower($base));
+        $this->slug = trim($slug ?? '', '-');
+
+        if ($this->slug === '') {
+            $this->slug = 'job-' . substr($this->getId(), 0, 8);
+        }
+
+        return $this;
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getSlug(): string { return $this->slug; }
+    public function setSlug(string $slug): self { $this->slug = $slug; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getCompany(): ?Company { return $this->company; }
+    public function setCompany(?Company $company): self { $this->company = $company; return $this; }
+    public function getSalary(): ?Salary { return $this->salary; }
+    public function setSalary(?Salary $salary): self { $this->salary = $salary; return $this; }
+    public function getLocation(): string { return $this->location; }
+    public function setLocation(string $location): self { $this->location = $location; return $this; }
+    public function getContractType(): ContractType { return $this->contractType; }
+    public function getContractTypeValue(): string { return $this->contractType->value; }
+    public function setContractType(ContractType|string $contractType): self { $this->contractType = $contractType instanceof ContractType ? $contractType : ContractType::from($contractType); return $this; }
+    public function getWorkMode(): WorkMode { return $this->workMode; }
+    public function getWorkModeValue(): string { return $this->workMode->value; }
+    public function setWorkMode(WorkMode|string $workMode): self { $this->workMode = $workMode instanceof WorkMode ? $workMode : WorkMode::from($workMode); return $this; }
+    public function getSchedule(): Schedule { return $this->schedule; }
+    public function getScheduleValue(): string { return $this->schedule->value; }
+    public function setSchedule(Schedule|string $schedule): self { $this->schedule = $schedule instanceof Schedule ? $schedule : Schedule::from($schedule); return $this; }
+    public function getSummary(): string { return $this->summary; }
+    public function setSummary(string $summary): self { $this->summary = $summary; return $this; }
+    public function getMatchScore(): int { return $this->matchScore; }
+    public function setMatchScore(int $matchScore): self { $this->matchScore = $matchScore; return $this; }
+    public function getMissionTitle(): string { return $this->missionTitle; }
+    public function setMissionTitle(string $missionTitle): self { $this->missionTitle = $missionTitle; return $this; }
+    public function getMissionDescription(): string { return $this->missionDescription; }
+    public function setMissionDescription(string $missionDescription): self { $this->missionDescription = $missionDescription; return $this; }
+    public function getResponsibilities(): array { return $this->responsibilities; }
+    public function setResponsibilities(array $responsibilities): self { $this->responsibilities = $responsibilities; return $this; }
+    public function getProfile(): array { return $this->profile; }
+    public function setProfile(array $profile): self { $this->profile = $profile; return $this; }
+    public function getBenefits(): array { return $this->benefits; }
+    public function setBenefits(array $benefits): self { $this->benefits = $benefits; return $this; }
+    /** @return Collection<int, Badge>|ArrayCollection<int, Badge> */
+    public function getBadges(): Collection|ArrayCollection { return $this->badges; }
+    public function addBadge(Badge $badge): self { if (!$this->badges->contains($badge)) { $this->badges->add($badge); } return $this; }
+    public function removeBadge(Badge $badge): self { $this->badges->removeElement($badge); return $this; }
+    /** @return Collection<int, Tag>|ArrayCollection<int, Tag> */
+    public function getTags(): Collection|ArrayCollection { return $this->tags; }
+    public function addTag(Tag $tag): self { if (!$this->tags->contains($tag)) { $this->tags->add($tag); } return $this; }
+    public function removeTag(Tag $tag): self { $this->tags->removeElement($tag); return $this; }
+}

--- a/src/Recruit/Domain/Entity/Salary.php
+++ b/src/Recruit/Domain/Entity/Salary.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_salary')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Salary implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['Salary', 'Salary.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'min_salary', type: Types::INTEGER)]
+    #[Groups(['Salary', 'Salary.min'])]
+    private int $min = 0;
+
+    #[ORM\Column(name: 'max_salary', type: Types::INTEGER)]
+    #[Groups(['Salary', 'Salary.max'])]
+    private int $max = 0;
+
+    #[ORM\Column(name: 'currency', type: Types::STRING, length: 5, options: ['default' => 'EUR'])]
+    #[Groups(['Salary', 'Salary.currency'])]
+    private string $currency = 'EUR';
+
+    #[ORM\Column(name: 'period', type: Types::STRING, length: 20, options: ['default' => 'year'])]
+    #[Groups(['Salary', 'Salary.period'])]
+    private string $period = 'year';
+
+    public function __construct() { $this->id = $this->createUuid(); }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getMin(): int { return $this->min; }
+    public function setMin(int $min): self { $this->min = $min; return $this; }
+    public function getMax(): int { return $this->max; }
+    public function setMax(int $max): self { $this->max = $max; return $this; }
+    public function getCurrency(): string { return $this->currency; }
+    public function setCurrency(string $currency): self { $this->currency = $currency; return $this; }
+    public function getPeriod(): string { return $this->period; }
+    public function setPeriod(string $period): self { $this->period = $period; return $this; }
+}

--- a/src/Recruit/Domain/Entity/Tag.php
+++ b/src/Recruit/Domain/Entity/Tag.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_tag')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Tag implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['Tag', 'Tag.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'label', type: Types::STRING, length: 100)]
+    #[Groups(['Tag', 'Tag.label'])]
+    private string $label = '';
+
+    public function __construct() { $this->id = $this->createUuid(); }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getLabel(): string { return $this->label; }
+    public function setLabel(string $label): self { $this->label = $label; return $this; }
+}

--- a/src/Recruit/Domain/Enum/ContractType.php
+++ b/src/Recruit/Domain/Enum/ContractType.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Enum;
+
+enum ContractType: string
+{
+    case CDI = 'CDI';
+    case CDD = 'CDD';
+    case FREELANCE = 'Freelance';
+    case INTERNSHIP = 'Internship';
+}

--- a/src/Recruit/Domain/Enum/Schedule.php
+++ b/src/Recruit/Domain/Enum/Schedule.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Enum;
+
+enum Schedule: string
+{
+    case FULL_TIME = 'Vollzeit';
+    case PART_TIME = 'Teilzeit';
+    case CONTRACT = 'Contract';
+}

--- a/src/Recruit/Domain/Enum/WorkMode.php
+++ b/src/Recruit/Domain/Enum/WorkMode.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Enum;
+
+enum WorkMode: string
+{
+    case ONSITE = 'Onsite';
+    case REMOTE = 'Remote';
+    case HYBRID = 'Hybrid';
+}

--- a/src/Recruit/Domain/Repository/Interfaces/BadgeRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/BadgeRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface BadgeRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/CompanyRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/CompanyRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface CompanyRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/JobRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/JobRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface JobRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/SalaryRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/SalaryRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface SalaryRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/TagRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/TagRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface TagRepositoryInterface
+{
+}

--- a/src/Recruit/Infrastructure/Repository/BadgeRepository.php
+++ b/src/Recruit/Infrastructure/Repository/BadgeRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Badge as Entity;
+use App\Recruit\Domain\Repository\Interfaces\BadgeRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class BadgeRepository extends BaseRepository implements BadgeRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/CompanyRepository.php
+++ b/src/Recruit/Infrastructure/Repository/CompanyRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Company as Entity;
+use App\Recruit\Domain\Repository\Interfaces\CompanyRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class CompanyRepository extends BaseRepository implements CompanyRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/JobRepository.php
+++ b/src/Recruit/Infrastructure/Repository/JobRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Job as Entity;
+use App\Recruit\Domain\Repository\Interfaces\JobRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class JobRepository extends BaseRepository implements JobRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/SalaryRepository.php
+++ b/src/Recruit/Infrastructure/Repository/SalaryRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Salary as Entity;
+use App\Recruit\Domain\Repository\Interfaces\SalaryRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class SalaryRepository extends BaseRepository implements SalaryRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/TagRepository.php
+++ b/src/Recruit/Infrastructure/Repository/TagRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Tag as Entity;
+use App\Recruit\Domain\Repository\Interfaces\TagRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class TagRepository extends BaseRepository implements TagRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Transport/AutoMapper/Badge/AutoMapperConfiguration.php
+++ b/src/Recruit/Transport/AutoMapper/Badge/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Badge;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Recruit\Application\DTO\Badge\BadgeCreate;
+use App\Recruit\Application\DTO\Badge\BadgePatch;
+use App\Recruit\Application\DTO\Badge\BadgeUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        BadgeCreate::class,
+        BadgeUpdate::class,
+        BadgePatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Recruit/Transport/AutoMapper/Badge/RequestMapper.php
+++ b/src/Recruit/Transport/AutoMapper/Badge/RequestMapper.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Badge;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = ['label'];
+}

--- a/src/Recruit/Transport/AutoMapper/Company/AutoMapperConfiguration.php
+++ b/src/Recruit/Transport/AutoMapper/Company/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Company;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Recruit\Application\DTO\Company\CompanyCreate;
+use App\Recruit\Application\DTO\Company\CompanyPatch;
+use App\Recruit\Application\DTO\Company\CompanyUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        CompanyCreate::class,
+        CompanyUpdate::class,
+        CompanyPatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Recruit/Transport/AutoMapper/Company/RequestMapper.php
+++ b/src/Recruit/Transport/AutoMapper/Company/RequestMapper.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Company;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = ['name','logo','sector','size'];
+}

--- a/src/Recruit/Transport/AutoMapper/Job/AutoMapperConfiguration.php
+++ b/src/Recruit/Transport/AutoMapper/Job/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Job;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Recruit\Application\DTO\Job\JobCreate;
+use App\Recruit\Application\DTO\Job\JobPatch;
+use App\Recruit\Application\DTO\Job\JobUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        JobCreate::class,
+        JobUpdate::class,
+        JobPatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Recruit/Transport/AutoMapper/Job/RequestMapper.php
+++ b/src/Recruit/Transport/AutoMapper/Job/RequestMapper.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Job;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = ['title','location','contractType','workMode','schedule','summary','matchScore','missionTitle','missionDescription','responsibilities','profile','benefits'];
+}

--- a/src/Recruit/Transport/AutoMapper/Salary/AutoMapperConfiguration.php
+++ b/src/Recruit/Transport/AutoMapper/Salary/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Salary;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Recruit\Application\DTO\Salary\SalaryCreate;
+use App\Recruit\Application\DTO\Salary\SalaryPatch;
+use App\Recruit\Application\DTO\Salary\SalaryUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        SalaryCreate::class,
+        SalaryUpdate::class,
+        SalaryPatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Recruit/Transport/AutoMapper/Salary/RequestMapper.php
+++ b/src/Recruit/Transport/AutoMapper/Salary/RequestMapper.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Salary;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = ['min','max','currency','period'];
+}

--- a/src/Recruit/Transport/AutoMapper/Tag/AutoMapperConfiguration.php
+++ b/src/Recruit/Transport/AutoMapper/Tag/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Tag;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Recruit\Application\DTO\Tag\TagCreate;
+use App\Recruit\Application\DTO\Tag\TagPatch;
+use App\Recruit\Application\DTO\Tag\TagUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        TagCreate::class,
+        TagUpdate::class,
+        TagPatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Recruit/Transport/AutoMapper/Tag/RequestMapper.php
+++ b/src/Recruit/Transport/AutoMapper/Tag/RequestMapper.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Tag;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = ['label'];
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Badge/BadgeController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Badge/BadgeController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Badge;
+
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\Traits\Actions;
+use App\Recruit\Application\DTO\Badge\BadgeCreate;
+use App\Recruit\Application\DTO\Badge\BadgePatch;
+use App\Recruit\Application\DTO\Badge\BadgeUpdate;
+use App\Recruit\Application\Resource\BadgeResource;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[Route(path: '/v1/recruit/badge')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Recruit Badge Management')]
+class BadgeController extends Controller
+{
+    use Actions\Root\CountAction;
+    use Actions\Root\FindAction;
+    use Actions\Root\FindOneAction;
+    use Actions\Root\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => BadgeCreate::class,
+        Controller::METHOD_UPDATE => BadgeUpdate::class,
+        Controller::METHOD_PATCH => BadgePatch::class,
+    ];
+
+    public function __construct(BadgeResource $resource)
+    {
+        parent::__construct($resource);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Company;
+
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\Traits\Actions;
+use App\Recruit\Application\DTO\Company\CompanyCreate;
+use App\Recruit\Application\DTO\Company\CompanyPatch;
+use App\Recruit\Application\DTO\Company\CompanyUpdate;
+use App\Recruit\Application\Resource\CompanyResource;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[Route(path: '/v1/recruit/company')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Recruit Company Management')]
+class CompanyController extends Controller
+{
+    use Actions\Root\CountAction;
+    use Actions\Root\FindAction;
+    use Actions\Root\FindOneAction;
+    use Actions\Root\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => CompanyCreate::class,
+        Controller::METHOD_UPDATE => CompanyUpdate::class,
+        Controller::METHOD_PATCH => CompanyPatch::class,
+    ];
+
+    public function __construct(CompanyResource $resource)
+    {
+        parent::__construct($resource);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Job;
+
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\Traits\Actions;
+use App\Recruit\Application\DTO\Job\JobCreate;
+use App\Recruit\Application\DTO\Job\JobPatch;
+use App\Recruit\Application\DTO\Job\JobUpdate;
+use App\Recruit\Application\Resource\JobResource;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[Route(path: '/v1/recruit/job')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Recruit Job Management')]
+class JobController extends Controller
+{
+    use Actions\Root\CountAction;
+    use Actions\Root\FindAction;
+    use Actions\Root\FindOneAction;
+    use Actions\Root\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => JobCreate::class,
+        Controller::METHOD_UPDATE => JobUpdate::class,
+        Controller::METHOD_PATCH => JobPatch::class,
+    ];
+
+    public function __construct(JobResource $resource)
+    {
+        parent::__construct($resource);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobListController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Job;
+
+use App\Recruit\Application\Service\JobPublicListService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Job')]
+class PublicJobListController
+{
+    public function __construct(private readonly JobPublicListService $jobPublicListService)
+    {
+    }
+
+    #[Route(path: '/v1/recruit/job/public', methods: [Request::METHOD_GET])]
+    #[OA\Get(security: [], summary: 'Liste publique des offres jobs, paginée et filtrable.')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse($this->jobPublicListService->getList($request));
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Salary;
+
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\Traits\Actions;
+use App\Recruit\Application\DTO\Salary\SalaryCreate;
+use App\Recruit\Application\DTO\Salary\SalaryPatch;
+use App\Recruit\Application\DTO\Salary\SalaryUpdate;
+use App\Recruit\Application\Resource\SalaryResource;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[Route(path: '/v1/recruit/salary')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Recruit Salary Management')]
+class SalaryController extends Controller
+{
+    use Actions\Root\CountAction;
+    use Actions\Root\FindAction;
+    use Actions\Root\FindOneAction;
+    use Actions\Root\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => SalaryCreate::class,
+        Controller::METHOD_UPDATE => SalaryUpdate::class,
+        Controller::METHOD_PATCH => SalaryPatch::class,
+    ];
+
+    public function __construct(SalaryResource $resource)
+    {
+        parent::__construct($resource);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Tag;
+
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\Traits\Actions;
+use App\Recruit\Application\DTO\Tag\TagCreate;
+use App\Recruit\Application\DTO\Tag\TagPatch;
+use App\Recruit\Application\DTO\Tag\TagUpdate;
+use App\Recruit\Application\Resource\TagResource;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[Route(path: '/v1/recruit/tag')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Recruit Tag Management')]
+class TagController extends Controller
+{
+    use Actions\Root\CountAction;
+    use Actions\Root\FindAction;
+    use Actions\Root\FindOneAction;
+    use Actions\Root\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => TagCreate::class,
+        Controller::METHOD_UPDATE => TagUpdate::class,
+        Controller::METHOD_PATCH => TagPatch::class,
+    ];
+
+    public function __construct(TagResource $resource)
+    {
+        parent::__construct($resource);
+    }
+}

--- a/src/Recruit/Transport/EventListener/RecruitEntityEventListener.php
+++ b/src/Recruit/Transport/EventListener/RecruitEntityEventListener.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\EventListener;
+
+use App\Recruit\Domain\Entity\Job;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+
+class RecruitEntityEventListener
+{
+    public function prePersist(LifecycleEventArgs $event): void
+    {
+        $this->process($event);
+    }
+
+    public function preUpdate(LifecycleEventArgs $event): void
+    {
+        $this->process($event);
+    }
+
+    private function process(LifecycleEventArgs $event): void
+    {
+        $entity = $event->getObject();
+
+        if ($entity instanceof Job) {
+            $entity->ensureGeneratedSlug();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `Recruit` module following existing architecture (`Domain`, `Infrastructure`, `Application`, `Transport`)
- create recruit entities implementing `EntityInterface`:
  - `Job`
  - `Company`
  - `Badge`
  - `Tag`
  - `Salary`
- add enums:
  - `ContractType`
  - `WorkMode`
  - `Schedule`
- implement backend CRUD stack for all recruit entities:
  - repositories + interfaces
  - resources
  - DTOs (create/update/patch)
  - automapper request mapping/configuration
  - REST controllers (`count/list/view/ids/create/update/patch/delete`)
- add a public endpoint `GET /v1/recruit/job/public` with pagination and filters via `JobPublicListService`

## Public jobs response and filters
The endpoint returns data in the required shape with:
- `jobs` array
- nested `company` and `salary`
- `badges`, `tags`
- job details (`summary`, `missionTitle`, `missionDescription`, `responsibilities`, `profile`, `benefits`)
- `postedAtLabel` computed from `createdAt`
- `pagination` block
- `filters` block with active filters

Supported filters:
- `company`
- `salaryMin`, `salaryMax`
- `contractType`
- `workMode`
- `schedule`
- `postedAtLabel`
- `location`
- plus `page` / `limit`

## Persistence / wiring
- add Doctrine mapping alias for `Recruit` entities in `config/packages/doctrine.yaml`
- add recruit doctrine lifecycle listener registration in `config/packages/event_listeners.yaml`
- add migration `Version20260307110000` creating recruit tables and relations

## Notes
- `postedAtLabel` is generated dynamically from `createdAt` at read time (as requested from creation date semantics).
- `Job` slug is auto-generated on persist/update via `RecruitEntityEventListener`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acae5fc4588326919317d1dd1d8214)