### PR TITLE
feat(recruit): add public job detail endpoint with indexed similar jobs and hourly cron

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,9 +346,10 @@ migrate: ## Runs all migrations for main/test databases
 	@make exec cmd="php bin/console doctrine:migrations:migrate --no-interaction"
 	@make exec cmd="php bin/console doctrine:migrations:migrate --no-interaction --env=test"
 
-migrate-cron-jobs: ## Creates cron job tasks (cleanup logs, failed old messenger messages)
+migrate-cron-jobs: ## Creates cron job tasks (cleanup logs, failed old messenger messages, recruit similar jobs indexing)
 	@make exec cmd="php bin/console scheduler:cleanup-logs"
 	@make exec cmd="php bin/console scheduler:cleanup-messenger-messages"
+	@make exec cmd="php bin/console scheduler:recruit-index-similar-jobs"
 
 fixtures: ## Runs all fixtures for test database without --append option (tables will be dropped and recreated)
 	@make exec cmd="php bin/console doctrine:fixtures:load --env=test --no-interaction"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -76,7 +76,7 @@ make logs-kibana                        # Shows logs from the kibana container. 
 make drop-migrate                       # Drops databases and runs all migrations for the main/test databases
 make migrate                            # Runs all migrations for the main/test databases
 make migrate-no-test                    # Runs all migrations for the main database
-make migrate-cron-jobs                  # Creates cron job tasks (cleanup logs, failed old messenger messages)
+make migrate-cron-jobs                  # Creates cron job tasks (cleanup logs, failed old messenger messages, recruit similar jobs indexing)
 
 make fixtures                           # Runs all fixtures for test database without --append option (tables will be dropped and recreated)
 

