### PR TITLE
feat: rename Doctrine tables to explicit module prefixes

### DIFF
--- a/migrations/Version20260309120000.php
+++ b/migrations/Version20260309120000.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260309120000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Rename core domain tables to explicit module-prefixed names and recreate impacted foreign keys.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE platform_application DROP FOREIGN KEY FK_PLATFORM_APPLICATION_PLATFORM_ID');
+        $this->addSql('ALTER TABLE plugin DROP FOREIGN KEY FK_PLUGIN_PLATFORM_ID');
+        $this->addSql('ALTER TABLE configuration DROP FOREIGN KEY FK_CONFIGURATION_PLATFORM_ID');
+        $this->addSql('ALTER TABLE configuration DROP FOREIGN KEY FK_CONFIGURATION_PLUGIN_ID');
+        $this->addSql('ALTER TABLE platform_application_plugin DROP FOREIGN KEY FK_PLATFORM_APPLICATION_PLUGIN_PLUGIN_ID');
+        $this->addSql('ALTER TABLE calendar_event DROP FOREIGN KEY FK_E72A1268A40BC2D5');
+        $this->addSql('ALTER TABLE conversation_participant DROP FOREIGN KEY FK_C7A1A4B28E7927C9');
+        $this->addSql('ALTER TABLE chat_message DROP FOREIGN KEY FK_6EEC5A898E7927C9');
+
+        $this->addSql('RENAME TABLE configuration TO configuration_configuration');
+        $this->addSql('RENAME TABLE conversation TO chat_conversation');
+        $this->addSql('RENAME TABLE conversation_participant TO chat_conversation_participant');
+        $this->addSql('RENAME TABLE calendar TO calendar_calendar');
+        $this->addSql('RENAME TABLE platform TO platform_platform');
+        $this->addSql('RENAME TABLE plugin TO platform_plugin');
+
+        $this->addSql('ALTER TABLE chat_conversation RENAME INDEX idx_conversation_chat_id TO idx_chat_conversation_chat_id');
+        $this->addSql('ALTER TABLE chat_conversation RENAME INDEX idx_conversation_application_slug TO idx_chat_conversation_application_slug');
+        $this->addSql('ALTER TABLE chat_conversation RENAME INDEX uq_conversation_chat_application_slug TO uq_chat_conversation_chat_application_slug');
+
+        $this->addSql('ALTER TABLE chat_conversation_participant RENAME INDEX idx_conversation_participant_conversation_id TO idx_chat_conversation_participant_conversation_id');
+        $this->addSql('ALTER TABLE chat_conversation_participant RENAME INDEX idx_conversation_participant_user_id TO idx_chat_conversation_participant_user_id');
+        $this->addSql('ALTER TABLE chat_conversation_participant RENAME INDEX uq_conversation_participant_conversation_user TO uq_chat_conversation_participant_conversation_user');
+
+        $this->addSql('ALTER TABLE platform_platform RENAME INDEX idx_platform_user_id TO idx_platform_platform_user_id');
+        $this->addSql('ALTER TABLE platform_plugin RENAME INDEX idx_plugin_platform_id TO idx_platform_plugin_platform_id');
+
+        $this->addSql('ALTER TABLE platform_application ADD CONSTRAINT FK_PLATFORM_APPLICATION_PLATFORM_ID FOREIGN KEY (platform_id) REFERENCES platform_platform (id) ON DELETE RESTRICT');
+        $this->addSql('ALTER TABLE platform_plugin ADD CONSTRAINT FK_PLUGIN_PLATFORM_ID FOREIGN KEY (platform_id) REFERENCES platform_platform (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE configuration_configuration ADD CONSTRAINT FK_CONFIGURATION_PLATFORM_ID FOREIGN KEY (platform_id) REFERENCES platform_platform (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE configuration_configuration ADD CONSTRAINT FK_CONFIGURATION_PLUGIN_ID FOREIGN KEY (plugin_id) REFERENCES platform_plugin (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE platform_application_plugin ADD CONSTRAINT FK_PLATFORM_APPLICATION_PLUGIN_PLUGIN_ID FOREIGN KEY (plugin_id) REFERENCES platform_plugin (id) ON DELETE RESTRICT');
+        $this->addSql('ALTER TABLE calendar_event ADD CONSTRAINT FK_E72A1268A40BC2D5 FOREIGN KEY (calendar_id) REFERENCES calendar_calendar (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE chat_conversation_participant ADD CONSTRAINT FK_C7A1A4B28E7927C9 FOREIGN KEY (conversation_id) REFERENCES chat_conversation (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE chat_message ADD CONSTRAINT FK_6EEC5A898E7927C9 FOREIGN KEY (conversation_id) REFERENCES chat_conversation (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE platform_application DROP FOREIGN KEY FK_PLATFORM_APPLICATION_PLATFORM_ID');
+        $this->addSql('ALTER TABLE platform_plugin DROP FOREIGN KEY FK_PLUGIN_PLATFORM_ID');
+        $this->addSql('ALTER TABLE configuration_configuration DROP FOREIGN KEY FK_CONFIGURATION_PLATFORM_ID');
+        $this->addSql('ALTER TABLE configuration_configuration DROP FOREIGN KEY FK_CONFIGURATION_PLUGIN_ID');
+        $this->addSql('ALTER TABLE platform_application_plugin DROP FOREIGN KEY FK_PLATFORM_APPLICATION_PLUGIN_PLUGIN_ID');
+        $this->addSql('ALTER TABLE calendar_event DROP FOREIGN KEY FK_E72A1268A40BC2D5');
+        $this->addSql('ALTER TABLE chat_conversation_participant DROP FOREIGN KEY FK_C7A1A4B28E7927C9');
+        $this->addSql('ALTER TABLE chat_message DROP FOREIGN KEY FK_6EEC5A898E7927C9');
+
+        $this->addSql('ALTER TABLE chat_conversation_participant RENAME INDEX idx_chat_conversation_participant_conversation_id TO idx_conversation_participant_conversation_id');
+        $this->addSql('ALTER TABLE chat_conversation_participant RENAME INDEX idx_chat_conversation_participant_user_id TO idx_conversation_participant_user_id');
+        $this->addSql('ALTER TABLE chat_conversation_participant RENAME INDEX uq_chat_conversation_participant_conversation_user TO uq_conversation_participant_conversation_user');
+
+        $this->addSql('ALTER TABLE chat_conversation RENAME INDEX idx_chat_conversation_chat_id TO idx_conversation_chat_id');
+        $this->addSql('ALTER TABLE chat_conversation RENAME INDEX idx_chat_conversation_application_slug TO idx_conversation_application_slug');
+        $this->addSql('ALTER TABLE chat_conversation RENAME INDEX uq_chat_conversation_chat_application_slug TO uq_conversation_chat_application_slug');
+
+        $this->addSql('ALTER TABLE platform_platform RENAME INDEX idx_platform_platform_user_id TO idx_platform_user_id');
+        $this->addSql('ALTER TABLE platform_plugin RENAME INDEX idx_platform_plugin_platform_id TO idx_plugin_platform_id');
+
+        $this->addSql('RENAME TABLE configuration_configuration TO configuration');
+        $this->addSql('RENAME TABLE chat_conversation TO conversation');
+        $this->addSql('RENAME TABLE chat_conversation_participant TO conversation_participant');
+        $this->addSql('RENAME TABLE calendar_calendar TO calendar');
+        $this->addSql('RENAME TABLE platform_platform TO platform');
+        $this->addSql('RENAME TABLE platform_plugin TO plugin');
+
+        $this->addSql('ALTER TABLE platform_application ADD CONSTRAINT FK_PLATFORM_APPLICATION_PLATFORM_ID FOREIGN KEY (platform_id) REFERENCES platform (id) ON DELETE RESTRICT');
+        $this->addSql('ALTER TABLE plugin ADD CONSTRAINT FK_PLUGIN_PLATFORM_ID FOREIGN KEY (platform_id) REFERENCES platform (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE configuration ADD CONSTRAINT FK_CONFIGURATION_PLATFORM_ID FOREIGN KEY (platform_id) REFERENCES platform (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE configuration ADD CONSTRAINT FK_CONFIGURATION_PLUGIN_ID FOREIGN KEY (plugin_id) REFERENCES plugin (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE platform_application_plugin ADD CONSTRAINT FK_PLATFORM_APPLICATION_PLUGIN_PLUGIN_ID FOREIGN KEY (plugin_id) REFERENCES plugin (id) ON DELETE RESTRICT');
+        $this->addSql('ALTER TABLE calendar_event ADD CONSTRAINT FK_E72A1268A40BC2D5 FOREIGN KEY (calendar_id) REFERENCES calendar (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE conversation_participant ADD CONSTRAINT FK_C7A1A4B28E7927C9 FOREIGN KEY (conversation_id) REFERENCES conversation (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE chat_message ADD CONSTRAINT FK_6EEC5A898E7927C9 FOREIGN KEY (conversation_id) REFERENCES conversation (id) ON DELETE CASCADE');
+    }
+}

