### PR TITLE
Fix application list pagination with joined plugins

### DIFF
--- a/src/Platform/Application/Service/ApplicationListService.php
+++ b/src/Platform/Application/Service/ApplicationListService.php
@@ -8,7 +8,6 @@ use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Repository\Interfaces\ApplicationRepositoryInterface;
 use App\User\Domain\Entity\User;
-use Doctrine\ORM\Tools\Pagination\Paginator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -73,13 +72,11 @@ class ApplicationListService
             }
 
             $query = $this->applicationRepository->createListQuery($filters, $loggedInUser, $esIds, $page, $limit);
-
-            $paginator = new Paginator($query, true);
-            $totalItems = $paginator->count();
+            $totalItems = $this->applicationRepository->countList($filters, $loggedInUser, $esIds);
 
             $items = [];
             /** @var Application $application */
-            foreach ($paginator as $application) {
+            foreach ($query->toIterable() as $application) {
                 $pluginKeys = [];
                 foreach ($application->getApplicationPlugins() as $applicationPlugin) {
                     $pluginKey = $applicationPlugin->getPlugin()?->getPluginKeyValue();

--- a/src/Platform/Domain/Repository/Interfaces/ApplicationRepositoryInterface.php
+++ b/src/Platform/Domain/Repository/Interfaces/ApplicationRepositoryInterface.php
@@ -15,4 +15,10 @@ interface ApplicationRepositoryInterface
      * @param array<int, string>|null $esIds
      */
     public function createListQuery(array $filters, ?User $loggedInUser, ?array $esIds, int $page, int $limit): Query;
+
+    /**
+     * @param array<string, string> $filters
+     * @param array<int, string>|null $esIds
+     */
+    public function countList(array $filters, ?User $loggedInUser, ?array $esIds): int;
 }

--- a/src/Platform/Infrastructure/Repository/ApplicationRepository.php
+++ b/src/Platform/Infrastructure/Repository/ApplicationRepository.php
@@ -10,6 +10,7 @@ use App\Platform\Domain\Repository\Interfaces\ApplicationRepositoryInterface;
 use App\User\Domain\Entity\User;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -32,12 +33,49 @@ class ApplicationRepository extends BaseRepository implements ApplicationReposit
 
     public function createListQuery(array $filters, ?User $loggedInUser, ?array $esIds, int $page, int $limit): Query
     {
-        $qb = $this->createQueryBuilder('application')
+        $ids = $this->createListIdsQueryBuilder($filters, $loggedInUser, $esIds)
+            ->setFirstResult(($page - 1) * $limit)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getSingleColumnResult();
+
+        if ($ids === []) {
+            return $this->createQueryBuilder('application')
+                ->where('1 = 0')
+                ->getQuery();
+        }
+
+        $query = $this->createQueryBuilder('application')
             ->leftJoin('application.platform', 'platform')
             ->leftJoin('application.user', 'user')
             ->leftJoin('application.applicationPlugins', 'applicationPlugin')
             ->leftJoin('applicationPlugin.plugin', 'plugin')
-            ->addSelect('platform', 'user', 'applicationPlugin', 'plugin');
+            ->addSelect('platform', 'user', 'applicationPlugin', 'plugin')
+            ->andWhere('application.id IN (:ids)')
+            ->setParameter('ids', $ids)
+            ->orderBy('application.title', 'ASC')
+            ->addOrderBy('application.id', 'ASC')
+            ->getQuery();
+
+        return $query;
+    }
+
+    public function countList(array $filters, ?User $loggedInUser, ?array $esIds): int
+    {
+        return (int) $this->createListIdsQueryBuilder($filters, $loggedInUser, $esIds)
+            ->select('COUNT(application.id)')
+            ->resetDQLPart('orderBy')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    private function createListIdsQueryBuilder(array $filters, ?User $loggedInUser, ?array $esIds): QueryBuilder
+    {
+        $qb = $this->createQueryBuilder('application')
+            ->leftJoin('application.platform', 'platform')
+            ->select('application.id')
+            ->orderBy('application.title', 'ASC')
+            ->addOrderBy('application.id', 'ASC');
 
         if ($loggedInUser === null) {
             $qb->where('application.private = :publicApplication')
@@ -74,11 +112,6 @@ class ApplicationRepository extends BaseRepository implements ApplicationReposit
                 ->setParameter('platformName', '%' . mb_strtolower($filters['platformName']) . '%');
         }
 
-        return $qb
-            ->orderBy('application.title', 'ASC')
-            ->addOrderBy('application.id', 'ASC')
-            ->setFirstResult(($page - 1) * $limit)
-            ->setMaxResults($limit)
-            ->getQuery();
+        return $qb;
     }
 }

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PublicApplicationListControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PublicApplicationListControllerTest.php
@@ -49,6 +49,53 @@ class PublicApplicationListControllerTest extends WebTestCase
         }
     }
 
