### PR TITLE
Ajout d'événements de mutation et handler de projection pour synchronisation cache/Elasticsearch

### DIFF
--- a/src/General/Application/Message/EntityCreated.php
+++ b/src/General/Application/Message/EntityCreated.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\Message;
+
+final readonly class EntityCreated extends EntityMutationMessage
+{
+}

--- a/src/General/Application/Message/EntityDeleted.php
+++ b/src/General/Application/Message/EntityDeleted.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\Message;
+
+final readonly class EntityDeleted extends EntityMutationMessage
+{
+}

--- a/src/General/Application/Message/EntityMutationMessage.php
+++ b/src/General/Application/Message/EntityMutationMessage.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\Message;
+
+use function uniqid;
+
+abstract class EntityMutationMessage
+{
+    /** @var array<string, mixed> */
+    public array $context;
+
+    public function __construct(
+        public readonly string $entityType,
+        public readonly string $entityId,
+        ?string $eventId = null,
+        array $context = [],
+    ) {
+        $this->eventId = $eventId ?? uniqid('evt_', true);
+        $this->context = $context;
+    }
+
+    public readonly string $eventId;
+}

--- a/src/General/Application/Message/EntityPatched.php
+++ b/src/General/Application/Message/EntityPatched.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\Message;
+
+final readonly class EntityPatched extends EntityMutationMessage
+{
+}

--- a/src/General/Application/MessageHandler/EntityProjectionHandler.php
+++ b/src/General/Application/MessageHandler/EntityProjectionHandler.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\MessageHandler;
+
+use App\General\Application\Message\EntityCreated;
+use App\General\Application\Message\EntityDeleted;
+use App\General\Application\Message\EntityMutationMessage;
+use App\General\Application\Message\EntityPatched;
+use App\General\Application\Service\CacheInvalidationService;
+use App\General\Application\Service\CriticalViewWarmer;
+use App\General\Application\Service\MessageIdempotenceGuard;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\Platform\Application\Projection\ApplicationProjection;
+use App\Platform\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Application\Projection\RecruitJobProjection;
+use App\Recruit\Infrastructure\Repository\JobRepository;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+use function array_map;
+
+#[AsMessageHandler]
+final readonly class EntityProjectionHandler
+{
+    private const string PLATFORM_APPLICATION = 'platform_application';
+    private const string RECRUIT_JOB = 'recruit_job';
+
+    public function __construct(
+        private ApplicationRepository $applicationRepository,
+        private JobRepository $jobRepository,
+        private CacheInvalidationService $cacheInvalidationService,
+        private CriticalViewWarmer $criticalViewWarmer,
+        private ElasticsearchServiceInterface $elasticsearchService,
+        private MessageIdempotenceGuard $messageIdempotenceGuard,
+    ) {
+    }
+
+    public function __invoke(EntityCreated|EntityPatched|EntityDeleted $message): void
+    {
+        if ($this->messageIdempotenceGuard->shouldProcess($message->eventId) === false) {
+            return;
+        }
+
+        if ($message->entityType === self::PLATFORM_APPLICATION) {
+            $this->projectPlatformApplication($message);
+
+            return;
+        }
+
+        if ($message->entityType === self::RECRUIT_JOB) {
+            $this->projectRecruitJob($message);
+        }
+    }
+
+    private function projectPlatformApplication(EntityMutationMessage $message): void
+    {
+        if ($message instanceof EntityDeleted) {
+            $this->elasticsearchService->delete(ApplicationProjection::INDEX_NAME, $message->entityId);
+            $this->cacheInvalidationService->invalidateApplicationListCaches();
+            $this->criticalViewWarmer->warmApplicationList();
+
+            return;
+        }
+
+        $application = $this->applicationRepository->find($message->entityId);
+        if ($application === null) {
+            return;
+        }
+
+        $this->elasticsearchService->index(ApplicationProjection::INDEX_NAME, $application->getId(), [
+            'id' => $application->getId(),
+            'title' => $application->getTitle(),
+            'description' => $application->getDescription(),
+            'slug' => $application->getSlug(),
+            'platformName' => $application->getPlatform()?->getName() ?? '',
+            'platformKey' => $application->getPlatform()?->getPlatformKeyValue() ?? '',
+            'status' => $application->getStatus()->value,
+            'private' => $application->isPrivate(),
+            'updatedAt' => $application->getUpdatedAt()?->format(DATE_ATOM),
+        ]);
+
+        $this->cacheInvalidationService->invalidateApplicationListCaches();
+        $this->criticalViewWarmer->warmApplicationList();
+    }
+
+    private function projectRecruitJob(EntityMutationMessage $message): void
+    {
+        $applicationSlug = (string) ($message->context['applicationSlug'] ?? '');
+
+        if ($message instanceof EntityDeleted) {
+            $this->elasticsearchService->delete(RecruitJobProjection::INDEX_NAME, $message->entityId);
+            if ($applicationSlug !== '') {
+                $this->cacheInvalidationService->invalidateRecruitJobListCaches($applicationSlug);
+                $this->criticalViewWarmer->warmRecruitJobList($applicationSlug);
+            }
+
+            return;
+        }
+
+        $job = $this->jobRepository->find($message->entityId);
+        if ($job === null) {
+            return;
+        }
+
+        $applicationSlug = $job->getRecruit()?->getApplication()?->getSlug() ?? $applicationSlug;
+
+        $this->elasticsearchService->index(RecruitJobProjection::INDEX_NAME, $job->getId(), [
+            'id' => $job->getId(),
+            'slug' => $job->getSlug(),
+            'title' => $job->getTitle(),
+            'summary' => $job->getSummary(),
+            'location' => $job->getLocation(),
+            'contractType' => $job->getContractTypeValue(),
+            'workMode' => $job->getWorkModeValue(),
+            'schedule' => $job->getScheduleValue(),
+            'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $job->getTags()->toArray()),
+            'applicationSlug' => $applicationSlug,
+            'updatedAt' => $job->getUpdatedAt()?->format(DATE_ATOM),
+        ]);
+
+        if ($applicationSlug !== '') {
+            $this->cacheInvalidationService->invalidateRecruitJobListCaches($applicationSlug);
+            $this->criticalViewWarmer->warmRecruitJobList($applicationSlug);
+        }
+    }
+}

