### PR TITLE
feat: ajouter les modules plugin Blog et Quiz complets

### DIFF
--- a/migrations/Version20260310100000.php
+++ b/migrations/Version20260310100000.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260310100000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Create blog and quiz plugin tables.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on mysql.');
+
+        $this->addSql('CREATE TABLE blog (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", application_id BINARY(16) DEFAULT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", owner_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title VARCHAR(255) NOT NULL, type VARCHAR(20) NOT NULL, post_status VARCHAR(20) NOT NULL, comment_status VARCHAR(20) NOT NULL, created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, PRIMARY KEY(id), INDEX IDX_CFC77A65A3C9036F (application_id), INDEX IDX_CFC77A657E3C61F9 (owner_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE blog_post (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", blog_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", author_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", content LONGTEXT DEFAULT NULL, file_path VARCHAR(255) DEFAULT NULL, created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, PRIMARY KEY(id), INDEX IDX_3D2997B8B489D9B (blog_id), INDEX IDX_3D2997BF675F31B (author_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE blog_comment (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", post_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", parent_id BINARY(16) DEFAULT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", author_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", content LONGTEXT DEFAULT NULL, file_path VARCHAR(255) DEFAULT NULL, created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, PRIMARY KEY(id), INDEX IDX_5833B3B24B89032C (post_id), INDEX IDX_5833B3B2727ACA70 (parent_id), INDEX IDX_5833B3B2F675F31B (author_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE blog_reaction (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", comment_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", author_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", type VARCHAR(40) NOT NULL, created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, PRIMARY KEY(id), INDEX IDX_9C6D0F45F8697D13 (comment_id), INDEX IDX_9C6D0F45F675F31B (author_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE blog_tag (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", blog_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", label VARCHAR(100) NOT NULL, created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, PRIMARY KEY(id), INDEX IDX_9196940DB489D9B (blog_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('CREATE TABLE quiz (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", application_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", owner_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", configuration_id BINARY(16) DEFAULT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, PRIMARY KEY(id), INDEX IDX_A412FA92A3C9036F (application_id), INDEX IDX_A412FA927E3C61F9 (owner_id), INDEX IDX_A412FA929DBB65DF (configuration_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE quiz_question (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", quiz_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title LONGTEXT NOT NULL, level VARCHAR(50) NOT NULL, category VARCHAR(100) NOT NULL, created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, PRIMARY KEY(id), INDEX IDX_D2F9A39A853CD175 (quiz_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE quiz_answer (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", question_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", label LONGTEXT NOT NULL, correct TINYINT(1) NOT NULL, created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, PRIMARY KEY(id), INDEX IDX_EF6E868D1E27F6BF (question_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE blog ADD CONSTRAINT FK_CFC77A65A3C9036F FOREIGN KEY (application_id) REFERENCES platform_application (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE blog ADD CONSTRAINT FK_CFC77A657E3C61F9 FOREIGN KEY (owner_id) REFERENCES user_user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE blog_post ADD CONSTRAINT FK_3D2997B8B489D9B FOREIGN KEY (blog_id) REFERENCES blog (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE blog_post ADD CONSTRAINT FK_3D2997BF675F31B FOREIGN KEY (author_id) REFERENCES user_user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE blog_comment ADD CONSTRAINT FK_5833B3B24B89032C FOREIGN KEY (post_id) REFERENCES blog_post (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE blog_comment ADD CONSTRAINT FK_5833B3B2727ACA70 FOREIGN KEY (parent_id) REFERENCES blog_comment (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE blog_comment ADD CONSTRAINT FK_5833B3B2F675F31B FOREIGN KEY (author_id) REFERENCES user_user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE blog_reaction ADD CONSTRAINT FK_9C6D0F45F8697D13 FOREIGN KEY (comment_id) REFERENCES blog_comment (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE blog_reaction ADD CONSTRAINT FK_9C6D0F45F675F31B FOREIGN KEY (author_id) REFERENCES user_user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE blog_tag ADD CONSTRAINT FK_9196940DB489D9B FOREIGN KEY (blog_id) REFERENCES blog (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE quiz ADD CONSTRAINT FK_A412FA92A3C9036F FOREIGN KEY (application_id) REFERENCES platform_application (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE quiz ADD CONSTRAINT FK_A412FA927E3C61F9 FOREIGN KEY (owner_id) REFERENCES user_user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE quiz ADD CONSTRAINT FK_A412FA929DBB65DF FOREIGN KEY (configuration_id) REFERENCES configuration_configuration (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE quiz_question ADD CONSTRAINT FK_D2F9A39A853CD175 FOREIGN KEY (quiz_id) REFERENCES quiz (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE quiz_answer ADD CONSTRAINT FK_EF6E868D1E27F6BF FOREIGN KEY (question_id) REFERENCES quiz_question (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on mysql.');
+        $this->addSql('ALTER TABLE blog_comment DROP FOREIGN KEY FK_5833B3B2727ACA70');
+        $this->addSql('DROP TABLE quiz_answer');
+        $this->addSql('DROP TABLE quiz_question');
+        $this->addSql('DROP TABLE quiz');
+        $this->addSql('DROP TABLE blog_reaction');
+        $this->addSql('DROP TABLE blog_comment');
+        $this->addSql('DROP TABLE blog_post');
+        $this->addSql('DROP TABLE blog_tag');
+        $this->addSql('DROP TABLE blog');
+    }
+}

--- a/src/Blog/Application/Message/CreateBlogCommentCommand.php
+++ b/src/Blog/Application/Message/CreateBlogCommentCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class CreateBlogCommentCommand implements MessageHighInterface
+{
+    public function __construct(public string $operationId, public string $actorUserId, public string $postId, public ?string $content, public ?string $filePath, public ?string $parentCommentId = null) {}
+}

--- a/src/Blog/Application/Message/CreateBlogPostCommand.php
+++ b/src/Blog/Application/Message/CreateBlogPostCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class CreateBlogPostCommand implements MessageHighInterface
+{
+    public function __construct(public string $operationId, public string $actorUserId, public string $blogId, public ?string $content, public ?string $filePath) {}
+}

--- a/src/Blog/Application/Message/CreateBlogReactionCommand.php
+++ b/src/Blog/Application/Message/CreateBlogReactionCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class CreateBlogReactionCommand implements MessageHighInterface
+{
+    public function __construct(public string $operationId, public string $actorUserId, public string $commentId, public string $type) {}
+}

--- a/src/Blog/Application/Message/CreateGeneralBlogCommand.php
+++ b/src/Blog/Application/Message/CreateGeneralBlogCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class CreateGeneralBlogCommand implements MessageHighInterface
+{
+    public function __construct(public string $operationId, public string $actorUserId, public string $title) {}
+}

--- a/src/Blog/Application/Message/DeleteBlogCommentCommand.php
+++ b/src/Blog/Application/Message/DeleteBlogCommentCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class DeleteBlogCommentCommand implements MessageHighInterface
+{
+    public function __construct(public string $operationId, public string $actorUserId, public string $commentId) {}
+}

--- a/src/Blog/Application/Message/DeleteBlogPostCommand.php
+++ b/src/Blog/Application/Message/DeleteBlogPostCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class DeleteBlogPostCommand implements MessageHighInterface
+{
+    public function __construct(public string $operationId, public string $actorUserId, public string $postId) {}
+}

--- a/src/Blog/Application/Message/DeleteBlogReactionCommand.php
+++ b/src/Blog/Application/Message/DeleteBlogReactionCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class DeleteBlogReactionCommand implements MessageHighInterface
+{
+    public function __construct(public string $operationId, public string $actorUserId, public string $reactionId) {}
+}

--- a/src/Blog/Application/Message/PatchBlogCommentCommand.php
+++ b/src/Blog/Application/Message/PatchBlogCommentCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class PatchBlogCommentCommand implements MessageHighInterface
+{
+    public function __construct(public string $operationId, public string $actorUserId, public string $commentId, public ?string $content, public ?string $filePath) {}
+}

--- a/src/Blog/Application/Message/PatchBlogPostCommand.php
+++ b/src/Blog/Application/Message/PatchBlogPostCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class PatchBlogPostCommand implements MessageHighInterface
+{
+    public function __construct(public string $operationId, public string $actorUserId, public string $postId, public ?string $content, public ?string $filePath) {}
+}

--- a/src/Blog/Application/Message/PatchBlogReactionCommand.php
+++ b/src/Blog/Application/Message/PatchBlogReactionCommand.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class PatchBlogReactionCommand implements MessageHighInterface
+{
+    public function __construct(public string $operationId, public string $actorUserId, public string $reactionId, public string $type) {}
+}

--- a/src/Blog/Application/MessageHandler/BlogMutationHandlers.php
+++ b/src/Blog/Application/MessageHandler/BlogMutationHandlers.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\MessageHandler;
+
+use App\Blog\Application\Message\CreateBlogCommentCommand;
+use App\Blog\Application\Message\CreateBlogPostCommand;
+use App\Blog\Application\Message\CreateBlogReactionCommand;
+use App\Blog\Application\Message\DeleteBlogCommentCommand;
+use App\Blog\Application\Message\DeleteBlogPostCommand;
+use App\Blog\Application\Message\DeleteBlogReactionCommand;
+use App\Blog\Application\Message\PatchBlogCommentCommand;
+use App\Blog\Application\Message\PatchBlogPostCommand;
+use App\Blog\Application\Message\PatchBlogReactionCommand;
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Entity\BlogComment;
+use App\Blog\Domain\Entity\BlogPost;
+use App\Blog\Domain\Entity\BlogReaction;
+use App\Blog\Domain\Enum\BlogStatus;
+use App\Blog\Infrastructure\Repository\BlogCommentRepository;
+use App\Blog\Infrastructure\Repository\BlogPostRepository;
+use App\Blog\Infrastructure\Repository\BlogReactionRepository;
+use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+trait BlogMutationAccessTrait
+{
+    private function canWritePost(Blog $blog, User $user): bool
+    {
+        return $blog->getPostStatus() === BlogStatus::OPEN || $blog->getOwner()->getId() === $user->getId();
+    }
+
+    private function canWriteComment(Blog $blog, User $user): bool
+    {
+        return $blog->getCommentStatus() === BlogStatus::OPEN || $blog->getOwner()->getId() === $user->getId();
+    }
+}
+
+#[AsMessageHandler]
+final readonly class CreateBlogPostCommandHandler
+{
+    use BlogMutationAccessTrait;
+
+    public function __construct(private BlogPostRepository $postRepository, private BlogRepository $blogRepository, private UserRepository $userRepository) {}
+
+    public function __invoke(CreateBlogPostCommand $command): void
+    {
+        $blog = $this->blogRepository->find($command->blogId);
+        $user = $this->userRepository->find($command->actorUserId);
+        if (!$blog instanceof Blog || !$user instanceof User) { throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found.'); }
+        if (!$this->canWritePost($blog, $user)) { throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Post creation is restricted to blog owner.'); }
+        if ($command->content === null && $command->filePath === null) { throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Post requires content and/or filePath.'); }
+        $this->postRepository->save((new BlogPost())->setBlog($blog)->setAuthor($user)->setContent($command->content)->setFilePath($command->filePath));
+    }
+}
+
+#[AsMessageHandler]
+final readonly class PatchBlogPostCommandHandler
+{
+    public function __construct(private BlogPostRepository $postRepository) {}
+
+    public function __invoke(PatchBlogPostCommand $command): void
+    {
+        $post = $this->postRepository->find($command->postId);
+        if (!$post instanceof BlogPost) { throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Post not found.'); }
+        if ($post->getAuthor()->getId() !== $command->actorUserId) { throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only post owner can patch.'); }
+        $post->setContent($command->content)->setFilePath($command->filePath);
+        $this->postRepository->save($post);
+    }
+}
+
+#[AsMessageHandler]
+final readonly class DeleteBlogPostCommandHandler
+{
+    public function __construct(private BlogPostRepository $postRepository) {}
+
+    public function __invoke(DeleteBlogPostCommand $command): void
+    {
+        $post = $this->postRepository->find($command->postId);
+        if (!$post instanceof BlogPost) { throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Post not found.'); }
+        if ($post->getAuthor()->getId() !== $command->actorUserId) { throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only post owner can delete.'); }
+        $this->postRepository->remove($post);
+    }
+}
+
+#[AsMessageHandler]
+final readonly class CreateBlogCommentCommandHandler
+{
+    use BlogMutationAccessTrait;
+
+    public function __construct(private BlogCommentRepository $commentRepository, private BlogPostRepository $postRepository, private UserRepository $userRepository) {}
+
+    public function __invoke(CreateBlogCommentCommand $command): void
+    {
+        $post = $this->postRepository->find($command->postId);
+        $user = $this->userRepository->find($command->actorUserId);
+        if (!$post instanceof BlogPost || !$user instanceof User) { throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found.'); }
+        if (!$this->canWriteComment($post->getBlog(), $user)) { throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Comments restricted to blog owner.'); }
+        if ($command->content === null && $command->filePath === null) { throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Comment requires content and/or filePath.'); }
+
+        $comment = (new BlogComment())->setPost($post)->setAuthor($user)->setContent($command->content)->setFilePath($command->filePath);
+        if ($command->parentCommentId !== null) {
+            $parent = $this->commentRepository->find($command->parentCommentId);
+            if (!$parent instanceof BlogComment) { throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Parent comment not found.'); }
+            $comment->setParent($parent);
+        }
+
+        $this->commentRepository->save($comment);
+    }
+}
+
+#[AsMessageHandler]
+final readonly class PatchBlogCommentCommandHandler
+{
+    public function __construct(private BlogCommentRepository $commentRepository) {}
+
+    public function __invoke(PatchBlogCommentCommand $command): void
+    {
+        $comment = $this->commentRepository->find($command->commentId);
+        if (!$comment instanceof BlogComment) { throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Comment not found.'); }
+        if ($comment->getAuthor()->getId() !== $command->actorUserId) { throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only comment owner can patch.'); }
+        $comment->setContent($command->content)->setFilePath($command->filePath);
+        $this->commentRepository->save($comment);
+    }
+}
+
+#[AsMessageHandler]
+final readonly class DeleteBlogCommentCommandHandler
+{
+    public function __construct(private BlogCommentRepository $commentRepository) {}
+
+    public function __invoke(DeleteBlogCommentCommand $command): void
+    {
+        $comment = $this->commentRepository->find($command->commentId);
+        if (!$comment instanceof BlogComment) { throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Comment not found.'); }
+        if ($comment->getAuthor()->getId() !== $command->actorUserId) { throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only comment owner can delete.'); }
+        $this->commentRepository->remove($comment);
+    }
+}
+
+#[AsMessageHandler]
+final readonly class CreateBlogReactionCommandHandler
+{
+    public function __construct(private BlogReactionRepository $reactionRepository, private BlogCommentRepository $commentRepository, private UserRepository $userRepository) {}
+
+    public function __invoke(CreateBlogReactionCommand $command): void
+    {
+        $comment = $this->commentRepository->find($command->commentId);
+        $user = $this->userRepository->find($command->actorUserId);
+        if (!$comment instanceof BlogComment || !$user instanceof User) { throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found.'); }
+        $this->reactionRepository->save((new BlogReaction())->setComment($comment)->setAuthor($user)->setType($command->type));
+    }
+}
+
+#[AsMessageHandler]
+final readonly class PatchBlogReactionCommandHandler
+{
+    public function __construct(private BlogReactionRepository $reactionRepository) {}
+
+    public function __invoke(PatchBlogReactionCommand $command): void
+    {
+        $reaction = $this->reactionRepository->find($command->reactionId);
+        if (!$reaction instanceof BlogReaction) { throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Reaction not found.'); }
+        if ($reaction->getAuthor()->getId() !== $command->actorUserId) { throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only reaction owner can patch.'); }
+        $reaction->setType($command->type);
+        $this->reactionRepository->save($reaction);
+    }
+}
+
+#[AsMessageHandler]
+final readonly class DeleteBlogReactionCommandHandler
+{
+    public function __construct(private BlogReactionRepository $reactionRepository) {}
+
+    public function __invoke(DeleteBlogReactionCommand $command): void
+    {
+        $reaction = $this->reactionRepository->find($command->reactionId);
+        if (!$reaction instanceof BlogReaction) { throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Reaction not found.'); }
+        if ($reaction->getAuthor()->getId() !== $command->actorUserId) { throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only reaction owner can delete.'); }
+        $this->reactionRepository->remove($reaction);
+    }
+}

--- a/src/Blog/Application/MessageHandler/CreateGeneralBlogCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateGeneralBlogCommandHandler.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\MessageHandler;
+
+use App\Blog\Application\Message\CreateGeneralBlogCommand;
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Enum\BlogType;
+use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class CreateGeneralBlogCommandHandler
+{
+    public function __construct(private BlogRepository $blogRepository, private UserRepository $userRepository) {}
+
+    public function __invoke(CreateGeneralBlogCommand $command): void
+    {
+        $user = $this->userRepository->find($command->actorUserId);
+        if (!$user instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'User not found.');
+        }
+
+        if ($this->blogRepository->findGeneralBlog() instanceof Blog) {
+            return;
+        }
+
+        $this->blogRepository->save((new Blog())->setTitle($command->title)->setOwner($user)->setType(BlogType::GENERAL));
+    }
+}

--- a/src/Blog/Application/Service/BlogReadService.php
+++ b/src/Blog/Application/Service/BlogReadService.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Service;
+
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Entity\BlogComment;
+use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final readonly class BlogReadService
+{
+    public function __construct(private BlogRepository $blogRepository, private CacheInterface $cache, private ElasticsearchServiceInterface $elasticsearchService) {}
+
+    /** @throws InvalidArgumentException */
+    public function getGeneralBlogWithTree(): array
+    {
+        return $this->cache->get('blog_general_tree', function (ItemInterface $item): array {
+            $item->expiresAfter(120);
+            $blog = $this->blogRepository->findGeneralBlog();
+
+            return $blog instanceof Blog ? $this->normalizeBlog($blog) : [];
+        });
+    }
+
+    /** @throws InvalidArgumentException */
+    public function getByApplicationSlug(string $applicationSlug): array
+    {
+        return $this->cache->get('blog_app_' . $applicationSlug, function (ItemInterface $item) use ($applicationSlug): array {
+            $item->expiresAfter(120);
+            $blog = $this->blogRepository->findOneBy(['application.slug' => $applicationSlug]);
+            if (!$blog instanceof Blog) {
+                $blog = $this->blogRepository->createQueryBuilder('b')
+                    ->leftJoin('b.application', 'a')
+                    ->andWhere('a.slug = :slug')
+                    ->setParameter('slug', $applicationSlug)
+                    ->getQuery()
+                    ->getOneOrNullResult();
+            }
+
+            return $blog instanceof Blog ? $this->normalizeBlog($blog) : [];
+        });
+    }
+
+    private function normalizeBlog(Blog $blog): array
+    {
+        return [
+            'id' => $blog->getId(),
+            'title' => $blog->getTitle(),
+            'type' => $blog->getType()->value,
+            'postStatus' => $blog->getPostStatus()->value,
+            'commentStatus' => $blog->getCommentStatus()->value,
+            'applicationSlug' => $blog->getApplication()?->getSlug(),
+            'posts' => array_map(fn ($p): array => [
+                'id' => $p->getId(),
+                'authorId' => $p->getAuthor()->getId(),
+                'content' => $p->getContent(),
+                'filePath' => $p->getFilePath(),
+                'comments' => $this->normalizeComments($p->getComments()->toArray(), null),
+            ], $blog->getPosts()->toArray()),
+        ];
+    }
+
+    /** @param array<int, BlogComment> $comments */
+    private function normalizeComments(array $comments, ?string $parentId): array
+    {
+        $filtered = array_filter($comments, static fn (BlogComment $comment): bool => $comment->getParent()?->getId() === $parentId);
+
+        return array_map(function (BlogComment $comment) use ($comments): array {
+            return [
+                'id' => $comment->getId(),
+                'authorId' => $comment->getAuthor()->getId(),
+                'content' => $comment->getContent(),
+                'filePath' => $comment->getFilePath(),
+                'reactions' => array_map(static fn ($r): array => ['id' => $r->getId(), 'authorId' => $r->getAuthor()->getId(), 'type' => $r->getType()], $comment->getReactions()->toArray()),
+                'children' => $this->normalizeComments($comments, $comment->getId()),
+            ];
+        }, array_values($filtered));
+    }
+}

--- a/src/Blog/Domain/Entity/Blog.php
+++ b/src/Blog/Domain/Entity/Blog.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Domain\Entity;
+
+use App\Blog\Domain\Enum\BlogStatus;
+use App\Blog\Domain\Enum\BlogType;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Platform\Domain\Entity\Application;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'blog')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Blog implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'title', type: 'string', length: 255)]
+    private string $title = '';
+
+    #[ORM\Column(name: 'type', type: 'string', length: 20, enumType: BlogType::class)]
+    private BlogType $type = BlogType::APPLICATION;
+
+    #[ORM\Column(name: 'post_status', type: 'string', length: 20, enumType: BlogStatus::class)]
+    private BlogStatus $postStatus = BlogStatus::OPEN;
+
+    #[ORM\Column(name: 'comment_status', type: 'string', length: 20, enumType: BlogStatus::class)]
+    private BlogStatus $commentStatus = BlogStatus::OPEN;
+
+    #[ORM\ManyToOne(targetEntity: Application::class)]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    private ?Application $application = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'owner_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $owner;
+
+    /** @var Collection<int, BlogPost> */
+    #[ORM\OneToMany(targetEntity: BlogPost::class, mappedBy: 'blog', cascade: ['remove'])]
+    private Collection $posts;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->posts = new ArrayCollection();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getType(): BlogType { return $this->type; }
+    public function setType(BlogType $type): self { $this->type = $type; return $this; }
+    public function getPostStatus(): BlogStatus { return $this->postStatus; }
+    public function setPostStatus(BlogStatus $postStatus): self { $this->postStatus = $postStatus; return $this; }
+    public function getCommentStatus(): BlogStatus { return $this->commentStatus; }
+    public function setCommentStatus(BlogStatus $commentStatus): self { $this->commentStatus = $commentStatus; return $this; }
+    public function getApplication(): ?Application { return $this->application; }
+    public function setApplication(?Application $application): self { $this->application = $application; return $this; }
+    public function getOwner(): User { return $this->owner; }
+    public function setOwner(User $owner): self { $this->owner = $owner; return $this; }
+    /** @return Collection<int, BlogPost> */
+    public function getPosts(): Collection { return $this->posts; }
+}

--- a/src/Blog/Domain/Entity/BlogComment.php
+++ b/src/Blog/Domain/Entity/BlogComment.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'blog_comment')]
+class BlogComment implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: BlogPost::class)]
+    #[ORM\JoinColumn(name: 'post_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private BlogPost $post;
+
+    #[ORM\ManyToOne(targetEntity: BlogComment::class)]
+    #[ORM\JoinColumn(name: 'parent_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    private ?BlogComment $parent = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'author_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $author;
+
+    #[ORM\Column(name: 'content', type: 'text', nullable: true)]
+    private ?string $content = null;
+
+    #[ORM\Column(name: 'file_path', type: 'string', length: 255, nullable: true)]
+    private ?string $filePath = null;
+
+    /** @var Collection<int, BlogReaction> */
+    #[ORM\OneToMany(targetEntity: BlogReaction::class, mappedBy: 'comment', cascade: ['remove'])]
+    private Collection $reactions;
+
+    /** @var Collection<int, BlogComment> */
+    #[ORM\OneToMany(targetEntity: BlogComment::class, mappedBy: 'parent', cascade: ['remove'])]
+    private Collection $children;
+
+    public function __construct() { $this->id = $this->createUuid(); $this->reactions = new ArrayCollection(); $this->children = new ArrayCollection(); }
+    #[Override] public function getId(): string { return $this->id->toString(); }
+    public function getPost(): BlogPost { return $this->post; }
+    public function setPost(BlogPost $post): self { $this->post = $post; return $this; }
+    public function getParent(): ?BlogComment { return $this->parent; }
+    public function setParent(?BlogComment $parent): self { $this->parent = $parent; return $this; }
+    public function getAuthor(): User { return $this->author; }
+    public function setAuthor(User $author): self { $this->author = $author; return $this; }
+    public function getContent(): ?string { return $this->content; }
+    public function setContent(?string $content): self { $this->content = $content; return $this; }
+    public function getFilePath(): ?string { return $this->filePath; }
+    public function setFilePath(?string $filePath): self { $this->filePath = $filePath; return $this; }
+    /** @return Collection<int, BlogReaction> */ public function getReactions(): Collection { return $this->reactions; }
+    /** @return Collection<int, BlogComment> */ public function getChildren(): Collection { return $this->children; }
+}

--- a/src/Blog/Domain/Entity/BlogPost.php
+++ b/src/Blog/Domain/Entity/BlogPost.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'blog_post')]
+class BlogPost implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Blog::class)]
+    #[ORM\JoinColumn(name: 'blog_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Blog $blog;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'author_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $author;
+
+    #[ORM\Column(name: 'content', type: 'text', nullable: true)]
+    private ?string $content = null;
+
+    #[ORM\Column(name: 'file_path', type: 'string', length: 255, nullable: true)]
+    private ?string $filePath = null;
+
+    /** @var Collection<int, BlogComment> */
+    #[ORM\OneToMany(targetEntity: BlogComment::class, mappedBy: 'post', cascade: ['remove'])]
+    private Collection $comments;
+
+    public function __construct() { $this->id = $this->createUuid(); $this->comments = new ArrayCollection(); }
+    #[Override] public function getId(): string { return $this->id->toString(); }
+    public function getBlog(): Blog { return $this->blog; }
+    public function setBlog(Blog $blog): self { $this->blog = $blog; return $this; }
+    public function getAuthor(): User { return $this->author; }
+    public function setAuthor(User $author): self { $this->author = $author; return $this; }
+    public function getContent(): ?string { return $this->content; }
+    public function setContent(?string $content): self { $this->content = $content; return $this; }
+    public function getFilePath(): ?string { return $this->filePath; }
+    public function setFilePath(?string $filePath): self { $this->filePath = $filePath; return $this; }
+    /** @return Collection<int, BlogComment> */ public function getComments(): Collection { return $this->comments; }
+}

--- a/src/Blog/Domain/Entity/BlogReaction.php
+++ b/src/Blog/Domain/Entity/BlogReaction.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'blog_reaction')]
+class BlogReaction implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: BlogComment::class)]
+    #[ORM\JoinColumn(name: 'comment_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private BlogComment $comment;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'author_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $author;
+
+    #[ORM\Column(name: 'type', type: 'string', length: 40)]
+    private string $type = 'like';
+
+    public function __construct() { $this->id = $this->createUuid(); }
+    #[Override] public function getId(): string { return $this->id->toString(); }
+    public function getComment(): BlogComment { return $this->comment; }
+    public function setComment(BlogComment $comment): self { $this->comment = $comment; return $this; }
+    public function getAuthor(): User { return $this->author; }
+    public function setAuthor(User $author): self { $this->author = $author; return $this; }
+    public function getType(): string { return $this->type; }
+    public function setType(string $type): self { $this->type = $type; return $this; }
+}

--- a/src/Blog/Domain/Entity/BlogTag.php
+++ b/src/Blog/Domain/Entity/BlogTag.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'blog_tag')]
+class BlogTag implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Blog::class)]
+    #[ORM\JoinColumn(name: 'blog_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Blog $blog;
+
+    #[ORM\Column(name: 'label', type: 'string', length: 100)]
+    private string $label = '';
+
+    public function __construct() { $this->id = $this->createUuid(); }
+    #[Override] public function getId(): string { return $this->id->toString(); }
+    public function getBlog(): Blog { return $this->blog; }
+    public function setBlog(Blog $blog): self { $this->blog = $blog; return $this; }
+    public function getLabel(): string { return $this->label; }
+    public function setLabel(string $label): self { $this->label = $label; return $this; }
+}

--- a/src/Blog/Domain/Enum/BlogStatus.php
+++ b/src/Blog/Domain/Enum/BlogStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Domain\Enum;
+
+enum BlogStatus: string
+{
+    case OPEN = 'open';
+    case CLOSED = 'closed';
+}

--- a/src/Blog/Domain/Enum/BlogType.php
+++ b/src/Blog/Domain/Enum/BlogType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Domain\Enum;
+
+enum BlogType: string
+{
+    case GENERAL = 'general';
+    case APPLICATION = 'application';
+}

--- a/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
+++ b/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Infrastructure\DataFixtures\ORM;
+
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Entity\BlogComment;
+use App\Blog\Domain\Entity\BlogPost;
+use App\Blog\Domain\Entity\BlogReaction;
+use App\Blog\Domain\Entity\BlogTag;
+use App\Blog\Domain\Enum\BlogType;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use App\Platform\Domain\Entity\Application;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+
+final class LoadBlogData extends Fixture implements OrderedFixtureInterface
+{
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        $johnRoot = $this->getReference('User-john-root', User::class);
+        $application = $this->getReference('Application-shop-ops-center', Application::class);
+
+        $generalBlog = (new Blog())->setTitle('General Blog Root')->setOwner($johnRoot)->setType(BlogType::GENERAL);
+        $applicationBlog = (new Blog())->setTitle('Shop Blog')->setOwner($johnRoot)->setType(BlogType::APPLICATION)->setApplication($application);
+        $manager->persist($generalBlog); $manager->persist($applicationBlog);
+
+        foreach ([$generalBlog, $applicationBlog] as $i => $blog) {
+            for ($p = 1; $p <= 4; ++$p) {
+                $post = (new BlogPost())->setBlog($blog)->setAuthor($johnRoot)->setContent(sprintf('Fixture post %d for %s', $p, $blog->getTitle()));
+                $manager->persist($post);
+                $tag = (new BlogTag())->setBlog($blog)->setLabel(sprintf('tag-%d-%d', $i + 1, $p));
+                $manager->persist($tag);
+
+                $parent = (new BlogComment())->setPost($post)->setAuthor($johnRoot)->setContent('Parent comment #' . $p);
+                $child = (new BlogComment())->setPost($post)->setAuthor($johnRoot)->setContent('Child comment #' . $p)->setParent($parent);
+                $manager->persist($parent); $manager->persist($child);
+
+                $manager->persist((new BlogReaction())->setComment($parent)->setAuthor($johnRoot)->setType('like'));
+                $manager->persist((new BlogReaction())->setComment($child)->setAuthor($johnRoot)->setType('heart'));
+            }
+        }
+
+        $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 41;
+    }
+}

--- a/src/Blog/Infrastructure/Repository/BlogCommentRepository.php
+++ b/src/Blog/Infrastructure/Repository/BlogCommentRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Infrastructure\Repository;
+
+use App\Blog\Domain\Entity\BlogComment;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class BlogCommentRepository extends BaseRepository
+{
+    protected static string $entityName = BlogComment::class;
+    protected static array $searchColumns = ['id', 'content'];
+
+    public function __construct(protected ManagerRegistry $managerRegistry) {}
+}

--- a/src/Blog/Infrastructure/Repository/BlogPostRepository.php
+++ b/src/Blog/Infrastructure/Repository/BlogPostRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Infrastructure\Repository;
+
+use App\Blog\Domain\Entity\BlogPost;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class BlogPostRepository extends BaseRepository
+{
+    protected static string $entityName = BlogPost::class;
+    protected static array $searchColumns = ['id', 'content'];
+
+    public function __construct(protected ManagerRegistry $managerRegistry) {}
+}

--- a/src/Blog/Infrastructure/Repository/BlogReactionRepository.php
+++ b/src/Blog/Infrastructure/Repository/BlogReactionRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Infrastructure\Repository;
+
+use App\Blog\Domain\Entity\BlogReaction;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class BlogReactionRepository extends BaseRepository
+{
+    protected static string $entityName = BlogReaction::class;
+    protected static array $searchColumns = ['id', 'type'];
+
+    public function __construct(protected ManagerRegistry $managerRegistry) {}
+}

--- a/src/Blog/Infrastructure/Repository/BlogRepository.php
+++ b/src/Blog/Infrastructure/Repository/BlogRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Infrastructure\Repository;
+
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Enum\BlogType;
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Platform\Domain\Entity\Application;
+use Doctrine\Persistence\ManagerRegistry;
+
+class BlogRepository extends BaseRepository
+{
+    protected static string $entityName = Blog::class;
+    protected static array $searchColumns = ['id', 'title'];
+
+    public function __construct(protected ManagerRegistry $managerRegistry) {}
+
+    public function findOneByApplication(Application $application): ?Blog
+    {
+        $result = $this->findOneBy(['application' => $application]);
+
+        return $result instanceof Blog ? $result : null;
+    }
+
+    public function findGeneralBlog(): ?Blog
+    {
+        $result = $this->findOneBy(['type' => BlogType::GENERAL]);
+
+        return $result instanceof Blog ? $result : null;
+    }
+}

--- a/src/Blog/Infrastructure/Repository/BlogTagRepository.php
+++ b/src/Blog/Infrastructure/Repository/BlogTagRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Infrastructure\Repository;
+
+use App\Blog\Domain\Entity\BlogTag;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class BlogTagRepository extends BaseRepository
+{
+    protected static string $entityName = BlogTag::class;
+    protected static array $searchColumns = ['id', 'label'];
+
+    public function __construct(protected ManagerRegistry $managerRegistry) {}
+}

--- a/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Transport\Controller\Api\V1;
+
+use App\Blog\Application\Message\CreateBlogCommentCommand;
+use App\Blog\Application\Message\CreateBlogPostCommand;
+use App\Blog\Application\Message\CreateBlogReactionCommand;
+use App\Blog\Application\Message\CreateGeneralBlogCommand;
+use App\Blog\Application\Message\DeleteBlogCommentCommand;
+use App\Blog\Application\Message\DeleteBlogPostCommand;
+use App\Blog\Application\Message\DeleteBlogReactionCommand;
+use App\Blog\Application\Message\PatchBlogCommentCommand;
+use App\Blog\Application\Message\PatchBlogPostCommand;
+use App\Blog\Application\Message\PatchBlogReactionCommand;
+use App\User\Domain\Entity\User;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class BlogMutationController
+{
+    public function __construct(private MessageBusInterface $messageBus) {}
+
+    #[Route('/v1/blogs/general', methods: [Request::METHOD_POST])]
+    public function createGeneral(Request $request): JsonResponse
+    {
+        $user = $request->getUser();
+        if (!$user instanceof User || !in_array('ROLE_ROOT', $user->getRoles(), true)) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only root can create General blog.');
+        }
+
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $this->messageBus->dispatch(new CreateGeneralBlogCommand((string) uniqid('op_', true), $user->getId(), (string) ($payload['title'] ?? 'General Blog')));
+
+        return new JsonResponse(['status' => 'accepted'], JsonResponse::HTTP_ACCEPTED);
+    }
+
+    #[Route('/v1/blogs/{blogId}/posts', methods: [Request::METHOD_POST])]
+    public function createPost(string $blogId, Request $request): JsonResponse
+    {
+        $user = $this->requireUser($request);
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $this->messageBus->dispatch(new CreateBlogPostCommand((string) uniqid('op_', true), $user->getId(), $blogId, $payload['content'] ?? null, $payload['filePath'] ?? null));
+
+        return new JsonResponse(['status' => 'accepted'], JsonResponse::HTTP_ACCEPTED);
+    }
+
+    #[Route('/v1/blog/posts/{postId}', methods: [Request::METHOD_PATCH])]
+    public function patchPost(string $postId, Request $request): JsonResponse
+    {
+        $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
+        $this->messageBus->dispatch(new PatchBlogPostCommand((string) uniqid('op_', true), $user->getId(), $postId, $payload['content'] ?? null, $payload['filePath'] ?? null));
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/blog/posts/{postId}', methods: [Request::METHOD_DELETE])]
+    public function deletePost(string $postId, Request $request): JsonResponse
+    {
+        $user = $this->requireUser($request); $this->messageBus->dispatch(new DeleteBlogPostCommand((string) uniqid('op_', true), $user->getId(), $postId));
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/blog/posts/{postId}/comments', methods: [Request::METHOD_POST])]
+    public function createComment(string $postId, Request $request): JsonResponse
+    {
+        $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
+        $this->messageBus->dispatch(new CreateBlogCommentCommand((string) uniqid('op_', true), $user->getId(), $postId, $payload['content'] ?? null, $payload['filePath'] ?? null, $payload['parentCommentId'] ?? null));
+        return new JsonResponse(['status' => 'accepted'], JsonResponse::HTTP_ACCEPTED);
+    }
+
+    #[Route('/v1/blog/comments/{commentId}', methods: [Request::METHOD_PATCH])]
+    public function patchComment(string $commentId, Request $request): JsonResponse
+    {
+        $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
+        $this->messageBus->dispatch(new PatchBlogCommentCommand((string) uniqid('op_', true), $user->getId(), $commentId, $payload['content'] ?? null, $payload['filePath'] ?? null));
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/blog/comments/{commentId}', methods: [Request::METHOD_DELETE])]
+    public function deleteComment(string $commentId, Request $request): JsonResponse
+    {
+        $user = $this->requireUser($request); $this->messageBus->dispatch(new DeleteBlogCommentCommand((string) uniqid('op_', true), $user->getId(), $commentId));
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/blog/comments/{commentId}/reactions', methods: [Request::METHOD_POST])]
+    public function createReaction(string $commentId, Request $request): JsonResponse
+    {
+        $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
+        $this->messageBus->dispatch(new CreateBlogReactionCommand((string) uniqid('op_', true), $user->getId(), $commentId, (string) ($payload['type'] ?? 'like')));
+        return new JsonResponse(['status' => 'accepted'], JsonResponse::HTTP_ACCEPTED);
+    }
+
+    #[Route('/v1/blog/reactions/{reactionId}', methods: [Request::METHOD_PATCH])]
+    public function patchReaction(string $reactionId, Request $request): JsonResponse
+    {
+        $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
+        $this->messageBus->dispatch(new PatchBlogReactionCommand((string) uniqid('op_', true), $user->getId(), $reactionId, (string) ($payload['type'] ?? 'like')));
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/blog/reactions/{reactionId}', methods: [Request::METHOD_DELETE])]
+    public function deleteReaction(string $reactionId, Request $request): JsonResponse
+    {
+        $user = $this->requireUser($request); $this->messageBus->dispatch(new DeleteBlogReactionCommand((string) uniqid('op_', true), $user->getId(), $reactionId));
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    private function requireUser(Request $request): User
+    {
+        $user = $request->getUser();
+        if (!$user instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_UNAUTHORIZED, 'User required.');
+        }
+
+        return $user;
+    }
+}

--- a/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Transport\Controller\Api\V1;
+
+use App\Blog\Application\Service\BlogReadService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+final readonly class BlogReadController
+{
+    public function __construct(private BlogReadService $blogReadService) {}
+
+    #[Route('/v1/blogs/general', methods: [Request::METHOD_GET])]
+    public function general(): JsonResponse
+    {
+        return new JsonResponse($this->blogReadService->getGeneralBlogWithTree());
+    }
+
+    #[Route('/v1/blogs/application/{applicationSlug}', methods: [Request::METHOD_GET])]
+    public function byApplication(string $applicationSlug): JsonResponse
+    {
+        return new JsonResponse($this->blogReadService->getByApplicationSlug($applicationSlug));
+    }
+}

--- a/src/Platform/Application/Service/ApplicationPluginProvisioningService.php
+++ b/src/Platform/Application/Service/ApplicationPluginProvisioningService.php
@@ -8,7 +8,12 @@ use App\Calendar\Domain\Entity\Calendar;
 use App\Calendar\Infrastructure\Repository\CalendarRepository;
 use App\Chat\Domain\Entity\Chat;
 use App\Chat\Infrastructure\Repository\ChatRepository;
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Enum\BlogType;
+use App\Blog\Infrastructure\Repository\BlogRepository;
 use App\Platform\Domain\Entity\Application;
+use App\Quiz\Domain\Entity\Quiz;
+use App\Quiz\Infrastructure\Repository\QuizRepository;
 use App\Platform\Domain\Enum\PluginKey;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -19,6 +24,8 @@ final class ApplicationPluginProvisioningService
     public function __construct(
         private readonly CalendarRepository $calendarRepository,
         private readonly ChatRepository $chatRepository,
+        private readonly BlogRepository $blogRepository,
+        private readonly QuizRepository $quizRepository,
         private readonly EntityManagerInterface $entityManager,
     ) {
     }
@@ -34,6 +41,13 @@ final class ApplicationPluginProvisioningService
 
         if (in_array(PluginKey::CHAT, $pluginKeys, true)) {
             $this->provisionChat($application);
+        }
+        if (in_array(PluginKey::BLOG, $pluginKeys, true)) {
+            $this->provisionBlog($application);
+        }
+
+        if (in_array(PluginKey::QUIZ, $pluginKeys, true)) {
+            $this->provisionQuiz($application);
         }
     }
 
@@ -65,4 +79,33 @@ final class ApplicationPluginProvisioningService
 
         $this->entityManager->persist($chat);
     }
+
+    private function provisionBlog(Application $application): void
+    {
+        if ($this->blogRepository->findOneByApplication($application) instanceof Blog) {
+            return;
+        }
+
+        $blog = (new Blog())
+            ->setTitle($application->getTitle() . ' Blog')
+            ->setOwner($application->getUser())
+            ->setType(BlogType::APPLICATION)
+            ->setApplication($application);
+
+        $this->entityManager->persist($blog);
+    }
+
+    private function provisionQuiz(Application $application): void
+    {
+        if ($this->quizRepository->findOneByApplication($application) instanceof Quiz) {
+            return;
+        }
+
+        $quiz = (new Quiz())
+            ->setApplication($application)
+            ->setOwner($application->getUser());
+
+        $this->entityManager->persist($quiz);
+    }
+
 }

--- a/src/Platform/Domain/Enum/PluginKey.php
+++ b/src/Platform/Domain/Enum/PluginKey.php
@@ -12,5 +12,6 @@ enum PluginKey: string
     case CALENDAR = 'calendar';
     case CHAT = 'chat';
     case BLOG = 'blog';
+    case QUIZ = 'quiz';
     case LANGUAGE = 'language';
 }

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php
@@ -27,6 +27,7 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
         'Private Beta Plugin' => '50000000-0000-1000-8000-000000000003',
         'Disabled Public Plugin' => '50000000-0000-1000-8000-000000000004',
         'Knowledge Base Connector' => '50000000-0000-1000-8000-000000000005',
+        'Quiz Master' => '50000000-0000-1000-8000-000000000006',
     ];
 
     /**
@@ -77,6 +78,15 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
             'enabled' => true,
             'private' => false,
             'description' => 'Connector to sync articles and FAQs from external knowledge base systems.',
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000006',
+            'key' => 'Quiz-Master',
+            'pluginKey' => 'quiz',
+            'name' => 'Quiz Master',
+            'enabled' => true,
+            'private' => false,
+            'description' => 'Gamified quiz module with categories, difficulty levels and answer scoring.',
         ],
     ];
 

--- a/src/Quiz/Application/Message/CreateQuizQuestionCommand.php
+++ b/src/Quiz/Application/Message/CreateQuizQuestionCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class CreateQuizQuestionCommand implements MessageHighInterface
+{
+    /** @param array<int, array{label: string, correct: bool}> $answers */
+    public function __construct(public string $operationId, public string $actorUserId, public string $applicationSlug, public string $title, public string $level, public string $category, public array $answers, public ?array $configuration = null) {}
+}

--- a/src/Quiz/Application/MessageHandler/CreateQuizQuestionCommandHandler.php
+++ b/src/Quiz/Application/MessageHandler/CreateQuizQuestionCommandHandler.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Application\MessageHandler;
+
+use App\Configuration\Domain\Entity\Configuration;
+use App\Configuration\Domain\Enum\ConfigurationScope;
+use App\Configuration\Infrastructure\Repository\ConfigurationRepository;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Infrastructure\Repository\ApplicationRepository;
+use App\Quiz\Application\Message\CreateQuizQuestionCommand;
+use App\Quiz\Domain\Entity\Quiz;
+use App\Quiz\Domain\Entity\QuizAnswer;
+use App\Quiz\Domain\Entity\QuizQuestion;
+use App\Quiz\Infrastructure\Repository\QuizQuestionRepository;
+use App\Quiz\Infrastructure\Repository\QuizRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class CreateQuizQuestionCommandHandler
+{
+    public function __construct(
+        private QuizRepository $quizRepository,
+        private QuizQuestionRepository $questionRepository,
+        private ApplicationRepository $applicationRepository,
+        private ConfigurationRepository $configurationRepository,
+    ) {}
+
+    public function __invoke(CreateQuizQuestionCommand $command): void
+    {
+        $application = $this->applicationRepository->findOneBy(['slug' => $command->applicationSlug]);
+        if (!$application instanceof Application) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Application not found.');
+        }
+
+        $quiz = $this->quizRepository->findOneByApplication($application);
+        if (!$quiz instanceof Quiz) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Quiz not found for application.');
+        }
+
+        if ($quiz->getOwner()->getId() !== $command->actorUserId) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only application owner can create quiz questions.');
+        }
+
+        $question = (new QuizQuestion())
+            ->setQuiz($quiz)
+            ->setTitle($command->title)
+            ->setLevel($command->level)
+            ->setCategory($command->category);
+
+        foreach ($command->answers as $answerItem) {
+            $answer = (new QuizAnswer())
+                ->setQuestion($question)
+                ->setLabel((string) ($answerItem['label'] ?? ''))
+                ->setCorrect((bool) ($answerItem['correct'] ?? false));
+            $this->questionRepository->getEntityManager()->persist($answer);
+        }
+
+        if (is_array($command->configuration)) {
+            $configuration = (new Configuration())
+                ->setApplication($application)
+                ->setConfigurationKey('quiz.module.configuration')
+                ->setConfigurationValue($command->configuration)
+                ->setScope(ConfigurationScope::APPLICATION)
+                ->setPrivate(true);
+            $this->configurationRepository->save($configuration);
+            $quiz->setConfiguration($configuration);
+            $this->quizRepository->save($quiz);
+        }
+
+        $this->questionRepository->save($question);
+    }
+}

--- a/src/Quiz/Application/Service/QuizReadService.php
+++ b/src/Quiz/Application/Service/QuizReadService.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Application\Service;
+
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\Quiz\Domain\Entity\Quiz;
+use App\Quiz\Infrastructure\Repository\QuizRepository;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final readonly class QuizReadService
+{
+    public function __construct(private QuizRepository $quizRepository, private CacheInterface $cache, private ElasticsearchServiceInterface $elasticsearchService) {}
+
+    /** @throws InvalidArgumentException */
+    public function getByApplicationSlug(string $slug): array
+    {
+        return $this->cache->get('quiz_' . $slug, function (ItemInterface $item) use ($slug): array {
+            $item->expiresAfter(120);
+            $quiz = $this->quizRepository->createQueryBuilder('q')
+                ->leftJoin('q.application', 'a')
+                ->leftJoin('q.questions', 'qq')->addSelect('qq')
+                ->leftJoin('qq.answers', 'qa')->addSelect('qa')
+                ->andWhere('a.slug = :slug')->setParameter('slug', $slug)->getQuery()->getOneOrNullResult();
+
+            if (!$quiz instanceof Quiz) {
+                return [];
+            }
+
+            return [
+                'id' => $quiz->getId(),
+                'applicationSlug' => $slug,
+                'configuration' => $quiz->getConfiguration()?->getConfigurationValue(),
+                'questions' => array_map(static fn ($q): array => [
+                    'id' => $q->getId(),
+                    'title' => $q->getTitle(),
+                    'level' => $q->getLevel(),
+                    'category' => $q->getCategory(),
+                    'answers' => array_map(static fn ($a): array => ['id' => $a->getId(), 'label' => $a->getLabel(), 'correct' => $a->isCorrect()], $q->getAnswers()->toArray()),
+                ], $quiz->getQuestions()->toArray()),
+            ];
+        });
+    }
+}

--- a/src/Quiz/Domain/Entity/Quiz.php
+++ b/src/Quiz/Domain/Entity/Quiz.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Domain\Entity;
+
+use App\Configuration\Domain\Entity\Configuration;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Platform\Domain\Entity\Application;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'quiz')]
+class Quiz implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Application::class)]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Application $application;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'owner_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $owner;
+
+    /** @var Collection<int, QuizQuestion> */
+    #[ORM\OneToMany(targetEntity: QuizQuestion::class, mappedBy: 'quiz', cascade: ['remove'])]
+    private Collection $questions;
+
+    #[ORM\ManyToOne(targetEntity: Configuration::class)]
+    #[ORM\JoinColumn(name: 'configuration_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Configuration $configuration = null;
+
+    public function __construct() { $this->id = $this->createUuid(); $this->questions = new ArrayCollection(); }
+    #[Override] public function getId(): string { return $this->id->toString(); }
+    public function getApplication(): Application { return $this->application; }
+    public function setApplication(Application $application): self { $this->application = $application; return $this; }
+    public function getOwner(): User { return $this->owner; }
+    public function setOwner(User $owner): self { $this->owner = $owner; return $this; }
+    /** @return Collection<int, QuizQuestion> */ public function getQuestions(): Collection { return $this->questions; }
+    public function getConfiguration(): ?Configuration { return $this->configuration; }
+    public function setConfiguration(?Configuration $configuration): self { $this->configuration = $configuration; return $this; }
+}

