### PR TITLE
Add Calendar & Chat mutation endpoints and enrich john-root fixtures

### DIFF
--- a/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationOwnerEventMutationController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationOwnerEventMutationController.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Transport\Controller\Api\V1\Event;
+
+use App\Calendar\Domain\Entity\Event;
+use App\Calendar\Domain\Enum\EventStatus;
+use App\Calendar\Infrastructure\Repository\CalendarRepository;
+use App\Calendar\Infrastructure\Repository\EventRepository;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Infrastructure\Repository\ApplicationRepository;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Calendar Event')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class ApplicationOwnerEventMutationController
+{
+    public function __construct(
+        private readonly EventRepository $eventRepository,
+        private readonly ApplicationRepository $applicationRepository,
+        private readonly CalendarRepository $calendarRepository,
+    ) {
+    }
+
+    #[Route(path: '/v1/calendar/private/applications/{applicationSlug}/events', methods: [Request::METHOD_POST])]
+    public function create(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
+    {
+        $application = $this->findOwnedApplication($applicationSlug, $loggedInUser);
+        $calendar = $this->calendarRepository->findOneByApplication($application);
+        if ($calendar === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Application has no calendar.');
+        }
+
+        $payload = $request->toArray();
+        $event = (new Event())
+            ->setTitle($this->requireString($payload, 'title'))
+            ->setDescription((string) ($payload['description'] ?? ''))
+            ->setStartAt($this->requireDate($payload, 'startAt'))
+            ->setEndAt($this->requireDate($payload, 'endAt'))
+            ->setStatus((string) ($payload['status'] ?? EventStatus::CONFIRMED->value))
+            ->setCalendar($calendar)
+            ->setUser($loggedInUser);
+
+        $this->eventRepository->save($event);
+
+        return new JsonResponse(['id' => $event->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route(path: '/v1/calendar/private/applications/{applicationSlug}/events/{eventId}', methods: [Request::METHOD_PATCH])]
+    public function patch(string $applicationSlug, string $eventId, Request $request, User $loggedInUser): JsonResponse
+    {
+        $application = $this->findOwnedApplication($applicationSlug, $loggedInUser);
+        $event = $this->findOwnedApplicationEvent($eventId, $application, $loggedInUser);
+        $payload = $request->toArray();
+
+        if (isset($payload['title']) && is_string($payload['title'])) {
+            $event->setTitle($payload['title']);
+        }
+        if (isset($payload['description']) && is_string($payload['description'])) {
+            $event->setDescription($payload['description']);
+        }
+        if (isset($payload['startAt']) && is_string($payload['startAt'])) {
+            $event->setStartAt($this->parseDate($payload['startAt'], 'startAt'));
+        }
+        if (isset($payload['endAt']) && is_string($payload['endAt'])) {
+            $event->setEndAt($this->parseDate($payload['endAt'], 'endAt'));
+        }
+
+        $this->eventRepository->save($event);
+
+        return new JsonResponse(['id' => $event->getId()]);
+    }
+
+    #[Route(path: '/v1/calendar/private/applications/{applicationSlug}/events/{eventId}', methods: [Request::METHOD_DELETE])]
+    public function delete(string $applicationSlug, string $eventId, User $loggedInUser): JsonResponse
+    {
+        $application = $this->findOwnedApplication($applicationSlug, $loggedInUser);
+        $event = $this->findOwnedApplicationEvent($eventId, $application, $loggedInUser);
+        $this->eventRepository->remove($event);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route(path: '/v1/calendar/private/applications/{applicationSlug}/events/{eventId}/cancel', methods: [Request::METHOD_POST])]
+    public function cancel(string $applicationSlug, string $eventId, User $loggedInUser): JsonResponse
+    {
+        $application = $this->findOwnedApplication($applicationSlug, $loggedInUser);
+        $event = $this->findOwnedApplicationEvent($eventId, $application, $loggedInUser);
+        $event->setIsCancelled(true)->setStatus(EventStatus::CANCELLED);
+        $this->eventRepository->save($event);
+
+        return new JsonResponse(['id' => $event->getId(), 'status' => $event->getStatusValue(), 'isCancelled' => $event->isCancelled()]);
+    }
+
+    private function findOwnedApplication(string $slug, User $loggedInUser): Application
+    {
+        $application = $this->applicationRepository->findOneBy(['slug' => $slug]);
+        if (!$application instanceof Application || $application->getUser()?->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Application not found.');
+        }
+
+        return $application;
+    }
+
+    private function findOwnedApplicationEvent(string $eventId, Application $application, User $loggedInUser): Event
+    {
+        $event = $this->eventRepository->find($eventId);
+        if (!$event instanceof Event) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Event not found.');
+        }
+
+        $calendar = $event->getCalendar();
+        if ($calendar?->getApplication()?->getId() !== $application->getId() || $event->getUser()?->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Event not found.');
+        }
+
+        return $event;
+    }
+
+    /** @param array<string, mixed> $payload */
+    private function requireString(array $payload, string $field): string
+    {
+        $value = $payload[$field] ?? null;
+        if (!is_string($value) || $value === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" is required.');
+        }
+
+        return $value;
+    }
+
+    /** @param array<string, mixed> $payload */
+    private function requireDate(array $payload, string $field): DateTimeImmutable
+    {
+        $value = $payload[$field] ?? null;
+        if (!is_string($value)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" must be a valid date string.');
+        }
+
+        return $this->parseDate($value, $field);
+    }
+
+    private function parseDate(string $value, string $field): DateTimeImmutable
+    {
+        try {
+            return new DateTimeImmutable($value);
+        } catch (\Throwable) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" must be a valid date string.');
+        }
+    }
+}

--- a/src/Calendar/Transport/Controller/Api/V1/Event/UserEventMutationController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/UserEventMutationController.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Transport\Controller\Api\V1\Event;
+
+use App\Calendar\Domain\Entity\Event;
+use App\Calendar\Domain\Enum\EventStatus;
+use App\Calendar\Infrastructure\Repository\EventRepository;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Calendar Event')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class UserEventMutationController
+{
+    public function __construct(private readonly EventRepository $eventRepository)
+    {
+    }
+
+    #[Route(path: '/v1/calendar/private/events', methods: [Request::METHOD_POST])]
+    public function create(Request $request, User $loggedInUser): JsonResponse
+    {
+        $payload = $request->toArray();
+
+        $event = (new Event())
+            ->setTitle($this->requireString($payload, 'title'))
+            ->setDescription((string) ($payload['description'] ?? ''))
+            ->setStartAt($this->requireDate($payload, 'startAt'))
+            ->setEndAt($this->requireDate($payload, 'endAt'))
+            ->setStatus((string) ($payload['status'] ?? EventStatus::CONFIRMED->value))
+            ->setUser($loggedInUser);
+
+        if (isset($payload['location']) && is_string($payload['location'])) {
+            $event->setLocation($payload['location']);
+        }
+
+        $this->eventRepository->save($event);
+
+        return new JsonResponse(['id' => $event->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route(path: '/v1/calendar/private/events/{eventId}', methods: [Request::METHOD_PATCH])]
+    public function patch(string $eventId, Request $request, User $loggedInUser): JsonResponse
+    {
+        $event = $this->findOwnedEvent($eventId, $loggedInUser);
+        $payload = $request->toArray();
+
+        if (isset($payload['title']) && is_string($payload['title'])) {
+            $event->setTitle($payload['title']);
+        }
+        if (isset($payload['description']) && is_string($payload['description'])) {
+            $event->setDescription($payload['description']);
+        }
+        if (isset($payload['startAt']) && is_string($payload['startAt'])) {
+            $event->setStartAt($this->parseDate($payload['startAt'], 'startAt'));
+        }
+        if (isset($payload['endAt']) && is_string($payload['endAt'])) {
+            $event->setEndAt($this->parseDate($payload['endAt'], 'endAt'));
+        }
+
+        $this->eventRepository->save($event);
+
+        return new JsonResponse(['id' => $event->getId()]);
+    }
+
+    #[Route(path: '/v1/calendar/private/events/{eventId}', methods: [Request::METHOD_DELETE])]
+    public function delete(string $eventId, User $loggedInUser): JsonResponse
+    {
+        $event = $this->findOwnedEvent($eventId, $loggedInUser);
+        $this->eventRepository->remove($event);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route(path: '/v1/calendar/private/events/{eventId}/cancel', methods: [Request::METHOD_POST])]
+    public function cancel(string $eventId, User $loggedInUser): JsonResponse
+    {
+        $event = $this->findOwnedEvent($eventId, $loggedInUser);
+        $event->setIsCancelled(true)->setStatus(EventStatus::CANCELLED);
+        $this->eventRepository->save($event);
+
+        return new JsonResponse(['id' => $event->getId(), 'status' => $event->getStatusValue(), 'isCancelled' => $event->isCancelled()]);
+    }
+
+    private function findOwnedEvent(string $eventId, User $loggedInUser): Event
+    {
+        $event = $this->eventRepository->find($eventId);
+        if (!$event instanceof Event || $event->getUser()?->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Event not found.');
+        }
+
+        return $event;
+    }
+
+    /** @param array<string, mixed> $payload */
+    private function requireString(array $payload, string $field): string
+    {
+        $value = $payload[$field] ?? null;
+        if (!is_string($value) || $value === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" is required.');
+        }
+
+        return $value;
+    }
+
+    /** @param array<string, mixed> $payload */
+    private function requireDate(array $payload, string $field): DateTimeImmutable
+    {
+        $value = $payload[$field] ?? null;
+        if (!is_string($value)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" must be a valid date string.');
+        }
+
+        return $this->parseDate($value, $field);
+    }
+
+    private function parseDate(string $value, string $field): DateTimeImmutable
+    {
+        try {
+            return new DateTimeImmutable($value);
+        } catch (\Throwable) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" must be a valid date string.');
+        }
+    }
+}

--- a/src/Chat/Infrastructure/Repository/ChatMessageReactionRepository.php
+++ b/src/Chat/Infrastructure/Repository/ChatMessageReactionRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Infrastructure\Repository;
+
+use App\Chat\Domain\Entity\ChatMessageReaction as Entity;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ChatMessageReactionRepository extends BaseRepository
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = ['id', 'reaction'];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Chat/Infrastructure/Repository/ChatMessageRepository.php
+++ b/src/Chat/Infrastructure/Repository/ChatMessageRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Infrastructure\Repository;
+
+use App\Chat\Domain\Entity\ChatMessage as Entity;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ChatMessageRepository extends BaseRepository
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = ['id', 'content'];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationMutationController.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Transport\Controller\Api\V1\Conversation;
+
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Infrastructure\Repository\ChatRepository;
+use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
+use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Chat Conversation')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class UserConversationMutationController
+{
+    public function __construct(
+        private readonly ChatRepository $chatRepository,
+        private readonly UserRepository $userRepository,
+        private readonly ConversationRepository $conversationRepository,
+        private readonly ConversationParticipantRepository $participantRepository,
+    ) {
+    }
+
+    #[Route(path: '/v1/chat/private/chats/{chatId}/conversations', methods: [Request::METHOD_POST])]
+    public function create(string $chatId, Request $request, User $loggedInUser): JsonResponse
+    {
+        $chat = $this->chatRepository->find($chatId);
+        if ($chat === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Chat not found.');
+        }
+
+        $payload = $request->toArray();
+        $targetUserId = $payload['userId'] ?? null;
+        if (!is_string($targetUserId) || $targetUserId === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "userId" is required.');
+        }
+
+        $targetUser = $this->userRepository->find($targetUserId);
+        if (!$targetUser instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown userId.');
+        }
+
+        $conversation = (new Conversation())->setChat($chat);
+        $this->conversationRepository->save($conversation, false);
+
+        $this->participantRepository->save((new ConversationParticipant())->setConversation($conversation)->setUser($loggedInUser), false);
+        if ($targetUser->getId() !== $loggedInUser->getId()) {
+            $this->participantRepository->save((new ConversationParticipant())->setConversation($conversation)->setUser($targetUser), false);
+        }
+        $this->conversationRepository->getEntityManager()->flush();
+
+        return new JsonResponse(['id' => $conversation->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route(path: '/v1/chat/private/conversations/{conversationId}', methods: [Request::METHOD_PATCH])]
+    public function patch(string $conversationId, Request $request, User $loggedInUser): JsonResponse
+    {
+        $conversation = $this->findParticipantConversation($conversationId, $loggedInUser);
+        $payload = $request->toArray();
+
+        $targetUserId = $payload['userId'] ?? null;
+        if (!is_string($targetUserId) || $targetUserId === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "userId" is required.');
+        }
+
+        $targetUser = $this->userRepository->find($targetUserId);
+        if (!$targetUser instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown userId.');
+        }
+
+        $alreadyParticipant = $this->participantRepository->findOneByConversationAndUser($conversation, $targetUser);
+        if (!$alreadyParticipant instanceof ConversationParticipant) {
+            $this->participantRepository->save(
+                (new ConversationParticipant())->setConversation($conversation)->setUser($targetUser)
+            );
+        }
+
+        return new JsonResponse(['id' => $conversation->getId()]);
+    }
+
+    #[Route(path: '/v1/chat/private/conversations/{conversationId}', methods: [Request::METHOD_DELETE])]
+    public function delete(string $conversationId, User $loggedInUser): JsonResponse
+    {
+        $conversation = $this->findParticipantConversation($conversationId, $loggedInUser);
+        $this->conversationRepository->remove($conversation);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    private function findParticipantConversation(string $conversationId, User $loggedInUser): Conversation
+    {
+        $conversation = $this->conversationRepository->find($conversationId);
+        if (!$conversation instanceof Conversation) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+        }
+
+        $participant = $this->participantRepository->findOneByConversationAndUser($conversation, $loggedInUser);
+        if (!$participant instanceof ConversationParticipant) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+        }
+
+        return $conversation;
+    }
+}

--- a/src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Transport\Controller\Api\V1\Message;
+
+use App\Chat\Domain\Entity\ChatMessage;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Infrastructure\Repository\ChatMessageRepository;
+use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
+use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Chat Message')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class UserMessageMutationController
+{
+    public function __construct(
+        private readonly ConversationRepository $conversationRepository,
+        private readonly ConversationParticipantRepository $participantRepository,
+        private readonly ChatMessageRepository $messageRepository,
+    ) {
+    }
+
+    #[Route(path: '/v1/chat/private/conversations/{conversationId}/messages', methods: [Request::METHOD_POST])]
+    public function create(string $conversationId, Request $request, User $loggedInUser): JsonResponse
+    {
+        $conversation = $this->findParticipantConversation($conversationId, $loggedInUser);
+        $payload = $request->toArray();
+
+        $content = $payload['content'] ?? null;
+        if (!is_string($content) || $content === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "content" is required.');
+        }
+
+        $message = (new ChatMessage())
+            ->setConversation($conversation)
+            ->setSender($loggedInUser)
+            ->setContent($content)
+            ->setAttachments([]);
+
+        $this->messageRepository->save($message);
+
+        return new JsonResponse(['id' => $message->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route(path: '/v1/chat/private/messages/{messageId}', methods: [Request::METHOD_PATCH])]
+    public function patch(string $messageId, Request $request, User $loggedInUser): JsonResponse
+    {
+        $message = $this->findOwnMessage($messageId, $loggedInUser);
+        $payload = $request->toArray();
+
+        if (isset($payload['content']) && is_string($payload['content']) && $payload['content'] !== '') {
+            $message->setContent($payload['content']);
+            $this->messageRepository->save($message);
+        }
+
+        return new JsonResponse(['id' => $message->getId()]);
+    }
+
+    #[Route(path: '/v1/chat/private/messages/{messageId}', methods: [Request::METHOD_DELETE])]
+    public function delete(string $messageId, User $loggedInUser): JsonResponse
+    {
+        $message = $this->findOwnMessage($messageId, $loggedInUser);
+        $this->messageRepository->remove($message);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    private function findParticipantConversation(string $conversationId, User $loggedInUser): Conversation
+    {
+        $conversation = $this->conversationRepository->find($conversationId);
+        if (!$conversation instanceof Conversation) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+        }
+
+        $participant = $this->participantRepository->findOneByConversationAndUser($conversation, $loggedInUser);
+        if (!$participant instanceof ConversationParticipant) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+        }
+
+        return $conversation;
+    }
+
+    private function findOwnMessage(string $messageId, User $loggedInUser): ChatMessage
+    {
+        $message = $this->messageRepository->find($messageId);
+        if (!$message instanceof ChatMessage || $message->getSender()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Message not found.');
+        }
+
+        return $message;
+    }
+}

--- a/src/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationController.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Transport\Controller\Api\V1\Reaction;
+
+use App\Chat\Domain\Entity\ChatMessage;
+use App\Chat\Domain\Entity\ChatMessageReaction;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Infrastructure\Repository\ChatMessageReactionRepository;
+use App\Chat\Infrastructure\Repository\ChatMessageRepository;
+use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Chat Message Reaction')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class UserReactionMutationController
+{
+    public function __construct(
+        private readonly ChatMessageRepository $messageRepository,
+        private readonly ChatMessageReactionRepository $reactionRepository,
+        private readonly ConversationParticipantRepository $participantRepository,
+    ) {
+    }
+
+    #[Route(path: '/v1/chat/private/messages/{messageId}/reactions', methods: [Request::METHOD_POST])]
+    public function create(string $messageId, Request $request, User $loggedInUser): JsonResponse
+    {
+        $message = $this->findParticipantMessage($messageId, $loggedInUser);
+        $payload = $request->toArray();
+
+        $reactionType = $payload['reaction'] ?? null;
+        if (!is_string($reactionType) || $reactionType === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "reaction" is required.');
+        }
+
+        $reaction = (new ChatMessageReaction())
+            ->setMessage($message)
+            ->setUser($loggedInUser)
+            ->setReaction($reactionType);
+
+        $this->reactionRepository->save($reaction);
+
+        return new JsonResponse(['id' => $reaction->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route(path: '/v1/chat/private/reactions/{reactionId}', methods: [Request::METHOD_PATCH])]
+    public function patch(string $reactionId, Request $request, User $loggedInUser): JsonResponse
+    {
+        $reaction = $this->findOwnReaction($reactionId, $loggedInUser);
+        $payload = $request->toArray();
+
+        if (isset($payload['reaction']) && is_string($payload['reaction']) && $payload['reaction'] !== '') {
+            $reaction->setReaction($payload['reaction']);
+            $this->reactionRepository->save($reaction);
+        }
+
+        return new JsonResponse(['id' => $reaction->getId()]);
+    }
+
+    #[Route(path: '/v1/chat/private/reactions/{reactionId}', methods: [Request::METHOD_DELETE])]
+    public function delete(string $reactionId, User $loggedInUser): JsonResponse
+    {
+        $reaction = $this->findOwnReaction($reactionId, $loggedInUser);
+        $this->reactionRepository->remove($reaction);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    private function findParticipantMessage(string $messageId, User $loggedInUser): ChatMessage
+    {
+        $message = $this->messageRepository->find($messageId);
+        if (!$message instanceof ChatMessage) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Message not found.');
+        }
+
+        $participant = $this->participantRepository->findOneByConversationAndUser($message->getConversation(), $loggedInUser);
+        if (!$participant instanceof ConversationParticipant) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Message not found.');
+        }
+
+        return $message;
+    }
+
+    private function findOwnReaction(string $reactionId, User $loggedInUser): ChatMessageReaction
+    {
+        $reaction = $this->reactionRepository->find($reactionId);
+        if (!$reaction instanceof ChatMessageReaction || $reaction->getUser()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Reaction not found.');
+        }
+
+        return $reaction;
+    }
+}

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -297,6 +297,10 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
 
         /** @var User $johnRoot */
         $johnRoot = $this->getReference('User-john-root', User::class);
+        /** @var User $johnUser */
+        $johnUser = $this->getReference('User-john-user', User::class);
+        /** @var User $johnAdmin */
+        $johnAdmin = $this->getReference('User-john-admin', User::class);
 
         $otherOwner = $johnRootRecruitApplication->getJob()->getOwner();
         if (!$otherOwner instanceof User) {
@@ -308,6 +312,12 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $this->ensureParticipant($manager, $conversation, $johnRoot);
         if ($johnRoot->getId() !== $otherOwner->getId()) {
             $this->ensureParticipant($manager, $conversation, $otherOwner);
+        }
+        if ($johnRoot->getId() !== $johnUser->getId()) {
+            $this->ensureParticipant($manager, $conversation, $johnUser);
+        }
+        if ($johnRoot->getId() !== $johnAdmin->getId()) {
+            $this->ensureParticipant($manager, $conversation, $johnAdmin);
         }
 
         $johnRootMessage = $manager->getRepository(ChatMessage::class)->findOneBy([
@@ -351,6 +361,35 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
                 ->setUser($johnRoot)
                 ->setReaction('✅');
             $manager->persist($reaction);
+        }
+
+        $johnUserMessage = $manager->getRepository(ChatMessage::class)->findOneBy([
+            'conversation' => $conversation,
+            'content' => 'Salut John, je peux partager un retour sur le processus de recrutement.',
+        ]);
+
+        if (!$johnUserMessage instanceof ChatMessage) {
+            $johnUserMessage = (new ChatMessage())
+                ->setConversation($conversation)
+                ->setSender($johnUser)
+                ->setContent('Salut John, je peux partager un retour sur le processus de recrutement.')
+                ->setAttachments([])
+                ->setReadAt(new DateTimeImmutable());
+            $manager->persist($johnUserMessage);
+        }
+
+        $johnAdminReaction = $manager->getRepository(ChatMessageReaction::class)->findOneBy([
+            'message' => $johnUserMessage,
+            'user' => $johnAdmin,
+            'reaction' => '👀',
+        ]);
+
+        if (!$johnAdminReaction instanceof ChatMessageReaction) {
+            $johnAdminReaction = (new ChatMessageReaction())
+                ->setMessage($johnUserMessage)
+                ->setUser($johnAdmin)
+                ->setReaction('👀');
+            $manager->persist($johnAdminReaction);
         }
 
         $event = $this->ensureJohnRootEvent($manager, $calendar, $johnRoot);


### PR DESCRIPTION
### Motivation
- Provide authenticated mutation endpoints so logged users can manage their own calendar events and conversations/messages/reactions, and so application owners can manage application-scoped events.
- Populate fixtures with richer chat/calendar interactions between `john-root` and other users to support functional tests and development scenarios.

### Description
- Added Calendar user mutation controller `src/Calendar/Transport/Controller/Api/V1/Event/UserEventMutationController.php` exposing `POST /v1/calendar/private/events`, `PATCH /v1/calendar/private/events/{eventId}`, `DELETE /v1/calendar/private/events/{eventId}` and `POST /v1/calendar/private/events/{eventId}/cancel` with ownership checks on `event.user`.
- Added Calendar application-owner mutation controller `src/Calendar/Transport/Controller/Api/V1/Event/ApplicationOwnerEventMutationController.php` exposing `POST /v1/calendar/private/applications/{applicationSlug}/events`, `PATCH`/`DELETE` and `POST .../cancel` with validation that the authenticated user owns the referenced application and event calendar.
- Added Chat mutation controllers for conversations, messages and reactions under `src/Chat/Transport/Controller/Api/V1/` with routes for create/patch/delete and appropriate participant/sender/owner checks: `Conversation/UserConversationMutationController.php`, `Message/UserMessageMutationController.php`, and `Reaction/UserReactionMutationController.php`.
- Added repositories `src/Chat/Infrastructure/Repository/ChatMessageRepository.php` and `src/Chat/Infrastructure/Repository/ChatMessageReactionRepository.php` to support persistence operations.
- Enriched fixtures in `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` to add `john-user` and `john-admin` participants/messages/reactions in the `john-root` scenario.

### Testing
- Ran PHP syntax checks with `php -l` on all new and modified PHP files and they reported no syntax errors.
- Attempted to list routes via `php bin/console debug:router` but the command failed due to missing dependencies in the environment (`composer install` required), so full runtime verification of route wiring was not executed.
- All modified files were linted and committed; integration/runtime checks should be performed in an environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adc92a16d483268e25bbd3f24509e7)