### PR TITLE
Fix Doctrine fetch-join iteration error in application public list

### DIFF
--- a/src/Platform/Application/Service/ApplicationListService.php
+++ b/src/Platform/Application/Service/ApplicationListService.php
@@ -76,7 +76,7 @@ class ApplicationListService
 
             $items = [];
             /** @var Application $application */
-            foreach ($query->toIterable() as $application) {
+            foreach ($query->getResult() as $application) {
                 $pluginKeys = [];
                 foreach ($application->getApplicationPlugins() as $applicationPlugin) {
                     $pluginKey = $applicationPlugin->getPlugin()?->getPluginKeyValue();


### PR DESCRIPTION
### Motivation
- Prevent Doctrine's `iterateWithFetchJoinNotAllowed` QueryException when iterating results from a query that uses fetch joins on `applicationPlugins`/`plugin` associations.

### Description
- Replace `toIterable()` with `getResult()` in `src/Platform/Application/Service/ApplicationListService.php` so the paginated application list query can be iterated while using fetch-joined associations.

### Testing
- Ran PHP lint on the modified file with `php -l src/Platform/Application/Service/ApplicationListService.php` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69add4d8a284832688104121626d15df)