--- a/src/Quiz/Domain/Entity/QuizAnswer.php
+++ b/src/Quiz/Domain/Entity/QuizAnswer.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'quiz_answer')]
+class QuizAnswer implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: QuizQuestion::class)]
+    #[ORM\JoinColumn(name: 'question_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private QuizQuestion $question;
+
+    #[ORM\Column(name: 'label', type: 'text')]
+    private string $label = '';
+
+    #[ORM\Column(name: 'correct', type: 'boolean')]
+    private bool $correct = false;
+
+    public function __construct() { $this->id = $this->createUuid(); }
+    #[Override] public function getId(): string { return $this->id->toString(); }
+    public function getQuestion(): QuizQuestion { return $this->question; }
+    public function setQuestion(QuizQuestion $question): self { $this->question = $question; return $this; }
+    public function getLabel(): string { return $this->label; }
+    public function setLabel(string $label): self { $this->label = $label; return $this; }
+    public function isCorrect(): bool { return $this->correct; }
+    public function setCorrect(bool $correct): self { $this->correct = $correct; return $this; }
+}

--- a/src/Quiz/Domain/Entity/QuizQuestion.php
+++ b/src/Quiz/Domain/Entity/QuizQuestion.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'quiz_question')]
+class QuizQuestion implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Quiz::class)]
+    #[ORM\JoinColumn(name: 'quiz_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Quiz $quiz;
+
+    #[ORM\Column(name: 'title', type: 'text')]
+    private string $title = '';
+
+    #[ORM\Column(name: 'level', type: 'string', length: 50)]
+    private string $level = 'easy';
+
+    #[ORM\Column(name: 'category', type: 'string', length: 100)]
+    private string $category = '';
+
+    /** @var Collection<int, QuizAnswer> */
+    #[ORM\OneToMany(targetEntity: QuizAnswer::class, mappedBy: 'question', cascade: ['remove'])]
+    private Collection $answers;
+
+    public function __construct() { $this->id = $this->createUuid(); $this->answers = new ArrayCollection(); }
+    #[Override] public function getId(): string { return $this->id->toString(); }
+    public function getQuiz(): Quiz { return $this->quiz; }
+    public function setQuiz(Quiz $quiz): self { $this->quiz = $quiz; return $this; }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getLevel(): string { return $this->level; }
+    public function setLevel(string $level): self { $this->level = $level; return $this; }
+    public function getCategory(): string { return $this->category; }
+    public function setCategory(string $category): self { $this->category = $category; return $this; }
+    /** @return Collection<int, QuizAnswer> */ public function getAnswers(): Collection { return $this->answers; }
+}

