### PR TITLE
Update recruit application statuses and transitions

### DIFF
--- a/migrations/Version20260309090000.php
+++ b/migrations/Version20260309090000.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260309090000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Rename legacy REVIEWING application status to IN_PROGRESS.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("UPDATE recruit_application SET status = 'IN_PROGRESS' WHERE status = 'REVIEWING'");
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql("UPDATE recruit_application SET status = 'REVIEWING' WHERE status = 'IN_PROGRESS'");
+    }
+}

--- a/src/Recruit/Domain/Enum/ApplicationStatus.php
+++ b/src/Recruit/Domain/Enum/ApplicationStatus.php
@@ -7,7 +7,9 @@ namespace App\Recruit\Domain\Enum;
 enum ApplicationStatus: string
 {
     case WAITING = 'WAITING';
-    case REVIEWING = 'REVIEWING';
+    case IN_PROGRESS = 'IN_PROGRESS';
+    case DISCUSSION = 'DISCUSSION';
+    case INVITE_TO_INTERVIEW = 'INVITE_TO_INTERVIEW';
     case INTERVIEW = 'INTERVIEW';
     case ACCEPTED = 'ACCEPTED';
     case REJECTED = 'REJECTED';

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitApplicationData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitApplicationData.php
@@ -75,8 +75,8 @@ final class LoadRecruitApplicationData extends Fixture implements OrderedFixture
         $this->createApplication(
             applicant: $johnUserApplicant,
             job: $jobIncomingForRoot,
-            reference: 'Recruit-Application-john-user-incoming-root-reviewing',
-            status: ApplicationStatus::REVIEWING
+            reference: 'Recruit-Application-john-user-incoming-root-in-progress',
+            status: ApplicationStatus::IN_PROGRESS
         );
 
         $this->createApplication(
@@ -91,6 +91,27 @@ final class LoadRecruitApplicationData extends Fixture implements OrderedFixture
             job: $jobIncomingForRoot,
             reference: 'Recruit-Application-john-logged-incoming-root-rejected',
             status: ApplicationStatus::REJECTED
+        );
+
+        $this->createApplication(
+            applicant: $johnAdminApplicant,
+            job: $jobOwnedByOtherUser,
+            reference: 'Recruit-Application-john-admin-on-other-owner-discussion',
+            status: ApplicationStatus::DISCUSSION
+        );
+
+        $this->createApplication(
+            applicant: $johnUserApplicant,
+            job: $jobOwnedByOtherUser,
+            reference: 'Recruit-Application-john-user-on-other-owner-invite-to-interview',
+            status: ApplicationStatus::INVITE_TO_INTERVIEW
+        );
+
+        $this->createApplication(
+            applicant: $johnApiApplicant,
+            job: $jobOwnedByOtherUser,
+            reference: 'Recruit-Application-john-api-on-other-owner-accepted',
+            status: ApplicationStatus::ACCEPTED
         );
 
         $this->createApplication(

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php
@@ -20,8 +20,6 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
-use function is_string;
-use function strtoupper;
 
 #[AsController]
 #[OA\Tag(name: 'Recruit Application')]
@@ -45,7 +43,6 @@ class ApplicationCreateController
                 properties: [
                     new OA\Property(property: 'applicantId', type: 'string', format: 'uuid'),
                     new OA\Property(property: 'jobId', type: 'string', format: 'uuid'),
-                    new OA\Property(property: 'status', type: 'string', enum: ['WAITING']),
                 ],
             ),
         ),
@@ -61,8 +58,6 @@ class ApplicationCreateController
 
         $applicantId = $payload['applicantId'] ?? null;
         $jobId = $payload['jobId'] ?? null;
-        $status = $payload['status'] ?? null;
-
         if (!is_string($applicantId) || !Uuid::isValid($applicantId)) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "applicantId" must be a valid UUID.');
         }
@@ -70,11 +65,6 @@ class ApplicationCreateController
         if (!is_string($jobId) || !Uuid::isValid($jobId)) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "jobId" must be a valid UUID.');
         }
-
-        if ($status !== null && (!is_string($status) || strtoupper($status) !== ApplicationStatus::WAITING->value)) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" cannot be changed and must be "WAITING" when provided.');
-        }
-
         $applicant = $this->applicantRepository->find($applicantId);
         if ($applicant === null) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicantId".');

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
@@ -39,7 +39,7 @@ class ApplicationStatusUpdateController
             content: new OA\JsonContent(
                 required: ['status'],
                 properties: [
-                    new OA\Property(property: 'status', type: 'string', enum: ['WAITING', 'REVIEWING', 'INTERVIEW', 'ACCEPTED', 'REJECTED']),
+                    new OA\Property(property: 'status', type: 'string', enum: ['WAITING', 'IN_PROGRESS', 'DISCUSSION', 'INVITE_TO_INTERVIEW', 'INTERVIEW', 'ACCEPTED', 'REJECTED']),
                 ],
             ),
         ),
