### PR TITLE
Handle invalid UTF-8 in chat conversation JSON responses

### DIFF
--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
@@ -22,6 +22,8 @@ class ApplicationConversationListController
     #[Route(path: '/v1/chat/applications/{applicationSlug}/conversations', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug): JsonResponse
     {
-        return new JsonResponse($this->conversationListService->getByApplicationSlug($applicationSlug));
+        return ConversationJsonResponseFactory::create(
+            $this->conversationListService->getByApplicationSlug($applicationSlug)
+        );
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
@@ -26,6 +26,8 @@ class ApplicationUserConversationListController
     #[Route(path: '/v1/chat/private/applications/{applicationSlug}/conversations', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug, User $loggedInUser): JsonResponse
     {
-        return new JsonResponse($this->conversationListService->getByApplicationSlugAndUser($applicationSlug, $loggedInUser));
+        return ConversationJsonResponseFactory::create(
+            $this->conversationListService->getByApplicationSlugAndUser($applicationSlug, $loggedInUser)
+        );
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ConversationJsonResponseFactory.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ConversationJsonResponseFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Transport\Controller\Api\V1\Conversation;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+final class ConversationJsonResponseFactory
+{
+    /**
+     * @param array<int, array<string, mixed>> $payload
+     */
+    public static function create(array $payload): JsonResponse
+    {
+        $response = new JsonResponse($payload);
+        $response->setEncodingOptions(JsonResponse::DEFAULT_ENCODING_OPTIONS | JSON_INVALID_UTF8_SUBSTITUTE);
+
+        return $response;
+    }
+}

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationListController.php
@@ -26,6 +26,6 @@ class UserConversationListController
     #[Route(path: '/v1/chat/private/conversations', methods: [Request::METHOD_GET])]
     public function __invoke(User $loggedInUser): JsonResponse
     {
-        return new JsonResponse($this->conversationListService->getByUser($loggedInUser));
+        return ConversationJsonResponseFactory::create($this->conversationListService->getByUser($loggedInUser));
     }
 }

--- a/tests/Unit/Chat/Transport/Controller/Api/V1/Conversation/ConversationJsonResponseFactoryTest.php
+++ b/tests/Unit/Chat/Transport/Controller/Api/V1/Conversation/ConversationJsonResponseFactoryTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Chat\Transport\Controller\Api\V1\Conversation;
+
+use App\Chat\Transport\Controller\Api\V1\Conversation\ConversationJsonResponseFactory;
+use PHPUnit\Framework\TestCase;
+
+final class ConversationJsonResponseFactoryTest extends TestCase
+{
+    public function testCreateSubstitutesInvalidUtf8Bytes(): void
+    {
+        $response = ConversationJsonResponseFactory::create([
+            [
+                'content' => "Broken byte: \xB1",
+            ],
+        ]);
+
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertStringContainsString('\\ufffd', $content);
+        self::assertNotSame(0, $response->getEncodingOptions() & JSON_INVALID_UTF8_SUBSTITUTE);
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent HTTP 500 errors when conversation payloads contain malformed UTF-8 bytes by ensuring JSON encoding substitutes invalid bytes instead of failing.
- Make conversation list endpoints consistent in how JSON responses are produced and encoded.

### Description
- Added a shared factory `App\Chat\Transport\Controller\Api\V1\Conversation\ConversationJsonResponseFactory` that creates `JsonResponse` instances with `JSON_INVALID_UTF8_SUBSTITUTE` enabled.
- Updated conversation list controllers `ApplicationConversationListController`, `ApplicationUserConversationListController`, and `UserConversationListController` to return responses via `ConversationJsonResponseFactory::create(...)` instead of constructing `JsonResponse` directly.
- Added a unit test `tests/Unit/Chat/Transport/Controller/Api/V1/Conversation/ConversationJsonResponseFactoryTest.php` that verifies invalid UTF-8 bytes are substituted and the encoding option is set.

### Testing
- Ran PHP syntax checks with `php -l` for `ConversationJsonResponseFactory.php`, the three updated controllers, and the new test file, and all reported "No syntax errors detected." (success).
- Added `tests/Unit/...ConversationJsonResponseFactoryTest.php` to cover the behavior, but the project-local PHPUnit binary is not available in this environment so the test was not executed here (blocked).
- Attempted to run `./bin/phpunit` which failed with a missing binary error, so only static/syntax validation was performed (partial).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adbd8f2dc483269eb300328fe48167)