--- a/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
+++ b/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Infrastructure\DataFixtures\ORM;
+
+use App\Configuration\Domain\Entity\Configuration;
+use App\Configuration\Domain\Enum\ConfigurationScope;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use App\Platform\Domain\Entity\Application;
+use App\Quiz\Domain\Entity\Quiz;
+use App\Quiz\Domain\Entity\QuizAnswer;
+use App\Quiz\Domain\Entity\QuizQuestion;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+
+final class LoadQuizData extends Fixture implements OrderedFixtureInterface
+{
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        $johnRoot = $this->getReference('User-john-root', User::class);
+        $application = $this->getReference('Application-shop-ops-center', Application::class);
+
+        $configuration = (new Configuration())
+            ->setApplication($application)
+            ->setConfigurationKey('quiz.module.configuration')
+            ->setConfigurationValue(['shuffleQuestions' => true, 'timerSec' => 45])
+            ->setScope(ConfigurationScope::APPLICATION)
+            ->setPrivate(true);
+        $manager->persist($configuration);
+
+        $quiz = (new Quiz())->setApplication($application)->setOwner($johnRoot)->setConfiguration($configuration);
+        $manager->persist($quiz);
+
+        for ($i = 1; $i <= 8; ++$i) {
+            $question = (new QuizQuestion())
+                ->setQuiz($quiz)
+                ->setTitle('Question fixture #' . $i)
+                ->setLevel($i % 3 === 0 ? 'hard' : ($i % 2 === 0 ? 'medium' : 'easy'))
+                ->setCategory($i % 2 === 0 ? 'backend' : 'frontend');
+            $manager->persist($question);
+
+            $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Right answer ' . $i)->setCorrect(true));
+            $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer A ' . $i)->setCorrect(false));
+            $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer B ' . $i)->setCorrect(false));
+        }
+
+        $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 42;
+    }
+}

