### PR TITLE
Add recruit applicant/application/resume entities, repos and migration

### DIFF
--- a/migrations/Version20260308120000.php
+++ b/migrations/Version20260308120000.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260308120000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Add recruit applicant/application/resume domain with CV section entities';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('CREATE TABLE recruit_resume (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", owner_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", INDEX IDX_B4F6F8D57E3C61F9 (owner_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('CREATE TABLE recruit_applicant (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", user_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", resume_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", cover_letter LONGTEXT NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", UNIQUE INDEX UNIQ_A53D7BE939D0D039 (resume_id), INDEX IDX_A53D7BE9A76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('CREATE TABLE recruit_application (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", applicant_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", job_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", status VARCHAR(25) NOT NULL DEFAULT "WAITING", created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", INDEX IDX_2D3C03AFAE5E87E0 (applicant_id), INDEX IDX_2D3C03AFBE04EA9 (job_id), UNIQUE INDEX uq_recruit_application_applicant_job (applicant_id, job_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('CREATE TABLE recruit_resume_experience (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", resume_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", INDEX IDX_8E7D5A6E39D0D039 (resume_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_resume_education (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", resume_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", INDEX IDX_D4DE9A2639D0D039 (resume_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_resume_skill (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", resume_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", INDEX IDX_D8B8DE9039D0D039 (resume_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_resume_language (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", resume_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", INDEX IDX_C271844E39D0D039 (resume_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_resume_certification (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", resume_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", INDEX IDX_F4F9953B39D0D039 (resume_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_resume_project (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", resume_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", INDEX IDX_5468051139D0D039 (resume_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_resume_reference (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", resume_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", INDEX IDX_315D148939D0D039 (resume_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE recruit_resume_hobby (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", resume_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime)", INDEX IDX_89041E8A39D0D039 (resume_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE recruit_resume ADD CONSTRAINT FK_B4F6F8D57E3C61F9 FOREIGN KEY (owner_id) REFERENCES user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_applicant ADD CONSTRAINT FK_A53D7BE9A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_applicant ADD CONSTRAINT FK_A53D7BE939D0D039 FOREIGN KEY (resume_id) REFERENCES recruit_resume (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_application ADD CONSTRAINT FK_2D3C03AFAE5E87E0 FOREIGN KEY (applicant_id) REFERENCES recruit_applicant (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_application ADD CONSTRAINT FK_2D3C03AFBE04EA9 FOREIGN KEY (job_id) REFERENCES recruit_job (id) ON DELETE CASCADE');
+
+        $this->addSql('ALTER TABLE recruit_resume_experience ADD CONSTRAINT FK_8E7D5A6E39D0D039 FOREIGN KEY (resume_id) REFERENCES recruit_resume (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_resume_education ADD CONSTRAINT FK_D4DE9A2639D0D039 FOREIGN KEY (resume_id) REFERENCES recruit_resume (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_resume_skill ADD CONSTRAINT FK_D8B8DE9039D0D039 FOREIGN KEY (resume_id) REFERENCES recruit_resume (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_resume_language ADD CONSTRAINT FK_C271844E39D0D039 FOREIGN KEY (resume_id) REFERENCES recruit_resume (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_resume_certification ADD CONSTRAINT FK_F4F9953B39D0D039 FOREIGN KEY (resume_id) REFERENCES recruit_resume (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_resume_project ADD CONSTRAINT FK_5468051139D0D039 FOREIGN KEY (resume_id) REFERENCES recruit_resume (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_resume_reference ADD CONSTRAINT FK_315D148939D0D039 FOREIGN KEY (resume_id) REFERENCES recruit_resume (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_resume_hobby ADD CONSTRAINT FK_89041E8A39D0D039 FOREIGN KEY (resume_id) REFERENCES recruit_resume (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE recruit_application DROP FOREIGN KEY FK_2D3C03AFAE5E87E0');
+        $this->addSql('ALTER TABLE recruit_application DROP FOREIGN KEY FK_2D3C03AFBE04EA9');
+        $this->addSql('ALTER TABLE recruit_applicant DROP FOREIGN KEY FK_A53D7BE9A76ED395');
+        $this->addSql('ALTER TABLE recruit_applicant DROP FOREIGN KEY FK_A53D7BE939D0D039');
+        $this->addSql('ALTER TABLE recruit_resume DROP FOREIGN KEY FK_B4F6F8D57E3C61F9');
+
+        $this->addSql('ALTER TABLE recruit_resume_experience DROP FOREIGN KEY FK_8E7D5A6E39D0D039');
+        $this->addSql('ALTER TABLE recruit_resume_education DROP FOREIGN KEY FK_D4DE9A2639D0D039');
+        $this->addSql('ALTER TABLE recruit_resume_skill DROP FOREIGN KEY FK_D8B8DE9039D0D039');
+        $this->addSql('ALTER TABLE recruit_resume_language DROP FOREIGN KEY FK_C271844E39D0D039');
+        $this->addSql('ALTER TABLE recruit_resume_certification DROP FOREIGN KEY FK_F4F9953B39D0D039');
+        $this->addSql('ALTER TABLE recruit_resume_project DROP FOREIGN KEY FK_5468051139D0D039');
+        $this->addSql('ALTER TABLE recruit_resume_reference DROP FOREIGN KEY FK_315D148939D0D039');
+        $this->addSql('ALTER TABLE recruit_resume_hobby DROP FOREIGN KEY FK_89041E8A39D0D039');
+
+        $this->addSql('DROP TABLE recruit_application');
+        $this->addSql('DROP TABLE recruit_applicant');
+        $this->addSql('DROP TABLE recruit_resume');
+
+        $this->addSql('DROP TABLE recruit_resume_experience');
+        $this->addSql('DROP TABLE recruit_resume_education');
+        $this->addSql('DROP TABLE recruit_resume_skill');
+        $this->addSql('DROP TABLE recruit_resume_language');
+        $this->addSql('DROP TABLE recruit_resume_certification');
+        $this->addSql('DROP TABLE recruit_resume_project');
+        $this->addSql('DROP TABLE recruit_resume_reference');
+        $this->addSql('DROP TABLE recruit_resume_hobby');
+    }
+}

--- a/src/Recruit/Domain/Entity/Applicant.php
+++ b/src/Recruit/Domain/Entity/Applicant.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_applicant')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Applicant implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $user;
+
+    #[ORM\OneToOne(targetEntity: Resume::class, inversedBy: 'applicant', cascade: ['persist', 'remove'])]
+    #[ORM\JoinColumn(name: 'resume_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE', unique: true)]
+    private Resume $resume;
+
+    #[ORM\Column(name: 'cover_letter', type: Types::TEXT, options: ['default' => ''])]
+    private string $coverLetter = '';
+
+    /** @var Collection<int, Application>|ArrayCollection<int, Application> */
+    #[ORM\OneToMany(targetEntity: Application::class, mappedBy: 'applicant', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $applications;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->applications = new ArrayCollection();
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getUser(): User { return $this->user; }
+    public function setUser(User $user): self { $this->user = $user; return $this; }
+    public function getResume(): Resume { return $this->resume; }
+    public function setResume(Resume $resume): self { $this->resume = $resume; return $this; }
+    public function getCoverLetter(): string { return $this->coverLetter; }
+    public function setCoverLetter(string $coverLetter): self { $this->coverLetter = $coverLetter; return $this; }
+
+    /** @return Collection<int, Application>|ArrayCollection<int, Application> */
+    public function getApplications(): Collection|ArrayCollection { return $this->applications; }
+    public function addApplication(Application $application): self
+    {
+        if (!$this->applications->contains($application)) {
+            $this->applications->add($application);
+            $application->setApplicant($this);
+        }
+
+        return $this;
+    }
+
+    public function removeApplication(Application $application): self
+    {
+        $this->applications->removeElement($application);
+
+        return $this;
+    }
+}

--- a/src/Recruit/Domain/Entity/Application.php
+++ b/src/Recruit/Domain/Entity/Application.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_application')]
+#[ORM\UniqueConstraint(name: 'uq_recruit_application_applicant_job', columns: ['applicant_id', 'job_id'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Application implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Applicant::class, inversedBy: 'applications')]
+    #[ORM\JoinColumn(name: 'applicant_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Applicant $applicant;
+
+    #[ORM\ManyToOne(targetEntity: Job::class)]
+    #[ORM\JoinColumn(name: 'job_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Job $job;
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 25, enumType: ApplicationStatus::class, options: ['default' => 'WAITING'])]
+    private ApplicationStatus $status = ApplicationStatus::WAITING;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getApplicant(): Applicant { return $this->applicant; }
+    public function setApplicant(Applicant $applicant): self { $this->applicant = $applicant; return $this; }
+    public function getJob(): Job { return $this->job; }
+    public function setJob(Job $job): self { $this->job = $job; return $this; }
+    public function getStatus(): ApplicationStatus { return $this->status; }
+    public function getStatusValue(): string { return $this->status->value; }
+    public function setStatus(ApplicationStatus|string $status): self { $this->status = $status instanceof ApplicationStatus ? $status : ApplicationStatus::from($status); return $this; }
+}

