### PR TITLE
feat(calendar): add Calendar and Event entities, DTOs, repositories and migration

### DIFF
--- a/migrations/Version20260308210000.php
+++ b/migrations/Version20260308210000.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260308210000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Create calendar and calendar_event tables.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('CREATE TABLE calendar (id BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid_binary_ordered_time)\', user_id BINARY(16) DEFAULT NULL, title VARCHAR(255) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX IDX_FC84F7D8A76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE calendar_event (id BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid_binary_ordered_time)\', user_id BINARY(16) DEFAULT NULL, calendar_id BINARY(16) DEFAULT NULL, title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, start_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', end_at DATETIME NOT NULL COMMENT \'(DC2Type:datetime_immutable)\', status VARCHAR(25) NOT NULL DEFAULT \'confirmed\', visibility VARCHAR(25) NOT NULL DEFAULT \'private\', created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX idx_calendar_event_start_at (start_at), INDEX idx_calendar_event_end_at (end_at), INDEX idx_calendar_event_status (status), INDEX idx_calendar_event_visibility (visibility), INDEX idx_calendar_event_user_id (user_id), INDEX idx_calendar_event_calendar_id (calendar_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE calendar ADD CONSTRAINT FK_FC84F7D8A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE calendar_event ADD CONSTRAINT FK_E72A1268A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE calendar_event ADD CONSTRAINT FK_E72A1268A40BC2D5 FOREIGN KEY (calendar_id) REFERENCES calendar (id) ON DELETE SET NULL');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE calendar_event DROP FOREIGN KEY FK_E72A1268A76ED395');
+        $this->addSql('ALTER TABLE calendar_event DROP FOREIGN KEY FK_E72A1268A40BC2D5');
+        $this->addSql('ALTER TABLE calendar DROP FOREIGN KEY FK_FC84F7D8A76ED395');
+        $this->addSql('DROP TABLE calendar_event');
+        $this->addSql('DROP TABLE calendar');
+    }
+}

--- a/src/Calendar/Application/DTO/Calendar/Calendar.php
+++ b/src/Calendar/Application/DTO/Calendar/Calendar.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Application\DTO\Calendar;
+
+use App\Calendar\Domain\Entity\Calendar as Entity;
+use App\General\Application\DTO\RestDto;
+use App\General\Application\Validator\Constraints as AppAssert;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\User\Domain\Entity\User;
+use Override;
+
+class Calendar extends RestDto
+{
+    #[AppAssert\EntityReferenceExists(entityClass: User::class)]
+    protected ?User $user = null;
+
+    protected string $title = '';
+
+    public function getUser(): ?User { return $this->user; }
+    public function setUser(?User $user): self { $this->setVisited('user'); $this->user = $user; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->setVisited('title'); $this->title = $title; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->user = $entity->getUser();
+            $this->title = $entity->getTitle();
+        }
+
+        return $this;
+    }
+}

--- a/src/Calendar/Application/DTO/Calendar/CalendarCreate.php
+++ b/src/Calendar/Application/DTO/Calendar/CalendarCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Application\DTO\Calendar;
+
+class CalendarCreate extends Calendar
+{
+}

--- a/src/Calendar/Application/DTO/Calendar/CalendarPatch.php
+++ b/src/Calendar/Application/DTO/Calendar/CalendarPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Application\DTO\Calendar;
+
+class CalendarPatch extends Calendar
+{
+}

--- a/src/Calendar/Application/DTO/Calendar/CalendarUpdate.php
+++ b/src/Calendar/Application/DTO/Calendar/CalendarUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Application\DTO\Calendar;
+
+class CalendarUpdate extends Calendar
+{
+}