--- a/src/Quiz/Infrastructure/Repository/QuizAnswerRepository.php
+++ b/src/Quiz/Infrastructure/Repository/QuizAnswerRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Quiz\Domain\Entity\QuizAnswer;
+use Doctrine\Persistence\ManagerRegistry;
+
+class QuizAnswerRepository extends BaseRepository
+{
+    protected static string $entityName = QuizAnswer::class;
+    protected static array $searchColumns = ['id', 'label'];
+
+    public function __construct(protected ManagerRegistry $managerRegistry) {}
+}

--- a/src/Quiz/Infrastructure/Repository/QuizQuestionRepository.php
+++ b/src/Quiz/Infrastructure/Repository/QuizQuestionRepository.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Quiz\Domain\Entity\QuizQuestion;
+use Doctrine\Persistence\ManagerRegistry;
+
+class QuizQuestionRepository extends BaseRepository
+{
+    protected static string $entityName = QuizQuestion::class;
+    protected static array $searchColumns = ['id', 'title', 'category'];
+
+    public function __construct(protected ManagerRegistry $managerRegistry) {}
+}

--- a/src/Quiz/Infrastructure/Repository/QuizRepository.php
+++ b/src/Quiz/Infrastructure/Repository/QuizRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Platform\Domain\Entity\Application;
+use App\Quiz\Domain\Entity\Quiz;
+use Doctrine\Persistence\ManagerRegistry;
+
+class QuizRepository extends BaseRepository
+{
+    protected static string $entityName = Quiz::class;
+    protected static array $searchColumns = ['id'];
+
+    public function __construct(protected ManagerRegistry $managerRegistry) {}
+
+    public function findOneByApplication(Application $application): ?Quiz
+    {
+        $result = $this->findOneBy(['application' => $application]);
+
+        return $result instanceof Quiz ? $result : null;
+    }
+}

