### PR TITLE
Fix recruit chat/calendar fixture owner lookup

### DIFF
--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -200,7 +200,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $johnAdmin = $this->getReference('User-john-admin', User::class);
 
         $johnRootRecruitApplication->setStatus(ApplicationStatus::WAITING);
-        $otherOwner = $johnRootRecruitApplication->getRecruit()?->getApplication()?->getUser();
+        $otherOwner = $johnRootRecruitApplication->getJob()->getOwner();
 
         if (!$otherOwner instanceof User) {
             return;


### PR DESCRIPTION
### Motivation
- Loading fixtures crashed because the fixture attempted to call a non-existent method chain (`getRecruit()` / `getApplication()` / `getUser()`) on the recruit `Application` entity, causing an `Attempted to call an undefined method` error during `doctrine:fixtures:load`.

### Description
- Replace the invalid lookup with the correct owner resolution by using the recruit application's job owner (`$johnRootRecruitApplication->getJob()->getOwner()`) in `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php`.

### Testing
- Ran syntax check with `php -l src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php`, which succeeded.
- Attempted `php bin/console doctrine:fixtures:load -n`, which could not complete in this environment due to missing Composer dependencies and failed with `LogicException: Dependencies are missing. Try running "composer install"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adec1777288326b0f7812c4d84e51f)