@@ -71,7 +71,7 @@ class ApplicationStatusUpdateController
 
         $newStatus = ApplicationStatus::tryFrom(strtoupper($status));
         if ($newStatus === null) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" must be one of: WAITING, REVIEWING, INTERVIEW, ACCEPTED, REJECTED.');
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" must be one of: WAITING, IN_PROGRESS, DISCUSSION, INVITE_TO_INTERVIEW, INTERVIEW, ACCEPTED, REJECTED.');
         }
 
         $currentStatus = $application->getStatus();
@@ -91,8 +91,10 @@ class ApplicationStatusUpdateController
     private function isAllowedTransition(ApplicationStatus $from, ApplicationStatus $to): bool
     {
         $allowedTransitions = [
-            ApplicationStatus::WAITING->value => [ApplicationStatus::REVIEWING->value, ApplicationStatus::REJECTED->value],
-            ApplicationStatus::REVIEWING->value => [ApplicationStatus::INTERVIEW->value, ApplicationStatus::ACCEPTED->value, ApplicationStatus::REJECTED->value],
+            ApplicationStatus::WAITING->value => [ApplicationStatus::IN_PROGRESS->value, ApplicationStatus::REJECTED->value],
+            ApplicationStatus::IN_PROGRESS->value => [ApplicationStatus::DISCUSSION->value, ApplicationStatus::INVITE_TO_INTERVIEW->value, ApplicationStatus::REJECTED->value],
+            ApplicationStatus::DISCUSSION->value => [ApplicationStatus::INVITE_TO_INTERVIEW->value, ApplicationStatus::REJECTED->value],
+            ApplicationStatus::INVITE_TO_INTERVIEW->value => [ApplicationStatus::INTERVIEW->value, ApplicationStatus::REJECTED->value],
             ApplicationStatus::INTERVIEW->value => [ApplicationStatus::ACCEPTED->value, ApplicationStatus::REJECTED->value],
             ApplicationStatus::ACCEPTED->value => [],
             ApplicationStatus::REJECTED->value => [],


### PR DESCRIPTION
### Motivation

- Introduce a richer application lifecycle to replace `REVIEWING` with explicit states: `IN_PROGRESS`, `DISCUSSION`, `INVITE_TO_INTERVIEW` to better model hiring flows. 
- Ensure existing data using the old `REVIEWING` value is preserved by providing a migration to convert legacy values. 

### Description

- Extended `ApplicationStatus` enum with `IN_PROGRESS`, `DISCUSSION`, and `INVITE_TO_INTERVIEW` and kept `WAITING`, `INTERVIEW`, `ACCEPTED`, `REJECTED` (`src/Recruit/Domain/Enum/ApplicationStatus.php`).
- Updated `ApplicationStatusUpdateController` OpenAPI enum, validation error text and the allowed transition matrix in `isAllowedTransition` to reflect the new workflow (`src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php`).
- Changed `ApplicationCreateController` to always set status to `WAITING` server-side and removed `status` from the create payload/validation (`src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php`).
- Updated fixtures to replace `REVIEWING` with `IN_PROGRESS` and added sample scenarios using `DISCUSSION`, `INVITE_TO_INTERVIEW`, and `ACCEPTED` (`src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitApplicationData.php`).
- Added a data migration `migrations/Version20260309090000.php` to rename existing `REVIEWING` rows to `IN_PROGRESS` (with inverse on `down`).
- Verified the `status` column mapping remains `length: 25` in the entity mapping so no schema length change is required (`src/Recruit/Domain/Entity/Application.php`).

### Testing

- Ran PHP lint on updated sources with `php -l` for `ApplicationStatus`, both controllers, fixtures and the new migration and all reported no syntax errors. 
- Attempted schema validation with `php bin/console doctrine:schema:validate --skip-sync -q` but it failed in this environment due to missing Composer dependencies (run `composer install` in CI/target environment); this is an environment issue, not a code syntax failure. 
- Ensured the new migration file passes PHP linting (`php -l migrations/Version20260309090000.php`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb1ed17ec8326b497f6a8ff0a0101)