### PR TITLE
Add Recruit Resume/Applicant/Application DTOs, AutoMapper configs and authenticated V1 creation endpoints

### DIFF
--- a/src/Recruit/Application/DTO/Applicant/Applicant.php
+++ b/src/Recruit/Application/DTO/Applicant/Applicant.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Applicant;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Recruit\Domain\Entity\Applicant as Entity;
+use App\Recruit\Domain\Entity\Resume;
+use App\User\Domain\Entity\User;
+use Override;
+
+class Applicant extends RestDto
+{
+    protected ?User $user = null;
+    protected ?Resume $resume = null;
+    protected string $coverLetter = '';
+
+    public function getUser(): ?User { return $this->user; }
+    public function setUser(User $user): self { $this->setVisited('user'); $this->user = $user; return $this; }
+    public function getResume(): ?Resume { return $this->resume; }
+    public function setResume(Resume $resume): self { $this->setVisited('resume'); $this->resume = $resume; return $this; }
+    public function getCoverLetter(): string { return $this->coverLetter; }
+    public function setCoverLetter(string $coverLetter): self { $this->setVisited('coverLetter'); $this->coverLetter = $coverLetter; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->user = $entity->getUser();
+            $this->resume = $entity->getResume();
+            $this->coverLetter = $entity->getCoverLetter();
+        }
+
+        return $this;
+    }
+}

--- a/src/Recruit/Application/DTO/Applicant/ApplicantCreate.php
+++ b/src/Recruit/Application/DTO/Applicant/ApplicantCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Applicant;
+
+class ApplicantCreate extends Applicant
+{
+}

--- a/src/Recruit/Application/DTO/Applicant/ApplicantPatch.php
+++ b/src/Recruit/Application/DTO/Applicant/ApplicantPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Applicant;
+
+class ApplicantPatch extends Applicant
+{
+}

--- a/src/Recruit/Application/DTO/Applicant/ApplicantUpdate.php
+++ b/src/Recruit/Application/DTO/Applicant/ApplicantUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Applicant;
+
+class ApplicantUpdate extends Applicant
+{
+}

--- a/src/Recruit/Application/DTO/Application/Application.php
+++ b/src/Recruit/Application/DTO/Application/Application.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Application;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Recruit\Domain\Entity\Applicant;
+use App\Recruit\Domain\Entity\Application as Entity;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use Override;
+
+class Application extends RestDto
+{
+    protected ?Applicant $applicant = null;
+    protected ?Job $job = null;
+    protected string $status = ApplicationStatus::WAITING->value;
+
+    public function getApplicant(): ?Applicant { return $this->applicant; }
+    public function setApplicant(Applicant $applicant): self { $this->setVisited('applicant'); $this->applicant = $applicant; return $this; }
+    public function getJob(): ?Job { return $this->job; }
+    public function setJob(Job $job): self { $this->setVisited('job'); $this->job = $job; return $this; }
+    public function getStatus(): string { return $this->status; }
+    public function setStatus(string $status): self { $this->setVisited('status'); $this->status = $status; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->applicant = $entity->getApplicant();
+            $this->job = $entity->getJob();
+            $this->status = $entity->getStatusValue();
+        }
+
+        return $this;
+    }
+}

--- a/src/Recruit/Application/DTO/Application/ApplicationCreate.php
+++ b/src/Recruit/Application/DTO/Application/ApplicationCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Application;
+
+class ApplicationCreate extends Application
+{
+}

--- a/src/Recruit/Application/DTO/Application/ApplicationPatch.php
+++ b/src/Recruit/Application/DTO/Application/ApplicationPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Application;
+
+class ApplicationPatch extends Application
+{
+}

--- a/src/Recruit/Application/DTO/Application/ApplicationUpdate.php
+++ b/src/Recruit/Application/DTO/Application/ApplicationUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Application;
+
+class ApplicationUpdate extends Application
+{
+}