--- a/src/Recruit/Domain/Entity/Certification.php
+++ b/src/Recruit/Domain/Entity/Certification.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_resume_certification')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Certification implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Resume::class)]
+    #[ORM\JoinColumn(name: 'resume_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Resume $resume;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $title = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, options: ['default' => ''])]
+    private string $description = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getResume(): Resume { return $this->resume; }
+    public function setResume(Resume $resume): self { $this->resume = $resume; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getDescription(): string { return $this->description; }
+    public function setDescription(string $description): self { $this->description = $description; return $this; }
+}

--- a/src/Recruit/Domain/Entity/Education.php
+++ b/src/Recruit/Domain/Entity/Education.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_resume_education')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Education implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Resume::class)]
+    #[ORM\JoinColumn(name: 'resume_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Resume $resume;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $title = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, options: ['default' => ''])]
+    private string $description = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getResume(): Resume { return $this->resume; }
+    public function setResume(Resume $resume): self { $this->resume = $resume; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getDescription(): string { return $this->description; }
+    public function setDescription(string $description): self { $this->description = $description; return $this; }
+}

--- a/src/Recruit/Domain/Entity/Experience.php
+++ b/src/Recruit/Domain/Entity/Experience.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_resume_experience')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Experience implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Resume::class)]
+    #[ORM\JoinColumn(name: 'resume_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Resume $resume;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $title = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, options: ['default' => ''])]
+    private string $description = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getResume(): Resume { return $this->resume; }
+    public function setResume(Resume $resume): self { $this->resume = $resume; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getDescription(): string { return $this->description; }
+    public function setDescription(string $description): self { $this->description = $description; return $this; }
+}