--- a/src/Calendar/Domain/Entity/Calendar.php
+++ b/src/Calendar/Domain/Entity/Calendar.php
@@ -20,7 +20,7 @@ use Symfony\Component\Serializer\Attribute\Groups;
 use Throwable;
 
 #[ORM\Entity]
-#[ORM\Table(name: 'calendar')]
+#[ORM\Table(name: 'calendar_calendar')]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Calendar implements EntityInterface
 {

--- a/src/Chat/Domain/Entity/Conversation.php
+++ b/src/Chat/Domain/Entity/Conversation.php
@@ -15,7 +15,7 @@ use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
 
 #[ORM\Entity]
-#[ORM\Table(name: 'conversation')]
+#[ORM\Table(name: 'chat_conversation')]
 #[ORM\UniqueConstraint(name: 'uq_conversation_chat_application_slug', columns: ['chat_id', 'application_slug'])]
 #[ORM\Index(name: 'idx_conversation_chat_id', columns: ['chat_id'])]
 #[ORM\Index(name: 'idx_conversation_application_slug', columns: ['application_slug'])]

--- a/src/Chat/Domain/Entity/ConversationParticipant.php
+++ b/src/Chat/Domain/Entity/ConversationParticipant.php
@@ -14,7 +14,7 @@ use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
 
 #[ORM\Entity]
-#[ORM\Table(name: 'conversation_participant')]
+#[ORM\Table(name: 'chat_conversation_participant')]
 #[ORM\UniqueConstraint(name: 'uq_conversation_participant_conversation_user', columns: ['conversation_id', 'user_id'])]
 #[ORM\Index(name: 'idx_conversation_participant_conversation_id', columns: ['conversation_id'])]
 #[ORM\Index(name: 'idx_conversation_participant_user_id', columns: ['user_id'])]

--- a/src/Configuration/Domain/Entity/Configuration.php
+++ b/src/Configuration/Domain/Entity/Configuration.php
@@ -27,7 +27,7 @@ use Throwable;
  * @package App\Configuration
  */
 #[ORM\Entity]
-#[ORM\Table(name: 'configuration')]
+#[ORM\Table(name: 'configuration_configuration')]
 #[ORM\UniqueConstraint(name: 'uq_configuration_user_key', columns: ['user_id', 'configuration_key'])]
 #[ORM\UniqueConstraint(name: 'uq_configuration_platform_key', columns: ['platform_id', 'configuration_key'])]
 #[ORM\UniqueConstraint(name: 'uq_configuration_plugin_key', columns: ['plugin_id', 'configuration_key'])]

--- a/src/Platform/Domain/Entity/Platform.php
+++ b/src/Platform/Domain/Entity/Platform.php
@@ -30,7 +30,7 @@ use function str_starts_with;
  * @package App\Platform
  */
 #[ORM\Entity]
-#[ORM\Table(name: 'platform')]
+#[ORM\Table(name: 'platform_platform')]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Platform implements EntityInterface
 {

--- a/src/Platform/Domain/Entity/Plugin.php
+++ b/src/Platform/Domain/Entity/Plugin.php
@@ -28,7 +28,7 @@ use function str_starts_with;
  * @package App\Platform
  */
 #[ORM\Entity]
-#[ORM\Table(name: 'plugin')]
+#[ORM\Table(name: 'platform_plugin')]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Plugin implements EntityInterface
 {


### PR DESCRIPTION
### Motivation

- Uniformiser les noms SQL des tables Doctrine en ajoutant un préfixe de module explicite pour éviter les collisions et clarifier l’origine des entités.
- Préserver les données existantes en effectuant des renommages SQL (pas de drop/recreate) et mettre à jour les contraintes et index qui ciblent les tables renommées.

### Description

- Mise à jour des annotations `#[ORM\Table(name: ...)]` pour six entités afin d’utiliser des noms explicites : `configuration_configuration`, `chat_conversation`, `chat_conversation_participant`, `calendar_calendar`, `platform_platform` et `platform_plugin`.
- Ajout de la migration `migrations/Version20260309120000.php` qui exécute des `RENAME TABLE` pour les tables concernées, renomme les index impactés et recrée les clés étrangères ciblant les nouvelles tables sans perte de données.
- La migration contient un `down()` complet qui restaure les noms d’origine des tables, index et clés étrangères.
- Les entités modifiées sont `src/Configuration/Domain/Entity/Configuration.php`, `src/Chat/Domain/Entity/Conversation.php`, `src/Chat/Domain/Entity/ConversationParticipant.php`, `src/Calendar/Domain/Entity/Calendar.php`, `src/Platform/Domain/Entity/Platform.php` et `src/Platform/Domain/Entity/Plugin.php`.

### Testing

- Lint PHP sur la nouvelle migration avec `php -l migrations/Version20260309120000.php` a réussi.
- Lint PHP sur les entités modifiées avec `php -l` pour `src/Configuration/Domain/Entity/Configuration.php`, `src/Chat/Domain/Entity/Conversation.php`, `src/Chat/Domain/Entity/ConversationParticipant.php`, `src/Calendar/Domain/Entity/Calendar.php`, `src/Platform/Domain/Entity/Platform.php` et `src/Platform/Domain/Entity/Plugin.php` a réussi.
- Lint PHP sur les migrations récentes `migrations/Version20260308223000.php`, `migrations/Version20260308230000.php`, `migrations/Version20260309100000.php` et `migrations/Version20260309110000.php` a réussi pour vérifier la cohérence de la chaîne de migrations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adbd9962a48326a4f9469cf3275e9a)