### PR TITLE
Remove application_slug from Conversation and key conversations by chat_id

### DIFF
--- a/migrations/Version20260309143000.php
+++ b/migrations/Version20260309143000.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260309143000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Remove application_slug from chat_conversation and key conversations by chat_id only.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE chat_conversation DROP INDEX uq_chat_conversation_chat_application_slug');
+        $this->addSql('ALTER TABLE chat_conversation DROP INDEX idx_chat_conversation_application_slug');
+        $this->addSql('ALTER TABLE chat_conversation DROP COLUMN application_slug');
+        $this->addSql('CREATE UNIQUE INDEX uq_conversation_chat_id ON chat_conversation (chat_id)');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE chat_conversation ADD application_slug VARCHAR(100) NOT NULL');
+        $this->addSql('CREATE INDEX idx_chat_conversation_application_slug ON chat_conversation (application_slug)');
+        $this->addSql('CREATE UNIQUE INDEX uq_chat_conversation_chat_application_slug ON chat_conversation (chat_id, application_slug)');
+        $this->addSql('DROP INDEX uq_conversation_chat_id ON chat_conversation');
+    }
+}

--- a/src/Chat/Application/Service/ConversationCreatorService.php
+++ b/src/Chat/Application/Service/ConversationCreatorService.php
@@ -18,16 +18,15 @@ class ConversationCreatorService
     ) {
     }
 
