### PR TITLE
Add private recruit application management endpoints

### DIFF
--- a/src/Recruit/Application/Service/JobApplicationListService.php
+++ b/src/Recruit/Application/Service/JobApplicationListService.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Infrastructure\Repository\JobRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use function array_map;
+use function is_string;
+use function trim;
+
+class JobApplicationListService
+{
+    public function __construct(
+        private readonly JobRepository $jobRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getList(User $loggedInUser, ?string $jobId, ?string $jobSlug): array
+    {
+        $job = $this->resolveJob($jobId, $jobSlug);
+        $this->assertJobOwnership($job, $loggedInUser);
+
+        /** @var list<Application> $applications */
+        $applications = $this->entityManager
+            ->getRepository(Application::class)
+            ->createQueryBuilder('application')
+            ->innerJoin('application.applicant', 'applicant')->addSelect('applicant')
+            ->innerJoin('applicant.user', 'user')->addSelect('user')
+            ->leftJoin('applicant.resume', 'resume')->addSelect('resume')
+            ->andWhere('application.job = :job')
+            ->setParameter('job', $job)
+            ->orderBy('application.createdAt', 'DESC')
+            ->addOrderBy('application.id', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        return array_map(static function (Application $application): array {
+            $applicant = $application->getApplicant();
+            $applicantUser = $applicant->getUser();
+
+            return [
+                'id' => $application->getId(),
+                'status' => $application->getStatusValue(),
+                'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
+                'applicant' => [
+                    'id' => $applicant->getId(),
+                    'coverLetter' => $applicant->getCoverLetter(),
+                    'user' => [
+                        'id' => $applicantUser->getId(),
+                        'username' => $applicantUser->getUsername(),
+                        'firstName' => $applicantUser->getFirstName(),
+                        'lastName' => $applicantUser->getLastName(),
+                        'email' => $applicantUser->getEmail(),
+                    ],
+                    'resume' => [
+                        'id' => $applicant->getResume()->getId(),
+                    ],
+                ],
+            ];
+        }, $applications);
+    }
+
+    private function resolveJob(?string $jobId, ?string $jobSlug): Job
+    {
+        $cleanJobId = is_string($jobId) ? trim($jobId) : '';
+        $cleanJobSlug = is_string($jobSlug) ? trim($jobSlug) : '';
+
+        if ($cleanJobId === '' && $cleanJobSlug === '') {
+            throw new BadRequestHttpException('One of "jobId" or "jobSlug" query parameters must be provided.');
+        }
+
+        if ($cleanJobId !== '') {
+            $job = $this->jobRepository->find($cleanJobId);
+
+            if ($job instanceof Job) {
+                return $job;
+            }
+        }
+
+        if ($cleanJobSlug !== '') {
+            $job = $this->jobRepository->findOneBy([
+                'slug' => $cleanJobSlug,
+            ]);
+
+            if ($job instanceof Job) {
+                return $job;
+            }
+        }
+
+        throw new NotFoundHttpException('Job not found for the provided "jobId" or "jobSlug".');
+    }
+
+    private function assertJobOwnership(Job $job, User $loggedInUser): void
+    {
+        $ownerId = $job->getRecruit()?->getApplication()?->getUser()?->getId();
+
+        if ($ownerId === null || $ownerId !== $loggedInUser->getId()) {
+            throw new AccessDeniedHttpException('You are not allowed to access applications for this job.');
+        }
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Application;
+
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function array_key_exists;
+use function in_array;
+use function is_string;
+use function strtoupper;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Application')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class ApplicationStatusUpdateController
+{
+    public function __construct(private readonly ApplicationRepository $applicationRepository)
+    {
+    }
+
+    #[Route(path: '/v1/recruit/private/applications/{applicationId}/status', methods: [Request::METHOD_PATCH, Request::METHOD_PUT])]
+    #[OA\Patch(
+        summary: 'Modifie le statut d\'une candidature.',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['status'],
+                properties: [
+                    new OA\Property(property: 'status', type: 'string', enum: ['WAITING', 'REVIEWING', 'INTERVIEW', 'ACCEPTED', 'REJECTED']),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Statut de candidature mis à jour.'),
+            new OA\Response(response: 403, description: 'Vous n\'êtes pas propriétaire du job.'),
+        ],
+    )]
+    public function __invoke(string $applicationId, Request $request, User $loggedInUser): JsonResponse
+    {
+        $application = $this->applicationRepository->find($applicationId);
+
+        if ($application === null) {
+            throw new NotFoundHttpException('Application not found.');
+        }
+
+        $ownerId = $application->getJob()->getRecruit()?->getApplication()?->getUser()?->getId();
+        if ($ownerId === null || $ownerId !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You are not allowed to update the status for this application.');
+        }
+
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+        $status = $payload['status'] ?? null;
+
+        if (!is_string($status)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" must be provided as a string.');
+        }
+
+        $newStatus = ApplicationStatus::tryFrom(strtoupper($status));
+        if ($newStatus === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" must be one of: WAITING, REVIEWING, INTERVIEW, ACCEPTED, REJECTED.');
+        }
+
+        $currentStatus = $application->getStatus();
+        if ($newStatus !== $currentStatus && !$this->isAllowedTransition($currentStatus, $newStatus)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Status transition is not allowed for this application.');
+        }
+
+        $application->setStatus($newStatus);
+        $this->applicationRepository->save($application);
+
+        return new JsonResponse([
+            'id' => $application->getId(),
+            'status' => $application->getStatusValue(),
+        ]);
+    }
+
+    private function isAllowedTransition(ApplicationStatus $from, ApplicationStatus $to): bool
+    {
+        $allowedTransitions = [
+            ApplicationStatus::WAITING->value => [ApplicationStatus::REVIEWING->value, ApplicationStatus::REJECTED->value],
+            ApplicationStatus::REVIEWING->value => [ApplicationStatus::INTERVIEW->value, ApplicationStatus::ACCEPTED->value, ApplicationStatus::REJECTED->value],
+            ApplicationStatus::INTERVIEW->value => [ApplicationStatus::ACCEPTED->value, ApplicationStatus::REJECTED->value],
+            ApplicationStatus::ACCEPTED->value => [],
+            ApplicationStatus::REJECTED->value => [],
+        ];
+
+        if (!array_key_exists($from->value, $allowedTransitions)) {
+            return false;
+        }
+
+        return in_array($to->value, $allowedTransitions[$from->value], true);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Application/JobApplicationListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/JobApplicationListController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Application;
+
+use App\Recruit\Application\Service\JobApplicationListService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Application')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class JobApplicationListController
+{
+    public function __construct(private readonly JobApplicationListService $jobApplicationListService)
+    {
+    }
+
+    #[Route(path: '/v1/recruit/private/job-applications', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'Liste privée des candidatures d\'un job.',
+        parameters: [
+            new OA\Parameter(name: 'jobId', description: 'UUID du job', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'uuid')),
+            new OA\Parameter(name: 'jobSlug', description: 'Slug du job', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Liste des candidatures du job.'),
+            new OA\Response(response: 403, description: 'Vous n\'êtes pas propriétaire du job.'),
+        ],
+    )]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->jobApplicationListService->getList(
+            $loggedInUser,
+            $request->query->getString('jobId', ''),
+            $request->query->getString('jobSlug', ''),
+        ));
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide job owners with a private endpoint to list applications for a given job (by `jobId` or `jobSlug`) while ensuring only the owner (via `Job -> Recruit -> Application -> User`) can access them.
- Allow job owners to update an application's `status` through a secured PATCH/PUT endpoint with enum validation and controlled state transitions via `ApplicationStatus`.
- Keep API documentation consistent by adding OpenAPI annotations and return a clear 403 when a non-owner attempts access.

### Description
- Add `JobApplicationListService` (`src/Recruit/Application/Service/JobApplicationListService.php`) which resolves a `Job` by `jobId` or `jobSlug`, asserts ownership against the logged-in `User`, and returns applications with applicant user info and `resume.id`.
- Add `JobApplicationListController` (`src/Recruit/Transport/Controller/Api/V1/Application/JobApplicationListController.php`) exposing `GET /v1/recruit/private/job-applications` with OpenAPI params `jobId`/`jobSlug` and authenticated access.
- Add `ApplicationStatusUpdateController` (`src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php`) exposing `PATCH|PUT /v1/recruit/private/applications/{applicationId}/status`, enforcing authenticated access, owner-only updates (403), enum validation via `ApplicationStatus`, allowed-transition checks, and OpenAPI request/response annotations.

### Testing
- Ran PHP syntax checks with `php -l` for `JobApplicationListService.php`, `JobApplicationListController.php`, and `ApplicationStatusUpdateController.php`, which all reported no syntax errors.
- Attempted container lint with `php bin/console lint:container` which failed in this environment because project dependencies are not installed (suggests running `composer install`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acccb98cc08326848da5b53f5dabd7)