--- a/src/Recruit/Domain/Entity/Hobby.php
+++ b/src/Recruit/Domain/Entity/Hobby.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_resume_hobby')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Hobby implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Resume::class)]
+    #[ORM\JoinColumn(name: 'resume_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Resume $resume;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $title = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, options: ['default' => ''])]
+    private string $description = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getResume(): Resume { return $this->resume; }
+    public function setResume(Resume $resume): self { $this->resume = $resume; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getDescription(): string { return $this->description; }
+    public function setDescription(string $description): self { $this->description = $description; return $this; }
+}

--- a/src/Recruit/Domain/Entity/Language.php
+++ b/src/Recruit/Domain/Entity/Language.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_resume_language')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Language implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Resume::class)]
+    #[ORM\JoinColumn(name: 'resume_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Resume $resume;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $title = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, options: ['default' => ''])]
+    private string $description = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getResume(): Resume { return $this->resume; }
+    public function setResume(Resume $resume): self { $this->resume = $resume; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getDescription(): string { return $this->description; }
+    public function setDescription(string $description): self { $this->description = $description; return $this; }
+}

--- a/src/Recruit/Domain/Entity/Project.php
+++ b/src/Recruit/Domain/Entity/Project.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_resume_project')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Project implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Resume::class)]
+    #[ORM\JoinColumn(name: 'resume_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Resume $resume;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $title = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, options: ['default' => ''])]
+    private string $description = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getResume(): Resume { return $this->resume; }
+    public function setResume(Resume $resume): self { $this->resume = $resume; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getDescription(): string { return $this->description; }
+    public function setDescription(string $description): self { $this->description = $description; return $this; }
+}

--- a/src/Recruit/Domain/Entity/Recruit.php
+++ b/src/Recruit/Domain/Entity/Recruit.php
@@ -7,7 +7,7 @@ namespace App\Recruit\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
-use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\Application as PlatformApplication;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -28,9 +28,9 @@ class Recruit implements EntityInterface
     #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
     private UuidInterface $id;
 
-    #[ORM\OneToOne(targetEntity: Application::class)]
+    #[ORM\OneToOne(targetEntity: PlatformApplication::class)]
     #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: false, unique: true, onDelete: 'CASCADE')]
