### PR TITLE
Compute personalized job matchScore from user resume and remove manual matchScore input

### DIFF
--- a/src/Recruit/Application/Service/JobPublicListService.php
+++ b/src/Recruit/Application/Service/JobPublicListService.php
@@ -8,6 +8,7 @@ use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\Recruit\Domain\Entity\Application as RecruitApplication;
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Domain\Entity\Recruit;
+use App\Recruit\Domain\Entity\Resume;
 use App\User\Domain\Entity\User;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
@@ -26,6 +27,7 @@ use function array_map;
 use function array_unique;
 use function array_values;
 use function ceil;
+use function count;
 use function floor;
 use function in_array;
 use function is_array;
@@ -33,9 +35,14 @@ use function is_string;
 use function json_encode;
 use function mb_strtolower;
 use function md5;
+use function max;
 use function preg_match;
+use function preg_split;
+use function round;
 use function sprintf;
+use function strlen;
 use function strtolower;
+use function trim;
 
 class JobPublicListService
 {
@@ -150,6 +157,10 @@ class JobPublicListService
                     ->setParameter('esIds', $esIds);
             }
 
+            $userSkillKeywords = $loggedInUser instanceof User
+                ? $this->getUserResumeSkillKeywords($loggedInUser)
+                : [];
+
             $query = $qb
                 ->setFirstResult(($page - 1) * $limit)
                 ->setMaxResults($limit)
@@ -186,7 +197,9 @@ class JobPublicListService
                     ],
                     'postedAtLabel' => $this->buildPostedAtLabel($job->getCreatedAt()),
                     'summary' => $job->getSummary(),
-                    'matchScore' => $job->getMatchScore(),
+                    'matchScore' => $userSkillKeywords === []
+                        ? $job->getMatchScore()
+                        : $this->computeMatchScore($job, $userSkillKeywords),
                     'badges' => array_map(static fn ($badge): string => $badge->getLabel(), $job->getBadges()->toArray()),
                     'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $job->getTags()->toArray()),
                     'missionTitle' => $job->getMissionTitle(),
@@ -443,6 +456,89 @@ class JobPublicListService
 
         return $appliedJobIds;
     }
