### PR TITLE
feat(chat): add chat context entities, migration, and idempotent conversation creation

### DIFF
--- a/migrations/Version20260308223000.php
+++ b/migrations/Version20260308223000.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260308223000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Create chat and conversation tables with chat context relation.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('CREATE TABLE chat (id BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid_binary_ordered_time)\', application_id BINARY(16) NOT NULL, application_slug VARCHAR(100) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX idx_chat_application_slug (application_slug), INDEX IDX_5A9A02C5E030ACD (application_id), UNIQUE INDEX uq_chat_application_slug (application_slug), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE conversation (id BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid_binary_ordered_time)\', chat_id BINARY(16) NOT NULL, application_slug VARCHAR(100) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX idx_conversation_chat_id (chat_id), INDEX idx_conversation_application_slug (application_slug), UNIQUE INDEX uq_conversation_chat_application_slug (chat_id, application_slug), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE chat ADD CONSTRAINT FK_5A9A02C5E030ACD FOREIGN KEY (application_id) REFERENCES recruit_application (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE conversation ADD CONSTRAINT FK_8E7927C9117A0B0B FOREIGN KEY (chat_id) REFERENCES chat (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE conversation DROP FOREIGN KEY FK_8E7927C9117A0B0B');
+        $this->addSql('ALTER TABLE chat DROP FOREIGN KEY FK_5A9A02C5E030ACD');
+        $this->addSql('DROP TABLE conversation');
+        $this->addSql('DROP TABLE chat');
+    }
+}

--- a/src/Chat/Application/Service/ConversationCreatorService.php
+++ b/src/Chat/Application/Service/ConversationCreatorService.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Application\Service;
+
+use App\Chat\Domain\Entity\Chat;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Repository\Interfaces\ConversationRepositoryInterface;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+
+class ConversationCreatorService
+{
+    public function __construct(
+        private readonly ConversationRepositoryInterface $conversationRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function getOrCreate(Chat $chat, string $applicationSlug): Conversation
+    {
+        $conversation = $this->conversationRepository->findOneByChatAndApplicationSlug($chat, $applicationSlug);
+        if ($conversation instanceof Conversation) {
+            return $conversation;
+        }
+
+        $conversation = (new Conversation())
+            ->setChat($chat)
+            ->setApplicationSlug($applicationSlug);
+
+        try {
+            $this->entityManager->persist($conversation);
+            $this->entityManager->flush();
+
+            return $conversation;
+        } catch (UniqueConstraintViolationException) {
+            $conversation = $this->conversationRepository->findOneByChatAndApplicationSlug($chat, $applicationSlug);
+            if ($conversation instanceof Conversation) {
+                return $conversation;
+            }
+
+            throw new \RuntimeException('Unable to create an idempotent conversation.');
+        }
+    }
+}

--- a/src/Chat/Domain/Entity/Chat.php
+++ b/src/Chat/Domain/Entity/Chat.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Recruit\Domain\Entity\Application;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'chat')]
+#[ORM\UniqueConstraint(name: 'uq_chat_application_slug', columns: ['application_slug'])]
+#[ORM\Index(name: 'idx_chat_application_slug', columns: ['application_slug'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Chat implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Application::class)]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Application $application;
+
+    #[ORM\Column(name: 'application_slug', type: 'string', length: 100)]
+    private string $applicationSlug;
+
+    /**
+     * @var Collection<int, Conversation>
+     */
+    #[ORM\OneToMany(targetEntity: Conversation::class, mappedBy: 'chat')]
+    private Collection $conversations;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->conversations = new ArrayCollection();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getApplication(): Application
+    {
+        return $this->application;
+    }
+
+    public function setApplication(Application $application): self
+    {
+        $this->application = $application;
+
+        return $this;
+    }
+
+    public function getApplicationSlug(): string
+    {
+        return $this->applicationSlug;
+    }
+
+    public function setApplicationSlug(string $applicationSlug): self
+    {
+        $this->applicationSlug = $applicationSlug;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Conversation>
+     */
+    public function getConversations(): Collection
+    {
+        return $this->conversations;
+    }
+}

