### PR TITLE
Memoize Conversation in recruit fixtures to prevent duplicate DB inserts

### DIFF
--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -363,11 +363,20 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
 
     private function ensureConversation(ObjectManager $manager, Chat $chat): Conversation
     {
+        static $conversationByChat = [];
+
+        $chatKey = $chat->getId()?->toRfc4122() ?? 'new-' . spl_object_id($chat);
+
+        if (isset($conversationByChat[$chatKey]) && $conversationByChat[$chatKey] instanceof Conversation) {
+            return $conversationByChat[$chatKey];
+        }
+
         $conversation = $manager->getRepository(Conversation::class)->findOneBy([
             'chat' => $chat,
         ]);
 
         if ($conversation instanceof Conversation) {
+            $conversationByChat[$chatKey] = $conversation;
             return $conversation;
         }
 
@@ -375,6 +384,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             ->setChat($chat);
 
         $manager->persist($conversation);
+        $conversationByChat[$chatKey] = $conversation;
 
         return $conversation;
     }


### PR DESCRIPTION
### Motivation

- Prevent duplicate `Conversation` entities being persisted when multiple fixture scenario builders call `ensureConversation()` for the same `Chat` before Doctrine `flush()`, which caused a unique constraint violation on `chat_conversation.uq_conversation_chat_id`.

### Description

- Added a static in-memory cache `static $conversationByChat = []` inside `ensureConversation()` to memoize `Conversation` instances per chat.
- Compute a stable cache key from the chat with `$chat->getId()?->toRfc4122() ?? 'new-' . spl_object_id($chat)` so both persisted and new `Chat` objects are handled.
- Short-circuit to the cached `Conversation` before doing a repository lookup, and store repository-fetched and newly created `Conversation` objects in the cache for reuse.
- The change is localized to `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` and preserves existing DB lookup behavior.

### Testing

- Ran `php -l src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` which reported no syntax errors and succeeded.
- Attempted `php bin/console doctrine:fixtures:load -n` to validate fixture loading, but it failed in this environment due to missing project dependencies (`Dependencies are missing. Try running "composer install"`).
- No other automated tests were executed in this environment because dependency installation is required to run the full fixture load.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adc9a223788326b53c2cb6434ca3e7)