### PR TITLE
Bootstrap chat conversation on transition to DISCUSSION

### DIFF
--- a/migrations/Version20260309100000.php
+++ b/migrations/Version20260309100000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260309100000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Create conversation_participant table to store chat conversation members.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('CREATE TABLE conversation_participant (id BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid_binary_ordered_time)\', conversation_id BINARY(16) NOT NULL, user_id BINARY(16) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX idx_conversation_participant_conversation_id (conversation_id), INDEX idx_conversation_participant_user_id (user_id), UNIQUE INDEX uq_conversation_participant_conversation_user (conversation_id, user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE conversation_participant ADD CONSTRAINT FK_C7A1A4B28E7927C9 FOREIGN KEY (conversation_id) REFERENCES conversation (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE conversation_participant ADD CONSTRAINT FK_C7A1A4B2A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE conversation_participant DROP FOREIGN KEY FK_C7A1A4B28E7927C9');
+        $this->addSql('ALTER TABLE conversation_participant DROP FOREIGN KEY FK_C7A1A4B2A76ED395');
+        $this->addSql('DROP TABLE conversation_participant');
+    }
+}

--- a/src/Chat/Application/Service/ConversationParticipantCreatorService.php
+++ b/src/Chat/Application/Service/ConversationParticipantCreatorService.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Application\Service;
+
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Domain\Repository\Interfaces\ConversationParticipantRepositoryInterface;
+use App\User\Domain\Entity\User;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+
+class ConversationParticipantCreatorService
+{
+    public function __construct(
+        private readonly ConversationParticipantRepositoryInterface $conversationParticipantRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function getOrCreate(Conversation $conversation, User $user): ConversationParticipant
+    {
+        $conversationParticipant = $this->conversationParticipantRepository->findOneByConversationAndUser($conversation, $user);
+        if ($conversationParticipant instanceof ConversationParticipant) {
+            return $conversationParticipant;
+        }
+
+        $conversationParticipant = (new ConversationParticipant())
+            ->setConversation($conversation)
+            ->setUser($user);
+
+        try {
+            $this->entityManager->persist($conversationParticipant);
+            $this->entityManager->flush();
+
+            return $conversationParticipant;
+        } catch (UniqueConstraintViolationException) {
+            $conversationParticipant = $this->conversationParticipantRepository->findOneByConversationAndUser($conversation, $user);
+            if ($conversationParticipant instanceof ConversationParticipant) {
+                return $conversationParticipant;
+            }
+
+            throw new \RuntimeException('Unable to create an idempotent conversation participant.');
+        }
+    }
+}

--- a/src/Chat/Domain/Entity/ConversationParticipant.php
+++ b/src/Chat/Domain/Entity/ConversationParticipant.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'conversation_participant')]
+#[ORM\UniqueConstraint(name: 'uq_conversation_participant_conversation_user', columns: ['conversation_id', 'user_id'])]
+#[ORM\Index(name: 'idx_conversation_participant_conversation_id', columns: ['conversation_id'])]
+#[ORM\Index(name: 'idx_conversation_participant_user_id', columns: ['user_id'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class ConversationParticipant implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Conversation::class)]
+    #[ORM\JoinColumn(name: 'conversation_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Conversation $conversation;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $user;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getConversation(): Conversation
+    {
+        return $this->conversation;
+    }
+
+    public function setConversation(Conversation $conversation): self
+    {
+        $this->conversation = $conversation;
+
+        return $this;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+}

--- a/src/Chat/Domain/Repository/Interfaces/ConversationParticipantRepositoryInterface.php
+++ b/src/Chat/Domain/Repository/Interfaces/ConversationParticipantRepositoryInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Domain\Repository\Interfaces;
+
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\User\Domain\Entity\User;
+
+interface ConversationParticipantRepositoryInterface
+{
+    public function findOneByConversationAndUser(Conversation $conversation, User $user): ?ConversationParticipant;
+}