--- a/src/Calendar/Application/DTO/Event/Event.php
+++ b/src/Calendar/Application/DTO/Event/Event.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Application\DTO\Event;
+
+use App\Calendar\Domain\Entity\Calendar;
+use App\Calendar\Domain\Entity\Event as Entity;
+use App\Calendar\Domain\Enum\EventStatus;
+use App\Calendar\Domain\Enum\EventVisibility;
+use App\General\Application\DTO\RestDto;
+use App\General\Application\Validator\Constraints as AppAssert;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use Override;
+
+class Event extends RestDto
+{
+    #[AppAssert\EntityReferenceExists(entityClass: User::class)]
+    protected ?User $user = null;
+
+    #[AppAssert\EntityReferenceExists(entityClass: Calendar::class)]
+    protected ?Calendar $calendar = null;
+
+    protected string $title = '';
+    protected string $description = '';
+    protected DateTimeImmutable $startAt;
+    protected DateTimeImmutable $endAt;
+    protected string $status = EventStatus::CONFIRMED->value;
+    protected string $visibility = EventVisibility::PRIVATE->value;
+
+    public function __construct()
+    {
+        $this->startAt = new DateTimeImmutable();
+        $this->endAt = $this->startAt;
+    }
+
+    public function getUser(): ?User { return $this->user; }
+    public function setUser(?User $user): self { $this->setVisited('user'); $this->user = $user; return $this; }
+    public function getCalendar(): ?Calendar { return $this->calendar; }
+    public function setCalendar(?Calendar $calendar): self { $this->setVisited('calendar'); $this->calendar = $calendar; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->setVisited('title'); $this->title = $title; return $this; }
+    public function getDescription(): string { return $this->description; }
+    public function setDescription(string $description): self { $this->setVisited('description'); $this->description = $description; return $this; }
+    public function getStartAt(): DateTimeImmutable { return $this->startAt; }
+    public function setStartAt(DateTimeImmutable $startAt): self { $this->setVisited('startAt'); $this->startAt = $startAt; return $this; }
+    public function getEndAt(): DateTimeImmutable { return $this->endAt; }
+    public function setEndAt(DateTimeImmutable $endAt): self { $this->setVisited('endAt'); $this->endAt = $endAt; return $this; }
+    public function getStatus(): string { return $this->status; }
+    public function setStatus(string $status): self { $this->setVisited('status'); $this->status = $status; return $this; }
+    public function getVisibility(): string { return $this->visibility; }
+    public function setVisibility(string $visibility): self { $this->setVisited('visibility'); $this->visibility = $visibility; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->user = $entity->getUser();
+            $this->calendar = $entity->getCalendar();
+            $this->title = $entity->getTitle();
+            $this->description = $entity->getDescription();
+            $this->startAt = $entity->getStartAt();
+            $this->endAt = $entity->getEndAt();
+            $this->status = $entity->getStatusValue();
+            $this->visibility = $entity->getVisibilityValue();
+        }
+
+        return $this;
+    }
+}

--- a/src/Calendar/Application/DTO/Event/EventCreate.php
+++ b/src/Calendar/Application/DTO/Event/EventCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Application\DTO\Event;
+
+class EventCreate extends Event
+{
+}

--- a/src/Calendar/Application/DTO/Event/EventPatch.php
+++ b/src/Calendar/Application/DTO/Event/EventPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Application\DTO\Event;
+
+class EventPatch extends Event
+{
+}

--- a/src/Calendar/Application/DTO/Event/EventUpdate.php
+++ b/src/Calendar/Application/DTO/Event/EventUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Application\DTO\Event;
+
+class EventUpdate extends Event
+{
+}

--- a/src/Calendar/Domain/Entity/Calendar.php
+++ b/src/Calendar/Domain/Entity/Calendar.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Throwable;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'calendar')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Calendar implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['Calendar', 'Calendar.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
+    #[Groups(['Calendar', 'Calendar.title'])]
+    private string $title = '';
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['Calendar', 'Calendar.user'])]
+    private ?User $user = null;
+
+    /** @var Collection<int, Event>|ArrayCollection<int, Event> */
+    #[ORM\OneToMany(targetEntity: Event::class, mappedBy: 'calendar')]
+    #[Groups(['Calendar', 'Calendar.events'])]
+    private Collection|ArrayCollection $events;
+
+    /**
+     * @throws Throwable
+     */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->events = new ArrayCollection();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /** @return Collection<int, Event>|ArrayCollection<int, Event> */
+    public function getEvents(): Collection|ArrayCollection
+    {
+        return $this->events;
+    }
+
+    public function addEvent(Event $event): self
+    {
+        if (!$this->events->contains($event)) {
+            $this->events->add($event);
+            $event->setCalendar($this);
+        }
+
+        return $this;
+    }
+
+    public function removeEvent(Event $event): self
+    {
+        if ($this->events->removeElement($event) && $event->getCalendar() === $this) {
+            $event->setCalendar(null);
+        }
+
+        return $this;
+    }
+}