-    public function getOrCreate(Chat $chat, string $applicationSlug): Conversation
+    public function getOrCreate(Chat $chat): Conversation
     {
-        $conversation = $this->conversationRepository->findOneByChatAndApplicationSlug($chat, $applicationSlug);
+        $conversation = $this->conversationRepository->findOneByChat($chat);
         if ($conversation instanceof Conversation) {
             return $conversation;
         }
 
         $conversation = (new Conversation())
-            ->setChat($chat)
-            ->setApplicationSlug($applicationSlug);
+            ->setChat($chat);
 
         try {
             $this->entityManager->persist($conversation);
@@ -35,7 +34,7 @@ class ConversationCreatorService
 
             return $conversation;
         } catch (UniqueConstraintViolationException) {
-            $conversation = $this->conversationRepository->findOneByChatAndApplicationSlug($chat, $applicationSlug);
+            $conversation = $this->conversationRepository->findOneByChat($chat);
             if ($conversation instanceof Conversation) {
                 return $conversation;
             }

--- a/src/Chat/Application/Service/ConversationListService.php
+++ b/src/Chat/Application/Service/ConversationListService.php
@@ -30,17 +30,17 @@ final class ConversationListService
     /**
      * @return array<int, array<string, mixed>>
      */
-    public function getByApplicationSlug(string $applicationSlug): array
+    public function getByChatId(string $chatId): array
     {
-        return $this->normalizeConversations($this->conversationRepository->findByApplicationSlug($applicationSlug));
+        return $this->normalizeConversations($this->conversationRepository->findByChatId($chatId));
     }
 
     /**
      * @return array<int, array<string, mixed>>
      */
-    public function getByApplicationSlugAndUser(string $applicationSlug, User $user): array
+    public function getByChatIdAndUser(string $chatId, User $user): array
     {
-        return $this->normalizeConversations($this->conversationRepository->findByApplicationSlugAndUser($applicationSlug, $user));
+        return $this->normalizeConversations($this->conversationRepository->findByChatIdAndUser($chatId, $user));
     }
 
     /**
@@ -54,7 +54,6 @@ final class ConversationListService
             return [
                 'id' => $conversation->getId(),
                 'chatId' => $conversation->getChat()->getId(),
-                'applicationSlug' => $conversation->getApplicationSlug(),
                 'participants' => array_map(static function (ConversationParticipant $participant): array {
                     return [
                         'id' => $participant->getId(),

--- a/src/Chat/Domain/Entity/Conversation.php
+++ b/src/Chat/Domain/Entity/Conversation.php
@@ -16,9 +16,8 @@ use Ramsey\Uuid\UuidInterface;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'chat_conversation')]
-#[ORM\UniqueConstraint(name: 'uq_conversation_chat_application_slug', columns: ['chat_id', 'application_slug'])]
+#[ORM\UniqueConstraint(name: 'uq_conversation_chat_id', columns: ['chat_id'])]
 #[ORM\Index(name: 'idx_conversation_chat_id', columns: ['chat_id'])]
-#[ORM\Index(name: 'idx_conversation_application_slug', columns: ['application_slug'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Conversation implements EntityInterface
 {
@@ -32,9 +31,6 @@ class Conversation implements EntityInterface
     #[ORM\ManyToOne(targetEntity: Chat::class, inversedBy: 'conversations')]
     #[ORM\JoinColumn(name: 'chat_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private Chat $chat;
-
-    #[ORM\Column(name: 'application_slug', type: 'string', length: 100)]
-    private string $applicationSlug;
 
     /**
      * @var Collection<int, ConversationParticipant>
@@ -70,18 +66,6 @@ class Conversation implements EntityInterface
     public function setChat(Chat $chat): self
     {
         $this->chat = $chat;
-
-        return $this;
-    }
-
-    public function getApplicationSlug(): string
-    {
-        return $this->applicationSlug;
-    }
-
-    public function setApplicationSlug(string $applicationSlug): self
-    {
-        $this->applicationSlug = $applicationSlug;
 
         return $this;
     }

--- a/src/Chat/Domain/Repository/Interfaces/ConversationRepositoryInterface.php
+++ b/src/Chat/Domain/Repository/Interfaces/ConversationRepositoryInterface.php
@@ -10,7 +10,7 @@ use App\User\Domain\Entity\User;
 
 interface ConversationRepositoryInterface
 {
-    public function findOneByChatAndApplicationSlug(Chat $chat, string $applicationSlug): ?Conversation;
+    public function findOneByChat(Chat $chat): ?Conversation;
 
     /**
      * @return array<int, Conversation>
@@ -20,10 +20,10 @@ interface ConversationRepositoryInterface
     /**
      * @return array<int, Conversation>
      */
-    public function findByApplicationSlug(string $applicationSlug): array;
+    public function findByChatId(string $chatId): array;
 
     /**
      * @return array<int, Conversation>
      */
-    public function findByApplicationSlugAndUser(string $applicationSlug, User $user): array;
+    public function findByChatIdAndUser(string $chatId, User $user): array;
 }

--- a/src/Chat/Infrastructure/Repository/ConversationRepository.php
+++ b/src/Chat/Infrastructure/Repository/ConversationRepository.php
@@ -24,19 +24,17 @@ class ConversationRepository extends BaseRepository implements ConversationRepos
 
     protected static array $searchColumns = [
         'id',
-        'applicationSlug',
     ];
 
     public function __construct(protected ManagerRegistry $managerRegistry)
     {
     }
 
-    public function findOneByChatAndApplicationSlug(Chat $chat, string $applicationSlug): ?Entity
+    public function findOneByChat(Chat $chat): ?Entity
     {
         /** @var Entity|null $conversation */
         $conversation = $this->findOneBy([
             'chat' => $chat,
-            'applicationSlug' => $applicationSlug,
         ]);
 
         return $conversation;
@@ -53,23 +51,23 @@ class ConversationRepository extends BaseRepository implements ConversationRepos
             ->getResult();
     }
 
-    public function findByApplicationSlug(string $applicationSlug): array
+    public function findByChatId(string $chatId): array
     {
         return $this->getConversationQueryBuilder()
-            ->andWhere('conversation.applicationSlug = :applicationSlug')
-            ->setParameter('applicationSlug', $applicationSlug)
+            ->andWhere('chat.id = :chatId')
+            ->setParameter('chatId', $chatId, UuidBinaryOrderedTimeType::NAME)
             ->orderBy('conversation.createdAt', 'DESC')
             ->getQuery()
             ->getResult();
     }
 
-    public function findByApplicationSlugAndUser(string $applicationSlug, User $user): array
+    public function findByChatIdAndUser(string $chatId, User $user): array
     {
         return $this->getConversationQueryBuilder()
             ->innerJoin('conversation.participants', 'participant')
-            ->andWhere('conversation.applicationSlug = :applicationSlug')
+            ->andWhere('chat.id = :chatId')
             ->andWhere('participant.user = :user')
-            ->setParameter('applicationSlug', $applicationSlug)
+            ->setParameter('chatId', $chatId, UuidBinaryOrderedTimeType::NAME)
             ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
             ->orderBy('conversation.createdAt', 'DESC')
             ->getQuery()

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
@@ -19,11 +19,11 @@ class ApplicationConversationListController
     {
     }
 
-    #[Route(path: '/v1/chat/applications/{applicationSlug}/conversations', methods: [Request::METHOD_GET])]
-    public function __invoke(string $applicationSlug): JsonResponse
+    #[Route(path: '/v1/chat/chats/{chatId}/conversations', methods: [Request::METHOD_GET])]
+    public function __invoke(string $chatId): JsonResponse
     {
         return ConversationJsonResponseFactory::create(
-            $this->conversationListService->getByApplicationSlug($applicationSlug)
+            $this->conversationListService->getByChatId($chatId)
         );
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
@@ -23,11 +23,11 @@ class ApplicationUserConversationListController
     {
     }
 
-    #[Route(path: '/v1/chat/private/applications/{applicationSlug}/conversations', methods: [Request::METHOD_GET])]
-    public function __invoke(string $applicationSlug, User $loggedInUser): JsonResponse
+    #[Route(path: '/v1/chat/private/chats/{chatId}/conversations', methods: [Request::METHOD_GET])]
+    public function __invoke(string $chatId, User $loggedInUser): JsonResponse
     {
         return ConversationJsonResponseFactory::create(
-            $this->conversationListService->getByApplicationSlugAndUser($applicationSlug, $loggedInUser)
+            $this->conversationListService->getByChatIdAndUser($chatId, $loggedInUser)
         );
     }
 }

--- a/src/Recruit/Application/Service/ApplicationDiscussionBootstrapService.php
+++ b/src/Recruit/Application/Service/ApplicationDiscussionBootstrapService.php
@@ -41,12 +41,7 @@ final class ApplicationDiscussionBootstrapService
             throw new DomainException('Cannot bootstrap discussion: chat is not provisioned for this application.');
         }
 
-        $applicationSlug = $platformApplication->getSlug();
-        if ($applicationSlug === '') {
-            throw new DomainException('Cannot bootstrap discussion: platform application slug is missing.');
-        }
-
-        $conversation = $this->conversationCreatorService->getOrCreate($chat, $applicationSlug);
+        $conversation = $this->conversationCreatorService->getOrCreate($chat);
         $this->conversationParticipantCreatorService->getOrCreate($conversation, $jobOwner);
         $this->conversationParticipantCreatorService->getOrCreate($conversation, $applicantUser);
     }

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -54,8 +54,8 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             $this->ensureEvent($manager, $application, $calendar);
 
             if ($application->getTitle() === 'Recruit Talent Hub') {
-                $this->createDiscussionConversationScenario($manager, $application, $chat);
-                $this->createJohnRootConversationScenario($manager, $application, $chat, $calendar);
+                $this->createDiscussionConversationScenario($manager, $chat);
+                $this->createJohnRootConversationScenario($manager, $chat, $calendar);
             }
         }
 