--- a/src/General/Application/Service/CacheInvalidationService.php
+++ b/src/General/Application/Service/CacheInvalidationService.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\Service;
+
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+class CacheInvalidationService
+{
+    public function __construct(
+        private readonly CacheInterface $cache,
+        private readonly CacheKeyConventionService $cacheKeyConventionService,
+    ) {
+    }
+
+    public function invalidateApplicationListCaches(?string $applicationSlug = null): void
+    {
+        if ($this->cache instanceof TagAwareCacheInterface) {
+            $tags = [$this->cacheKeyConventionService->applicationListTag()];
+            if ($applicationSlug !== null && $applicationSlug !== '') {
+                $tags[] = $this->cacheKeyConventionService->recruitJobListTag($applicationSlug);
+            }
+
+            $this->cache->invalidateTags($tags);
+        }
+
+        $this->cache->delete($this->cacheKeyConventionService->buildApplicationListKey(null, 1, 20, [
+            'title' => '',
+            'description' => '',
+            'platformName' => '',
+            'platformKey' => '',
+        ]));
+
+        if ($applicationSlug !== null && $applicationSlug !== '') {
+            $this->invalidateRecruitJobListCaches($applicationSlug);
+        }
+    }
+
+    public function invalidateRecruitJobListCaches(string $applicationSlug): void
+    {
+        if ($this->cache instanceof TagAwareCacheInterface) {
+            $this->cache->invalidateTags([$this->cacheKeyConventionService->recruitJobListTag($applicationSlug)]);
+        }
+
+        $this->cache->delete($this->cacheKeyConventionService->buildRecruitJobPublicListKey($applicationSlug, null, 1, 20, [
+            'company' => '',
+            'salaryMin' => 0,
+            'salaryMax' => 0,
+            'contractType' => '',
+            'workMode' => '',
+            'schedule' => '',
+            'postedAtLabel' => '',
+            'location' => '',
+            'q' => '',
+        ]));
+    }
+}

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\Service;
+
+use function json_encode;
+use function md5;
+
+class CacheKeyConventionService
+{
+    /**
+     * @param array<string, mixed> $filters
+     */
+    public function buildApplicationListKey(?string $userId, int $page, int $limit, array $filters): string
+    {
+        return 'application_list_' . md5((string) json_encode([
+            'userId' => $userId,
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    public function buildRecruitJobPublicListKey(string $applicationSlug, ?string $userId, int $page, int $limit, array $filters): string
+    {
+        return 'recruit_job_public_' . md5((string) json_encode([
+            'applicationSlug' => $applicationSlug,
+            'userId' => $userId,
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function applicationListTag(): string
+    {
+        return 'cache:application:list';
+    }
+
+    public function recruitJobListTag(string $applicationSlug): string
+    {
+        return 'cache:recruit:job:list:' . $applicationSlug;
+    }
+}

--- a/src/General/Application/Service/CriticalViewWarmer.php
+++ b/src/General/Application/Service/CriticalViewWarmer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\Service;
+
+use App\Platform\Application\Service\ApplicationListService;
+use App\Recruit\Application\Service\JobPublicListService;
+use Symfony\Component\HttpFoundation\Request;
+use Throwable;
+
+class CriticalViewWarmer
+{
+    public function __construct(
+        private readonly ApplicationListService $applicationListService,
+        private readonly JobPublicListService $jobPublicListService,
+    ) {
+    }
+
+    public function warmApplicationList(): void
+    {
+        try {
+            $this->applicationListService->getPublicList(new Request());
+        } catch (Throwable) {
+        }
+    }
+
+    public function warmRecruitJobList(string $applicationSlug): void
+    {
+        try {
+            $this->jobPublicListService->getList(new Request(), $applicationSlug);
+        } catch (Throwable) {
+        }
+    }
+}

--- a/src/General/Application/Service/MessageIdempotenceGuard.php
+++ b/src/General/Application/Service/MessageIdempotenceGuard.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\Service;
+
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+class MessageIdempotenceGuard
+{
+    public function __construct(private readonly CacheInterface $cache)
+    {
+    }
+
+    public function shouldProcess(string $eventId): bool
+    {
+        $isFirstHandling = false;
+
+        $this->cache->get('message_handled_' . $eventId, static function (ItemInterface $item) use (&$isFirstHandling): bool {
+            $isFirstHandling = true;
+            $item->expiresAfter(86400);
+
+            return true;
+        });
+
+        return $isFirstHandling;
+    }
+}

--- a/src/General/Domain/Service/Interfaces/ElasticsearchServiceInterface.php
+++ b/src/General/Domain/Service/Interfaces/ElasticsearchServiceInterface.php
@@ -63,6 +63,11 @@ interface ElasticsearchServiceInterface
     public function search(string $index, array $body, int $from, int $size): mixed;
 
     /**
+     * Delete document from index.
+     */
+    public function delete(string $index, string $documentId): mixed;
+
+    /**
      * Create string with index name
      */
     public static function generateIndexName(?int $timestamp = null): string;

--- a/src/General/Infrastructure/Service/ElasticsearchService.php
+++ b/src/General/Infrastructure/Service/ElasticsearchService.php
@@ -88,6 +88,17 @@ class ElasticsearchService implements ElasticsearchServiceInterface
     /**
      * {@inheritdoc}
      */
+    public function delete(string $index, string $documentId): mixed
+    {
+        return $this->client->delete([
+            'index' => $index,
+            'id' => $documentId,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public static function generateIndexName(?int $timestamp = null): string
     {
         $date = $timestamp

--- a/src/Platform/Application/Projection/ApplicationProjection.php
+++ b/src/Platform/Application/Projection/ApplicationProjection.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Projection;
+
+final class ApplicationProjection
+{
+    final public const string INDEX_NAME = 'platform_application_v1';
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function mapping(): array
+    {
+        return [
+            'properties' => [
+                'id' => ['type' => 'keyword'],
+                'title' => ['type' => 'text'],
+                'description' => ['type' => 'text'],
+                'slug' => ['type' => 'keyword'],
+                'platformName' => ['type' => 'text'],
+                'platformKey' => ['type' => 'keyword'],
+                'status' => ['type' => 'keyword'],
+                'private' => ['type' => 'boolean'],
+                'updatedAt' => ['type' => 'date'],
+            ],
+        ];
+    }
+}

--- a/src/Platform/Application/Service/ApplicationListService.php
+++ b/src/Platform/Application/Service/ApplicationListService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Platform\Application\Service;
 
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\General\Application\Service\CacheKeyConventionService;
+use App\Platform\Application\Projection\ApplicationProjection;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Repository\Interfaces\ApplicationRepositoryInterface;
 use App\User\Domain\Entity\User;
@@ -12,6 +14,7 @@ use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Throwable;
 
 readonly class ApplicationListService
@@ -20,6 +23,7 @@ readonly class ApplicationListService
         private ApplicationRepositoryInterface $applicationRepository,
         private CacheInterface                 $cache,
         private ElasticsearchServiceInterface  $elasticsearchService,
+        private CacheKeyConventionService $cacheKeyConventionService,
     ) {
     }
 
@@ -63,16 +67,14 @@ readonly class ApplicationListService
             'platformKey' => trim((string) $request->query->get('platformKey', '')),
         ];
 
-        $cacheKey = 'application_list_' . md5((string)json_encode([
-                'userId' => $loggedInUser?->getId(),
-                'page' => $page,
-                'limit' => $limit,
-                'filters' => $filters,
-            ], JSON_THROW_ON_ERROR));
+        $cacheKey = $this->cacheKeyConventionService->buildApplicationListKey($loggedInUser?->getId(), $page, $limit, $filters);
 
         /** @var array<string, mixed> $result */
         $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($loggedInUser, $filters, $page, $limit): array {
             $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->applicationListTag());
+            }
 
             $esIds = $this->searchIdsFromElastic($filters);
             if ($esIds === []) {
@@ -165,7 +167,7 @@ readonly class ApplicationListService
             }
 
             $response = $this->elasticsearchService->search(
-                ElasticsearchServiceInterface::INDEX_PREFIX . '_*',
+                ApplicationProjection::INDEX_NAME,
                 [
                     'query' => ['bool' => ['must' => $must]],
                     '_source' => ['id'],

--- a/src/Recruit/Application/Projection/RecruitJobProjection.php
+++ b/src/Recruit/Application/Projection/RecruitJobProjection.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Projection;
+
+final class RecruitJobProjection
+{
+    final public const string INDEX_NAME = 'recruit_job_v1';
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function mapping(): array
+    {
+        return [
+            'properties' => [
+                'id' => ['type' => 'keyword'],
+                'slug' => ['type' => 'keyword'],
+                'title' => ['type' => 'text'],
+                'summary' => ['type' => 'text'],
+                'location' => ['type' => 'text'],
+                'contractType' => ['type' => 'keyword'],
+                'workMode' => ['type' => 'keyword'],
+                'schedule' => ['type' => 'keyword'],
+                'tags' => ['type' => 'keyword'],
+                'applicationSlug' => ['type' => 'keyword'],
+                'updatedAt' => ['type' => 'date'],
+            ],
+        ];
+    }
+}

--- a/src/Recruit/Application/Service/JobPublicListService.php
+++ b/src/Recruit/Application/Service/JobPublicListService.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Recruit\Application\Service;
 
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\General\Application\Service\CacheKeyConventionService;
 use App\Recruit\Domain\Entity\Application as RecruitApplication;
+use App\Recruit\Application\Projection\RecruitJobProjection;
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Domain\Entity\Recruit;
 use App\Recruit\Domain\Entity\Resume;
@@ -20,6 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Throwable;
 
 use function array_filter;
@@ -32,9 +35,7 @@ use function floor;
 use function in_array;
 use function is_array;
 use function is_string;
-use function json_encode;
 use function mb_strtolower;
-use function md5;
 use function max;
 use function preg_match;
 use function preg_split;
@@ -50,6 +51,7 @@ class JobPublicListService
         private readonly EntityManagerInterface $entityManager,
         private readonly CacheInterface $cache,
         private readonly ElasticsearchServiceInterface $elasticsearchService,
+        private readonly CacheKeyConventionService $cacheKeyConventionService,
     ) {
     }
 
@@ -76,17 +78,14 @@ class JobPublicListService
             'q' => trim((string) $request->query->get('q', '')),
         ];
 
-        $cacheKey = 'recruit_job_public_' . md5((string)json_encode([
-                'page' => $page,
-                'limit' => $limit,
-                'filters' => $filters,
-                'applicationSlug' => $applicationSlug,
-                'userId' => $loggedInUser?->getId(),
-            ], JSON_THROW_ON_ERROR));
+        $cacheKey = $this->cacheKeyConventionService->buildRecruitJobPublicListKey($applicationSlug, $loggedInUser?->getId(), $page, $limit, $filters);
 
         /** @var array<string, mixed> $result */
         $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($page, $limit, $filters, $applicationSlug, $loggedInUser): array {
             $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->recruitJobListTag($applicationSlug));
+            }
 
             $recruit = $this->resolveRecruitByApplicationSlug($applicationSlug);
 
@@ -317,7 +316,7 @@ class JobPublicListService
             }
 
             $response = $this->elasticsearchService->search(
-                ElasticsearchServiceInterface::INDEX_PREFIX . '_*',
+                RecruitJobProjection::INDEX_NAME,
                 [
                     'query' => [
                         'bool' => [

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
@@ -6,6 +6,7 @@ namespace App\Recruit\Transport\Controller\Api\V1\Job;
 
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Domain\Entity\Recruit;
+use App\General\Application\Message\EntityCreated;
 use App\Recruit\Domain\Enum\ContractType;
 use App\Recruit\Domain\Enum\Schedule;
 use App\Recruit\Domain\Enum\WorkMode;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 use function is_array;
 use function is_string;
@@ -33,6 +35,7 @@ class JobCreateFromApplicationController
     public function __construct(
         private readonly RecruitRepositoryInterface $recruitRepository,
         private readonly JobRepository $jobRepository,
+        private readonly MessageBusInterface $messageBus,
     ) {
     }
 
@@ -98,6 +101,9 @@ class JobCreateFromApplicationController
         $this->applyOptionalFields($job, $payload);
 
         $this->jobRepository->save($job);
+        $this->messageBus->dispatch(new EntityCreated('recruit_job', $job->getId(), context: [
+            'applicationSlug' => $application?->getSlug() ?? '',
+        ]));
 
         return new JsonResponse([
             'id' => $job->getId(),

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteFromApplicationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\Job;
 
+use App\General\Application\Message\EntityDeleted;
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Domain\Entity\Recruit;
 use App\Recruit\Domain\Repository\Interfaces\RecruitRepositoryInterface;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsController]
 #[OA\Tag(name: 'Recruit Job')]
@@ -26,6 +28,7 @@ class JobDeleteFromApplicationController
     public function __construct(
         private readonly RecruitRepositoryInterface $recruitRepository,
         private readonly JobRepository $jobRepository,
+        private readonly MessageBusInterface $messageBus,
     ) {
     }
 
@@ -61,6 +64,11 @@ class JobDeleteFromApplicationController
         }
 
         $this->jobRepository->remove($job);
+
+        $applicationSlugValue = $application?->getSlug() ?? '';
+        $this->messageBus->dispatch(new EntityDeleted('recruit_job', $jobId, context: [
+            'applicationSlug' => $applicationSlugValue,
+        ]));
 
         return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
     }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\Job;
 
+use App\General\Application\Message\EntityPatched;
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Domain\Entity\Recruit;
 use App\Recruit\Domain\Enum\ContractType;
@@ -20,6 +21,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 use function is_array;
 use function is_int;
@@ -34,6 +36,7 @@ class JobPatchFromApplicationController
     public function __construct(
         private readonly RecruitRepositoryInterface $recruitRepository,
         private readonly JobRepository $jobRepository,
+        private readonly MessageBusInterface $messageBus,
     ) {
     }
 
@@ -86,6 +89,9 @@ class JobPatchFromApplicationController
         $this->applyPatchFields($job, $payload);
 
         $this->jobRepository->save($job);
+        $this->messageBus->dispatch(new EntityPatched('recruit_job', $job->getId(), context: [
+            'applicationSlug' => $application?->getSlug() ?? '',
+        ]));
 
         return new JsonResponse([
             'id' => $job->getId(),

--- a/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\User\Transport\Controller\Api\V1\Profile;
 
 use App\Configuration\Domain\Entity\Configuration;
+use App\General\Application\Message\EntityCreated;
 use App\Configuration\Domain\Enum\ConfigurationScope;
 use App\Platform\Application\Resource\PlatformResource;
 use App\Platform\Application\Resource\PluginResource;
@@ -25,6 +26,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Throwable;
 
 use function array_values;
@@ -43,6 +45,7 @@ class ApplicationCreateController
         private readonly PluginResource $pluginResource,
         private readonly ApplicationPluginProvisioningService $applicationPluginProvisioningService,
         private readonly EntityManagerInterface $entityManager,
+        private readonly MessageBusInterface $messageBus,
     ) {
     }
 
@@ -209,6 +212,7 @@ class ApplicationCreateController
         $this->entityManager->persist($application);
         $this->applicationPluginProvisioningService->provision($application, array_values($detectedPluginKeys));
         $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('platform_application', $application->getId()));
 
         return new JsonResponse([
             'id' => $application->getId(),

--- a/tests/Unit/General/Application/MessageHandler/EntityProjectionHandlerTest.php
+++ b/tests/Unit/General/Application/MessageHandler/EntityProjectionHandlerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\General\Application\MessageHandler;
+
+use App\General\Application\Message\EntityCreated;
+use App\General\Application\Message\EntityDeleted;
+use App\General\Application\MessageHandler\EntityProjectionHandler;
+use App\General\Application\Service\CacheInvalidationService;
+use App\General\Application\Service\CriticalViewWarmer;
+use App\General\Application\Service\MessageIdempotenceGuard;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\Platform\Application\Projection\ApplicationProjection;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\Platform;
+use App\Platform\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Application\Projection\RecruitJobProjection;
+use App\Recruit\Domain\Entity\Recruit;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Infrastructure\Repository\JobRepository;
+use PHPUnit\Framework\TestCase;
+
+final class EntityProjectionHandlerTest extends TestCase
+{
+    public function testThatItIndexesApplicationAndWarmsCachesOnCreate(): void
+    {
+        $application = (new Application())
+            ->setTitle('App')
+            ->setDescription('Desc')
+            ->setPlatform((new Platform())->setName('Platform')->setPlatformKey('CRM'));
+
+        $applicationRepository = $this->createMock(ApplicationRepository::class);
+        $applicationRepository->method('find')->willReturn($application);
+
+        $jobRepository = $this->createMock(JobRepository::class);
+
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+        $cacheInvalidationService->expects(self::once())->method('invalidateApplicationListCaches');
+
+        $criticalViewWarmer = $this->createMock(CriticalViewWarmer::class);
+        $criticalViewWarmer->expects(self::once())->method('warmApplicationList');
+
+        $guard = $this->createMock(MessageIdempotenceGuard::class);
+        $guard->method('shouldProcess')->willReturn(true);
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $elastic->expects(self::once())->method('index')->with(
+            ApplicationProjection::INDEX_NAME,
+            $application->getId(),
+            self::arrayHasKey('title'),
+        );
+
+        $handler = new EntityProjectionHandler(
+            $applicationRepository,
+            $jobRepository,
+            $cacheInvalidationService,
+            $criticalViewWarmer,
+            $elastic,
+            $guard,
+        );
+
+        $handler(new EntityCreated('platform_application', $application->getId(), 'evt_1'));
+    }
+
+    public function testThatItDeletesRecruitJobDocumentAndInvalidatesJobCacheOnDelete(): void
+    {
+        $applicationRepository = $this->createMock(ApplicationRepository::class);
+        $jobRepository = $this->createMock(JobRepository::class);
+
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+        $cacheInvalidationService->expects(self::once())->method('invalidateRecruitJobListCaches')->with('slug-1');
+
+        $criticalViewWarmer = $this->createMock(CriticalViewWarmer::class);
+        $criticalViewWarmer->expects(self::once())->method('warmRecruitJobList')->with('slug-1');
+
+        $guard = $this->createMock(MessageIdempotenceGuard::class);
+        $guard->method('shouldProcess')->willReturn(true);
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $elastic->expects(self::once())->method('delete')->with(RecruitJobProjection::INDEX_NAME, 'job-1');
+
+        $handler = new EntityProjectionHandler(
+            $applicationRepository,
+            $jobRepository,
+            $cacheInvalidationService,
+            $criticalViewWarmer,
+            $elastic,
+            $guard,
+        );
+
+        $handler(new EntityDeleted('recruit_job', 'job-1', 'evt_2', ['applicationSlug' => 'slug-1']));
+    }
+
+    public function testThatItIsIdempotentForRetries(): void
+    {
+        $applicationRepository = $this->createMock(ApplicationRepository::class);
+        $jobRepository = $this->createMock(JobRepository::class);
+        $application = (new Application())->setTitle('app')->setPlatform((new Platform())->setName('p')->setPlatformKey('CRM'));
+        $application->ensureGeneratedSlug();
+        $recruit = (new Recruit())->setApplication($application);
+        $job = (new Job())->setRecruit($recruit)->setTitle('Job 1');
+        $job->ensureGeneratedSlug();
+        $jobRepository->method('find')->willReturn($job);
+
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+        $cacheInvalidationService->expects(self::once())->method('invalidateRecruitJobListCaches');
+
+        $criticalViewWarmer = $this->createMock(CriticalViewWarmer::class);
+        $criticalViewWarmer->expects(self::once())->method('warmRecruitJobList');
+
+        $guard = $this->createMock(MessageIdempotenceGuard::class);
+        $guard->expects(self::exactly(2))->method('shouldProcess')->willReturnOnConsecutiveCalls(true, false);
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $elastic->expects(self::once())->method('index');
+
+        $handler = new EntityProjectionHandler(
+            $applicationRepository,
+            $jobRepository,
+            $cacheInvalidationService,
+            $criticalViewWarmer,
+            $elastic,
+            $guard,
+        );
+
+        $message = new EntityCreated('recruit_job', 'job-1', 'evt_same', ['applicationSlug' => 'slug-1']);
+        $handler($message);
+        $handler($message);
+    }
+}


### PR DESCRIPTION
### Motivation
- Centraliser la propagation post-mutation (création/patch/suppression) pour garantir que le cache et les index Elasticsearch restent cohérents.
- Uniformiser les conventions de clés/tags de cache et remplacer les invalidations ad hoc par un service partagé.
- Garantir l'idempotence des handlers Messenger afin de supporter les retries sans effets secondaires.
- Stabiliser les index Elasticsearch (noms versionnés + mappings) pour rendre les projections prévisibles.

### Description
- Ajout de messages métier `EntityCreated`, `EntityPatched`, `EntityDeleted` et du socle `EntityMutationMessage` portant `entityType`, `entityId`, `eventId` et `context` et publication depuis les controllers de mutation concernés (`ApplicationCreate`, `JobCreate`, `JobPatch`, `JobDelete`).
- Implémentation d'un handler de projection `EntityProjectionHandler` qui, de manière idempotente (`MessageIdempotenceGuard`), invalide les caches via `CacheInvalidationService`, préchauffe les vues critiques via `CriticalViewWarmer` et upsert/delete les documents dans Elasticsearch en utilisant des projections explicites (`ApplicationProjection::INDEX_NAME`, `RecruitJobProjection::INDEX_NAME`).
- Introduit `CacheKeyConventionService` pour construire des clés cohérentes et tags de cache, et intégré ces conventions dans `ApplicationListService` et `JobPublicListService` (utilisation des tags quand `TagAwareCacheInterface` est disponible).
- Étendu l'interface et l'implémentation Elasticsearch avec la méthode `delete` et ajouté des mappings/stables index names `platform_application_v1` et `recruit_job_v1`.
- Ajout de tests unitaires `EntityProjectionHandlerTest` couvrant indexation/suppression, invalidation/warmup et comportement idempotent sur retry.

### Testing
- `php -l` (PHP lint) exécuté sur tous les fichiers modifiés: succès (pas d'erreurs de syntaxe).
- Tests unitaires ajoutés: `tests/Unit/General/Application/MessageHandler/EntityProjectionHandlerTest.php` (présent dans le diff) mais `phpunit` n'a pas pu être exécuté dans cet environnement car les binaires PHPUnit ne sont pas disponibles; les assertions et mocks sont fournis dans le fichier de test.
- Les modifications ont été vérifiées localement par linting et par exécution des vérifications de syntaxe sur tous les fichiers PHP touchés: succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69add986c0c483269209d57ddd2982ff)