--- a/docs/recruit.md
+++ b/docs/recruit.md
@@ -163,6 +163,19 @@ curl -X GET "http://localhost/api/v1/recruit/public/my-app/jobs?company=Acme&wor
   -H "Accept: application/json"
 ```
 
+### 2.2 Détail public d'un job (+ jobs similaires)
+`GET /v1/recruit/public/{applicationSlug}/jobs/{jobSlug}`
+
+Retourne:
+- `job`: détail d'une offre
+- `similarJobs`: liste des jobs similaires (indexés via Elasticsearch)
+
+Exemple:
+```bash
+curl -X GET "http://localhost/api/v1/recruit/public/my-app/jobs/backend-engineer-m-w-d-symfony-api-platform" \
+  -H "Accept: application/json"
+```
+
 ### 2.2 Liste privée des jobs d'une application
 `GET /v1/recruit/private/{applicationSlug}/jobs`
 

--- a/src/Recruit/Application/Service/JobPublicDetailService.php
+++ b/src/Recruit/Application/Service/JobPublicDetailService.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\Platform\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Entity\Recruit;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
+
+use function array_map;
+use function count;
+use function in_array;
+use function is_array;
+use function is_string;
+
+class JobPublicDetailService
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+    }
+
+    /** @return array<string, mixed> */
+    public function getDetail(string $applicationSlug, string $jobSlug): array
+    {
+        $application = $this->entityManager->getRepository(Application::class)->findOneBy([
+            'slug' => $applicationSlug,
+        ]);
+
+        if (!$application instanceof Application) {
+            throw new NotFoundHttpException('Application not found.');
+        }
+
+        $recruit = $this->entityManager->getRepository(Recruit::class)->findOneBy([
+            'application' => $application,
+        ]);
+
+        if (!$recruit instanceof Recruit) {
+            throw new NotFoundHttpException('Recruit not found for this application.');
+        }
+
+        $job = $this->entityManager->getRepository(Job::class)->findOneBy([
+            'recruit' => $recruit,
+            'slug' => $jobSlug,
+        ]);
+
+        if (!$job instanceof Job) {
+            throw new NotFoundHttpException('Job not found.');
+        }
+
+        $similarJobIds = $this->getSimilarJobIds($job->getId());
+        $similarJobs = $this->getSimilarJobs($recruit, $similarJobIds);
+
+        return [
+            'job' => $this->buildJobPayload($job),
+            'similarJobs' => $similarJobs,
+        ];
+    }
+
+    /** @return list<string> */
+    private function getSimilarJobIds(string $jobId): array
+    {
+        try {
+            $response = $this->elasticsearchService->search(
+                JobSimilarIndexerService::INDEX_NAME,
+                [
+                    'query' => [
+                        'ids' => [
+                            'values' => [$jobId],
+                        ],
+                    ],
+                    '_source' => ['similarJobIds'],
+                ],
+                0,
+                1,
+            );
+
+            if (!is_array($response) || !is_array($response['hits']['hits'] ?? null) || ($response['hits']['hits'] ?? []) === []) {
+                return [];
+            }
+
+            $first = $response['hits']['hits'][0] ?? null;
+            if (!is_array($first) || !is_array($first['_source']['similarJobIds'] ?? null)) {
+                return [];
+            }
+
+            /** @var list<string> $ids */
+            $ids = array_values(array_filter($first['_source']['similarJobIds'], static fn (mixed $id): bool => is_string($id) && $id !== ''));
+
+            return $ids;
+        } catch (Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @param list<string> $similarJobIds
+     * @return list<array<string, mixed>>
+     */
+    private function getSimilarJobs(Recruit $recruit, array $similarJobIds): array
+    {
+        if ($similarJobIds === []) {
+            return [];
+        }
+
+        /** @var list<Job> $jobs */
+        $jobs = $this->entityManager->getRepository(Job::class)
+            ->createQueryBuilder('job')
+            ->leftJoin('job.company', 'company')->addSelect('company')
+            ->leftJoin('job.salary', 'salary')->addSelect('salary')
+            ->leftJoin('job.badges', 'badge')->addSelect('badge')
+            ->leftJoin('job.tags', 'tag')->addSelect('tag')
+            ->andWhere('job.recruit = :recruit')
+            ->andWhere('job.id IN (:ids)')
+            ->setParameter('recruit', $recruit)
+            ->setParameter('ids', $similarJobIds)
+            ->getQuery()
+            ->getResult();
+
+        usort($jobs, static function (Job $left, Job $right) use ($similarJobIds): int {
+            $leftIndex = array_search($left->getId(), $similarJobIds, true);
+            $rightIndex = array_search($right->getId(), $similarJobIds, true);
+
+            return ($leftIndex === false ? count($similarJobIds) : $leftIndex) <=> ($rightIndex === false ? count($similarJobIds) : $rightIndex);
+        });
+
+        return array_map(fn (Job $item): array => $this->buildJobPayload($item), array_values(array_filter($jobs, static fn (Job $item): bool => in_array($item->getId(), $similarJobIds, true))));
+    }
+
+    /** @return array<string, mixed> */
+    private function buildJobPayload(Job $job): array
+    {
+        return [
+            'id' => $job->getId(),
+            'slug' => $job->getSlug(),
+            'title' => $job->getTitle(),
+            'company' => [
+                'name' => $job->getCompany()?->getName() ?? '',
+                'logo' => $job->getCompany()?->getLogo() ?? '',
+                'sector' => $job->getCompany()?->getSector() ?? '',
+                'size' => $job->getCompany()?->getSize() ?? '',
+            ],
+            'location' => $job->getLocation(),
+            'contractType' => $job->getContractTypeValue(),
+            'workMode' => $job->getWorkModeValue(),
+            'schedule' => $job->getScheduleValue(),
+            'salary' => [
+                'min' => $job->getSalary()?->getMin() ?? 0,
+                'max' => $job->getSalary()?->getMax() ?? 0,
+                'currency' => $job->getSalary()?->getCurrency() ?? 'EUR',
+                'period' => $job->getSalary()?->getPeriod() ?? 'year',
+            ],
+            'summary' => $job->getSummary(),
+            'matchScore' => $job->getMatchScore(),
+            'badges' => array_map(static fn ($badge): string => $badge->getLabel(), $job->getBadges()->toArray()),
+            'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $job->getTags()->toArray()),
+            'missionTitle' => $job->getMissionTitle(),
+            'missionDescription' => $job->getMissionDescription(),
+            'responsibilities' => $job->getResponsibilities(),
+            'profile' => $job->getProfile(),
+            'benefits' => $job->getBenefits(),
+        ];
+    }
+}

--- a/src/Recruit/Application/Service/JobSimilarIndexerService.php
+++ b/src/Recruit/Application/Service/JobSimilarIndexerService.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\Recruit\Domain\Entity\Job;
+use Doctrine\ORM\EntityManagerInterface;
+
+use function array_count_values;
+use function array_filter;
+use function array_keys;
+use function array_map;
+use function array_slice;
+use function array_values;
+use function implode;
+use function is_string;
+use function mb_strtolower;
+use function preg_replace;
+use function str_contains;
+use function trim;
+
+class JobSimilarIndexerService
+{
+    final public const string INDEX_NAME = 'recruit_job_similar';
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+    }
+
+    public function reindexAll(): int
+    {
+        /** @var list<Job> $jobs */
+        $jobs = $this->entityManager->getRepository(Job::class)
+            ->createQueryBuilder('job')
+            ->leftJoin('job.tags', 'tag')->addSelect('tag')
+            ->leftJoin('job.recruit', 'recruit')->addSelect('recruit')
+            ->getQuery()
+            ->getResult();
+
+        foreach ($jobs as $job) {
+            $scores = [];
+
+            foreach ($jobs as $candidate) {
+                if ($candidate->getId() === $job->getId()) {
+                    continue;
+                }
+
+                if ($candidate->getRecruit()?->getId() !== $job->getRecruit()?->getId()) {
+                    continue;
+                }
+
+                $score = $this->computeScore($job, $candidate);
+                if ($score <= 0.0) {
+                    continue;
+                }
+
+                $scores[] = [
+                    'id' => $candidate->getId(),
+                    'score' => $score,
+                ];
+            }
+
+            usort($scores, static fn (array $a, array $b): int => $b['score'] <=> $a['score']);
+
+            $similarJobIds = array_values(array_map(
+                static fn (array $item): string => (string) $item['id'],
+                array_slice($scores, 0, 3),
+            ));
+
+            $this->elasticsearchService->index(self::INDEX_NAME, $job->getId(), [
+                'jobId' => $job->getId(),
+                'similarJobIds' => $similarJobIds,
+                'updatedAt' => (new \DateTimeImmutable())->format(DATE_ATOM),
+            ]);
+        }
+
+        return count($jobs);
+    }
+
+    private function computeScore(Job $job, Job $candidate): float
+    {
+        $score = 0.0;
+
+        $score += 5 * $this->tokenOverlap($job->getTitle(), $candidate->getTitle());
+        $score += 3 * $this->tokenOverlap($job->getMissionTitle(), $candidate->getMissionTitle());
+        $score += 3 * $this->tokenOverlap($job->getSummary(), $candidate->getSummary());
+        $score += 3 * $this->tokenOverlap($job->getMissionDescription(), $candidate->getMissionDescription());
+
+        $jobResponsibilities = $this->tokenize(implode(' ', array_map(static fn (mixed $value): string => is_string($value) ? $value : '', $job->getResponsibilities())));
+        $candidateResponsibilities = $this->tokenize(implode(' ', array_map(static fn (mixed $value): string => is_string($value) ? $value : '', $candidate->getResponsibilities())));
+        $score += 4 * $this->overlapBetweenTokenLists($jobResponsibilities, $candidateResponsibilities);
+
+        $jobProfile = $this->tokenize(implode(' ', array_map(static fn (mixed $value): string => is_string($value) ? $value : '', $job->getProfile())));
+        $candidateProfile = $this->tokenize(implode(' ', array_map(static fn (mixed $value): string => is_string($value) ? $value : '', $candidate->getProfile())));
+        $score += 4 * $this->overlapBetweenTokenLists($jobProfile, $candidateProfile);
+
+        $jobTags = array_map(static fn ($tag): string => mb_strtolower($tag->getLabel()), $job->getTags()->toArray());
+        $candidateTags = array_map(static fn ($tag): string => mb_strtolower($tag->getLabel()), $candidate->getTags()->toArray());
+        $score += 2 * $this->overlapBetweenTokenLists($jobTags, $candidateTags);
+
+        return $score;
+    }
+
+    private function tokenOverlap(string $left, string $right): float
+    {
+        return $this->overlapBetweenTokenLists($this->tokenize($left), $this->tokenize($right));
+    }
+
+    /**
+     * @param list<string> $left
+     * @param list<string> $right
+     */
+    private function overlapBetweenTokenLists(array $left, array $right): float
+    {
+        if ($left === [] || $right === []) {
+            return 0.0;
+        }
+
+        $leftIndex = array_count_values($left);
+        $rightIndex = array_count_values($right);
+
+        $common = 0;
+        $total = 0;
+
+        $keys = array_keys($leftIndex + $rightIndex);
+        foreach ($keys as $token) {
+            $leftCount = (int) ($leftIndex[$token] ?? 0);
+            $rightCount = (int) ($rightIndex[$token] ?? 0);
+            $common += min($leftCount, $rightCount);
+            $total += max($leftCount, $rightCount);
+        }
+
+        if ($total === 0) {
+            return 0.0;
+        }
+
+        return $common / $total;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function tokenize(string $text): array
+    {
+        $normalized = mb_strtolower(trim($text));
+        if ($normalized === '') {
+            return [];
+        }
+
+        $normalized = (string) preg_replace('/[^\p{L}\p{N}\s]+/u', ' ', $normalized);
+        $parts = preg_split('/\s+/u', $normalized) ?: [];
+
+        return array_values(array_filter($parts, static fn (mixed $part): bool => is_string($part) && $part !== '' && !str_contains($part, '\n')));
+    }
+}

--- a/src/Recruit/Transport/Command/Scheduler/IndexSimilarJobsScheduledCommand.php
+++ b/src/Recruit/Transport/Command/Scheduler/IndexSimilarJobsScheduledCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Command\Scheduler;
+
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Recruit\Transport\Command\Utils\IndexSimilarJobsCommand;
+use App\Tool\Application\Service\Scheduler\Interfaces\ScheduledCommandServiceInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Commande pour créer un cron job horaire d\'indexation des jobs similaires.',
+)]
+class IndexSimilarJobsScheduledCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'scheduler:recruit-index-similar-jobs';
+
+    public function __construct(
+        private readonly ScheduledCommandServiceInterface $scheduledCommandService,
+    ) {
+        parent::__construct();
+    }
+
+    /** @throws Throwable */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = $this->getSymfonyStyle($input, $output);
+        $message = $this->createScheduledCommand();
+
+        if ($input->isInteractive()) {
+            $io->success($message);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /** @throws Throwable */
+    private function createScheduledCommand(): string
+    {
+        $entity = $this->scheduledCommandService->findByCommand(IndexSimilarJobsCommand::NAME);
+
+        if ($entity !== null) {
+            return "The job RecruitIndexSimilarJobs is already present [id='{$entity->getId()}'] - have a nice day";
+        }
+
+        $this->scheduledCommandService->create(
+            'Index top 3 similar jobs for each recruit job',
+            IndexSimilarJobsCommand::NAME,
+            '0 * * * *',
+            '/recruit-index-similar-jobs.log'
+        );
+
+        return 'The job RecruitIndexSimilarJobs is created - have a nice day';
+    }
+}

--- a/src/Recruit/Transport/Command/Utils/IndexSimilarJobsCommand.php
+++ b/src/Recruit/Transport/Command/Utils/IndexSimilarJobsCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Command\Utils;
+
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Recruit\Application\Service\JobSimilarIndexerService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Indexe les 3 jobs les plus proches pour chaque job dans Elasticsearch.',
+)]
+class IndexSimilarJobsCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'recruit:jobs:index-similar';
+
+    public function __construct(private readonly JobSimilarIndexerService $jobSimilarIndexerService)
+    {
+        parent::__construct();
+    }
+
+    /** @throws Throwable */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = $this->getSymfonyStyle($input, $output);
+        $jobsCount = $this->jobSimilarIndexerService->reindexAll();
+
+        if ($input->isInteractive()) {
+            $io->success('Similar jobs indexed for ' . $jobsCount . ' jobs.');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Job;
+
+use App\Recruit\Application\Service\JobPublicDetailService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Job')]
+class PublicJobDetailController
+{
+    public function __construct(private readonly JobPublicDetailService $jobPublicDetailService)
+    {
+    }
+
+    #[Route(path: '/v1/recruit/public/{applicationSlug}/jobs/{jobSlug}', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'Détail public d\'un job avec jobs similaires indexés.',
+        security: [],
+        parameters: [
+            new OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'jobSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+    )]
+    public function __invoke(string $applicationSlug, string $jobSlug): JsonResponse
+    {
+        return new JsonResponse($this->jobPublicDetailService->getDetail($applicationSlug, $jobSlug));
+    }
+}

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Job;
+
+use App\General\Domain\Utils\JSON;
+use App\Platform\Domain\Entity\Application as PlatformApplication;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Entity\Recruit;
+use App\Tests\TestCase\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+class PublicJobDetailControllerTest extends WebTestCase
+{
+    #[TestDox('Test that GET /v1/recruit/public/{applicationSlug}/jobs/{jobSlug} returns job detail and similar jobs list.')]
+    public function testThatPublicJobDetailReturnsJobAndSimilarJobsList(): void
+    {
+        [$applicationSlug, $jobSlug] = $this->getApplicationSlugAndJobSlug();
+
+        $client = $this->getTestClient();
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/public/' . $applicationSlug . '/jobs/' . $jobSlug);
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+
+        self::assertArrayHasKey('job', $payload);
+        self::assertArrayHasKey('similarJobs', $payload);
+        self::assertSame($jobSlug, $payload['job']['slug'] ?? null);
+        self::assertIsArray($payload['similarJobs']);
+    }
+
+    /** @return array{0: string, 1: string} */
+    private function getApplicationSlugAndJobSlug(): array
+    {
+        self::bootKernel();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $application = $entityManager->getRepository(PlatformApplication::class)->findOneBy([
+            'title' => 'Recruit Lite App',
+        ]);
+        self::assertInstanceOf(PlatformApplication::class, $application);
+
+        $recruit = $entityManager->getRepository(Recruit::class)->findOneBy([
+            'application' => $application,
+        ]);
+        self::assertInstanceOf(Recruit::class, $recruit);
+
+        $job = $entityManager->getRepository(Job::class)->findOneBy([
+            'recruit' => $recruit,
+        ]);
+        self::assertInstanceOf(Job::class, $job);
+
+        return [$application->getSlug(), $job->getSlug()];
+    }
+}


### PR DESCRIPTION
### Motivation
- Fournir un endpoint `GET /v1/recruit/public/{applicationSlug}/jobs/{jobSlug}` qui retourne le job demandé accompagné d'une liste de jobs similaires pré-calculés pour améliorer l'expérience de navigation et de découverte.
- Calculer et stocker périodiquement (horaire) les 3 jobs les plus proches par offre afin de permettre des requêtes rapides via Elasticsearch au moment de l'appel de l'endpoint.
- Intégrer l'indexation dans la surface d'administration/cron existante pour automatiser la création du job planifié.

### Description
- Ajout du contrôleur `PublicJobDetailController` exposant `GET /v1/recruit/public/{applicationSlug}/jobs/{jobSlug}` qui délègue au service `JobPublicDetailService` et renvoie `{ job, similarJobs }`.
- Ajout du service `JobPublicDetailService` qui résout `application -> recruit -> job`, récupère les `similarJobIds` depuis l'index Elasticsearch `recruit_job_similar` et hydrate les jobs similaires depuis la base de données.
- Ajout du service `JobSimilarIndexerService` qui calcule un score de similarité (pondérations sur `title`, `missionTitle`, `summary`, `missionDescription`, recoupements `responsibilities`, `profile` et `tags`) et indexe les `3` meilleurs candidats par job dans Elasticsearch.
- Ajout de la commande console `recruit:jobs:index-similar` pour lancer l'indexation complète et de la commande scheduler `scheduler:recruit-index-similar-jobs` qui crée un cron horaire `0 * * * *` pour automatiser l'indexation.
- Mise à jour de `Makefile` et de la documentation (`docs/commands.md`, `docs/recruit.md`) pour inclure la création du cron et la description du nouvel endpoint.
- Ajout d'un test fonctionnel `tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailControllerTest.php` vérifiant la forme de la réponse (`job` + `similarJobs`).

### Testing
- Syntaxe PHP vérifiée avec `php -l` sur tous les nouveaux/fichiers modifiés et sans erreur détectée ✅.
- Test fonctionnel ciblé ajouté (`tests/.../PublicJobDetailControllerTest.php`) et syntaxiquement valide ; l'exécution de `phpunit` n'a pas été possible dans cet environnement car les dépendances sous `vendor/` ne sont pas installées (erreur: `./vendor/bin/phpunit: No such file or directory`) ⚠️.
- Les nouveaux fichiers de commande et de service ont été contrôlés localement pour l'absence d'erreurs de parsing (`php -l`) avant inclusion dans la PR ✅.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad09d9fc4c8326a7a5638d77a93d3f)