+
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/application/public` paginates applications (not joined plugin rows) when an application has multiple plugins.')]
+    public function testThatPublicListPaginationIsStableWithMultiplePlugins(): void
+    {
+        $createClient = $this->getTestClient('john-user', 'password-user');
+        $createClient->request('POST', self::API_URL_PREFIX . '/v1/profile/applications', content: JSON::encode([
+            'platformId' => '40000000-0000-1000-8000-000000000001',
+            'title' => 'AA Multi Plugin App',
+            'description' => 'Pagination regression guard',
+            'plugins' => [
+                ['pluginId' => '50000000-0000-1000-8000-000000000001'],
+                ['pluginId' => '50000000-0000-1000-8000-000000000002'],
+            ],
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $createClient->getResponse()->getStatusCode());
+
+        $client = $this->getTestClient();
+        $client->request('GET', $this->baseUrl . '?page=1&limit=1');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertCount(1, $responseData['items']);
+        self::assertSame('AA Multi Plugin App', $responseData['items'][0]['title']);
+        $pluginKeys = $responseData['items'][0]['pluginKeys'];
+        sort($pluginKeys);
+        self::assertSame(['calendar', 'chat'], $pluginKeys);
+        self::assertSame(3, $responseData['pagination']['totalItems']);
+
+        $client->request('GET', $this->baseUrl . '?page=2&limit=1');
+        $page2Response = $client->getResponse();
+        $page2Content = $page2Response->getContent();
+
+        self::assertNotFalse($page2Content);
+        self::assertSame(Response::HTTP_OK, $page2Response->getStatusCode(), "Response:\n" . $page2Response);
+
+        $page2Data = JSON::decode($page2Content, true);
+        self::assertIsArray($page2Data);
+        self::assertCount(1, $page2Data['items']);
+        self::assertSame('CRM Growth App', $page2Data['items'][0]['title']);
+    }
+
     /** @throws Throwable */
     #[TestDox('Test that `GET /v1/application/public` supports filters and pagination.')]
     public function testThatPublicListSupportsFiltersAndPagination(): void


### PR DESCRIPTION
### Motivation
- Prevent incorrect pagination and inflated row counts when listing applications joined with multi-row relations like `applicationPlugins`/`plugin` by avoiding direct pagination on the joined result.
- Ensure pagination and totals are computed over distinct applications while keeping a stable ordering (`application.title`, `application.id`).

### Description
- Reworked `ApplicationRepository::createListQuery` to use a two-step strategy: paginate application IDs with `createListIdsQueryBuilder(...)` then reload applications with required joins (`platform`, `user`, `applicationPlugins`, `plugin`) using `IN (:ids)`.
- Added `countList(...)` to the repository interface and implemented it to compute `totalItems` from the IDs query without depending on Doctrine pagination over joined rows.
- Updated `ApplicationListService` to use `countList(...)` for pagination totals and iterate the final query with `toIterable()` instead of a `Paginator` over joined rows.
- Added a functional regression test `testThatPublicListPaginationIsStableWithMultiplePlugins` to `PublicApplicationListControllerTest` to validate pagination when an application has multiple plugins and to avoid future regressions.

### Testing
- Ran `php -l` syntax checks for modified files `src/Platform/Domain/Repository/Interfaces/ApplicationRepositoryInterface.php`, `src/Platform/Infrastructure/Repository/ApplicationRepository.php`, `src/Platform/Application/Service/ApplicationListService.php`, and `tests/Application/Platform/Transport/Controller/Api/V1/PublicApplicationListControllerTest.php`, all returning no syntax errors.
- Added and linted the new regression test file successfully with `php -l`.
- Attempted to run the functional test suite via `bin/phpunit` but the PHPUnit binary is not available in this environment so the test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adc1ec134083268d1f32421c5c8706)