### PR TITLE
Add endpoint to create recruit jobs from applicationId

### DIFF
--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Job;
+
+use App\Platform\Domain\Entity\Application as PlatformApplication;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Entity\Recruit;
+use App\Recruit\Domain\Enum\ContractType;
+use App\Recruit\Domain\Enum\Schedule;
+use App\Recruit\Domain\Enum\WorkMode;
+use App\Recruit\Infrastructure\Repository\JobRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_array;
+use function is_int;
+use function is_string;
+use function trim;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Job')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class JobCreateFromApplicationController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly JobRepository $jobRepository,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/jobs', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Crée un job en résolvant automatiquement le recruit via applicationId.')]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+
+        $applicationId = $payload['applicationId'] ?? null;
+        $title = $payload['title'] ?? null;
+
+        if (!is_string($applicationId) || !Uuid::isValid($applicationId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "applicationId" must be a valid UUID.');
+        }
+
+        if (!is_string($title) || trim($title) === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "title" is required and must be a non-empty string.');
+        }
+
+        $application = $this->entityManager->getRepository(PlatformApplication::class)->find($applicationId);
+        if (!$application instanceof PlatformApplication) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicationId".');
+        }
+
+        if ($application->getUser()?->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot create a job for this application.');
+        }
+
+        $recruit = $this->entityManager->getRepository(Recruit::class)->findOneBy([
+            'application' => $application,
+        ]);
+
+        if (!$recruit instanceof Recruit) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'No recruit found for the given "applicationId".');
+        }
+
+        $job = (new Job())
+            ->setRecruit($recruit)
+            ->setTitle(trim($title));
+
+        $this->applyOptionalFields($job, $payload);
+
+        $this->jobRepository->save($job);
+
+        return new JsonResponse([
+            'id' => $job->getId(),
+            'recruitId' => $recruit->getId(),
+            'slug' => $job->getSlug(),
+            'title' => $job->getTitle(),
+        ], JsonResponse::HTTP_CREATED);
+    }
+
+    /** @param array<string, mixed> $payload */
+    private function applyOptionalFields(Job $job, array $payload): void
+    {
+        $location = $payload['location'] ?? null;
+        if ($location !== null) {
+            if (!is_string($location)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "location" must be a string.');
+            }
+
+            $job->setLocation($location);
+        }
+
+        $summary = $payload['summary'] ?? null;
+        if ($summary !== null) {
+            if (!is_string($summary)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "summary" must be a string.');
+            }
+
+            $job->setSummary($summary);
+        }
+
+        $missionTitle = $payload['missionTitle'] ?? null;
+        if ($missionTitle !== null) {
+            if (!is_string($missionTitle)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "missionTitle" must be a string.');
+            }
+
+            $job->setMissionTitle($missionTitle);
+        }
+
+        $missionDescription = $payload['missionDescription'] ?? null;
+        if ($missionDescription !== null) {
+            if (!is_string($missionDescription)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "missionDescription" must be a string.');
+            }
+
+            $job->setMissionDescription($missionDescription);
+        }
+
+        $matchScore = $payload['matchScore'] ?? null;
+        if ($matchScore !== null) {
+            if (!is_int($matchScore)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "matchScore" must be an integer.');
+            }
+
+            $job->setMatchScore($matchScore);
+        }
+
+        $contractType = $payload['contractType'] ?? null;
+        if ($contractType !== null) {
+            if (!is_string($contractType) || ContractType::tryFrom($contractType) === null) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "contractType" has an invalid value.');
+            }
+
+            $job->setContractType($contractType);
+        }
+
+        $workMode = $payload['workMode'] ?? null;
+        if ($workMode !== null) {
+            if (!is_string($workMode) || WorkMode::tryFrom($workMode) === null) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "workMode" has an invalid value.');
+            }
+
+            $job->setWorkMode($workMode);
+        }
+
+        $schedule = $payload['schedule'] ?? null;
+        if ($schedule !== null) {
+            if (!is_string($schedule) || Schedule::tryFrom($schedule) === null) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "schedule" has an invalid value.');
+            }
+
+            $job->setSchedule($schedule);
+        }
+
+        $responsibilities = $payload['responsibilities'] ?? null;
+        if ($responsibilities !== null) {
+            if (!is_array($responsibilities)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "responsibilities" must be an array.');
+            }
+
+            $job->setResponsibilities($responsibilities);
+        }
+
+        $profile = $payload['profile'] ?? null;
+        if ($profile !== null) {
+            if (!is_array($profile)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "profile" must be an array.');
+            }
+
+            $job->setProfile($profile);
+        }
+
+        $benefits = $payload['benefits'] ?? null;
+        if ($benefits !== null) {
+            if (!is_array($benefits)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "benefits" must be an array.');
+            }
+
+            $job->setBenefits($benefits);
+        }
+    }
+}

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationControllerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Job;
+
+use App\General\Domain\Utils\JSON;
+use App\Platform\Domain\Entity\Application as PlatformApplication;
+use App\User\Domain\Entity\User;
+use App\Tests\TestCase\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class JobCreateFromApplicationControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/recruit/jobs';
+
+    /** @throws Throwable */
+    #[TestDox('Test that `POST /v1/recruit/jobs` creates a job from applicationId for the owner.')]
+    public function testThatCreateFromApplicationCreatesJob(): void
+    {
+        $applicationId = $this->getApplicationIdForUsername('john-root');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('POST', $this->baseUrl, content: JSON::encode([
+            'applicationId' => $applicationId,
+            'title' => 'Backend Engineer API',
+            'location' => 'Paris',
+            'contractType' => 'CDI',
+        ]));
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+        self::assertArrayHasKey('id', $payload);
+        self::assertArrayHasKey('recruitId', $payload);
+        self::assertArrayHasKey('slug', $payload);
+        self::assertSame('Backend Engineer API', $payload['title']);
+    }
+
+    /** @throws Throwable */
+    #[TestDox('Test that `POST /v1/recruit/jobs` returns forbidden if application is not owned by logged user.')]
+    public function testThatCreateFromApplicationRejectsForeignApplication(): void
+    {
+        $applicationId = $this->getApplicationIdForUsername('john-root');
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request('POST', $this->baseUrl, content: JSON::encode([
+            'applicationId' => $applicationId,
+            'title' => 'Should fail',
+        ]));
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $client->getResponse()->getStatusCode());
+    }
+
+    private function getApplicationIdForUsername(string $username): string
+    {
+        self::bootKernel();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $user = $entityManager->getRepository(User::class)->findOneBy([
+            'username' => $username,
+        ]);
+
+        self::assertInstanceOf(User::class, $user);
+
+        $application = $entityManager->getRepository(PlatformApplication::class)->findOneBy([
+            'user' => $user,
+            'title' => 'Recruit Lite App',
+        ]);
+
+        self::assertInstanceOf(PlatformApplication::class, $application);
+
+        return $application->getId();
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide an authenticated API that allows creating a `Job` by supplying an `applicationId`, resolving the corresponding `Recruit`, and ensuring the application belongs to the authenticated user.

### Description

- Added `JobCreateFromApplicationController` at `src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php` exposing `POST /v1/recruit/jobs` which validates `applicationId` and `title`, resolves the `Recruit`, checks ownership, creates the `Job`, and returns `201` with `id`, `recruitId`, `slug`, and `title`.
- The controller applies optional payload fields (`location`, `summary`, `missionTitle`, `missionDescription`, `matchScore`, `contractType`, `workMode`, `schedule`, `responsibilities`, `profile`, `benefits`) with explicit format and enum validations and returns `400` on invalid input.
- Persisting is done through the existing `JobRepository::save` and `EntityManager` lookups for `PlatformApplication` and `Recruit` are used to resolve relations.
- Added functional tests in `tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationControllerTest.php` covering successful creation by the owner and forbidden creation for a foreign application.

### Testing

- Syntax checks passed: `php -l src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php` and `php -l tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationControllerTest.php` both returned no syntax errors.
- Added PHPUnit functional tests for the new behavior located under `tests/Application/Recruit/...` but full `phpunit` run could not be executed in this environment because `bin/phpunit` / `vendor/bin/phpunit` are not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf22d414c832687a17ae8768fd904)