--- a/src/Recruit/Application/DTO/Resume/Resume.php
+++ b/src/Recruit/Application/DTO/Resume/Resume.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Resume;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\Recruit\Domain\Entity\Resume as Entity;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\Collection;
+use Override;
+
+class Resume extends RestDto
+{
+    protected ?User $owner = null;
+    protected array $experiences = [];
+    protected array $educations = [];
+    protected array $skills = [];
+    protected array $languages = [];
+    protected array $certifications = [];
+    protected array $projects = [];
+    protected array $references = [];
+    protected array $hobbies = [];
+
+    public function getOwner(): ?User { return $this->owner; }
+    public function setOwner(User $owner): self { $this->setVisited('owner'); $this->owner = $owner; return $this; }
+    public function getExperiences(): array { return $this->experiences; }
+    public function setExperiences(array $experiences): self { $this->setVisited('experiences'); $this->experiences = $experiences; return $this; }
+    public function getEducations(): array { return $this->educations; }
+    public function setEducations(array $educations): self { $this->setVisited('educations'); $this->educations = $educations; return $this; }
+    public function getSkills(): array { return $this->skills; }
+    public function setSkills(array $skills): self { $this->setVisited('skills'); $this->skills = $skills; return $this; }
+    public function getLanguages(): array { return $this->languages; }
+    public function setLanguages(array $languages): self { $this->setVisited('languages'); $this->languages = $languages; return $this; }
+    public function getCertifications(): array { return $this->certifications; }
+    public function setCertifications(array $certifications): self { $this->setVisited('certifications'); $this->certifications = $certifications; return $this; }
+    public function getProjects(): array { return $this->projects; }
+    public function setProjects(array $projects): self { $this->setVisited('projects'); $this->projects = $projects; return $this; }
+    public function getReferences(): array { return $this->references; }
+    public function setReferences(array $references): self { $this->setVisited('references'); $this->references = $references; return $this; }
+    public function getHobbies(): array { return $this->hobbies; }
+    public function setHobbies(array $hobbies): self { $this->setVisited('hobbies'); $this->hobbies = $hobbies; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->owner = $entity->getOwner();
+            $this->experiences = $this->mapSections($entity->getExperiences());
+            $this->educations = $this->mapSections($entity->getEducations());
+            $this->skills = $this->mapSections($entity->getSkills());
+            $this->languages = $this->mapSections($entity->getLanguages());
+            $this->certifications = $this->mapSections($entity->getCertifications());
+            $this->projects = $this->mapSections($entity->getProjects());
+            $this->references = $this->mapSections($entity->getReferences());
+            $this->hobbies = $this->mapSections($entity->getHobbies());
+        }
+
+        return $this;
+    }
+
+    private function mapSections(Collection $sections): array
+    {
+        $items = [];
+
+        foreach ($sections as $section) {
+            $items[] = new ResumeSection($section->getId(), $section->getTitle(), $section->getDescription());
+        }
+
+        return $items;
+    }
+}

--- a/src/Recruit/Application/DTO/Resume/ResumeCreate.php
+++ b/src/Recruit/Application/DTO/Resume/ResumeCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Resume;
+
+class ResumeCreate extends Resume
+{
+}

--- a/src/Recruit/Application/DTO/Resume/ResumePatch.php
+++ b/src/Recruit/Application/DTO/Resume/ResumePatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Resume;
+
+class ResumePatch extends Resume
+{
+}

--- a/src/Recruit/Application/DTO/Resume/ResumeSection.php
+++ b/src/Recruit/Application/DTO/Resume/ResumeSection.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Resume;
+
+class ResumeSection
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $title,
+        public readonly string $description,
+    ) {
+    }
+}

--- a/src/Recruit/Application/DTO/Resume/ResumeUpdate.php
+++ b/src/Recruit/Application/DTO/Resume/ResumeUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\DTO\Resume;
+
+class ResumeUpdate extends Resume
+{
+}

--- a/src/Recruit/Application/Resource/ApplicantResource.php
+++ b/src/Recruit/Application/Resource/ApplicantResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Recruit\Domain\Repository\Interfaces\ApplicantRepositoryInterface as Repository;
+
+class ApplicantResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Recruit/Application/Resource/ApplicationResource.php
+++ b/src/Recruit/Application/Resource/ApplicationResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Recruit\Domain\Repository\Interfaces\ApplicationRepositoryInterface as Repository;
+
+class ApplicationResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Recruit/Application/Resource/ResumeResource.php
+++ b/src/Recruit/Application/Resource/ResumeResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Recruit\Domain\Repository\Interfaces\ResumeRepositoryInterface as Repository;
+
+class ResumeResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Recruit/Domain/Entity/Resume.php
+++ b/src/Recruit/Domain/Entity/Resume.php
@@ -84,4 +84,100 @@ class Resume implements EntityInterface
     public function getOwner(): User { return $this->owner; }
     public function setOwner(User $owner): self { $this->owner = $owner; return $this; }
     public function getApplicant(): ?Applicant { return $this->applicant; }