--- a/src/Calendar/Domain/Entity/Event.php
+++ b/src/Calendar/Domain/Entity/Event.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Domain\Entity;
+
+use App\Calendar\Domain\Enum\EventStatus;
+use App\Calendar\Domain\Enum\EventVisibility;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Throwable;
+
+#[ORM\Entity]
+#[ORM\Table(
+    name: 'calendar_event',
+    indexes: [
+        new ORM\Index(name: 'idx_calendar_event_start_at', columns: ['start_at']),
+        new ORM\Index(name: 'idx_calendar_event_end_at', columns: ['end_at']),
+        new ORM\Index(name: 'idx_calendar_event_status', columns: ['status']),
+        new ORM\Index(name: 'idx_calendar_event_visibility', columns: ['visibility']),
+        new ORM\Index(name: 'idx_calendar_event_user_id', columns: ['user_id']),
+        new ORM\Index(name: 'idx_calendar_event_calendar_id', columns: ['calendar_id']),
+    ]
+)]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Event implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['Event', 'Event.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
+    #[Groups(['Event', 'Event.title'])]
+    private string $title = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, options: ['default' => ''])]
+    #[Groups(['Event', 'Event.description'])]
+    private string $description = '';
+
+    #[ORM\Column(name: 'start_at', type: Types::DATETIME_IMMUTABLE)]
+    #[Groups(['Event', 'Event.startAt'])]
+    private DateTimeImmutable $startAt;
+
+    #[ORM\Column(name: 'end_at', type: Types::DATETIME_IMMUTABLE)]
+    #[Groups(['Event', 'Event.endAt'])]
+    private DateTimeImmutable $endAt;
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 25, enumType: EventStatus::class, options: ['default' => EventStatus::CONFIRMED->value])]
+    #[Groups(['Event', 'Event.status'])]
+    private EventStatus $status = EventStatus::CONFIRMED;
+
+    #[ORM\Column(name: 'visibility', type: Types::STRING, length: 25, enumType: EventVisibility::class, options: ['default' => EventVisibility::PRIVATE->value])]
+    #[Groups(['Event', 'Event.visibility'])]
+    private EventVisibility $visibility = EventVisibility::PRIVATE;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['Event', 'Event.user'])]
+    private ?User $user = null;
+
+    #[ORM\ManyToOne(targetEntity: Calendar::class, inversedBy: 'events')]
+    #[ORM\JoinColumn(name: 'calendar_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    #[Groups(['Event', 'Event.calendar'])]
+    private ?Calendar $calendar = null;
+
+    /**
+     * @throws Throwable
+     */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->startAt = new DateTimeImmutable();
+        $this->endAt = $this->startAt;
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getDescription(): string { return $this->description; }
+    public function setDescription(string $description): self { $this->description = $description; return $this; }
+    public function getStartAt(): DateTimeImmutable { return $this->startAt; }
+    public function setStartAt(DateTimeImmutable $startAt): self { $this->startAt = $startAt; return $this; }
+    public function getEndAt(): DateTimeImmutable { return $this->endAt; }
+    public function setEndAt(DateTimeImmutable $endAt): self { $this->endAt = $endAt; return $this; }
+    public function getStatus(): EventStatus { return $this->status; }
+    public function getStatusValue(): string { return $this->status->value; }
+    public function setStatus(EventStatus|string $status): self { $this->status = $status instanceof EventStatus ? $status : EventStatus::from($status); return $this; }
+    public function getVisibility(): EventVisibility { return $this->visibility; }
+    public function getVisibilityValue(): string { return $this->visibility->value; }
+    public function setVisibility(EventVisibility|string $visibility): self { $this->visibility = $visibility instanceof EventVisibility ? $visibility : EventVisibility::from($visibility); return $this; }
+    public function getUser(): ?User { return $this->user; }
+    public function setUser(?User $user): self { $this->user = $user; return $this; }
+    public function getCalendar(): ?Calendar { return $this->calendar; }
+    public function setCalendar(?Calendar $calendar): self { $this->calendar = $calendar; return $this; }
+}