--- a/src/Chat/Infrastructure/Repository/ConversationParticipantRepository.php
+++ b/src/Chat/Infrastructure/Repository/ConversationParticipantRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Infrastructure\Repository;
+
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant as Entity;
+use App\Chat\Domain\Repository\Interfaces\ConversationParticipantRepositoryInterface;
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ConversationParticipantRepository extends BaseRepository implements ConversationParticipantRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+
+    public function findOneByConversationAndUser(Conversation $conversation, User $user): ?Entity
+    {
+        $conversationParticipant = $this->findOneBy([
+            'conversation' => $conversation,
+            'user' => $user,
+        ]);
+
+        return $conversationParticipant instanceof Entity ? $conversationParticipant : null;
+    }
+}

--- a/src/Recruit/Application/Service/ApplicationDiscussionBootstrapService.php
+++ b/src/Recruit/Application/Service/ApplicationDiscussionBootstrapService.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Chat\Application\Service\ConversationCreatorService;
+use App\Chat\Application\Service\ConversationParticipantCreatorService;
+use App\Chat\Domain\Repository\Interfaces\ChatRepositoryInterface;
+use App\Recruit\Domain\Entity\Application;
+use DomainException;
+
+final class ApplicationDiscussionBootstrapService
+{
+    public function __construct(
+        private readonly ChatRepositoryInterface $chatRepository,
+        private readonly ConversationCreatorService $conversationCreatorService,
+        private readonly ConversationParticipantCreatorService $conversationParticipantCreatorService,
+    ) {
+    }
+
+    public function bootstrap(Application $application): void
+    {
+        $jobOwner = $application->getJob()->getOwner();
+        if ($jobOwner === null) {
+            throw new DomainException('Cannot bootstrap discussion: job owner is missing.');
+        }
+
+        $applicantUser = $application->getApplicant()->getUser();
+        if ($applicantUser === null) {
+            throw new DomainException('Cannot bootstrap discussion: applicant user is missing.');
+        }
+
+        $platformApplication = $application->getJob()->getRecruit()?->getApplication();
+        if ($platformApplication === null) {
+            throw new DomainException('Cannot bootstrap discussion: platform application is missing for the job.');
+        }
+
+        $chat = $this->chatRepository->findOneByApplication($platformApplication);
+        if ($chat === null) {
+            throw new DomainException('Cannot bootstrap discussion: chat is not provisioned for this application.');
+        }
+
+        $applicationSlug = $platformApplication->getSlug();
+        if ($applicationSlug === '') {
+            throw new DomainException('Cannot bootstrap discussion: platform application slug is missing.');
+        }
+
+        $conversation = $this->conversationCreatorService->getOrCreate($chat, $applicationSlug);
+        $this->conversationParticipantCreatorService->getOrCreate($conversation, $jobOwner);
+        $this->conversationParticipantCreatorService->getOrCreate($conversation, $applicantUser);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\Application;
 
+use App\Recruit\Application\Service\ApplicationDiscussionBootstrapService;
 use App\Recruit\Domain\Enum\ApplicationStatus;
 use App\Recruit\Infrastructure\Repository\ApplicationRepository;
 use App\User\Domain\Entity\User;
+use DomainException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,8 +29,10 @@ use function strtoupper;
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 class ApplicationStatusUpdateController
 {
-    public function __construct(private readonly ApplicationRepository $applicationRepository)
-    {
+    public function __construct(
+        private readonly ApplicationRepository $applicationRepository,
+        private readonly ApplicationDiscussionBootstrapService $applicationDiscussionBootstrapService,
+    ) {
     }
 
     #[Route(path: '/v1/recruit/private/applications/{applicationId}/status', methods: [Request::METHOD_PATCH, Request::METHOD_PUT])]
@@ -77,6 +81,14 @@ class ApplicationStatusUpdateController
         $currentStatus = $application->getStatus();
         if ($newStatus !== $currentStatus && !$this->isAllowedTransition($currentStatus, $newStatus)) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Status transition is not allowed for this application.');
+        }
+
+        if ($newStatus === ApplicationStatus::DISCUSSION && $currentStatus !== ApplicationStatus::DISCUSSION) {
+            try {
+                $this->applicationDiscussionBootstrapService->bootstrap($application);
+            } catch (DomainException $exception) {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, $exception->getMessage(), $exception);
+            }
         }
 
         $application->setStatus($newStatus);

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateControllerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Application;
+
+use App\Chat\Domain\Entity\Chat;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\General\Domain\Utils\JSON;
+use App\Platform\Domain\Entity\Application as PlatformApplication;
+use App\Recruit\Domain\Entity\Application as RecruitApplication;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class ApplicationStatusUpdateControllerTest extends WebTestCase
+{
+    /** @throws Throwable */
+    #[TestDox('Test that transition to DISCUSSION creates conversation and participants for owner and applicant.')]
+    public function testThatTransitionToDiscussionCreatesConversation(): void
+    {
+        [$recruitApplication, $platformApplication] = $this->prepareApplicationForDiscussionTransition();
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('PATCH', self::API_URL_PREFIX . '/v1/recruit/private/applications/' . $recruitApplication->getId() . '/status', content: JSON::encode([
+            'status' => ApplicationStatus::DISCUSSION->value,
+        ]));
+
+        $response = $client->getResponse();
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        self::bootKernel();
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $chat = $entityManager->getRepository(Chat::class)->findOneBy([
+            'application' => $platformApplication,
+        ]);
+        self::assertInstanceOf(Chat::class, $chat);
+
+        $conversation = $entityManager->getRepository(Conversation::class)->findOneBy([
+            'chat' => $chat,
+            'applicationSlug' => $platformApplication->getSlug(),
+        ]);
+        self::assertInstanceOf(Conversation::class, $conversation);
+
+        $participants = $entityManager->getRepository(ConversationParticipant::class)->findBy([
+            'conversation' => $conversation,
+        ]);
+        self::assertCount(2, $participants);
+
+        $participantUserIds = array_map(static fn (ConversationParticipant $participant): string => $participant->getUser()->getId(), $participants);
+        self::assertContains($recruitApplication->getJob()->getOwner()?->getId(), $participantUserIds);
+        self::assertContains($recruitApplication->getApplicant()->getUser()->getId(), $participantUserIds);
+    }
+
+    /** @throws Throwable */
+    #[TestDox('Test that repeated transition to DISCUSSION is idempotent and does not duplicate conversation or participants.')]
+    public function testThatSecondTransitionToDiscussionDoesNotDuplicateConversation(): void
+    {
+        [$recruitApplication, $platformApplication] = $this->prepareApplicationForDiscussionTransition();
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $url = self::API_URL_PREFIX . '/v1/recruit/private/applications/' . $recruitApplication->getId() . '/status';
+
+        $client->request('PATCH', $url, content: JSON::encode([
+            'status' => ApplicationStatus::DISCUSSION->value,
+        ]));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request('PATCH', $url, content: JSON::encode([
+            'status' => ApplicationStatus::DISCUSSION->value,
+        ]));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        self::bootKernel();
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $chat = $entityManager->getRepository(Chat::class)->findOneBy([
+            'application' => $platformApplication,
+        ]);
+        self::assertInstanceOf(Chat::class, $chat);
+
+        $conversations = $entityManager->getRepository(Conversation::class)->findBy([
+            'chat' => $chat,
+            'applicationSlug' => $platformApplication->getSlug(),
+        ]);
+        self::assertCount(1, $conversations);
+
+        $participants = $entityManager->getRepository(ConversationParticipant::class)->findBy([
+            'conversation' => $conversations[0],
+        ]);
+        self::assertCount(2, $participants);
+    }
+
+    /** @return array{0: RecruitApplication, 1: PlatformApplication} */
+    private function prepareApplicationForDiscussionTransition(): array
+    {
+        self::bootKernel();
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $owner = $entityManager->getRepository(User::class)->findOneBy([
+            'username' => 'john-root',
+        ]);
+        self::assertInstanceOf(User::class, $owner);
+
+        $recruitApplication = $entityManager->getRepository(RecruitApplication::class)->findOneBy([
+            'status' => ApplicationStatus::IN_PROGRESS,
+        ]);
+        self::assertInstanceOf(RecruitApplication::class, $recruitApplication);
+        self::assertSame($owner->getId(), $recruitApplication->getJob()->getOwner()?->getId());
+
+        $platformApplication = $recruitApplication->getJob()->getRecruit()?->getApplication();
+        self::assertInstanceOf(PlatformApplication::class, $platformApplication);
+
+        $chat = $entityManager->getRepository(Chat::class)->findOneBy([
+            'application' => $platformApplication,
+        ]);
+
+        if (!$chat instanceof Chat) {
+            $chat = (new Chat())
+                ->setApplication($platformApplication)
+                ->setApplicationSlug($platformApplication->getSlug());
+            $entityManager->persist($chat);
+            $entityManager->flush();
+        }
+
+        $conversation = $entityManager->getRepository(Conversation::class)->findOneBy([
+            'chat' => $chat,
+            'applicationSlug' => $platformApplication->getSlug(),
+        ]);
+
+        if ($conversation instanceof Conversation) {
+            $participants = $entityManager->getRepository(ConversationParticipant::class)->findBy([
+                'conversation' => $conversation,
+            ]);
+
+            foreach ($participants as $participant) {
+                $entityManager->remove($participant);
+            }
+
+            $entityManager->remove($conversation);
+            $entityManager->flush();
+        }
+
+        $recruitApplication->setStatus(ApplicationStatus::IN_PROGRESS);
+        $entityManager->flush();
+
+        return [$recruitApplication, $platformApplication];
+    }
+}


### PR DESCRIPTION
### Motivation

- When an application moves to `ApplicationStatus::DISCUSSION`, a chat conversation must exist so owner and applicant can communicate. 
- The flow must be idempotent and prevent duplicate conversations or participants for the same `(chat, applicationSlug)` pair. 
- Missing domain data (owner, applicant user, platform application, chat, slug) must produce a clear business error.

### Description

- Detects the transition to `DISCUSSION` in `ApplicationStatusUpdateController` and triggers `ApplicationDiscussionBootstrapService` only on a real state change, converting domain errors to `422 Unprocessable Entity`.  
- Adds `ApplicationDiscussionBootstrapService` which resolves `job.owner`, `applicant.user`, the provisioned `Chat` and then gets/creates a `Conversation` and two `ConversationParticipant` entries (owner + applicant).  
- Introduces `ConversationParticipant` entity, repository interface + implementation, and `ConversationParticipantCreatorService` implementing idempotent creation (handles `UniqueConstraintViolationException`).  
- Adds a migration `Version20260309100000` to create the `conversation_participant` table with FK, indexes and unique constraint `(conversation_id, user_id)`, and adds an integration test `ApplicationStatusUpdateControllerTest` that asserts conversation/participants are created and that repeated transitions do not duplicate records.

### Testing

- Static checks: ran `php -l` on the modified/added PHP files and they reported no syntax errors.  
- Integration tests were added under `tests/Application/Recruit/.../ApplicationStatusUpdateControllerTest.php`, but running `./vendor/bin/phpunit` was not possible in this environment because the project test binary/dependencies are not available here (`./vendor/bin/phpunit: No such file or directory`).  
- The new tests should be executed in CI or a dev environment with dependencies installed and are expected to verify creation and idempotence of conversation/participants.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb30fcad483269770fd7817e4a6f1)