-    private ?Application $application = null;
+    private ?PlatformApplication $application = null;
 
     /**
      * @var Collection<int, Job>|ArrayCollection<int, Job>
@@ -51,12 +51,12 @@ class Recruit implements EntityInterface
         return $this->id->toString();
     }
 
-    public function getApplication(): ?Application
+    public function getApplication(): ?PlatformApplication
     {
         return $this->application;
     }
 
-    public function setApplication(?Application $application): self
+    public function setApplication(?PlatformApplication $application): self
     {
         $this->application = $application;
 

--- a/src/Recruit/Domain/Entity/Reference.php
+++ b/src/Recruit/Domain/Entity/Reference.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_resume_reference')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Reference implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Resume::class)]
+    #[ORM\JoinColumn(name: 'resume_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Resume $resume;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $title = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, options: ['default' => ''])]
+    private string $description = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getResume(): Resume { return $this->resume; }
+    public function setResume(Resume $resume): self { $this->resume = $resume; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getDescription(): string { return $this->description; }
+    public function setDescription(string $description): self { $this->description = $description; return $this; }
+}

--- a/src/Recruit/Domain/Entity/Resume.php
+++ b/src/Recruit/Domain/Entity/Resume.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_resume')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Resume implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'owner_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $owner;
+
+    #[ORM\OneToOne(targetEntity: Applicant::class, mappedBy: 'resume')]
+    private ?Applicant $applicant = null;
+
+    /** @var Collection<int, Experience>|ArrayCollection<int, Experience> */
+    #[ORM\OneToMany(targetEntity: Experience::class, mappedBy: 'resume', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $experiences;
+
+    /** @var Collection<int, Education>|ArrayCollection<int, Education> */
+    #[ORM\OneToMany(targetEntity: Education::class, mappedBy: 'resume', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $educations;
+
+    /** @var Collection<int, Skill>|ArrayCollection<int, Skill> */
+    #[ORM\OneToMany(targetEntity: Skill::class, mappedBy: 'resume', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $skills;
+
+    /** @var Collection<int, Language>|ArrayCollection<int, Language> */
+    #[ORM\OneToMany(targetEntity: Language::class, mappedBy: 'resume', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $languages;
+
+    /** @var Collection<int, Certification>|ArrayCollection<int, Certification> */
+    #[ORM\OneToMany(targetEntity: Certification::class, mappedBy: 'resume', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $certifications;
+
+    /** @var Collection<int, Project>|ArrayCollection<int, Project> */
+    #[ORM\OneToMany(targetEntity: Project::class, mappedBy: 'resume', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $projects;
+
+    /** @var Collection<int, Reference>|ArrayCollection<int, Reference> */
+    #[ORM\OneToMany(targetEntity: Reference::class, mappedBy: 'resume', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $references;
+
+    /** @var Collection<int, Hobby>|ArrayCollection<int, Hobby> */
+    #[ORM\OneToMany(targetEntity: Hobby::class, mappedBy: 'resume', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $hobbies;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->experiences = new ArrayCollection();
+        $this->educations = new ArrayCollection();
+        $this->skills = new ArrayCollection();
+        $this->languages = new ArrayCollection();
+        $this->certifications = new ArrayCollection();
+        $this->projects = new ArrayCollection();
+        $this->references = new ArrayCollection();
+        $this->hobbies = new ArrayCollection();
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getOwner(): User { return $this->owner; }
+    public function setOwner(User $owner): self { $this->owner = $owner; return $this; }
+    public function getApplicant(): ?Applicant { return $this->applicant; }
+}

--- a/src/Recruit/Domain/Entity/Skill.php
+++ b/src/Recruit/Domain/Entity/Skill.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_resume_skill')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Skill implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Resume::class)]
+    #[ORM\JoinColumn(name: 'resume_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Resume $resume;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255, options: ['default' => ''])]
+    private string $title = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, options: ['default' => ''])]
+    private string $description = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getResume(): Resume { return $this->resume; }
+    public function setResume(Resume $resume): self { $this->resume = $resume; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getDescription(): string { return $this->description; }
+    public function setDescription(string $description): self { $this->description = $description; return $this; }
+}

--- a/src/Recruit/Domain/Enum/ApplicationStatus.php
+++ b/src/Recruit/Domain/Enum/ApplicationStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Enum;
+
+enum ApplicationStatus: string
+{
+    case WAITING = 'WAITING';
+    case REVIEWING = 'REVIEWING';
+    case INTERVIEW = 'INTERVIEW';
+    case ACCEPTED = 'ACCEPTED';
+    case REJECTED = 'REJECTED';
+}

--- a/src/Recruit/Domain/Repository/Interfaces/ApplicantRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/ApplicantRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface ApplicantRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/ApplicationRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/ApplicationRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface ApplicationRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/CertificationRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/CertificationRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface CertificationRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/EducationRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/EducationRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface EducationRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/ExperienceRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/ExperienceRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface ExperienceRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/HobbyRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/HobbyRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface HobbyRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/LanguageRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/LanguageRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface LanguageRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/ProjectRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/ProjectRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface ProjectRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/ReferenceRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/ReferenceRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface ReferenceRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/ResumeRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/ResumeRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface ResumeRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/SkillRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/SkillRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface SkillRepositoryInterface
+{
+}