--- a/src/Calendar/Domain/Enum/EventStatus.php
+++ b/src/Calendar/Domain/Enum/EventStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Domain\Enum;
+
+enum EventStatus: string
+{
+    case TENTATIVE = 'tentative';
+    case CONFIRMED = 'confirmed';
+    case CANCELLED = 'cancelled';
+}

--- a/src/Calendar/Domain/Enum/EventVisibility.php
+++ b/src/Calendar/Domain/Enum/EventVisibility.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Domain\Enum;
+
+enum EventVisibility: string
+{
+    case PRIVATE = 'private';
+    case PUBLIC = 'public';
+}

--- a/src/Calendar/Domain/Repository/Interfaces/CalendarRepositoryInterface.php
+++ b/src/Calendar/Domain/Repository/Interfaces/CalendarRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Domain\Repository\Interfaces;
+
+interface CalendarRepositoryInterface
+{
+}

--- a/src/Calendar/Domain/Repository/Interfaces/EventRepositoryInterface.php
+++ b/src/Calendar/Domain/Repository/Interfaces/EventRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Domain\Repository\Interfaces;
+
+interface EventRepositoryInterface
+{
+}

--- a/src/Calendar/Infrastructure/Repository/CalendarRepository.php
+++ b/src/Calendar/Infrastructure/Repository/CalendarRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Infrastructure\Repository;
+
+use App\Calendar\Domain\Entity\Calendar as Entity;
+use App\Calendar\Domain\Repository\Interfaces\CalendarRepositoryInterface;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class CalendarRepository extends BaseRepository implements CalendarRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+        'title',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Calendar/Infrastructure/Repository/EventRepository.php
+++ b/src/Calendar/Infrastructure/Repository/EventRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Infrastructure\Repository;
+
+use App\Calendar\Domain\Entity\Event as Entity;
+use App\Calendar\Domain\Repository\Interfaces\EventRepositoryInterface;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class EventRepository extends BaseRepository implements EventRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+        'title',
+        'description',
+        'status',
+        'visibility',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce a calendar domain to store user-owned or shared calendars and timeboxed events with status/visibility semantics for REST exposure and querying.
- Keep the existing architecture patterns (UUIDs, timestampable traits, repository interfaces, DTOs) to integrate cleanly with current services and migrations.

### Description

- Add `Calendar` entity at `src/Calendar/Domain/Entity/Calendar.php` with UUID id, timestamp traits, optional owner `User` (`user_id` nullable, `ON DELETE SET NULL`), `title`, and a `OneToMany` relation to `Event`.
- Add `Event` entity at `src/Calendar/Domain/Entity/Event.php` with fields `title`, `description`, `start_at`, `end_at`, `status`, `visibility`, nullable `ManyToOne` to `App\User\Domain\Entity\User` (`user_id`, `SET NULL`) and nullable `ManyToOne` to `Calendar` (`calendar_id`, `SET NULL`), plus Doctrine indexes on `start_at`, `end_at`, `status`, `visibility`, `user_id`, `calendar_id`.
- Add domain enums `EventStatus` and `EventVisibility` under `src/Calendar/Domain/Enum` and repository interfaces + infra repositories following project patterns under `src/Calendar/Domain/Repository/Interfaces` and `src/Calendar/Infrastructure/Repository`.
- Add REST DTOs for `Calendar` and `Event` including `Create/Update/Patch` variants under `src/Calendar/Application/DTO/*` with entity loading support and entity reference validators.
- Add Doctrine migration `migrations/Version20260308210000.php` creating `calendar` and `calendar_event` tables with requested FK constraints and indexes.

### Testing

- Run syntax checks with `php -l` on `src/Calendar/Domain/Entity/Calendar.php`, `src/Calendar/Domain/Entity/Event.php`, `src/Calendar/Application/DTO/Event/Event.php` and `migrations/Version20260308210000.php`, all returned "No syntax errors detected".
- Attempted `php bin/console doctrine:schema:validate --skip-sync` which failed in this environment due to missing Composer dependencies and therefore could not validate the schema end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adaaf0fc788326807bfbb63ad26c99)