### PR TITLE
feat(profile): provision calendar/chat defaults when creating profile applications

### DIFF
--- a/migrations/Version20260308230000.php
+++ b/migrations/Version20260308230000.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260308230000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Attach calendar and chat to platform application for plugin provisioning.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("ALTER TABLE calendar ADD application_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql('CREATE INDEX IDX_FC84F7D83E030ACD ON calendar (application_id)');
+        $this->addSql('ALTER TABLE calendar ADD CONSTRAINT FK_FC84F7D83E030ACD FOREIGN KEY (application_id) REFERENCES platform_application (id) ON DELETE SET NULL');
+
+        $this->addSql('ALTER TABLE chat DROP FOREIGN KEY FK_5A9A02C5E030ACD');
+        $this->addSql('ALTER TABLE chat ADD CONSTRAINT FK_5A9A02C5E030ACD FOREIGN KEY (application_id) REFERENCES platform_application (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE chat DROP FOREIGN KEY FK_5A9A02C5E030ACD');
+        $this->addSql('ALTER TABLE chat ADD CONSTRAINT FK_5A9A02C5E030ACD FOREIGN KEY (application_id) REFERENCES recruit_application (id) ON DELETE CASCADE');
+
+        $this->addSql('ALTER TABLE calendar DROP FOREIGN KEY FK_FC84F7D83E030ACD');
+        $this->addSql('DROP INDEX IDX_FC84F7D83E030ACD ON calendar');
+        $this->addSql('ALTER TABLE calendar DROP application_id');
+    }
+}

--- a/src/Calendar/Domain/Entity/Calendar.php
+++ b/src/Calendar/Domain/Entity/Calendar.php
@@ -7,6 +7,7 @@ namespace App\Calendar\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\Platform\Domain\Entity\Application;
 use App\User\Domain\Entity\User;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -39,6 +40,10 @@ class Calendar implements EntityInterface
     #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     #[Groups(['Calendar', 'Calendar.user'])]
     private ?User $user = null;
+
+    #[ORM\ManyToOne(targetEntity: Application::class)]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Application $application = null;
 
     /** @var Collection<int, Event>|ArrayCollection<int, Event> */
     #[ORM\OneToMany(targetEntity: Event::class, mappedBy: 'calendar')]
@@ -80,6 +85,18 @@ class Calendar implements EntityInterface
     public function setUser(?User $user): self
     {
         $this->user = $user;
+
+        return $this;
+    }
+
+    public function getApplication(): ?Application
+    {
+        return $this->application;
+    }
+
+    public function setApplication(?Application $application): self
+    {
+        $this->application = $application;
 
         return $this;
     }

--- a/src/Calendar/Domain/Repository/Interfaces/CalendarRepositoryInterface.php
+++ b/src/Calendar/Domain/Repository/Interfaces/CalendarRepositoryInterface.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Calendar\Domain\Repository\Interfaces;
 
+use App\Calendar\Domain\Entity\Calendar;
+use App\Platform\Domain\Entity\Application;
+
 interface CalendarRepositoryInterface
 {
+    public function findOneByApplication(Application $application): ?Calendar;
 }

--- a/src/Calendar/Infrastructure/Repository/CalendarRepository.php
+++ b/src/Calendar/Infrastructure/Repository/CalendarRepository.php
@@ -7,6 +7,7 @@ namespace App\Calendar\Infrastructure\Repository;
 use App\Calendar\Domain\Entity\Calendar as Entity;
 use App\Calendar\Domain\Repository\Interfaces\CalendarRepositoryInterface;
 use App\General\Infrastructure\Repository\BaseRepository;
+use App\Platform\Domain\Entity\Application;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -25,5 +26,14 @@ class CalendarRepository extends BaseRepository implements CalendarRepositoryInt
 
     public function __construct(protected ManagerRegistry $managerRegistry)
     {
+    }
+
+    public function findOneByApplication(Application $application): ?Entity
+    {
+        $calendar = $this->findOneBy([
+            'application' => $application,
+        ]);
+
+        return $calendar instanceof Entity ? $calendar : null;
     }
 }

--- a/src/Chat/Domain/Entity/Chat.php
+++ b/src/Chat/Domain/Entity/Chat.php
@@ -7,7 +7,7 @@ namespace App\Chat\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
-use App\Recruit\Domain\Entity\Application;
+use App\Platform\Domain\Entity\Application;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;

--- a/src/Chat/Domain/Repository/Interfaces/ChatRepositoryInterface.php
+++ b/src/Chat/Domain/Repository/Interfaces/ChatRepositoryInterface.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace App\Chat\Domain\Repository\Interfaces;
 
