### PR TITLE
fix(recruit): assign and enforce ownerId on Recruit jobs

### DIFF
--- a/migrations/Version20260308183000.php
+++ b/migrations/Version20260308183000.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+/**
+ * Add owner relation to recruit_job.
+ */
+final class Version20260308183000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Add owner_id to recruit_job and backfill from recruit application owner.';
+    }
+
+    #[Override]
+    public function isTransactional(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("ALTER TABLE recruit_job ADD owner_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql('CREATE INDEX IDX_D76F4BDA7E3C61F9 ON recruit_job (owner_id)');
+
+        $this->addSql('UPDATE recruit_job job INNER JOIN recruit recruit ON recruit.id = job.recruit_id INNER JOIN platform_application application ON application.id = recruit.application_id SET job.owner_id = application.user_id WHERE job.owner_id IS NULL');
+
+        $this->addSql('ALTER TABLE recruit_job CHANGE owner_id owner_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)"');
+        $this->addSql('ALTER TABLE recruit_job ADD CONSTRAINT FK_D76F4BDA7E3C61F9 FOREIGN KEY (owner_id) REFERENCES user (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE recruit_job DROP FOREIGN KEY FK_D76F4BDA7E3C61F9');
+        $this->addSql('DROP INDEX IDX_D76F4BDA7E3C61F9 ON recruit_job');
+        $this->addSql('ALTER TABLE recruit_job DROP owner_id');
+    }
+}