+
+    /** @return Collection<int, Experience>|ArrayCollection<int, Experience> */
+    public function getExperiences(): Collection|ArrayCollection { return $this->experiences; }
+    public function addExperience(Experience $experience): self
+    {
+        if (!$this->experiences->contains($experience)) {
+            $this->experiences->add($experience);
+            $experience->setResume($this);
+        }
+
+        return $this;
+    }
+
+    /** @return Collection<int, Education>|ArrayCollection<int, Education> */
+    public function getEducations(): Collection|ArrayCollection { return $this->educations; }
+    public function addEducation(Education $education): self
+    {
+        if (!$this->educations->contains($education)) {
+            $this->educations->add($education);
+            $education->setResume($this);
+        }
+
+        return $this;
+    }
+
+    /** @return Collection<int, Skill>|ArrayCollection<int, Skill> */
+    public function getSkills(): Collection|ArrayCollection { return $this->skills; }
+    public function addSkill(Skill $skill): self
+    {
+        if (!$this->skills->contains($skill)) {
+            $this->skills->add($skill);
+            $skill->setResume($this);
+        }
+
+        return $this;
+    }
+
+    /** @return Collection<int, Language>|ArrayCollection<int, Language> */
+    public function getLanguages(): Collection|ArrayCollection { return $this->languages; }
+    public function addLanguage(Language $language): self
+    {
+        if (!$this->languages->contains($language)) {
+            $this->languages->add($language);
+            $language->setResume($this);
+        }
+
+        return $this;
+    }
+
+    /** @return Collection<int, Certification>|ArrayCollection<int, Certification> */
+    public function getCertifications(): Collection|ArrayCollection { return $this->certifications; }
+    public function addCertification(Certification $certification): self
+    {
+        if (!$this->certifications->contains($certification)) {
+            $this->certifications->add($certification);
+            $certification->setResume($this);
+        }
+
+        return $this;
+    }
+
+    /** @return Collection<int, Project>|ArrayCollection<int, Project> */
+    public function getProjects(): Collection|ArrayCollection { return $this->projects; }
+    public function addProject(Project $project): self
+    {
+        if (!$this->projects->contains($project)) {
+            $this->projects->add($project);
+            $project->setResume($this);
+        }
+
+        return $this;
+    }
+
+    /** @return Collection<int, Reference>|ArrayCollection<int, Reference> */
+    public function getReferences(): Collection|ArrayCollection { return $this->references; }
+    public function addReference(Reference $reference): self
+    {
+        if (!$this->references->contains($reference)) {
+            $this->references->add($reference);
+            $reference->setResume($this);
+        }
+
+        return $this;
+    }
+
+    /** @return Collection<int, Hobby>|ArrayCollection<int, Hobby> */
+    public function getHobbies(): Collection|ArrayCollection { return $this->hobbies; }
+    public function addHobby(Hobby $hobby): self
+    {
+        if (!$this->hobbies->contains($hobby)) {
+            $this->hobbies->add($hobby);
+            $hobby->setResume($this);
+        }
+
+        return $this;
+    }
 }

--- a/src/Recruit/Transport/AutoMapper/Applicant/AutoMapperConfiguration.php
+++ b/src/Recruit/Transport/AutoMapper/Applicant/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Applicant;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Recruit\Application\DTO\Applicant\ApplicantCreate;
+use App\Recruit\Application\DTO\Applicant\ApplicantPatch;
+use App\Recruit\Application\DTO\Applicant\ApplicantUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        ApplicantCreate::class,
+        ApplicantUpdate::class,
+        ApplicantPatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Recruit/Transport/AutoMapper/Applicant/RequestMapper.php
+++ b/src/Recruit/Transport/AutoMapper/Applicant/RequestMapper.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Applicant;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = ['user', 'resume', 'coverLetter'];
+}

--- a/src/Recruit/Transport/AutoMapper/Application/AutoMapperConfiguration.php
+++ b/src/Recruit/Transport/AutoMapper/Application/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Application;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Recruit\Application\DTO\Application\ApplicationCreate;
+use App\Recruit\Application\DTO\Application\ApplicationPatch;
+use App\Recruit\Application\DTO\Application\ApplicationUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        ApplicationCreate::class,
+        ApplicationUpdate::class,
+        ApplicationPatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Recruit/Transport/AutoMapper/Application/RequestMapper.php
+++ b/src/Recruit/Transport/AutoMapper/Application/RequestMapper.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Application;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = ['applicant', 'job', 'status'];
+}

