### PR TITLE
feat(recruit): add endpoint to list resumes of authenticated user

### DIFF
--- a/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListController.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Resume;
+
+use App\Recruit\Domain\Entity\Resume;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Resume')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class MyResumeListController
+{
+    public function __construct(private readonly ResumeRepository $resumeRepository)
+    {
+    }
+
+    #[Route(path: '/v1/recruit/private/me/resumes', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Retourne les CV du user connecté.')]
+    #[OA\Response(
+        response: 200,
+        description: 'List of resumes for the connected user',
+        content: new OA\JsonContent(
+            type: 'array',
+            items: new OA\Items(
+                type: 'object',
+                properties: [
+                    new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                    new OA\Property(property: 'documentUrl', type: 'string', nullable: true),
+                    new OA\Property(property: 'experiences', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'educations', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'skills', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'languages', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'certifications', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'projects', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'references', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'hobbies', type: 'array', items: new OA\Items(type: 'object')),
+                ],
+            ),
+        ),
+    )]
+    #[OA\Response(response: 401, description: 'Authentication required')]
+    public function __invoke(User $loggedInUser): JsonResponse
+    {
+        $resumes = $this->resumeRepository->findBy(['owner' => $loggedInUser], ['createdAt' => 'DESC']);
+
+        return new JsonResponse(array_map([$this, 'normalizeResume'], $resumes));
+    }
+
+    /** @return array<string, mixed> */
+    private function normalizeResume(Resume $resume): array
+    {
+        return [
+            'id' => $resume->getId(),
+            'documentUrl' => $resume->getDocumentUrl(),
+            'experiences' => $this->normalizeSections($resume->getExperiences()->toArray()),
+            'educations' => $this->normalizeSections($resume->getEducations()->toArray()),
+            'skills' => $this->normalizeSections($resume->getSkills()->toArray()),
+            'languages' => $this->normalizeSections($resume->getLanguages()->toArray()),
+            'certifications' => $this->normalizeSections($resume->getCertifications()->toArray()),
+            'projects' => $this->normalizeSections($resume->getProjects()->toArray()),
+            'references' => $this->normalizeSections($resume->getReferences()->toArray()),
+            'hobbies' => $this->normalizeSections($resume->getHobbies()->toArray()),
+        ];
+    }
+
+    /**
+     * @param array<int, object> $sections
+     *
+     * @return array<int, array<string, string>>
+     */
+    private function normalizeSections(array $sections): array
+    {
+        return array_map(
+            static fn (object $section): array => [
+                'id' => $section->getId(),
+                'title' => $section->getTitle(),
+                'description' => $section->getDescription(),
+            ],
+            $sections,
+        );
+    }
+}

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListControllerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Resume;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class MyResumeListControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/recruit/private/me/resumes';
+
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/recruit/private/me/resumes` requires authentication.')]
+    public function testThatMyResumeListRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', $this->baseUrl);
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
+    }
+
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/recruit/private/me/resumes` returns only connected user resumes.')]
+    public function testThatMyResumeListReturnsOnlyConnectedUserResumes(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', $this->baseUrl);
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+
+        self::assertIsArray($payload);
+        self::assertCount(1, $payload);
+
+        $resume = $payload[0];
+        self::assertArrayHasKey('id', $resume);
+        self::assertArrayHasKey('documentUrl', $resume);
+
+        foreach (['experiences', 'educations', 'skills', 'languages', 'certifications', 'projects', 'references', 'hobbies'] as $field) {
+            self::assertArrayHasKey($field, $resume);
+            self::assertIsArray($resume[$field]);
+            self::assertNotEmpty($resume[$field]);
+
+            self::assertArrayHasKey('id', $resume[$field][0]);
+            self::assertArrayHasKey('title', $resume[$field][0]);
+            self::assertArrayHasKey('description', $resume[$field][0]);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an authenticated API endpoint to let a connected user retrieve their own resumes. 
- Ensure resumes are returned with all sections and the uploaded `documentUrl` so clients can render full CV data.

### Description
- Added `MyResumeListController` in `src/Recruit/Transport/Controller/Api/V1/Resume/` exposing `GET /v1/recruit/private/me/resumes` protected by `IS_AUTHENTICATED_FULLY` and accepting the logged `User` as an argument. 
- Controller queries resumes with `ResumeRepository::findBy(['owner' => $loggedInUser], ['createdAt' => 'DESC'])` and returns a JSON array of resumes. 
- Implemented response normalization via private methods `normalizeResume` and `normalizeSections` to include `id`, `documentUrl` and all resume sections (`experiences`, `educations`, `skills`, `languages`, `certifications`, `projects`, `references`, `hobbies`). 
- Added integration tests in `tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListControllerTest.php` that assert authentication is required and that the endpoint returns the expected payload structure for the connected user.

### Testing
- Ran `php -l` syntax checks on `src/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListController.php` which passed. 
- Ran `php -l` syntax checks on `tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListControllerTest.php` which passed. 
- Attempted to run `vendor/bin/phpunit` for the new tests but the test runner is not available in this environment (`vendor/bin/phpunit` missing), so the PHPUnit integration tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acffbf2224832693d81b706ad9745b)