+
+    /**
+     * @return list<string>
+     */
+    private function getUserResumeSkillKeywords(User $loggedInUser): array
+    {
+        $resume = $this->entityManager
+            ->getRepository(Resume::class)
+            ->createQueryBuilder('resume')
+            ->leftJoin('resume.skills', 'skill')->addSelect('skill')
+            ->andWhere('resume.owner = :owner')
+            ->setParameter('owner', $loggedInUser->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->orderBy('resume.createdAt', 'DESC')
+            ->addOrderBy('resume.id', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if (!$resume instanceof Resume) {
+            return [];
+        }
+
+        $keywords = [];
+        foreach ($resume->getSkills() as $skill) {
+            $title = trim(mb_strtolower($skill->getTitle()));
+            if ($title === '') {
+                continue;
+            }
+
+            $keywords[] = $title;
+
+            $parts = preg_split('/[^\p{L}\p{N}]+/u', $title);
+            if (!is_array($parts)) {
+                continue;
+            }
+
+            foreach ($parts as $part) {
+                $word = trim($part);
+                if ($word !== '' && strlen($word) >= 3) {
+                    $keywords[] = $word;
+                }
+            }
+        }
+
+        /** @var list<string> $uniqueKeywords */
+        $uniqueKeywords = array_values(array_unique(array_filter($keywords, static fn (string $value): bool => $value !== '')));
+
+        return $uniqueKeywords;
+    }
+
+    /**
+     * @param list<string> $userSkillKeywords
+     */
+    private function computeMatchScore(Job $job, array $userSkillKeywords): int
+    {
+        if ($userSkillKeywords === []) {
+            return $job->getMatchScore();
+        }
+
+        $jobCorpusParts = [
+            mb_strtolower($job->getTitle()),
+            mb_strtolower($job->getSummary()),
+            mb_strtolower($job->getMissionDescription()),
+            mb_strtolower(implode(' ', $job->getProfile())),
+            mb_strtolower(implode(' ', $job->getResponsibilities())),
+        ];
+
+        foreach ($job->getTags() as $tag) {
+            $jobCorpusParts[] = mb_strtolower($tag->getLabel());
+        }
+
+        $jobCorpus = ' ' . implode(' ', $jobCorpusParts) . ' ';
+
+        $matchedSkills = 0;
+        foreach ($userSkillKeywords as $keyword) {
+            if ($keyword !== '' && str_contains($jobCorpus, ' ' . $keyword . ' ')) {
+                ++$matchedSkills;
+            }
+        }
+
+        return (int) max(0, min(100, round(($matchedSkills / count($userSkillKeywords)) * 100)));
+    }
+
     private function resolveRecruitByApplicationSlug(string $applicationSlug): Recruit
     {
         $recruit = $this->entityManager

--- a/src/Recruit/Transport/AutoMapper/Job/RequestMapper.php
+++ b/src/Recruit/Transport/AutoMapper/Job/RequestMapper.php
@@ -8,5 +8,5 @@ use App\General\Transport\AutoMapper\RestRequestMapper;
 
 class RequestMapper extends RestRequestMapper
 {
-    protected static array $properties = ['recruit','title','location','contractType','workMode','schedule','summary','matchScore','missionTitle','missionDescription','responsibilities','profile','benefits'];
+    protected static array $properties = ['recruit','title','location','contractType','workMode','schedule','summary','missionTitle','missionDescription','responsibilities','profile','benefits'];
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
@@ -22,7 +22,6 @@ use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 use function is_array;
-use function is_int;
 use function is_string;
 use function trim;
 
@@ -50,7 +49,6 @@ class JobCreateFromApplicationController
                     new OA\Property(property: 'summary', type: 'string', example: 'Build robust APIs'),
                     new OA\Property(property: 'missionTitle', type: 'string', example: 'Your mission'),
                     new OA\Property(property: 'missionDescription', type: 'string', example: 'Develop and maintain services'),
-                    new OA\Property(property: 'matchScore', type: 'integer', example: 85),
                     new OA\Property(property: 'contractType', type: 'string', enum: ['CDI', 'CDD', 'Freelance', 'Internship']),
                     new OA\Property(property: 'workMode', type: 'string', enum: ['Onsite', 'Remote', 'Hybrid']),
                     new OA\Property(property: 'schedule', type: 'string', enum: ['Vollzeit', 'Teilzeit', 'Contract']),
@@ -148,16 +146,6 @@ class JobCreateFromApplicationController
 
             $job->setMissionDescription($missionDescription);
         }
-
-        $matchScore = $payload['matchScore'] ?? null;
-        if ($matchScore !== null) {
-            if (!is_int($matchScore)) {
-                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "matchScore" must be an integer.');
-            }
-
-            $job->setMatchScore($matchScore);
-        }
-
         $contractType = $payload['contractType'] ?? null;
         if ($contractType !== null) {
             if (!is_string($contractType) || ContractType::tryFrom($contractType) === null) {

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationControllerTest.php
@@ -15,20 +15,18 @@ use Throwable;
 
 class JobCreateFromApplicationControllerTest extends WebTestCase
 {
-    private string $baseUrl = self::API_URL_PREFIX . '/v1/recruit/jobs';
-
     /** @throws Throwable */
-    #[TestDox('Test that `POST /v1/recruit/jobs` creates a job from applicationId for the owner.')]
-    public function testThatCreateFromApplicationCreatesJob(): void
+    #[TestDox('Test that `POST /v1/recruit/applications/{applicationSlug}/jobs` creates a job for owner without requiring matchScore.')]
+    public function testThatCreateFromApplicationCreatesJobWithoutMatchScore(): void
     {
-        $applicationId = $this->getApplicationIdForUsername('john-root');
+        $applicationSlug = $this->getApplicationSlugForUsername('john-root');
 
         $client = $this->getTestClient('john-root', 'password-root');
-        $client->request('POST', $this->baseUrl, content: JSON::encode([
-            'applicationId' => $applicationId,
+        $client->request('POST', self::API_URL_PREFIX . '/v1/recruit/applications/' . $applicationSlug . '/jobs', content: JSON::encode([
             'title' => 'Backend Engineer API',
             'location' => 'Paris',
             'contractType' => 'CDI',
+            'matchScore' => 'should-be-ignored',
         ]));
 
         $response = $client->getResponse();
@@ -40,25 +38,26 @@ class JobCreateFromApplicationControllerTest extends WebTestCase
         self::assertArrayHasKey('id', $payload);
         self::assertArrayHasKey('recruitId', $payload);
         self::assertArrayHasKey('slug', $payload);
+        self::assertArrayHasKey('applicationSlug', $payload);
+        self::assertSame($applicationSlug, $payload['applicationSlug']);
         self::assertSame('Backend Engineer API', $payload['title']);
     }
 
     /** @throws Throwable */
-    #[TestDox('Test that `POST /v1/recruit/jobs` returns forbidden if application is not owned by logged user.')]
+    #[TestDox('Test that `POST /v1/recruit/applications/{applicationSlug}/jobs` returns forbidden if application is not owned by logged user.')]
     public function testThatCreateFromApplicationRejectsForeignApplication(): void
     {
-        $applicationId = $this->getApplicationIdForUsername('john-root');
+        $applicationSlug = $this->getApplicationSlugForUsername('john-root');
 
         $client = $this->getTestClient('john-user', 'password-user');
-        $client->request('POST', $this->baseUrl, content: JSON::encode([
-            'applicationId' => $applicationId,
+        $client->request('POST', self::API_URL_PREFIX . '/v1/recruit/applications/' . $applicationSlug . '/jobs', content: JSON::encode([
             'title' => 'Should fail',
         ]));
 
         self::assertSame(Response::HTTP_FORBIDDEN, $client->getResponse()->getStatusCode());
     }
 
-    private function getApplicationIdForUsername(string $username): string
+    private function getApplicationSlugForUsername(string $username): string
     {
         self::bootKernel();
 
@@ -77,6 +76,6 @@ class JobCreateFromApplicationControllerTest extends WebTestCase
 
         self::assertInstanceOf(PlatformApplication::class, $application);
 
-        return $application->getId();
+        return $application->getSlug();
     }
 }

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PrivateJobListControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PrivateJobListControllerTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Job;
+
+use App\General\Domain\Utils\JSON;
+use App\Platform\Domain\Entity\Application as PlatformApplication;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Entity\Recruit;
+use App\Recruit\Domain\Entity\Resume;
+use App\User\Domain\Entity\User;
+use App\Tests\TestCase\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+use function array_filter;
+use function array_unique;
+use function array_values;
+use function count;
+use function implode;
+use function is_array;
+use function max;
+use function mb_strtolower;
+use function preg_split;
+use function round;
+use function strlen;
+use function str_contains;
+use function trim;
+
+class PrivateJobListControllerTest extends WebTestCase
+{
+    #[TestDox('Test that `GET /v1/recruit/private/{applicationSlug}/jobs` requires authentication.')]
+    public function testThatPrivateJobListRequiresAuthentication(): void
+    {
+        [$applicationSlug] = $this->getFixtureContext();
+
+        $client = $this->getTestClient();
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/private/' . $applicationSlug . '/jobs');
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
+    }
+
+    #[TestDox('Test that `GET /v1/recruit/private/{applicationSlug}/jobs` returns computed matchScore from user resume skills.')]
+    public function testThatPrivateJobListReturnsComputedMatchScoreFromResumeSkills(): void
+    {
+        [$applicationSlug, $jobId, $expectedMatchScore] = $this->getFixtureContext();
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/private/' . $applicationSlug . '/jobs?limit=100');
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+
+        self::assertArrayHasKey('jobs', $payload);
+        self::assertIsArray($payload['jobs']);
+
+        $jobPayload = null;
+        foreach ($payload['jobs'] as $job) {
+            if (($job['id'] ?? null) === $jobId) {
+                $jobPayload = $job;
+                break;
+            }
+        }
+
+        self::assertIsArray($jobPayload);
+        self::assertArrayHasKey('matchScore', $jobPayload);
+        self::assertSame($expectedMatchScore, $jobPayload['matchScore']);
+    }
+
+    /** @return array{0: string, 1: string, 2: int} */
+    private function getFixtureContext(): array
+    {
+        self::bootKernel();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $application = $entityManager->getRepository(PlatformApplication::class)->findOneBy([
+            'title' => 'Recruit Lite App',
+        ]);
+        self::assertInstanceOf(PlatformApplication::class, $application);
+
+        $recruit = $entityManager->getRepository(Recruit::class)->findOneBy([
+            'application' => $application,
+        ]);
+        self::assertInstanceOf(Recruit::class, $recruit);
+
+        $job = $entityManager->getRepository(Job::class)->findOneBy([
+            'recruit' => $recruit,
+        ], [
+            'createdAt' => 'DESC',
+            'id' => 'DESC',
+        ]);
+        self::assertInstanceOf(Job::class, $job);
+
+        $user = $entityManager->getRepository(User::class)->findOneBy([
+            'username' => 'john-root',
+        ]);
+        self::assertInstanceOf(User::class, $user);
+
+        $resume = $entityManager->getRepository(Resume::class)->findOneBy([
+            'owner' => $user,
+        ], [
+            'createdAt' => 'DESC',
+            'id' => 'DESC',
+        ]);
+        self::assertInstanceOf(Resume::class, $resume);
+
+        return [$application->getSlug(), $job->getId(), $this->computeExpectedMatchScore($job, $resume)];
+    }
+
+    private function computeExpectedMatchScore(Job $job, Resume $resume): int
+    {
+        $keywords = [];
+        foreach ($resume->getSkills() as $skill) {
+            $title = trim(mb_strtolower($skill->getTitle()));
+            if ($title === '') {
+                continue;
+            }
+
+            $keywords[] = $title;
+
+            $parts = preg_split('/[^\p{L}\p{N}]+/u', $title);
+            if (!is_array($parts)) {
+                continue;
+            }
+
+            foreach ($parts as $part) {
+                $word = trim($part);
+                if ($word !== '' && strlen($word) >= 3) {
+                    $keywords[] = $word;
+                }
+            }
+        }
+
+        $keywords = array_values(array_unique(array_filter($keywords, static fn (string $value): bool => $value !== '')));
+        self::assertNotEmpty($keywords);
+
+        $jobCorpus = [
+            mb_strtolower($job->getTitle()),
+            mb_strtolower($job->getSummary()),
+            mb_strtolower($job->getMissionDescription()),
+            mb_strtolower(implode(' ', $job->getProfile())),
+            mb_strtolower(implode(' ', $job->getResponsibilities())),
+        ];
+
+        foreach ($job->getTags() as $tag) {
+            $jobCorpus[] = mb_strtolower($tag->getLabel());
+        }
+
+        $searchable = ' ' . implode(' ', $jobCorpus) . ' ';
+
+        $matched = 0;
+        foreach ($keywords as $keyword) {
+            if ($keyword !== '' && str_contains($searchable, ' ' . $keyword . ' ')) {
+                ++$matched;
+            }
+        }
+
+        return (int) max(0, min(100, round(($matched / count($keywords)) * 100)));
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide personalized `matchScore` values in private job listings by computing them from the authenticated user resume skills instead of relying on a stored or client-provided value.
- Prevent clients from setting or overriding `matchScore` when creating jobs and simplify the job creation flow to target application slugs.

### Description

- Added `getUserResumeSkillKeywords()` and `computeMatchScore()` to `JobPublicListService` and use the computed score when a `User` is authenticated, falling back to the job's stored `getMatchScore()` when no resume skills are available. 
- Updated the job request mapping by removing `matchScore` from `RequestMapper::$properties` so it is no longer mapped from requests.
- Changed `JobCreateFromApplicationController` to use `applicationSlug` in the route path and removed validation/handling of a `matchScore` request field (also updated OpenAPI docs accordingly).
- Updated tests to reflect the new route and behavior: adapted `JobCreateFromApplicationControllerTest` and added `PrivateJobListControllerTest` which verifies authentication requirement and that the returned `matchScore` is computed from the user's resume skills.

### Testing

- Ran the test suite with `vendor/bin/phpunit` including the updated `JobCreateFromApplicationControllerTest` and the new `PrivateJobListControllerTest`, and the tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adafeac2848326afd79e627e09f42d)