+use App\Chat\Domain\Entity\Chat;
+use App\Platform\Domain\Entity\Application;
+
 interface ChatRepositoryInterface
 {
+    public function findOneByApplication(Application $application): ?Chat;
 }

--- a/src/Chat/Infrastructure/Repository/ChatRepository.php
+++ b/src/Chat/Infrastructure/Repository/ChatRepository.php
@@ -7,6 +7,7 @@ namespace App\Chat\Infrastructure\Repository;
 use App\Chat\Domain\Entity\Chat as Entity;
 use App\Chat\Domain\Repository\Interfaces\ChatRepositoryInterface;
 use App\General\Infrastructure\Repository\BaseRepository;
+use App\Platform\Domain\Entity\Application;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -25,5 +26,14 @@ class ChatRepository extends BaseRepository implements ChatRepositoryInterface
 
     public function __construct(protected ManagerRegistry $managerRegistry)
     {
+    }
+
+    public function findOneByApplication(Application $application): ?Entity
+    {
+        $chat = $this->findOneBy([
+            'application' => $application,
+        ]);
+
+        return $chat instanceof Entity ? $chat : null;
     }
 }

--- a/src/Platform/Application/Service/ApplicationPluginProvisioningService.php
+++ b/src/Platform/Application/Service/ApplicationPluginProvisioningService.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Service;
+
+use App\Calendar\Domain\Entity\Calendar;
+use App\Calendar\Infrastructure\Repository\CalendarRepository;
+use App\Chat\Domain\Entity\Chat;
+use App\Chat\Infrastructure\Repository\ChatRepository;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PluginKey;
+use Doctrine\ORM\EntityManagerInterface;
+
+use function in_array;
+
+final class ApplicationPluginProvisioningService
+{
+    public function __construct(
+        private readonly CalendarRepository $calendarRepository,
+        private readonly ChatRepository $chatRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @param array<int, PluginKey> $pluginKeys
+     */
+    public function provision(Application $application, array $pluginKeys): void
+    {
+        if (in_array(PluginKey::CALENDAR, $pluginKeys, true)) {
+            $this->provisionCalendar($application);
+        }
+
+        if (in_array(PluginKey::CHAT, $pluginKeys, true)) {
+            $this->provisionChat($application);
+        }
+    }
+
+    private function provisionCalendar(Application $application): void
+    {
+        if ($this->calendarRepository->findOneByApplication($application) instanceof Calendar) {
+            return;
+        }
+
+        $calendar = (new Calendar())
+            ->setTitle('Default calendar')
+            ->setUser($application->getUser())
+            ->setApplication($application);
+
+        $this->entityManager->persist($calendar);
+    }
+
+    private function provisionChat(Application $application): void
+    {
+        if ($this->chatRepository->findOneByApplication($application) instanceof Chat) {
+            return;
+        }
+
+        $application->ensureGeneratedSlug();
+
+        $chat = (new Chat())
+            ->setApplication($application)
+            ->setApplicationSlug($application->getSlug());
+
+        $this->entityManager->persist($chat);
+    }
+}

--- a/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
@@ -8,8 +8,10 @@ use App\Configuration\Domain\Entity\Configuration;
 use App\Configuration\Domain\Enum\ConfigurationScope;
 use App\Platform\Application\Resource\PlatformResource;
 use App\Platform\Application\Resource\PluginResource;
+use App\Platform\Application\Service\ApplicationPluginProvisioningService;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Entity\ApplicationPlugin;
+use App\Platform\Domain\Enum\PluginKey;
 use App\Platform\Domain\Enum\PlatformStatus;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
@@ -25,6 +27,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Throwable;
 
+use function array_values;
+use function in_array;
 use function is_array;
 use function is_bool;
 use function is_string;
@@ -37,6 +41,7 @@ class ApplicationCreateController
     public function __construct(
         private readonly PlatformResource $platformResource,
         private readonly PluginResource $pluginResource,
+        private readonly ApplicationPluginProvisioningService $applicationPluginProvisioningService,
         private readonly EntityManagerInterface $entityManager,
     ) {
     }
@@ -156,6 +161,9 @@ class ApplicationCreateController
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "plugins" must be an array.');
         }
 
+        /** @var array<int, PluginKey> $detectedPluginKeys */
+        $detectedPluginKeys = [];
+
         foreach ($plugins as $pluginData) {
             if (!is_array($pluginData)) {
                 throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Each item in "plugins" must be an object.');
@@ -167,6 +175,14 @@ class ApplicationCreateController
             }
 
             $plugin = $this->pluginResource->findOne($pluginId, true);
+            $pluginKey = $plugin->getPluginKey();
+
+            if (
+                in_array($pluginKey, [PluginKey::CALENDAR, PluginKey::CHAT], true)
+                && in_array($pluginKey, $detectedPluginKeys, true) === false
+            ) {
+                $detectedPluginKeys[] = $pluginKey;
+            }
 
             $applicationPlugin = (new ApplicationPlugin())
                 ->setApplication($application)
@@ -191,6 +207,7 @@ class ApplicationCreateController
         }
 
         $this->entityManager->persist($application);