@@ -216,7 +216,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         return $event;
     }
 
-    private function createDiscussionConversationScenario(ObjectManager $manager, PlatformApplication $application, Chat $chat): void
+    private function createDiscussionConversationScenario(ObjectManager $manager, Chat $chat): void
     {
         /** @var RecruitApplication $discussionApplication */
         $discussionApplication = $this->getReference('Recruit-Application-john-admin-on-other-owner-discussion', RecruitApplication::class);
@@ -225,18 +225,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             return;
         }
 
-        $conversation = $manager->getRepository(Conversation::class)->findOneBy([
-            'chat' => $chat,
-            'applicationSlug' => $application->getSlug(),
-        ]);
-
-        if (!$conversation instanceof Conversation) {
-            $conversation = (new Conversation())
-                ->setChat($chat)
-                ->setApplicationSlug($application->getSlug());
-
-            $manager->persist($conversation);
-        }
+        $conversation = $this->ensureConversation($manager, $chat);
 
         $owner = $discussionApplication->getJob()->getOwner();
         $applicant = $discussionApplication->getApplicant()->getUser();
@@ -300,7 +289,6 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
 
     private function createJohnRootConversationScenario(
         ObjectManager $manager,
-        PlatformApplication $application,
         Chat $chat,
         Calendar $calendar,
     ): void {
@@ -315,18 +303,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             return;
         }
 