--- a/src/Quiz/Transport/Controller/Api/V1/QuizController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/QuizController.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Transport\Controller\Api\V1;
+
+use App\Quiz\Application\Message\CreateQuizQuestionCommand;
+use App\Quiz\Application\Service\QuizReadService;
+use App\User\Domain\Entity\User;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class QuizController
+{
+    public function __construct(private MessageBusInterface $messageBus, private QuizReadService $quizReadService) {}
+
+    #[Route('/v1/quiz/application/{applicationSlug}', methods: [Request::METHOD_GET])]
+    public function getByApplication(string $applicationSlug): JsonResponse
+    {
+        return new JsonResponse($this->quizReadService->getByApplicationSlug($applicationSlug));
+    }
+
+    #[Route('/v1/quiz/application/{applicationSlug}/questions', methods: [Request::METHOD_POST])]
+    public function createQuestion(string $applicationSlug, Request $request): JsonResponse
+    {
+        $user = $request->getUser();
+        if (!$user instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_UNAUTHORIZED, 'User required.');
+        }
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $this->messageBus->dispatch(new CreateQuizQuestionCommand(
+            (string) uniqid('op_', true),
+            $user->getId(),
+            $applicationSlug,
+            (string) ($payload['title'] ?? ''),
+            (string) ($payload['level'] ?? 'easy'),
+            (string) ($payload['category'] ?? 'general'),
+            (array) ($payload['answers'] ?? []),
+            is_array($payload['configuration'] ?? null) ? $payload['configuration'] : null,
+        ));
+
+        return new JsonResponse(['status' => 'accepted'], JsonResponse::HTTP_ACCEPTED);
+    }
+}

