### PR TITLE
Cache-first listing for Calendar & Chat with optional ES shortlist and DB fallback

### DIFF
--- a/src/Calendar/Application/Service/EventListService.php
+++ b/src/Calendar/Application/Service/EventListService.php
@@ -6,38 +6,180 @@ namespace App\Calendar\Application\Service;
 
 use App\Calendar\Domain\Entity\Event;
 use App\Calendar\Domain\Repository\Interfaces\EventRepositoryInterface;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\User\Domain\Entity\User;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Throwable;
 
+use function array_filter;
 use function array_map;
 
-final class EventListService
+final readonly class EventListService
 {
-    public function __construct(private readonly EventRepositoryInterface $eventRepository)
-    {
+    public function __construct(
+        private EventRepositoryInterface $eventRepository,
+        private CacheInterface $cache,
+        private ElasticsearchServiceInterface $elasticsearchService,
+    ) {
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @param array<string, string> $filters
+     *
+     * @return array<string, mixed>
+     * @throws InvalidArgumentException
+     * @throws \JsonException
      */
-    public function getByUser(User $user): array
+    public function getByUser(User $user, array $filters = [], int $page = 1, int $limit = 20): array
     {
-        return $this->normalizeEvents($this->eventRepository->findByUser($user));
+        return $this->getList('user', $filters, $page, $limit, $user, null);
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @param array<string, string> $filters
+     *
+     * @return array<string, mixed>
+     * @throws InvalidArgumentException
+     * @throws \JsonException
      */
-    public function getByApplicationSlug(string $applicationSlug): array
+    public function getByApplicationSlug(string $applicationSlug, array $filters = [], int $page = 1, int $limit = 20): array
     {
-        return $this->normalizeEvents($this->eventRepository->findByApplicationSlug($applicationSlug));
+        return $this->getList('application_public', $filters, $page, $limit, null, $applicationSlug);
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @param array<string, string> $filters
+     *
+     * @return array<string, mixed>
+     * @throws InvalidArgumentException
+     * @throws \JsonException
      */
-    public function getByApplicationSlugAndUser(string $applicationSlug, User $user): array
+    public function getByApplicationSlugAndUser(string $applicationSlug, User $user, array $filters = [], int $page = 1, int $limit = 20): array
     {
-        return $this->normalizeEvents($this->eventRepository->findByApplicationSlugAndUser($applicationSlug, $user));
+        return $this->getList('application_private', $filters, $page, $limit, $user, $applicationSlug);
+    }
+
+    /**
+     * @param array<string, string> $filters
+     *
+     * @return array<string, mixed>
+     * @throws InvalidArgumentException
+     * @throws \JsonException
+     */
+    private function getList(string $accessContext, array $filters, int $page, int $limit, ?User $user, ?string $applicationSlug): array
+    {
+        $page = max(1, $page);
+        $limit = max(1, min(100, $limit));
+
+        $filters = [
+            'title' => trim((string)($filters['title'] ?? '')),
+            'description' => trim((string)($filters['description'] ?? '')),
+            'location' => trim((string)($filters['location'] ?? '')),
+        ];
+
+        $cacheKey = 'event_list_' . md5((string) json_encode([
+            'accessContext' => $accessContext,
+            'userId' => $user?->getId(),
+            'applicationSlug' => $applicationSlug,
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+
+        /** @var array<string, mixed> $result */
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($accessContext, $user, $applicationSlug, $filters, $page, $limit): array {
+            $item->expiresAfter(120);
+
+            $esIds = $this->searchIdsFromElastic($filters);
+            if ($esIds === []) {
+                return [
+                    'items' => [],
+                    'pagination' => [
+                        'page' => $page,
+                        'limit' => $limit,
+                        'totalItems' => 0,
+                        'totalPages' => 0,
+                    ],
+                ];
+            }
+
+            if ($accessContext === 'user') {
+                $events = $this->eventRepository->findByUser($user, $filters, $page, $limit, $esIds);
+                $totalItems = $this->eventRepository->countByUser($user, $filters, $esIds);
+            } elseif ($accessContext === 'application_private') {
+                $events = $this->eventRepository->findByApplicationSlugAndUser($applicationSlug, $user, $filters, $page, $limit, $esIds);
+                $totalItems = $this->eventRepository->countByApplicationSlugAndUser($applicationSlug, $user, $filters, $esIds);
+            } else {
+                $events = $this->eventRepository->findByApplicationSlug($applicationSlug, $filters, $page, $limit, $esIds);
+                $totalItems = $this->eventRepository->countByApplicationSlug($applicationSlug, $filters, $esIds);
+            }
+
+            return [
+                'items' => $this->normalizeEvents($events),
+                'pagination' => [
+                    'page' => $page,
+                    'limit' => $limit,
+                    'totalItems' => $totalItems,
+                    'totalPages' => $totalItems > 0 ? (int) ceil($totalItems / $limit) : 0,
+                ],
+            ];
+        });
+
+        $result['filters'] = array_filter($filters, static fn (string $value): bool => $value !== '');
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, string> $filters
+     *
+     * @return array<int, string>|null
+     */
+    private function searchIdsFromElastic(array $filters): ?array
+    {
+        if ($filters['title'] === '' && $filters['description'] === '' && $filters['location'] === '') {
+            return null;
+        }
+
+        try {
+            $must = [];
+            if ($filters['title'] !== '') {
+                $must[] = ['match_phrase_prefix' => ['title' => $filters['title']]];
+            }
+            if ($filters['description'] !== '') {
+                $must[] = ['match_phrase_prefix' => ['description' => $filters['description']]];
+            }
+            if ($filters['location'] !== '') {
+                $must[] = ['match_phrase_prefix' => ['location' => $filters['location']]];
+            }
+
+            $response = $this->elasticsearchService->search(
+                ElasticsearchServiceInterface::INDEX_PREFIX . '_*',
+                [
+                    'query' => ['bool' => ['must' => $must]],
+                    '_source' => ['id'],
+                ],
+                0,
+                1000,
+            );
+
+            if (!is_array($response) || !isset($response['hits']['hits']) || !is_array($response['hits']['hits'])) {
+                return null;
+            }
+
+            $ids = [];
+            foreach ($response['hits']['hits'] as $hit) {
+                if (is_array($hit) && isset($hit['_source']['id']) && is_string($hit['_source']['id'])) {
+                    $ids[] = $hit['_source']['id'];
+                }
+            }
+
+            return array_values(array_unique($ids));
+        } catch (Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/src/Calendar/Domain/Repository/Interfaces/EventRepositoryInterface.php
+++ b/src/Calendar/Domain/Repository/Interfaces/EventRepositoryInterface.php
@@ -12,15 +12,21 @@ interface EventRepositoryInterface
     /**
      * @return array<int, Event>
      */
-    public function findByUser(User $user): array;
+    public function findByUser(User $user, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array;
+
+    public function countByUser(User $user, array $filters = [], ?array $esIds = null): int;
 
     /**
      * @return array<int, Event>
      */
-    public function findByApplicationSlug(string $applicationSlug): array;
+    public function findByApplicationSlug(string $applicationSlug, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array;
+
+    public function countByApplicationSlug(string $applicationSlug, array $filters = [], ?array $esIds = null): int;
 
     /**
      * @return array<int, Event>
      */
-    public function findByApplicationSlugAndUser(string $applicationSlug, User $user): array;
+    public function findByApplicationSlugAndUser(string $applicationSlug, User $user, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array;
+
+    public function countByApplicationSlugAndUser(string $applicationSlug, User $user, array $filters = [], ?array $esIds = null): int;
 }

--- a/src/Calendar/Infrastructure/Repository/EventRepository.php
+++ b/src/Calendar/Infrastructure/Repository/EventRepository.php
@@ -33,38 +33,81 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
     {
     }
 
-    public function findByUser(User $user): array
+    public function findByUser(User $user, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array
     {
-        return $this->createBaseQueryBuilder()
+        $offset = max(0, ($page - 1) * $limit);
+
+        return $this->applyListFilters($this->createBaseQueryBuilder(), $filters, $esIds)
             ->andWhere('event.user = :user OR calendar.user = :user')
             ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
             ->orderBy('event.startAt', 'ASC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
     }
 
-    public function findByApplicationSlug(string $applicationSlug): array
+    public function countByUser(User $user, array $filters = [], ?array $esIds = null): int
     {
-        return $this->createBaseQueryBuilder()
+        return (int) $this->applyListFilters($this->createCountQueryBuilder(), $filters, $esIds)
+            ->andWhere('event.user = :user OR calendar.user = :user')
+            ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function findByApplicationSlug(string $applicationSlug, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array
+    {
+        $offset = max(0, ($page - 1) * $limit);
+
+        return $this->applyListFilters($this->createBaseQueryBuilder(), $filters, $esIds)
             ->innerJoin('calendar.application', 'application')
             ->andWhere('application.slug = :applicationSlug')
             ->setParameter('applicationSlug', $applicationSlug)
             ->orderBy('event.startAt', 'ASC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
     }
 
-    public function findByApplicationSlugAndUser(string $applicationSlug, User $user): array
+    public function countByApplicationSlug(string $applicationSlug, array $filters = [], ?array $esIds = null): int
     {
-        return $this->createBaseQueryBuilder()
+        return (int) $this->applyListFilters($this->createCountQueryBuilder(), $filters, $esIds)
+            ->innerJoin('calendar.application', 'application')
+            ->andWhere('application.slug = :applicationSlug')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function findByApplicationSlugAndUser(string $applicationSlug, User $user, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array
+    {
+        $offset = max(0, ($page - 1) * $limit);
+
+        return $this->applyListFilters($this->createBaseQueryBuilder(), $filters, $esIds)
             ->innerJoin('calendar.application', 'application')
             ->andWhere('application.slug = :applicationSlug')
             ->andWhere('event.user = :user OR calendar.user = :user')
             ->setParameter('applicationSlug', $applicationSlug)
             ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
             ->orderBy('event.startAt', 'ASC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
+    }
+
+    public function countByApplicationSlugAndUser(string $applicationSlug, User $user, array $filters = [], ?array $esIds = null): int
+    {
+        return (int) $this->applyListFilters($this->createCountQueryBuilder(), $filters, $esIds)
+            ->innerJoin('calendar.application', 'application')
+            ->andWhere('application.slug = :applicationSlug')
+            ->andWhere('event.user = :user OR calendar.user = :user')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     private function createBaseQueryBuilder(): QueryBuilder
@@ -73,5 +116,41 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
             ->addSelect('calendar')
             ->leftJoin('event.calendar', 'calendar')
             ->distinct();
+    }
+
+    private function createCountQueryBuilder(): QueryBuilder
+    {
+        return $this->createQueryBuilder('event')
+            ->select('COUNT(DISTINCT event.id)')
+            ->leftJoin('event.calendar', 'calendar');
+    }
+
+    private function applyListFilters(QueryBuilder $queryBuilder, array $filters, ?array $esIds): QueryBuilder
+    {
+        if ($esIds !== null) {
+            return $queryBuilder
+                ->andWhere('event.id IN (:esIds)')
+                ->setParameter('esIds', $esIds);
+        }
+
+        if (($filters['title'] ?? '') !== '') {
+            $queryBuilder
+                ->andWhere('LOWER(event.title) LIKE LOWER(:title)')
+                ->setParameter('title', '%' . $filters['title'] . '%');
+        }
+
+        if (($filters['description'] ?? '') !== '') {
+            $queryBuilder
+                ->andWhere('LOWER(event.description) LIKE LOWER(:description)')
+                ->setParameter('description', '%' . $filters['description'] . '%');
+        }
+
+        if (($filters['location'] ?? '') !== '') {
+            $queryBuilder
+                ->andWhere('LOWER(event.location) LIKE LOWER(:location)')
+                ->setParameter('location', '%' . $filters['location'] . '%');
+        }
+
+        return $queryBuilder;
     }
 }

--- a/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListController.php
@@ -20,8 +20,16 @@ class ApplicationEventListController
     }
 
     #[Route(path: '/v1/calendar/applications/{applicationSlug}/events', methods: [Request::METHOD_GET])]
-    public function __invoke(string $applicationSlug): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
-        return new JsonResponse($this->eventListService->getByApplicationSlug($applicationSlug));
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'title' => trim((string) $request->query->get('title', '')),
+            'description' => trim((string) $request->query->get('description', '')),
+            'location' => trim((string) $request->query->get('location', '')),
+        ];
+
+        return new JsonResponse($this->eventListService->getByApplicationSlug($applicationSlug, $filters, $page, $limit));
     }
 }

--- a/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationUserEventListController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationUserEventListController.php
@@ -24,8 +24,16 @@ class ApplicationUserEventListController
     }
 
     #[Route(path: '/v1/calendar/private/applications/{applicationSlug}/events', methods: [Request::METHOD_GET])]
-    public function __invoke(string $applicationSlug, User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
     {
-        return new JsonResponse($this->eventListService->getByApplicationSlugAndUser($applicationSlug, $loggedInUser));
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'title' => trim((string) $request->query->get('title', '')),
+            'description' => trim((string) $request->query->get('description', '')),
+            'location' => trim((string) $request->query->get('location', '')),
+        ];
+
+        return new JsonResponse($this->eventListService->getByApplicationSlugAndUser($applicationSlug, $loggedInUser, $filters, $page, $limit));
     }
 }

--- a/src/Calendar/Transport/Controller/Api/V1/Event/UserEventListController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/UserEventListController.php
@@ -24,8 +24,16 @@ class UserEventListController
     }
 
     #[Route(path: '/v1/calendar/private/events', methods: [Request::METHOD_GET])]
-    public function __invoke(User $loggedInUser): JsonResponse
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {
-        return new JsonResponse($this->eventListService->getByUser($loggedInUser));
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'title' => trim((string) $request->query->get('title', '')),
+            'description' => trim((string) $request->query->get('description', '')),
+            'location' => trim((string) $request->query->get('location', '')),
+        ];
+
+        return new JsonResponse($this->eventListService->getByUser($loggedInUser, $filters, $page, $limit));
     }
 }

--- a/src/Chat/Application/Service/ConversationListService.php
+++ b/src/Chat/Application/Service/ConversationListService.php
@@ -9,38 +9,173 @@ use App\Chat\Domain\Entity\ChatMessage;
 use App\Chat\Domain\Entity\ChatMessageReaction;
 use App\Chat\Domain\Entity\ConversationParticipant;
 use App\Chat\Domain\Repository\Interfaces\ConversationRepositoryInterface;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\User\Domain\Entity\User;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Throwable;
 
+use function array_filter;
 use function array_map;
 
-final class ConversationListService
+final readonly class ConversationListService
 {
-    public function __construct(private readonly ConversationRepositoryInterface $conversationRepository)
-    {
+    public function __construct(
+        private ConversationRepositoryInterface $conversationRepository,
+        private CacheInterface $cache,
+        private ElasticsearchServiceInterface $elasticsearchService,
+    ) {
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @param array<string, string> $filters
+     *
+     * @return array<string, mixed>
+     * @throws InvalidArgumentException
+     * @throws \JsonException
      */
-    public function getByUser(User $user): array
+    public function getByUser(User $user, array $filters = [], int $page = 1, int $limit = 20): array
     {
-        return $this->normalizeConversations($this->conversationRepository->findByUser($user));
+        return $this->getList('user', $filters, $page, $limit, $user, null);
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @param array<string, string> $filters
+     *
+     * @return array<string, mixed>
+     * @throws InvalidArgumentException
+     * @throws \JsonException
      */
-    public function getByChatId(string $chatId): array
+    public function getByChatId(string $chatId, array $filters = [], int $page = 1, int $limit = 20): array
     {
-        return $this->normalizeConversations($this->conversationRepository->findByChatId($chatId));
+        return $this->getList('chat_public', $filters, $page, $limit, null, $chatId);
     }
 
     /**
-     * @return array<int, array<string, mixed>>
+     * @param array<string, string> $filters
+     *
+     * @return array<string, mixed>
+     * @throws InvalidArgumentException
+     * @throws \JsonException
      */
-    public function getByChatIdAndUser(string $chatId, User $user): array
+    public function getByChatIdAndUser(string $chatId, User $user, array $filters = [], int $page = 1, int $limit = 20): array
     {
-        return $this->normalizeConversations($this->conversationRepository->findByChatIdAndUser($chatId, $user));
+        return $this->getList('chat_private', $filters, $page, $limit, $user, $chatId);
+    }
+
+    /**
+     * @param array<string, string> $filters
+     *
+     * @return array<string, mixed>
+     * @throws InvalidArgumentException
+     * @throws \JsonException
+     */
+    private function getList(string $accessContext, array $filters, int $page, int $limit, ?User $user, ?string $chatId): array
+    {
+        $page = max(1, $page);
+        $limit = max(1, min(100, $limit));
+
+        $filters = [
+            'message' => trim((string)($filters['message'] ?? '')),
+        ];
+
+        $cacheKey = 'conversation_list_' . md5((string) json_encode([
+            'accessContext' => $accessContext,
+            'userId' => $user?->getId(),
+            'chatId' => $chatId,
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+
+        /** @var array<string, mixed> $result */
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($accessContext, $user, $chatId, $filters, $page, $limit): array {
+            $item->expiresAfter(120);
+
+            $esIds = $this->searchIdsFromElastic($filters);
+            if ($esIds === []) {
+                return [
+                    'items' => [],
+                    'pagination' => [
+                        'page' => $page,
+                        'limit' => $limit,
+                        'totalItems' => 0,
+                        'totalPages' => 0,
+                    ],
+                ];
+            }
+
+            if ($accessContext === 'user') {
+                $conversations = $this->conversationRepository->findByUser($user, $filters, $page, $limit, $esIds);
+                $totalItems = $this->conversationRepository->countByUser($user, $filters, $esIds);
+            } elseif ($accessContext === 'chat_private') {
+                $conversations = $this->conversationRepository->findByChatIdAndUser($chatId, $user, $filters, $page, $limit, $esIds);
+                $totalItems = $this->conversationRepository->countByChatIdAndUser($chatId, $user, $filters, $esIds);
+            } else {
+                $conversations = $this->conversationRepository->findByChatId($chatId, $filters, $page, $limit, $esIds);
+                $totalItems = $this->conversationRepository->countByChatId($chatId, $filters, $esIds);
+            }
+
+            return [
+                'items' => $this->normalizeConversations($conversations),
+                'pagination' => [
+                    'page' => $page,
+                    'limit' => $limit,
+                    'totalItems' => $totalItems,
+                    'totalPages' => $totalItems > 0 ? (int) ceil($totalItems / $limit) : 0,
+                ],
+            ];
+        });
+
+        $result['filters'] = array_filter($filters, static fn (string $value): bool => $value !== '');
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, string> $filters
+     *
+     * @return array<int, string>|null
+     */
+    private function searchIdsFromElastic(array $filters): ?array
+    {
+        if ($filters['message'] === '') {
+            return null;
+        }
+
+        try {
+            $response = $this->elasticsearchService->search(
+                ElasticsearchServiceInterface::INDEX_PREFIX . '_*',
+                [
+                    'query' => [
+                        'bool' => [
+                            'must' => [
+                                ['match_phrase_prefix' => ['message' => $filters['message']]],
+                            ],
+                        ],
+                    ],
+                    '_source' => ['id'],
+                ],
+                0,
+                1000,
+            );
+
+            if (!is_array($response) || !isset($response['hits']['hits']) || !is_array($response['hits']['hits'])) {
+                return null;
+            }
+
+            $ids = [];
+            foreach ($response['hits']['hits'] as $hit) {
+                if (is_array($hit) && isset($hit['_source']['id']) && is_string($hit['_source']['id'])) {
+                    $ids[] = $hit['_source']['id'];
+                }
+            }
+
+            return array_values(array_unique($ids));
+        } catch (Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/src/Chat/Domain/Repository/Interfaces/ConversationRepositoryInterface.php
+++ b/src/Chat/Domain/Repository/Interfaces/ConversationRepositoryInterface.php
@@ -15,15 +15,21 @@ interface ConversationRepositoryInterface
     /**
      * @return array<int, Conversation>
      */
-    public function findByUser(User $user): array;
+    public function findByUser(User $user, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array;
+
+    public function countByUser(User $user, array $filters = [], ?array $esIds = null): int;
 
     /**
      * @return array<int, Conversation>
      */
-    public function findByChatId(string $chatId): array;
+    public function findByChatId(string $chatId, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array;
+
+    public function countByChatId(string $chatId, array $filters = [], ?array $esIds = null): int;
 
     /**
      * @return array<int, Conversation>
      */
-    public function findByChatIdAndUser(string $chatId, User $user): array;
+    public function findByChatIdAndUser(string $chatId, User $user, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array;
+
+    public function countByChatIdAndUser(string $chatId, User $user, array $filters = [], ?array $esIds = null): int;
 }

--- a/src/Chat/Infrastructure/Repository/ConversationRepository.php
+++ b/src/Chat/Infrastructure/Repository/ConversationRepository.php
@@ -40,38 +40,81 @@ class ConversationRepository extends BaseRepository implements ConversationRepos
         return $conversation;
     }
 
-    public function findByUser(User $user): array
+    public function findByUser(User $user, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array
     {
-        return $this->getConversationQueryBuilder()
+        $offset = max(0, ($page - 1) * $limit);
+
+        return $this->applyListFilters($this->getConversationQueryBuilder(), $filters, $esIds)
             ->innerJoin('conversation.participants', 'participant')
             ->andWhere('participant.user = :user')
             ->setParameter('user', $user)
             ->orderBy('conversation.createdAt', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
     }
 
-    public function findByChatId(string $chatId): array
+    public function countByUser(User $user, array $filters = [], ?array $esIds = null): int
     {
-        return $this->getConversationQueryBuilder()
+        return (int) $this->applyListFilters($this->getConversationCountQueryBuilder(), $filters, $esIds)
+            ->innerJoin('conversation.participants', 'participant')
+            ->andWhere('participant.user = :user')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function findByChatId(string $chatId, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array
+    {
+        $offset = max(0, ($page - 1) * $limit);
+
+        return $this->applyListFilters($this->getConversationQueryBuilder(), $filters, $esIds)
             ->andWhere('chat.id = :chatId')
             ->setParameter('chatId', $chatId, UuidBinaryOrderedTimeType::NAME)
             ->orderBy('conversation.createdAt', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
     }
 
-    public function findByChatIdAndUser(string $chatId, User $user): array
+    public function countByChatId(string $chatId, array $filters = [], ?array $esIds = null): int
     {
-        return $this->getConversationQueryBuilder()
+        return (int) $this->applyListFilters($this->getConversationCountQueryBuilder(), $filters, $esIds)
+            ->andWhere('chat.id = :chatId')
+            ->setParameter('chatId', $chatId, UuidBinaryOrderedTimeType::NAME)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function findByChatIdAndUser(string $chatId, User $user, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array
+    {
+        $offset = max(0, ($page - 1) * $limit);
+
+        return $this->applyListFilters($this->getConversationQueryBuilder(), $filters, $esIds)
             ->innerJoin('conversation.participants', 'participant')
             ->andWhere('chat.id = :chatId')
             ->andWhere('participant.user = :user')
             ->setParameter('chatId', $chatId, UuidBinaryOrderedTimeType::NAME)
             ->setParameter('user', $user)
             ->orderBy('conversation.createdAt', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
             ->getQuery()
             ->getResult();
+    }
+
+    public function countByChatIdAndUser(string $chatId, User $user, array $filters = [], ?array $esIds = null): int
+    {
+        return (int) $this->applyListFilters($this->getConversationCountQueryBuilder(), $filters, $esIds)
+            ->innerJoin('conversation.participants', 'participant')
+            ->andWhere('chat.id = :chatId')
+            ->andWhere('participant.user = :user')
+            ->setParameter('chatId', $chatId, UuidBinaryOrderedTimeType::NAME)
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     private function getConversationQueryBuilder(): QueryBuilder
@@ -86,5 +129,30 @@ class ConversationRepository extends BaseRepository implements ConversationRepos
             ->leftJoin('messages.reactions', 'reactions')
             ->leftJoin('reactions.user', 'reactionUser')
             ->distinct();
+    }
+
+    private function getConversationCountQueryBuilder(): QueryBuilder
+    {
+        return $this->createQueryBuilder('conversation')
+            ->select('COUNT(DISTINCT conversation.id)')
+            ->innerJoin('conversation.chat', 'chat')
+            ->leftJoin('conversation.messages', 'messages');
+    }
+
+    private function applyListFilters(QueryBuilder $queryBuilder, array $filters, ?array $esIds): QueryBuilder
+    {
+        if ($esIds !== null) {
+            return $queryBuilder
+                ->andWhere('conversation.id IN (:esIds)')
+                ->setParameter('esIds', $esIds);
+        }
+
+        if (($filters['message'] ?? '') !== '') {
+            $queryBuilder
+                ->andWhere('LOWER(messages.content) LIKE LOWER(:message)')
+                ->setParameter('message', '%' . $filters['message'] . '%');
+        }
+
+        return $queryBuilder;
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
@@ -20,10 +20,16 @@ class ApplicationConversationListController
     }
 
     #[Route(path: '/v1/chat/chats/{chatId}/conversations', methods: [Request::METHOD_GET])]
-    public function __invoke(string $chatId): JsonResponse
+    public function __invoke(string $chatId, Request $request): JsonResponse
     {
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'message' => trim((string) $request->query->get('message', '')),
+        ];
+
         return ConversationJsonResponseFactory::create(
-            $this->conversationListService->getByChatId($chatId)
+            $this->conversationListService->getByChatId($chatId, $filters, $page, $limit)
         );
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
@@ -24,10 +24,16 @@ class ApplicationUserConversationListController
     }
 
     #[Route(path: '/v1/chat/private/chats/{chatId}/conversations', methods: [Request::METHOD_GET])]
-    public function __invoke(string $chatId, User $loggedInUser): JsonResponse
+    public function __invoke(string $chatId, Request $request, User $loggedInUser): JsonResponse
     {
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'message' => trim((string) $request->query->get('message', '')),
+        ];
+
         return ConversationJsonResponseFactory::create(
-            $this->conversationListService->getByChatIdAndUser($chatId, $loggedInUser)
+            $this->conversationListService->getByChatIdAndUser($chatId, $loggedInUser, $filters, $page, $limit)
         );
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationListController.php
@@ -24,8 +24,14 @@ class UserConversationListController
     }
 
     #[Route(path: '/v1/chat/private/conversations', methods: [Request::METHOD_GET])]
-    public function __invoke(User $loggedInUser): JsonResponse
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {
-        return ConversationJsonResponseFactory::create($this->conversationListService->getByUser($loggedInUser));
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'message' => trim((string) $request->query->get('message', '')),
+        ];
+
+        return ConversationJsonResponseFactory::create($this->conversationListService->getByUser($loggedInUser, $filters, $page, $limit));
     }
 }

--- a/tests/Unit/Calendar/Application/Service/EventListServiceTest.php
+++ b/tests/Unit/Calendar/Application/Service/EventListServiceTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Calendar\Application\Service;
+
+use App\Calendar\Application\Service\EventListService;
+use App\Calendar\Domain\Repository\Interfaces\EventRepositoryInterface;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final class EventListServiceTest extends TestCase
+{
+    public function testGetByUserReturnsCacheHitWithoutRepositoryCall(): void
+    {
+        $repo = $this->createMock(EventRepositoryInterface::class);
+        $repo->expects(self::never())->method('findByUser');
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())
+            ->method('get')
+            ->willReturn([
+                'items' => [],
+                'pagination' => ['page' => 1, 'limit' => 20, 'totalItems' => 0, 'totalPages' => 0],
+            ]);
+
+        $service = new EventListService($repo, $cache, $elastic);
+        $result = $service->getByUser($this->mockUser(), ['title' => 'foo'], 1, 20);
+
+        self::assertSame(['title' => 'foo'], $result['filters']);
+    }
+
+    public function testGetByUserCacheMissCallsRepository(): void
+    {
+        $repo = $this->createMock(EventRepositoryInterface::class);
+        $repo->expects(self::once())->method('findByUser')->willReturn([]);
+        $repo->expects(self::once())->method('countByUser')->willReturn(0);
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $elastic->expects(self::once())->method('search')->willReturn(['hits' => ['hits' => []]]);
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects(self::once())->method('expiresAfter')->with(120);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('get')->willReturnCallback(static function (string $key, callable $callback) use ($item): array {
+            return $callback($item);
+        });
+
+        $service = new EventListService($repo, $cache, $elastic);
+        $result = $service->getByUser($this->mockUser(), ['title' => 'foo'], 1, 20);
+
+        self::assertSame(0, $result['pagination']['totalItems']);
+    }
+
+    public function testGetByUserFallsBackToDatabaseWhenElasticThrows(): void
+    {
+        $repo = $this->createMock(EventRepositoryInterface::class);
+        $repo->expects(self::once())->method('findByUser')->with(self::anything(), self::anything(), 1, 20, null)->willReturn([]);
+        $repo->expects(self::once())->method('countByUser')->with(self::anything(), self::anything(), null)->willReturn(0);
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $elastic->expects(self::once())->method('search')->willThrowException(new \RuntimeException('ES down'));
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects(self::once())->method('expiresAfter')->with(120);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('get')->willReturnCallback(static function (string $key, callable $callback) use ($item): array {
+            return $callback($item);
+        });
+
+        $service = new EventListService($repo, $cache, $elastic);
+        $result = $service->getByUser($this->mockUser(), ['title' => 'foo'], 1, 20);
+
+        self::assertSame([], $result['items']);
+    }
+
+    private function mockUser(): User
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn('user-id');
+
+        return $user;
+    }
+}

--- a/tests/Unit/Chat/Application/Service/ConversationListServiceTest.php
+++ b/tests/Unit/Chat/Application/Service/ConversationListServiceTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Chat\Application\Service;
+
+use App\Chat\Application\Service\ConversationListService;
+use App\Chat\Domain\Repository\Interfaces\ConversationRepositoryInterface;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final class ConversationListServiceTest extends TestCase
+{
+    public function testGetByUserReturnsCacheHitWithoutRepositoryCall(): void
+    {
+        $repo = $this->createMock(ConversationRepositoryInterface::class);
+        $repo->expects(self::never())->method('findByUser');
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())
+            ->method('get')
+            ->willReturn([
+                'items' => [],
+                'pagination' => ['page' => 1, 'limit' => 20, 'totalItems' => 0, 'totalPages' => 0],
+            ]);
+
+        $service = new ConversationListService($repo, $cache, $elastic);
+        $result = $service->getByUser($this->mockUser(), ['message' => 'foo'], 1, 20);
+
+        self::assertSame(['message' => 'foo'], $result['filters']);
+    }
+
+    public function testGetByUserCacheMissCallsRepository(): void
+    {
+        $repo = $this->createMock(ConversationRepositoryInterface::class);
+        $repo->expects(self::once())->method('findByUser')->willReturn([]);
+        $repo->expects(self::once())->method('countByUser')->willReturn(0);
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $elastic->expects(self::once())->method('search')->willReturn(['hits' => ['hits' => []]]);
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects(self::once())->method('expiresAfter')->with(120);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('get')->willReturnCallback(static function (string $key, callable $callback) use ($item): array {
+            return $callback($item);
+        });
+
+        $service = new ConversationListService($repo, $cache, $elastic);
+        $result = $service->getByUser($this->mockUser(), ['message' => 'foo'], 1, 20);
+
+        self::assertSame(0, $result['pagination']['totalItems']);
+    }
+
+    public function testGetByUserFallsBackToDatabaseWhenElasticThrows(): void
+    {
+        $repo = $this->createMock(ConversationRepositoryInterface::class);
+        $repo->expects(self::once())->method('findByUser')->with(self::anything(), self::anything(), 1, 20, null)->willReturn([]);
+        $repo->expects(self::once())->method('countByUser')->with(self::anything(), self::anything(), null)->willReturn(0);
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $elastic->expects(self::once())->method('search')->willThrowException(new \RuntimeException('ES down'));
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects(self::once())->method('expiresAfter')->with(120);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('get')->willReturnCallback(static function (string $key, callable $callback) use ($item): array {
+            return $callback($item);
+        });
+
+        $service = new ConversationListService($repo, $cache, $elastic);
+        $result = $service->getByUser($this->mockUser(), ['message' => 'foo'], 1, 20);
+
+        self::assertSame([], $result['items']);
+    }
+
+    private function mockUser(): User
+    {
+        $user = $this->createMock(User::class);
+        $user->method('getId')->willReturn('user-id');
+
+        return $user;
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve list endpoints performance by introducing cache-first read services for Calendar and Chat using a pattern aligned with existing `ApplicationListService`.
- Ensure deterministic cache keys that include access context, user, pagination, filters and target resource to avoid incorrect cache hits.
- Support efficient textual filtering via an optional Elasticsearch shortlist while keeping a robust SQL fallback when ES is unavailable or returns invalid results.
- Make pagination and filter parameters explicit at controller level and propagate them to the new services.

### Description
- Reworked `EventListService` and `ConversationListService` to a cache-first pattern with TTL 120s and deterministic keys built from access context, `userId`/`chatId`/`applicationSlug`, `page`, `limit`, and `filters`, returning `items`, `pagination` and `filters` in responses.
- Added optional ES shortlist methods `searchIdsFromElastic(): ?array` to both services that return an ID whitelist or `null` (no ES search needed) and catch `Throwable` to fallback to DB on errors.
- Extended repository interfaces and implementations (`EventRepository` and `ConversationRepository`) with paginated `findBy*` and `countBy*` signatures that accept `array $filters` and optional `?array $esIds`, and added SQL filter application and `esIds` constraint logic.
- Updated controllers for Calendar and Chat list endpoints to accept `Request`, expose `page`, `limit`, and textual filter params (Calendar: `title`, `description`, `location`; Chat: `message`) and forward them to the new services.
- Added unit tests `EventListServiceTest` and `ConversationListServiceTest` that cover cache hit, cache miss (calls repository), and DB fallback when Elasticsearch throws.

### Testing
- Static syntax checks with `php -l` were run against modified service/repository/controller files and passed.
- Unit tests were added under `tests/Unit/...` for Calendar and Chat services (cache hit, cache miss, ES failure -> DB fallback), but running `./vendor/bin/phpunit` in this environment failed because `phpunit` binary is not available; tests were not executed here.
- All modified PHP files were validated locally with `php -l` in this environment (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69add77cb1b883268ccf2f92707f7809)