--- a/src/Chat/Domain/Entity/Conversation.php
+++ b/src/Chat/Domain/Entity/Conversation.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'conversation')]
+#[ORM\UniqueConstraint(name: 'uq_conversation_chat_application_slug', columns: ['chat_id', 'application_slug'])]
+#[ORM\Index(name: 'idx_conversation_chat_id', columns: ['chat_id'])]
+#[ORM\Index(name: 'idx_conversation_application_slug', columns: ['application_slug'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Conversation implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Chat::class, inversedBy: 'conversations')]
+    #[ORM\JoinColumn(name: 'chat_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Chat $chat;
+
+    #[ORM\Column(name: 'application_slug', type: 'string', length: 100)]
+    private string $applicationSlug;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getChat(): Chat
+    {
+        return $this->chat;
+    }
+
+    public function setChat(Chat $chat): self
+    {
+        $this->chat = $chat;
+
+        return $this;
+    }
+
+    public function getApplicationSlug(): string
+    {
+        return $this->applicationSlug;
+    }
+
+    public function setApplicationSlug(string $applicationSlug): self
+    {
+        $this->applicationSlug = $applicationSlug;
+
+        return $this;
+    }
+}

--- a/src/Chat/Domain/Repository/Interfaces/ChatRepositoryInterface.php
+++ b/src/Chat/Domain/Repository/Interfaces/ChatRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Domain\Repository\Interfaces;
+
+interface ChatRepositoryInterface
+{
+}

--- a/src/Chat/Domain/Repository/Interfaces/ConversationRepositoryInterface.php
+++ b/src/Chat/Domain/Repository/Interfaces/ConversationRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Domain\Repository\Interfaces;
+
+use App\Chat\Domain\Entity\Chat;
+use App\Chat\Domain\Entity\Conversation;
+
+interface ConversationRepositoryInterface
+{
+    public function findOneByChatAndApplicationSlug(Chat $chat, string $applicationSlug): ?Conversation;
+}

--- a/src/Chat/Infrastructure/Repository/ChatRepository.php
+++ b/src/Chat/Infrastructure/Repository/ChatRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Infrastructure\Repository;
+
+use App\Chat\Domain\Entity\Chat as Entity;
+use App\Chat\Domain\Repository\Interfaces\ChatRepositoryInterface;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ChatRepository extends BaseRepository implements ChatRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+        'applicationSlug',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Chat/Infrastructure/Repository/ConversationRepository.php
+++ b/src/Chat/Infrastructure/Repository/ConversationRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Infrastructure\Repository;
+
+use App\Chat\Domain\Entity\Chat;
+use App\Chat\Domain\Entity\Conversation as Entity;
+use App\Chat\Domain\Repository\Interfaces\ConversationRepositoryInterface;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ConversationRepository extends BaseRepository implements ConversationRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+        'applicationSlug',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+
+    public function findOneByChatAndApplicationSlug(Chat $chat, string $applicationSlug): ?Entity
+    {
+        /** @var Entity|null $conversation */
+        $conversation = $this->findOneBy([
+            'chat' => $chat,
+            'applicationSlug' => $applicationSlug,
+        ]);
+
+        return $conversation;
+    }
+}


### PR DESCRIPTION
### Motivation
- Add a `Chat` domain entity to model a chat context tied to an existing `Recruit\Application` and store an application-level slug for direct lookups.
- Ensure `Conversation` objects are always created in the context of a `Chat` (non-null `chat_id`) and provide a business context (`applicationSlug`) to enable deterministic lookups.
- Prevent duplicate conversations per chat+application context and make creation idempotent even under concurrent requests.

### Description
- Added `src/Chat/Domain/Entity/Chat.php` implementing UUID/timestamps, a non-null `ManyToOne` relation to `Recruit\Application`, an `applicationSlug` field, and a `OneToMany` collection of `Conversation` entities.
- Added `src/Chat/Domain/Entity/Conversation.php` with UUID/timestamps, a non-null `ManyToOne` `chat` relation (`chat_id`), and an indexed `applicationSlug` with a unique constraint on `(chat_id, application_slug)`.
- Added repository interfaces and implementations under `src/Chat/Domain/Repository/Interfaces` and `src/Chat/Infrastructure/Repository`, including `ConversationRepository::findOneByChatAndApplicationSlug(...)` and a `ChatRepository` with appropriate search columns.
- Implemented `src/Chat/Application/Service/ConversationCreatorService.php` exposing `getOrCreate(Chat $chat, string $applicationSlug)` which first queries for an existing conversation and otherwise attempts to persist a new one while handling `UniqueConstraintViolationException` to provide idempotent creation.
- Added Doctrine migration `migrations/Version20260308223000.php` to create `chat` and `conversation` tables, add indexes, unique constraints, and foreign keys (`chat.application_id -> recruit_application.id` and `conversation.chat_id -> chat.id`).

### Testing
- Ran syntax checks with `php -l` on all added files (`Chat.php`, `Conversation.php`, repository files, `ConversationCreatorService.php`, and the migration) and they reported no syntax errors.
- Attempted to run `php bin/console doctrine:migrations:diff --no-interaction` but it failed due to missing project dependencies and requires `composer install` in the environment to run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adac8d71f08326a8814ca664f844b0)