### PR TITLE
Prevent duplicate conversation participant insertion in recruit fixture

### DIFF
--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -177,7 +177,10 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         }
 
         $this->ensureParticipant($manager, $conversation, $owner);
-        $this->ensureParticipant($manager, $conversation, $applicant);
+
+        if ($owner->getId() !== $applicant->getId()) {
+            $this->ensureParticipant($manager, $conversation, $applicant);
+        }
 
         $introMessage = $manager->getRepository(ChatMessage::class)->findOneBy([
             'conversation' => $conversation,


### PR DESCRIPTION
### Motivation
- Prevent a unique constraint violation on `(conversation_id, user_id)` when a discussion fixture scenario resolves the job owner and applicant to the same user.

### Description
- Update `LoadRecruitChatCalendarScenarioData` so the owner is always added as a `ConversationParticipant` and the applicant is added only when `owner->getId() !== applicant->getId()`.

### Testing
- Ran `php -l src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` which passed, and attempted `php bin/console doctrine:fixtures:load -n --append` which could not be executed in this environment due to missing dependencies (needs `composer install`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adba807e3c8326a85da0ea9533c866)