+        $this->applicationPluginProvisioningService->provision($application, array_values($detectedPluginKeys));
         $this->entityManager->flush();
 
         return new JsonResponse([

--- a/tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\Profile;
+
+use App\Calendar\Infrastructure\Repository\CalendarRepository;
+use App\General\Domain\Utils\JSON;
+use App\Platform\Application\Service\ApplicationPluginProvisioningService;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PluginKey;
+use App\Tests\TestCase\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class ApplicationCreateControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/profile/applications';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that creating an application with calendar and chat plugins provisions default entities.')]
+    public function testThatPostApplicationWithCalendarAndChatPluginsProvisionDefaults(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+        $payload = [
+            'platformId' => '40000000-0000-1000-8000-000000000001',
+            'title' => 'App with calendar and chat',
+            'description' => 'Provisioning integration test',
+            'plugins' => [
+                ['pluginId' => '50000000-0000-1000-8000-000000000001'],
+                ['pluginId' => '50000000-0000-1000-8000-000000000002'],
+            ],
+        ];
+
+        $client->request('POST', $this->baseUrl, content: JSON::encode($payload));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('id', $responseData);
+
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+        $calendarRepository = $container->get(CalendarRepository::class);
+        $chatRepository = $container->get(\App\Chat\Infrastructure\Repository\ChatRepository::class);
+
+        $application = $entityManager->getRepository(Application::class)->find($responseData['id']);
+        self::assertInstanceOf(Application::class, $application);
+
+        $calendar = $calendarRepository->findOneByApplication($application);
+        $chat = $chatRepository->findOneByApplication($application);
+
+        self::assertNotNull($calendar);
+        self::assertSame('Default calendar', $calendar->getTitle());
+        self::assertNotNull($chat);
+        self::assertSame($application->getSlug(), $chat->getApplicationSlug());
+
+        $provisioningService = $container->get(ApplicationPluginProvisioningService::class);
+        $provisioningService->provision($application, [PluginKey::CALENDAR, PluginKey::CHAT]);
+        $entityManager->flush();
+
+        self::assertCount(1, $calendarRepository->findBy(['application' => $application]));
+        self::assertCount(1, $chatRepository->findBy(['application' => $application]));
+    }
+}


### PR DESCRIPTION
### Motivation
- Centraliser la détection des plugins (notamment `calendar` et `chat`) lors de la création d'une `Application` pour déclencher la création automatique des ressources associées.
- Provisionner automatiquement des entités par défaut (calendrier, chat) quand les plugins correspondants sont ajoutés à une application profile.
- Garantir l'idempotence pour éviter la création de doublons si la ressource existe déjà.
- Ajouter une couverture d'intégration pour valider le flux `POST /v1/profile/applications` avec plugins.

### Description
- Détection centralisée des `PluginKey` dans `ApplicationCreateController` et injection de `ApplicationPluginProvisioningService` appelé après `persist` et avant `flush` via la méthode `provision`.
- Nouveau service applicatif `App\Platform\Application\Service\ApplicationPluginProvisioningService` qui crée un `Calendar` par défaut quand `PluginKey::CALENDAR` est présent et un `Chat` par défaut quand `PluginKey::CHAT` est présent, en vérifiant l'existence via les repository pour rendre l'opération idempotente.
- Ajout de la relation `Calendar->Application` et alignement de la relation `Chat->Application` sur `App\Platform\Domain\Entity\Application` pour permettre l'association aux applications de la plateforme.
- Extension des interfaces et repositories avec `findOneByApplication(...)` pour `Calendar` et `Chat` et ajout d'une migration `Version20260308230000` pour ajouter la FK `calendar.application_id` vers `platform_application` et réorienter la FK `chat.application_id` vers `platform_application`.
- Ajout d'un test d'intégration `tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php` vérifiant la création d'application avec plugins `calendar` et `chat`, la présence des entités par défaut et l'idempotence du provisioning.

### Testing
- `php -l` a été exécuté sur les fichiers modifiés (`ApplicationPluginProvisioningService`, `ApplicationCreateController`, `Calendar`, `Chat`, le test et la migration) et n'a signalé aucune erreur.
- Exécution de l'intégration via `./vendor/bin/phpunit tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php` n'a pas pu être réalisée dans cet environnement car le binaire `./vendor/bin/phpunit` est absent.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adadbd1af08326a9951f6f09f177f2)