### PR TITLE
Fix duplicate conversation participant inserts in recruit fixture scenario

### DIFF
--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -430,12 +430,23 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
 
     private function ensureParticipant(ObjectManager $manager, Conversation $conversation, User $user): void
     {
+        static $participantsByConversationAndUser = [];
+
+        $conversationKey = (string) ($conversation->getId() ?? 'new-' . spl_object_id($conversation));
+        $userKey = (string) ($user->getId() ?? 'new-' . spl_object_id($user));
+        $participantKey = $conversationKey . '::' . $userKey;
+
+        if (isset($participantsByConversationAndUser[$participantKey])) {
+            return;
+        }
+
         $existing = $manager->getRepository(ConversationParticipant::class)->findOneBy([
             'conversation' => $conversation,
             'user' => $user,
         ]);
 
         if ($existing instanceof ConversationParticipant) {
+            $participantsByConversationAndUser[$participantKey] = true;
             return;
         }
 
@@ -444,6 +455,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             ->setUser($user);
 
         $manager->persist($participant);
+        $participantsByConversationAndUser[$participantKey] = true;
     }
 
     #[Override]


### PR DESCRIPTION
### Motivation

- Prevent a SQL unique constraint violation when fixture code may persist the same `ConversationParticipant` multiple times during a single fixtures run (including when entities are not yet flushed).

### Description

- Add an in-memory deduplication cache in `LoadRecruitChatCalendarScenarioData::ensureParticipant` keyed by conversation + user so repeated calls short-circuit before persisting a duplicate.
- Compute keys using the entity `getId()` when available or `spl_object_id()` for new in-memory objects, and store a combined `conversation::user` key.
- Preserve the existing repository lookup (`findOneBy`) and mark discovered existing rows in the cache to avoid further DB lookups during the same run.
- Modified file: `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php`.

### Testing

- Ran `php -l src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` and it returned no syntax errors.
- Attempted to run `php bin/console doctrine:fixtures:load -n` but it failed in this environment due to missing project dependencies and requires `composer install` to run; no fixture-run verification could be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adcbcaf8888326a1d90299b26504b4)