--- a/src/Recruit/Infrastructure/Repository/ApplicantRepository.php
+++ b/src/Recruit/Infrastructure/Repository/ApplicantRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Applicant as Entity;
+use App\Recruit\Domain\Repository\Interfaces\ApplicantRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ApplicantRepository extends BaseRepository implements ApplicantRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/ApplicationRepository.php
+++ b/src/Recruit/Infrastructure/Repository/ApplicationRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Application as Entity;
+use App\Recruit\Domain\Repository\Interfaces\ApplicationRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ApplicationRepository extends BaseRepository implements ApplicationRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/CertificationRepository.php
+++ b/src/Recruit/Infrastructure/Repository/CertificationRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Certification as Entity;
+use App\Recruit\Domain\Repository\Interfaces\CertificationRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class CertificationRepository extends BaseRepository implements CertificationRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/EducationRepository.php
+++ b/src/Recruit/Infrastructure/Repository/EducationRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Education as Entity;
+use App\Recruit\Domain\Repository\Interfaces\EducationRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class EducationRepository extends BaseRepository implements EducationRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/ExperienceRepository.php
+++ b/src/Recruit/Infrastructure/Repository/ExperienceRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Experience as Entity;
+use App\Recruit\Domain\Repository\Interfaces\ExperienceRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ExperienceRepository extends BaseRepository implements ExperienceRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/HobbyRepository.php
+++ b/src/Recruit/Infrastructure/Repository/HobbyRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Hobby as Entity;
+use App\Recruit\Domain\Repository\Interfaces\HobbyRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class HobbyRepository extends BaseRepository implements HobbyRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/LanguageRepository.php
+++ b/src/Recruit/Infrastructure/Repository/LanguageRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Language as Entity;
+use App\Recruit\Domain\Repository\Interfaces\LanguageRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class LanguageRepository extends BaseRepository implements LanguageRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/ProjectRepository.php
+++ b/src/Recruit/Infrastructure/Repository/ProjectRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Project as Entity;
+use App\Recruit\Domain\Repository\Interfaces\ProjectRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ProjectRepository extends BaseRepository implements ProjectRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/ReferenceRepository.php
+++ b/src/Recruit/Infrastructure/Repository/ReferenceRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Reference as Entity;
+use App\Recruit\Domain\Repository\Interfaces\ReferenceRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ReferenceRepository extends BaseRepository implements ReferenceRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/ResumeRepository.php
+++ b/src/Recruit/Infrastructure/Repository/ResumeRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Resume as Entity;
+use App\Recruit\Domain\Repository\Interfaces\ResumeRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ResumeRepository extends BaseRepository implements ResumeRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/SkillRepository.php
+++ b/src/Recruit/Infrastructure/Repository/SkillRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Skill as Entity;
+use App\Recruit\Domain\Repository\Interfaces\SkillRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class SkillRepository extends BaseRepository implements SkillRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a complete recruiting model to support applicants, job applications and resumes with reusable CV section entities and clear DB schema. 
- Provide repository interfaces and Doctrine repositories to integrate the new domain into the existing persistence layer. 
- Avoid naming collision with the platform `Application` entity by using explicit import aliasing. 

### Description
- Added domain entities under `src/Recruit/Domain/Entity/`: `Applicant`, `Application`, `Resume` and CV section entities `Experience`, `Education`, `Skill`, `Language`, `Certification`, `Project`, `Reference`, `Hobby`, with appropriate Doctrine mapping, relationships and basic getters/setters. 
- Added `ApplicationStatus` enum in `src/Recruit/Domain/Enum/ApplicationStatus.php` and used `WAITING` as the default for `Application`. 
- Added repository interfaces in `src/Recruit/Domain/Repository/Interfaces/*RepositoryInterface.php` and corresponding Doctrine repositories in `src/Recruit/Infrastructure/Repository/*Repository.php` for all new entities. 
- Added migration `migrations/Version20260308120000.php` that creates all new tables, indexes, unique constraints and foreign key relationships; updated `Recruit` entity to alias `App\Platform\Domain\Entity\Application` as `PlatformApplication` to avoid name collisions. 

### Testing
- Ran PHP syntax checks across changed files with `php -l` on all modified files and the linting passed. 
- Attempted to run `php bin/console doctrine:migrations:diff` but it was blocked in this environment due to missing vendor dependencies and platform extensions. 
- `composer install` failed here due to missing PHP extensions (`ext-amqp`, `ext-sodium`) and network restrictions when fetching packages, so migration generation was authored manually following the project's migration style and mappings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acc8fba71c832698aab2231ce00e01)