### PR TITLE
Refactor Recruit and Platform query logic into repositories

### DIFF
--- a/src/Platform/Application/Service/ApplicationListService.php
+++ b/src/Platform/Application/Service/ApplicationListService.php
@@ -6,8 +6,8 @@ namespace App\Platform\Application\Service;
 
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Repository\Interfaces\ApplicationRepositoryInterface;
 use App\User\Domain\Entity\User;
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -17,7 +17,7 @@ use Throwable;
 class ApplicationListService
 {
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
+        private readonly ApplicationRepositoryInterface $applicationRepository,
         private readonly CacheInterface $cache,
         private readonly ElasticsearchServiceInterface $elasticsearchService,
     ) {
@@ -59,73 +59,20 @@ class ApplicationListService
         $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($loggedInUser, $filters, $page, $limit): array {
             $item->expiresAfter(120);
 
-            $qb = $this->entityManager
-                ->getRepository(Application::class)
-                ->createQueryBuilder('application')
-                ->leftJoin('application.platform', 'platform')
-                ->leftJoin('application.user', 'user')
-                ->leftJoin('application.applicationPlugins', 'applicationPlugin')
-                ->leftJoin('applicationPlugin.plugin', 'plugin')
-                ->addSelect('platform')
-                ->addSelect('user')
-                ->addSelect('applicationPlugin')
-                ->addSelect('plugin');
-
-            if ($loggedInUser === null) {
-                $qb->where('application.private = :publicApplication')
-                    ->setParameter('publicApplication', false);
-            } else {
-                $qb->where('application.private = :publicApplication')
-                    ->orWhere('application.user = :loggedInUser')
-                    ->setParameter('publicApplication', false)
-                    ->setParameter('loggedInUser', $loggedInUser);
-            }
-
-            if ($filters['platformKey'] !== '') {
-                $qb->andWhere('LOWER(platform.platformKey) = :platformKey')
-                    ->setParameter('platformKey', mb_strtolower($filters['platformKey']));
-            }
-
             $esIds = $this->searchIdsFromElastic($filters);
-            if ($esIds !== null) {
-                if ($esIds === []) {
-                    return [
-                        'items' => [],
-                        'pagination' => [
-                            'page' => $page,
-                            'limit' => $limit,
-                            'totalItems' => 0,
-                            'totalPages' => 0,
-                        ],
-                    ];
-                }
-
-                $qb->andWhere('application.id IN (:esIds)')
-                    ->setParameter('esIds', $esIds);
+            if ($esIds === []) {
+                return [
+                    'items' => [],
+                    'pagination' => [
+                        'page' => $page,
+                        'limit' => $limit,
+                        'totalItems' => 0,
+                        'totalPages' => 0,
+                    ],
+                ];
             }
 
-            if ($filters['title'] !== '') {
-                $qb->andWhere('LOWER(application.title) LIKE :title')
-                    ->setParameter('title', '%' . mb_strtolower($filters['title']) . '%');
-            }
-
-            if ($filters['description'] !== '') {
-                $qb->andWhere('LOWER(application.description) LIKE :description')
-                    ->setParameter('description', '%' . mb_strtolower($filters['description']) . '%');
-            }
-
-            if ($filters['platformName'] !== '') {
-                $qb->andWhere('LOWER(platform.name) LIKE :platformName')
-                    ->setParameter('platformName', '%' . mb_strtolower($filters['platformName']) . '%');
-            }
-
-            $qb->orderBy('application.title', 'ASC')
-                ->addOrderBy('application.id', 'ASC');
-
-            $query = $qb
-                ->setFirstResult(($page - 1) * $limit)
-                ->setMaxResults($limit)
-                ->getQuery();
+            $query = $this->applicationRepository->createListQuery($filters, $loggedInUser, $esIds, $page, $limit);
 
             $paginator = new Paginator($query, true);
             $totalItems = $paginator->count();

--- a/src/Platform/Domain/Repository/Interfaces/ApplicationRepositoryInterface.php
+++ b/src/Platform/Domain/Repository/Interfaces/ApplicationRepositoryInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Domain\Repository\Interfaces;
+
+use App\Platform\Domain\Entity\Application;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Query;
+
+interface ApplicationRepositoryInterface
+{
+    /**
+     * @param array<string, string> $filters
+     * @param array<int, string>|null $esIds
+     */
+    public function createListQuery(array $filters, ?User $loggedInUser, ?array $esIds, int $page, int $limit): Query;
+}

--- a/src/Platform/Infrastructure/Repository/ApplicationRepository.php
+++ b/src/Platform/Infrastructure/Repository/ApplicationRepository.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Platform\Domain\Entity\Application as Entity;
+use App\Platform\Domain\Repository\Interfaces\ApplicationRepositoryInterface;
+use App\User\Domain\Entity\User;
+use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\Query;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ApplicationRepository extends BaseRepository implements ApplicationRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'title',
+        'description',
+        'slug',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+
+    public function createListQuery(array $filters, ?User $loggedInUser, ?array $esIds, int $page, int $limit): Query
+    {
+        $qb = $this->createQueryBuilder('application')
+            ->leftJoin('application.platform', 'platform')
+            ->leftJoin('application.user', 'user')
+            ->leftJoin('application.applicationPlugins', 'applicationPlugin')
+            ->leftJoin('applicationPlugin.plugin', 'plugin')
+            ->addSelect('platform', 'user', 'applicationPlugin', 'plugin');
+
+        if ($loggedInUser === null) {
+            $qb->where('application.private = :publicApplication')
+                ->setParameter('publicApplication', false);
+        } else {
+            $qb->where('application.private = :publicApplication')
+                ->orWhere('application.user = :loggedInUser')
+                ->setParameter('publicApplication', false)
+                ->setParameter('loggedInUser', $loggedInUser);
+        }
+
+        if ($filters['platformKey'] !== '') {
+            $qb->andWhere('LOWER(platform.platformKey) = :platformKey')
+                ->setParameter('platformKey', mb_strtolower($filters['platformKey']));
+        }
+
+        if ($esIds !== null) {
+            $qb->andWhere('application.id IN (:esIds)')
+                ->setParameter('esIds', $esIds);
+        }
+
+        if ($filters['title'] !== '') {
+            $qb->andWhere('LOWER(application.title) LIKE :title')
+                ->setParameter('title', '%' . mb_strtolower($filters['title']) . '%');
+        }
+
+        if ($filters['description'] !== '') {
+            $qb->andWhere('LOWER(application.description) LIKE :description')
+                ->setParameter('description', '%' . mb_strtolower($filters['description']) . '%');
+        }
+
+        if ($filters['platformName'] !== '') {
+            $qb->andWhere('LOWER(platform.name) LIKE :platformName')
+                ->setParameter('platformName', '%' . mb_strtolower($filters['platformName']) . '%');
+        }
+
+        return $qb
+            ->orderBy('application.title', 'ASC')
+            ->addOrderBy('application.id', 'ASC')
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit)
+            ->getQuery();
+    }
+}

--- a/src/Recruit/Domain/Repository/Interfaces/RecruitRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/RecruitRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+use App\Recruit\Domain\Entity\Recruit;
+
+interface RecruitRepositoryInterface
+{
+    public function findOneByApplicationSlug(string $applicationSlug): ?Recruit;
+}

--- a/src/Recruit/Infrastructure/Repository/RecruitRepository.php
+++ b/src/Recruit/Infrastructure/Repository/RecruitRepository.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Recruit as Entity;
+use App\Recruit\Domain\Repository\Interfaces\RecruitRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class RecruitRepository extends BaseRepository implements RecruitRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+
+    public function findOneByApplicationSlug(string $applicationSlug): ?Entity
+    {
+        $recruit = $this->createQueryBuilder('recruit')
+            ->innerJoin('recruit.application', 'application')
+            ->addSelect('application')
+            ->where('application.slug = :applicationSlug')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $recruit instanceof Entity ? $recruit : null;
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
@@ -9,9 +9,9 @@ use App\Recruit\Domain\Entity\Recruit;
 use App\Recruit\Domain\Enum\ContractType;
 use App\Recruit\Domain\Enum\Schedule;
 use App\Recruit\Domain\Enum\WorkMode;
+use App\Recruit\Domain\Repository\Interfaces\RecruitRepositoryInterface;
 use App\Recruit\Infrastructure\Repository\JobRepository;
 use App\User\Domain\Entity\User;
-use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,7 +31,7 @@ use function trim;
 class JobCreateFromApplicationController
 {
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
+        private readonly RecruitRepositoryInterface $recruitRepository,
         private readonly JobRepository $jobRepository,
     ) {
     }
@@ -203,15 +203,7 @@ class JobCreateFromApplicationController
 
     private function resolveRecruitByApplicationSlug(string $applicationSlug): Recruit
     {
-        $recruit = $this->entityManager
-            ->getRepository(Recruit::class)
-            ->createQueryBuilder('recruit')
-            ->innerJoin('recruit.application', 'application')
-            ->addSelect('application')
-            ->where('application.slug = :applicationSlug')
-            ->setParameter('applicationSlug', $applicationSlug)
-            ->getQuery()
-            ->getOneOrNullResult();
+        $recruit = $this->recruitRepository->findOneByApplicationSlug($applicationSlug);
 
         if (!$recruit instanceof Recruit) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicationSlug".');

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteFromApplicationController.php
@@ -6,9 +6,9 @@ namespace App\Recruit\Transport\Controller\Api\V1\Job;
 
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Domain\Entity\Recruit;
+use App\Recruit\Domain\Repository\Interfaces\RecruitRepositoryInterface;
 use App\Recruit\Infrastructure\Repository\JobRepository;
 use App\User\Domain\Entity\User;
-use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class JobDeleteFromApplicationController
 {
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
+        private readonly RecruitRepositoryInterface $recruitRepository,
         private readonly JobRepository $jobRepository,
     ) {
     }
@@ -67,15 +67,7 @@ class JobDeleteFromApplicationController
 
     private function resolveRecruitByApplicationSlug(string $applicationSlug): Recruit
     {
-        $recruit = $this->entityManager
-            ->getRepository(Recruit::class)
-            ->createQueryBuilder('recruit')
-            ->innerJoin('recruit.application', 'application')
-            ->addSelect('application')
-            ->where('application.slug = :applicationSlug')
-            ->setParameter('applicationSlug', $applicationSlug)
-            ->getQuery()
-            ->getOneOrNullResult();
+        $recruit = $this->recruitRepository->findOneByApplicationSlug($applicationSlug);
 
         if (!$recruit instanceof Recruit) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicationSlug".');

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
@@ -9,9 +9,9 @@ use App\Recruit\Domain\Entity\Recruit;
 use App\Recruit\Domain\Enum\ContractType;
 use App\Recruit\Domain\Enum\Schedule;
 use App\Recruit\Domain\Enum\WorkMode;
+use App\Recruit\Domain\Repository\Interfaces\RecruitRepositoryInterface;
 use App\Recruit\Infrastructure\Repository\JobRepository;
 use App\User\Domain\Entity\User;
-use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,7 +32,7 @@ use function trim;
 class JobPatchFromApplicationController
 {
     public function __construct(
-        private readonly EntityManagerInterface $entityManager,
+        private readonly RecruitRepositoryInterface $recruitRepository,
         private readonly JobRepository $jobRepository,
     ) {
     }
@@ -199,15 +199,7 @@ class JobPatchFromApplicationController
     }
     private function resolveRecruitByApplicationSlug(string $applicationSlug): Recruit
     {
-        $recruit = $this->entityManager
-            ->getRepository(Recruit::class)
-            ->createQueryBuilder('recruit')
-            ->innerJoin('recruit.application', 'application')
-            ->addSelect('application')
-            ->where('application.slug = :applicationSlug')
-            ->setParameter('applicationSlug', $applicationSlug)
-            ->getQuery()
-            ->getOneOrNullResult();
+        $recruit = $this->recruitRepository->findOneByApplicationSlug($applicationSlug);
 
         if (!$recruit instanceof Recruit) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicationSlug".');


### PR DESCRIPTION
## Summary
- extracted Recruit lookup by `applicationSlug` from Recruit job controllers into a dedicated `RecruitRepositoryInterface` + `RecruitRepository`
- updated `JobCreateFromApplicationController`, `JobPatchFromApplicationController`, and `JobDeleteFromApplicationController` to depend on the repository interface instead of building Doctrine queries in controllers
- extracted Platform application listing query-building from `ApplicationListService` into `ApplicationRepositoryInterface` + `ApplicationRepository`
- simplified `ApplicationListService` so service logic focuses on caching, Elasticsearch filtering, and response mapping

## Why
This reduces SQL/query concerns in controllers/services and centralizes data-access logic in repositories, making code easier to maintain and test.

## Validation
- `php -l src/Recruit/Domain/Repository/Interfaces/RecruitRepositoryInterface.php`
- `php -l src/Recruit/Infrastructure/Repository/RecruitRepository.php`
- `php -l src/Platform/Domain/Repository/Interfaces/ApplicationRepositoryInterface.php`
- `php -l src/Platform/Infrastructure/Repository/ApplicationRepository.php`
- `php -l src/Platform/Application/Service/ApplicationListService.php`
- `php -l src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php`
- `php -l src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php`
- `php -l src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteFromApplicationController.php`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb970dde08326ad4ca03227135d2a)