--- a/src/Recruit/Application/Service/JobApplicationListService.php
+++ b/src/Recruit/Application/Service/JobApplicationListService.php
@@ -105,7 +105,7 @@ class JobApplicationListService
 
     private function assertJobOwnership(Job $job, User $loggedInUser): void
     {
-        $ownerId = $job->getRecruit()?->getApplication()?->getUser()?->getId();
+        $ownerId = $job->getOwner()?->getId();
 
         if ($ownerId === null || $ownerId !== $loggedInUser->getId()) {
             throw new AccessDeniedHttpException('You are not allowed to access applications for this job.');

--- a/src/Recruit/Application/Service/JobPublicListService.php
+++ b/src/Recruit/Application/Service/JobPublicListService.php
@@ -178,7 +178,7 @@ class JobPublicListService
             /** @var Job $job */
             foreach ($paginator as $job) {
                 $jobIds[] = $job->getId();
-                $ownerId = $job->getRecruit()?->getApplication()?->getUser()?->getId();
+                $ownerId = $job->getOwner()?->getId();
                 $jobPayload = [
                     'id' => $job->getId(),
                     'slug' => $job->getSlug(),

--- a/src/Recruit/Application/Service/MyJobListService.php
+++ b/src/Recruit/Application/Service/MyJobListService.php
@@ -27,9 +27,7 @@ class MyJobListService
         $createdJobs = $this->entityManager
             ->getRepository(Job::class)
             ->createQueryBuilder('job')
-            ->innerJoin('job.recruit', 'recruit')
-            ->innerJoin('recruit.application', 'platformApplication')
-            ->innerJoin('platformApplication.user', 'owner')
+            ->innerJoin('job.owner', 'owner')
             ->leftJoin('job.company', 'company')->addSelect('company')
             ->andWhere('owner = :owner')
             ->setParameter('owner', $loggedInUser->getId(), UuidBinaryOrderedTimeType::NAME)

--- a/src/Recruit/Domain/Entity/Job.php
+++ b/src/Recruit/Domain/Entity/Job.php
@@ -10,6 +10,7 @@ use App\General\Domain\Entity\Traits\Uuid;
 use App\Recruit\Domain\Enum\ContractType;
 use App\Recruit\Domain\Enum\Schedule;
 use App\Recruit\Domain\Enum\WorkMode;
+use App\User\Domain\Entity\User;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -44,6 +45,10 @@ class Job implements EntityInterface
     #[ORM\JoinColumn(name: 'recruit_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
     #[Groups(['Job', 'Job.recruit'])]
     private ?Recruit $recruit = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'owner_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?User $owner = null;
 
     #[ORM\Column(name: 'slug', type: Types::STRING, length: 255, options: ['default' => ''])]
     #[Groups(['Job', 'Job.slug'])]
@@ -146,6 +151,10 @@ class Job implements EntityInterface
     public function setTitle(string $title): self { $this->title = $title; return $this; }
     public function getRecruit(): ?Recruit { return $this->recruit; }
     public function setRecruit(?Recruit $recruit): self { $this->recruit = $recruit; return $this; }
+    public function getOwner(): ?User { return $this->owner; }
+    public function setOwner(?User $owner): self { $this->owner = $owner; return $this; }
+    #[Groups(['Job', 'Job.ownerId'])]
+    public function getOwnerId(): ?string { return $this->owner?->getId(); }
     public function getCompany(): ?Company { return $this->company; }
     public function setCompany(?Company $company): self { $this->company = $company; return $this; }
     public function getSalary(): ?Salary { return $this->salary; }

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitData.php
@@ -143,6 +143,7 @@ final class LoadRecruitData extends Fixture implements OrderedFixtureInterface
 
                 $job = (new Job())
                     ->setRecruit($recruit)
+                    ->setOwner($application->getUser())
                     ->setTitle($title)
                     ->setCompany($company)
                     ->setSalary($salary)

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
@@ -56,7 +56,7 @@ class ApplicationStatusUpdateController
             throw new NotFoundHttpException('Application not found.');
         }
 
-        $ownerId = $application->getJob()->getRecruit()?->getApplication()?->getUser()?->getId();
+        $ownerId = $application->getJob()->getOwner()?->getId();
         if ($ownerId === null || $ownerId !== $loggedInUser->getId()) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You are not allowed to update the status for this application.');
         }

--- a/src/Recruit/Transport/EventListener/RecruitEntityEventListener.php
+++ b/src/Recruit/Transport/EventListener/RecruitEntityEventListener.php
@@ -5,10 +5,16 @@ declare(strict_types=1);
 namespace App\Recruit\Transport\EventListener;
 
 use App\Recruit\Domain\Entity\Job;
+use App\User\Application\Security\UserTypeIdentification;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 
 class RecruitEntityEventListener
 {
+    public function __construct(
+        private readonly UserTypeIdentification $userTypeIdentification,
+    ) {
+    }
+
     public function prePersist(LifecycleEventArgs $event): void
     {
         $this->process($event);
@@ -24,6 +30,10 @@ class RecruitEntityEventListener
         $entity = $event->getObject();
 
         if ($entity instanceof Job) {
+            if ($entity->getOwner() === null) {
+                $entity->setOwner($this->userTypeIdentification->getUser());
+            }
+
             $entity->ensureGeneratedSlug();
         }
     }


### PR DESCRIPTION
### Motivation
- Jobs were inheriting ownership indirectly via `Recruit -> Application -> User`, which allowed any authenticated user to create jobs without an explicit per-job owner; ownership must be explicit and enforceable at entity and DB level.

### Description
- Add an explicit `owner` relation on `App\Recruit\Domain\Entity\Job` and expose `ownerId` via a serializer group (`Job.ownerId`).
- Auto-assign `Job.owner` from the authenticated user in `App\Recruit\Transport\EventListener\RecruitEntityEventListener` when the owner is missing.
- Replace indirect ownership checks with direct checks against `job->getOwner()` across job-related services/controllers (`JobApplicationListService`, `JobPublicListService`, `MyJobListService`, `ApplicationStatusUpdateController`).
- Update fixtures (`LoadRecruitData`) to set the job owner when creating seeded jobs and add a migration `Version20260308183000` that adds `recruit_job.owner_id`, backfills it from the recruit application owner, and enforces `NOT NULL` + foreign key.

### Testing
- Ran PHP syntax checks with `php -l` on all modified PHP files and the new migration and they reported no syntax errors.
- Verified the code compiles locally (syntax-only validation) for `src/Recruit/*` files and `migrations/Version20260308183000.php` with success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ace6c744e4832698953bab9981b87b)