--- a/src/Recruit/Transport/AutoMapper/Resume/AutoMapperConfiguration.php
+++ b/src/Recruit/Transport/AutoMapper/Resume/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Resume;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Recruit\Application\DTO\Resume\ResumeCreate;
+use App\Recruit\Application\DTO\Resume\ResumePatch;
+use App\Recruit\Application\DTO\Resume\ResumeUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        ResumeCreate::class,
+        ResumeUpdate::class,
+        ResumePatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Recruit/Transport/AutoMapper/Resume/RequestMapper.php
+++ b/src/Recruit/Transport/AutoMapper/Resume/RequestMapper.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\AutoMapper\Resume;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = [
+        'owner',
+        'experiences',
+        'educations',
+        'skills',
+        'languages',
+        'certifications',
+        'projects',
+        'references',
+        'hobbies',
+    ];
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Applicant/ApplicantCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Applicant/ApplicantCreateController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Applicant;
+
+use App\Recruit\Domain\Entity\Applicant;
+use App\Recruit\Infrastructure\Repository\ApplicantRepository;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_string;
+use function trim;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Applicant')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class ApplicantCreateController
+{
+    public function __construct(
+        private readonly ApplicantRepository $applicantRepository,
+        private readonly ResumeRepository $resumeRepository,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/applicants', methods: [Request::METHOD_POST])]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+
+        $resumeId = $payload['resumeId'] ?? null;
+        $coverLetter = $payload['coverLetter'] ?? '';
+
+        if (!is_string($resumeId) || !Uuid::isValid($resumeId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "resumeId" must be a valid UUID.');
+        }
+
+        if (!is_string($coverLetter)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "coverLetter" must be a string.');
+        }
+
+        $resume = $this->resumeRepository->find($resumeId);
+        if ($resume === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "resumeId".');
+        }
+
+        if ($resume->getOwner()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'The given resume does not belong to the authenticated user.');
+        }
+
+        $applicant = (new Applicant())
+            ->setUser($loggedInUser)
+            ->setResume($resume)
+            ->setCoverLetter(trim($coverLetter));
+
+        $this->applicantRepository->save($applicant);
+
+        return new JsonResponse(['id' => $applicant->getId()], JsonResponse::HTTP_CREATED);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Application;
+
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Recruit\Infrastructure\Repository\ApplicantRepository;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Infrastructure\Repository\JobRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_string;
+use function strtoupper;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Application')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class ApplicationCreateController
+{
+    public function __construct(
+        private readonly ApplicationRepository $applicationRepository,
+        private readonly ApplicantRepository $applicantRepository,
+        private readonly JobRepository $jobRepository,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/applications', methods: [Request::METHOD_POST])]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+
+        $applicantId = $payload['applicantId'] ?? null;
+        $jobId = $payload['jobId'] ?? null;
+        $status = $payload['status'] ?? null;
+
+        if (!is_string($applicantId) || !Uuid::isValid($applicantId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "applicantId" must be a valid UUID.');
+        }
+
+        if (!is_string($jobId) || !Uuid::isValid($jobId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "jobId" must be a valid UUID.');
+        }
+
+        if ($status !== null && (!is_string($status) || strtoupper($status) !== ApplicationStatus::WAITING->value)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" cannot be changed and must be "WAITING" when provided.');
+        }
+
+        $applicant = $this->applicantRepository->find($applicantId);
+        if ($applicant === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicantId".');
+        }
+
+        if ($applicant->getUser()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'The given applicant does not belong to the authenticated user.');
+        }
+
+        $job = $this->jobRepository->find($jobId);
+        if ($job === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "jobId".');
+        }
+
+        $application = (new Application())
+            ->setApplicant($applicant)
+            ->setJob($job)
+            ->setStatus(ApplicationStatus::WAITING);
+
+        $this->applicationRepository->save($application);
+
+        return new JsonResponse([
+            'id' => $application->getId(),
+            'status' => $application->getStatusValue(),
+        ], JsonResponse::HTTP_CREATED);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Resume/ResumeCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/ResumeCreateController.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Resume;
+
+use App\Recruit\Domain\Entity\Certification;
+use App\Recruit\Domain\Entity\Education;
+use App\Recruit\Domain\Entity\Experience;
+use App\Recruit\Domain\Entity\Hobby;
+use App\Recruit\Domain\Entity\Language;
+use App\Recruit\Domain\Entity\Project;
+use App\Recruit\Domain\Entity\Reference;
+use App\Recruit\Domain\Entity\Resume;
+use App\Recruit\Domain\Entity\Skill;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_array;
+use function is_string;
+use function trim;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Resume')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class ResumeCreateController
+{
+    public function __construct(
+        private readonly ResumeRepository $resumeRepository,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/resumes', methods: [Request::METHOD_POST])]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+
+        $resume = (new Resume())->setOwner($loggedInUser);
+
+        $this->hydrateSections($payload, 'experiences', static fn (): Experience => new Experience(), static fn (Resume $entity, Experience $item) => $entity->addExperience($item), $resume);
+        $this->hydrateSections($payload, 'educations', static fn (): Education => new Education(), static fn (Resume $entity, Education $item) => $entity->addEducation($item), $resume);
+        $this->hydrateSections($payload, 'skills', static fn (): Skill => new Skill(), static fn (Resume $entity, Skill $item) => $entity->addSkill($item), $resume);
+        $this->hydrateSections($payload, 'languages', static fn (): Language => new Language(), static fn (Resume $entity, Language $item) => $entity->addLanguage($item), $resume);
+        $this->hydrateSections($payload, 'certifications', static fn (): Certification => new Certification(), static fn (Resume $entity, Certification $item) => $entity->addCertification($item), $resume);
+        $this->hydrateSections($payload, 'projects', static fn (): Project => new Project(), static fn (Resume $entity, Project $item) => $entity->addProject($item), $resume);
+        $this->hydrateSections($payload, 'references', static fn (): Reference => new Reference(), static fn (Resume $entity, Reference $item) => $entity->addReference($item), $resume);
+        $this->hydrateSections($payload, 'hobbies', static fn (): Hobby => new Hobby(), static fn (Resume $entity, Hobby $item) => $entity->addHobby($item), $resume);
+
+        $this->resumeRepository->save($resume);
+
+        return new JsonResponse(['id' => $resume->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param callable(): object $factory
+     * @param callable(Resume, object): void $adder
+     */
+    private function hydrateSections(array $payload, string $field, callable $factory, callable $adder, Resume $resume): void
+    {
+        $sections = $payload[$field] ?? [];
+
+        if (!is_array($sections)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" must be an array.');
+        }
+
+        foreach ($sections as $index => $sectionData) {
+            if (!is_array($sectionData)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '[' . $index . ']" must be an object.');
+            }
+
+            $title = $sectionData['title'] ?? null;
+            $description = $sectionData['description'] ?? '';
+
+            if (!is_string($title) || trim($title) === '') {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '[' . $index . '].title" must be a non-empty string.');
+            }
+
+            if (!is_string($description)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '[' . $index . '].description" must be a string.');
+            }
+
+            $section = $factory();
+            $section->setTitle(trim($title));
+            $section->setDescription(trim($description));
+            $adder($resume, $section);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduire DTOs et ressources REST pour gérer les entités de recrutement `Resume`, `Applicant` et `Application` afin de permettre la création et la lecture via l’API.
- Offrir des mappings AutoMapper pour accepter les payloads HTTP et hydrater les DTOs depuis les requêtes.
- Exposer endpoints API V1 authentifiés pour créer `resume`, `applicant` et `application` en appliquant les règles de propriété et validation nécessaires.

### Description
- Ajout des DTOs sous `src/Recruit/Application/DTO/` pour `Resume` (avec `ResumeSection`), `Applicant` et `Application` et leurs variantes `Create`/`Update`/`Patch`.
- Ajout des resources REST `ResumeResource`, `ApplicantResource` et `ApplicationResource` sous `src/Recruit/Application/Resource/` pour l’intégration avec le mécanisme `RestResource` existant.
- Ajout des configurations AutoMapper et des `RequestMapper` correspondants sous `src/Recruit/Transport/AutoMapper/` pour `Resume`, `Applicant` et `Application` afin de définir les propriétés acceptées en entrée.
- Création des contrôleurs API V1 authentifiés et sécurisés : `POST /v1/recruit/resumes` (hydrate sections et fixe `owner` via `User $loggedInUser`), `POST /v1/recruit/applicants` (valide `resumeId`, vérifie propriété) et `POST /v1/recruit/applications` (valide `applicantId` et `jobId`, impose `status=WAITING` côté serveur et rejette les valeurs clientes incompatibles).
- Extension de l’entité domaine `Resume` avec getters et adders pour les collections de sections (`experiences`, `educations`, `skills`, `languages`, `certifications`, `projects`, `references`, `hobbies`) pour supporter l’hydratation côté contrôleur.

### Testing
- Exécuté des vérifications de syntaxe PHP (`php -l`) sur tous les nouveaux/fichiers modifiés et corrigé une erreur de syntaxe initiale dans le contrôleur de création de `Resume`; la vérification finale est passée avec succès.
- Vérification ciblée par fichier des contrôleurs créés (`php -l` sur les fichiers dans `src/Recruit/Transport/Controller/Api/V1/Resume`, `.../Applicant`, `.../Application`) réalisée avec succès.
- Aucun test unitaire/functional automatique supplémentaire n’a été ajouté dans cette PR, seules des validations statiques/parse-time ont été exécutées et terminées avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69accaa45cb48326b1641144f63535c5)