-        $conversation = $manager->getRepository(Conversation::class)->findOneBy([
-            'chat' => $chat,
-            'applicationSlug' => $application->getSlug() . '-john-root-scenario',
-        ]);
-
-        if (!$conversation instanceof Conversation) {
-            $conversation = (new Conversation())
-                ->setChat($chat)
-                ->setApplicationSlug($application->getSlug() . '-john-root-scenario');
-
-            $manager->persist($conversation);
-        }
+        $conversation = $this->ensureConversation($manager, $chat);
 
         $this->ensureParticipant($manager, $conversation, $johnRoot);
         if ($johnRoot->getId() !== $otherOwner->getId()) {
@@ -382,6 +359,24 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $this->addReference('Recruit-Message-john-root-scenario-from-john-root', $johnRootMessage);
         $this->addReference('Recruit-Message-john-root-scenario-from-owner', $ownerReplyMessage);
         $this->addReference('Recruit-Event-john-root-scenario', $event);
+    }
+
+    private function ensureConversation(ObjectManager $manager, Chat $chat): Conversation
+    {
+        $conversation = $manager->getRepository(Conversation::class)->findOneBy([
+            'chat' => $chat,
+        ]);
+
+        if ($conversation instanceof Conversation) {
+            return $conversation;
+        }
+
+        $conversation = (new Conversation())
+            ->setChat($chat);
+
+        $manager->persist($conversation);
+
+        return $conversation;
     }
 
     private function ensureParticipant(ObjectManager $manager, Conversation $conversation, User $user): void

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateControllerTest.php
@@ -45,7 +45,6 @@ class ApplicationStatusUpdateControllerTest extends WebTestCase
 
         $conversation = $entityManager->getRepository(Conversation::class)->findOneBy([
             'chat' => $chat,
-            'applicationSlug' => $platformApplication->getSlug(),
         ]);
         self::assertInstanceOf(Conversation::class, $conversation);
 
@@ -89,7 +88,6 @@ class ApplicationStatusUpdateControllerTest extends WebTestCase
 
         $conversations = $entityManager->getRepository(Conversation::class)->findBy([
             'chat' => $chat,
-            'applicationSlug' => $platformApplication->getSlug(),
         ]);
         self::assertCount(1, $conversations);
 
@@ -134,7 +132,6 @@ class ApplicationStatusUpdateControllerTest extends WebTestCase
 
         $conversation = $entityManager->getRepository(Conversation::class)->findOneBy([
             'chat' => $chat,
-            'applicationSlug' => $platformApplication->getSlug(),
         ]);
 
         if ($conversation instanceof Conversation) {


### PR DESCRIPTION
### Motivation
- Simplify conversation model by removing the `application_slug` column and treat conversations as unique per `chat_id`, removing per-application duplication and related indexes.

### Description
- Added migration `Version20260309143000` that drops the `application_slug` column and its indexes and creates a unique index on `chat_id`.
- Removed the `application_slug` property and its getter/setter from the `Conversation` entity and updated the ORM unique constraint and indexes to use `chat_id` only.
- Reworked repository API and implementation to use `findOneByChat`, `findByChatId` and `findByChatIdAndUser` and adjusted queries and `searchColumns` accordingly.
- Updated services, controllers, fixtures and tests to stop passing or expecting `applicationSlug` and to use `Chat`/`chatId` instead, including changes to `ConversationCreatorService`, `ConversationListService`, the public and private conversation list controllers, the recruit bootstrap service, and fixture helpers (added `ensureConversation`).

### Testing
- Ran the PHPUnit test suite including the modified `tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateControllerTest`, and the updated tests passed.
- Executed Doctrine migrations against a MySQL test database using `bin/console doctrine:migrations:migrate` and the migration applied successfully.
- Ran affected repository and integration tests for conversation lookup changes and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adc6eabf108326af8deae78093bdea)