--- a/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
@@ -181,7 +181,7 @@ class ApplicationCreateController
             $pluginKey = $plugin->getPluginKey();
 
             if (
-                in_array($pluginKey, [PluginKey::CALENDAR, PluginKey::CHAT], true)
+                in_array($pluginKey, [PluginKey::CALENDAR, PluginKey::CHAT, PluginKey::BLOG, PluginKey::QUIZ], true)
                 && in_array($pluginKey, $detectedPluginKeys, true) === false
             ) {
                 $detectedPluginKeys[] = $pluginKey;


### PR DESCRIPTION
## Résumé
- Ajout d’un module **Blog** complet (entités `Blog`, `BlogPost`, `BlogComment`, `BlogReaction`, `BlogTag`) avec endpoints GET/POST/PATCH/DELETE.
- Ajout d’un module **Quiz** complet (entités `Quiz`, `QuizQuestion`, `QuizAnswer`) avec endpoint lecture et création de questions.
- Intégration plugin: ajout de `PluginKey::QUIZ` et provisioning automatique Blog/Quiz à la création d’application.
- Création du blog général (root only) via Messenger.
- Ajout de fixtures riches liées à `john-root` pour Blog et Quiz.
- Ajout d’une migration SQL pour les tables Blog/Quiz.

## Détails fonctionnels
### Blog
- Provisioning automatique d’un blog application quand plugin `blog` est détecté.
- Blog général root via `/v1/blogs/general` (POST) + lecture avec arborescence posts/comments/sous-comments/réactions.
- Lecture blog application par slug via `/v1/blogs/application/{applicationSlug}` avec structure imbriquée complète.
- Règles `post_status` / `comment_status` (open/closed) respectées côté handlers.
- Mutations (create/edit/delete) passent par Messenger pour post/comment/reaction.
- Ownership appliqué pour patch/delete des posts/comments/reactions.

### Quiz
- Provisioning automatique d’un quiz application quand plugin `quiz` est détecté.
- Endpoint création de question pour owner app (`/v1/quiz/application/{applicationSlug}/questions`) via Messenger.
- Support des réponses correctes/fausses, level, category et configuration module liée au quiz.
- Endpoint lecture `/v1/quiz/application/{applicationSlug}`.

## Données de test
- `LoadBlogData` et `LoadQuizData` ajoutent beaucoup de fixtures reliées à `User-john-root` et `Application-shop-ops-center`.

## Validation
- Vérification syntaxe PHP (`php -l`) sur les fichiers modifiés/ajoutés: OK.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ade419f5308326a55b922574a77d19)