### PR TITLE
Add authenticated Resume management endpoints (list, patch, delete) with tests

### DIFF
--- a/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumeDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumeDeleteController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Resume;
+
+use App\Recruit\Domain\Entity\Resume;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Resume')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class MyResumeDeleteController
+{
+    public function __construct(private readonly ResumeRepository $resumeRepository)
+    {
+    }
+
+    #[Route(path: '/v1/recruit/private/me/resumes/{resumeId}', methods: [Request::METHOD_DELETE])]
+    #[OA\Delete(summary: 'Supprime un CV appartenant au user connecté.')]
+    public function __invoke(string $resumeId, User $loggedInUser): JsonResponse
+    {
+        if (!Uuid::isValid($resumeId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Route "resumeId" must be a valid UUID.');
+        }
+
+        $resume = $this->resumeRepository->find($resumeId);
+        if (!$resume instanceof Resume) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resume not found.');
+        }
+
+        if ($resume->getOwner()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot delete this resume.');
+        }
+
+        $this->resumeRepository->remove($resume);
+
+        return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListController.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Resume;
+
+use App\Recruit\Domain\Entity\Resume;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Resume')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class MyResumeListController
+{
+    public function __construct(private readonly ResumeRepository $resumeRepository)
+    {
+    }
+
+    #[Route(path: '/v1/recruit/private/me/resumes', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Retourne les CV du user connecté.')]
+    #[OA\Response(
+        response: 200,
+        description: 'List of resumes for the connected user',
+        content: new OA\JsonContent(
+            type: 'array',
+            items: new OA\Items(
+                type: 'object',
+                properties: [
+                    new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                    new OA\Property(property: 'documentUrl', type: 'string', nullable: true),
+                    new OA\Property(property: 'experiences', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'educations', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'skills', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'languages', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'certifications', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'projects', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'references', type: 'array', items: new OA\Items(type: 'object')),
+                    new OA\Property(property: 'hobbies', type: 'array', items: new OA\Items(type: 'object')),
+                ],
+            ),
+        ),
+    )]
+    #[OA\Response(response: 401, description: 'Authentication required')]
+    public function __invoke(User $loggedInUser): JsonResponse
+    {
+        $resumes = $this->resumeRepository->findBy(['owner' => $loggedInUser], ['createdAt' => 'DESC']);
+
+        return new JsonResponse(array_map([$this, 'normalizeResume'], $resumes));
+    }
+
+    /** @return array<string, mixed> */
+    private function normalizeResume(Resume $resume): array
+    {
+        return [
+            'id' => $resume->getId(),
+            'documentUrl' => $resume->getDocumentUrl(),
+            'experiences' => $this->normalizeSections($resume->getExperiences()->toArray()),
+            'educations' => $this->normalizeSections($resume->getEducations()->toArray()),
+            'skills' => $this->normalizeSections($resume->getSkills()->toArray()),
+            'languages' => $this->normalizeSections($resume->getLanguages()->toArray()),
+            'certifications' => $this->normalizeSections($resume->getCertifications()->toArray()),
+            'projects' => $this->normalizeSections($resume->getProjects()->toArray()),
+            'references' => $this->normalizeSections($resume->getReferences()->toArray()),
+            'hobbies' => $this->normalizeSections($resume->getHobbies()->toArray()),
+        ];
+    }
+
+    /**
+     * @param array<int, object> $sections
+     *
+     * @return array<int, array<string, string>>
+     */
+    private function normalizeSections(array $sections): array
+    {
+        return array_map(
+            static fn (object $section): array => [
+                'id' => $section->getId(),
+                'title' => $section->getTitle(),
+                'description' => $section->getDescription(),
+            ],
+            $sections,
+        );
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumePatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumePatchController.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Resume;
+
+use App\Recruit\Domain\Entity\Certification;
+use App\Recruit\Domain\Entity\Education;
+use App\Recruit\Domain\Entity\Experience;
+use App\Recruit\Domain\Entity\Hobby;
+use App\Recruit\Domain\Entity\Language;
+use App\Recruit\Domain\Entity\Project;
+use App\Recruit\Domain\Entity\Reference;
+use App\Recruit\Domain\Entity\Resume;
+use App\Recruit\Domain\Entity\Skill;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function array_key_exists;
+use function is_array;
+use function is_string;
+use function trim;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Resume')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class MyResumePatchController
+{
+    public function __construct(
+        private readonly ResumeRepository $resumeRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/private/me/resumes/{resumeId}', methods: [Request::METHOD_PATCH])]
+    #[OA\Patch(summary: 'Met à jour un CV appartenant au user connecté.')]
+    public function __invoke(string $resumeId, Request $request, User $loggedInUser): JsonResponse
+    {
+        if (!Uuid::isValid($resumeId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Route "resumeId" must be a valid UUID.');
+        }
+
+        $resume = $this->resumeRepository->find($resumeId);
+        if (!$resume instanceof Resume) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resume not found.');
+        }
+
+        if ($resume->getOwner()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot update this resume.');
+        }
+
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+
+        if (is_array($payload['experiences'] ?? null)) {
+            $this->replaceSections($resume->getExperiences()->toArray(), $payload['experiences'], static fn (): Experience => new Experience(), static function (Resume $item, Experience $section): void { $item->addExperience($section); }, $resume);
+        }
+
+        if (is_array($payload['educations'] ?? null)) {
+            $this->replaceSections($resume->getEducations()->toArray(), $payload['educations'], static fn (): Education => new Education(), static function (Resume $item, Education $section): void { $item->addEducation($section); }, $resume);
+        }
+
+        if (is_array($payload['skills'] ?? null)) {
+            $this->replaceSections($resume->getSkills()->toArray(), $payload['skills'], static fn (): Skill => new Skill(), static function (Resume $item, Skill $section): void { $item->addSkill($section); }, $resume);
+        }
+
+        if (is_array($payload['languages'] ?? null)) {
+            $this->replaceSections($resume->getLanguages()->toArray(), $payload['languages'], static fn (): Language => new Language(), static function (Resume $item, Language $section): void { $item->addLanguage($section); }, $resume);
+        }
+
+        if (is_array($payload['certifications'] ?? null)) {
+            $this->replaceSections($resume->getCertifications()->toArray(), $payload['certifications'], static fn (): Certification => new Certification(), static function (Resume $item, Certification $section): void { $item->addCertification($section); }, $resume);
+        }
+
+        if (is_array($payload['projects'] ?? null)) {
+            $this->replaceSections($resume->getProjects()->toArray(), $payload['projects'], static fn (): Project => new Project(), static function (Resume $item, Project $section): void { $item->addProject($section); }, $resume);
+        }
+
+        if (is_array($payload['references'] ?? null)) {
+            $this->replaceSections($resume->getReferences()->toArray(), $payload['references'], static fn (): Reference => new Reference(), static function (Resume $item, Reference $section): void { $item->addReference($section); }, $resume);
+        }
+
+        if (is_array($payload['hobbies'] ?? null)) {
+            $this->replaceSections($resume->getHobbies()->toArray(), $payload['hobbies'], static fn (): Hobby => new Hobby(), static function (Resume $item, Hobby $section): void { $item->addHobby($section); }, $resume);
+        }
+
+        if (array_key_exists('documentUrl', $payload)) {
+            $documentUrl = $payload['documentUrl'];
+
+            if ($documentUrl !== null && !is_string($documentUrl)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "documentUrl" must be a string or null.');
+            }
+
+            $resume->setDocumentUrl($documentUrl !== null ? trim($documentUrl) : null);
+        }
+
+        $this->resumeRepository->save($resume);
+
+        return new JsonResponse([
+            'id' => $resume->getId(),
+            'documentUrl' => $resume->getDocumentUrl(),
+        ]);
+    }
+
+    /**
+     * @param array<int, object> $existing
+     * @param array<int, mixed> $input
+     * @param callable(): object $factory
+     * @param callable(Resume, object): void $adder
+     */
+    private function replaceSections(array $existing, array $input, callable $factory, callable $adder, Resume $resume): void
+    {
+        foreach ($existing as $section) {
+            $this->entityManager->remove($section);
+        }
+
+        foreach ($input as $index => $item) {
+            if (!is_array($item)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Section at index ' . $index . ' must be an object.');
+            }
+
+            $title = $item['title'] ?? null;
+            $description = $item['description'] ?? '';
+
+            if (!is_string($title) || trim($title) === '') {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "title" must be a non-empty string.');
+            }
+
+            if (!is_string($description)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "description" must be a string.');
+            }
+
+            $section = $factory();
+            $section->setTitle(trim($title));
+            $section->setDescription(trim($description));
+            $adder($resume, $section);
+        }
+    }
+}

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListControllerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Resume;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class MyResumeListControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/recruit/private/me/resumes';
+
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/recruit/private/me/resumes` requires authentication.')]
+    public function testThatMyResumeListRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', $this->baseUrl);
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
+    }
+
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/recruit/private/me/resumes` returns only connected user resumes.')]
+    public function testThatMyResumeListReturnsOnlyConnectedUserResumes(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', $this->baseUrl);
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+
+        self::assertIsArray($payload);
+        self::assertCount(1, $payload);
+
+        $resume = $payload[0];
+        self::assertArrayHasKey('id', $resume);
+        self::assertArrayHasKey('documentUrl', $resume);
+
+        foreach (['experiences', 'educations', 'skills', 'languages', 'certifications', 'projects', 'references', 'hobbies'] as $field) {
+            self::assertArrayHasKey($field, $resume);
+            self::assertIsArray($resume[$field]);
+            self::assertNotEmpty($resume[$field]);
+
+            self::assertArrayHasKey('id', $resume[$field][0]);
+            self::assertArrayHasKey('title', $resume[$field][0]);
+            self::assertArrayHasKey('description', $resume[$field][0]);
+        }
+    }
+}

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumePatchDeleteControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumePatchDeleteControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Resume;
+
+use App\General\Domain\Utils\JSON;
+use App\Recruit\Domain\Entity\Resume;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class MyResumePatchDeleteControllerTest extends WebTestCase
+{
+    /** @throws Throwable */
+    #[TestDox('Test that PATCH /v1/recruit/private/me/resumes/{resumeId} updates connected user resume.')]
+    public function testThatPatchMyResumeUpdatesResume(): void
+    {
+        $resumeId = $this->getResumeIdForUsername('john-root');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('PATCH', self::API_URL_PREFIX . '/v1/recruit/private/me/resumes/' . $resumeId, content: JSON::encode([
+            'documentUrl' => 'https://localhost/uploads/resumes/updated.pdf',
+            'experiences' => [
+                ['title' => 'Staff Engineer', 'description' => 'Architecture API'],
+            ],
+        ]));
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+        self::assertSame('https://localhost/uploads/resumes/updated.pdf', $payload['documentUrl']);
+
+        self::bootKernel();
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $resume = $entityManager->getRepository(Resume::class)->find($resumeId);
+        self::assertInstanceOf(Resume::class, $resume);
+        self::assertSame('https://localhost/uploads/resumes/updated.pdf', $resume->getDocumentUrl());
+        self::assertCount(1, $resume->getExperiences());
+        self::assertSame('Staff Engineer', $resume->getExperiences()->first()->getTitle());
+    }
+
+    /** @throws Throwable */
+    #[TestDox('Test that PATCH /v1/recruit/private/me/resumes/{resumeId} forbids foreign user.')]
+    public function testThatPatchMyResumeRejectsForeignUser(): void
+    {
+        $resumeId = $this->getResumeIdForUsername('john-root');
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request('PATCH', self::API_URL_PREFIX . '/v1/recruit/private/me/resumes/' . $resumeId, content: JSON::encode([
+            'documentUrl' => 'https://localhost/uploads/resumes/should-fail.pdf',
+        ]));
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $client->getResponse()->getStatusCode());
+    }
+
+    /** @throws Throwable */
+    #[TestDox('Test that DELETE /v1/recruit/private/me/resumes/{resumeId} deletes connected user resume.')]
+    public function testThatDeleteMyResumeDeletesResume(): void
+    {
+        $resumeId = $this->getResumeIdForUsername('john-api');
+
+        $client = $this->getTestClient('john-api', 'password-api');
+        $client->request('DELETE', self::API_URL_PREFIX . '/v1/recruit/private/me/resumes/' . $resumeId);
+
+        self::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+
+        self::bootKernel();
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $deletedResume = $entityManager->getRepository(Resume::class)->find($resumeId);
+        self::assertNull($deletedResume);
+    }
+
+    /** @return non-empty-string */
+    private function getResumeIdForUsername(string $username): string
+    {
+        self::bootKernel();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
+        self::assertInstanceOf(User::class, $user);
+
+        $resume = $entityManager->getRepository(Resume::class)->findOneBy(['owner' => $user]);
+        self::assertInstanceOf(Resume::class, $resume);
+
+        return $resume->getId();
+    }
+}


### PR DESCRIPTION
### Motivation

- Expose API endpoints so authenticated users can list, update and delete their own resumes via the Recruit v1 private API. 

### Description

- Add `MyResumeListController` to return the connected user resumes with a normalized payload and OpenAPI annotations. 
- Add `MyResumePatchController` to update a resume owned by the connected user, replace section collections (experiences, educations, skills, languages, certifications, projects, references, hobbies) using an `EntityManagerInterface`, validate input and update `documentUrl`. 
- Add `MyResumeDeleteController` to delete a resume owned by the connected user with UUID validation and ownership checks. 
- Add integration tests `MyResumeListControllerTest` and `MyResumePatchDeleteControllerTest` covering authentication, listing, patch update behavior, ownership rejection and deletion. 

### Testing

- Ran the new tests `tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListControllerTest` and `tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumePatchDeleteControllerTest` and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acffbf2224832693d81b706ad9745b)