### PR TITLE
Use PLATFORM config scope for quiz and update recruit owner lookup

### DIFF
--- a/src/Quiz/Application/MessageHandler/CreateQuizQuestionCommandHandler.php
+++ b/src/Quiz/Application/MessageHandler/CreateQuizQuestionCommandHandler.php
@@ -64,7 +64,7 @@ final readonly class CreateQuizQuestionCommandHandler
                 ->setApplication($application)
                 ->setConfigurationKey('quiz.module.configuration')
                 ->setConfigurationValue($command->configuration)
-                ->setScope(ConfigurationScope::APPLICATION)
+                ->setScope(ConfigurationScope::PLATFORM)
                 ->setPrivate(true);
             $this->configurationRepository->save($configuration);
             $quiz->setConfiguration($configuration);

--- a/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
+++ b/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
@@ -28,7 +28,7 @@ final class LoadQuizData extends Fixture implements OrderedFixtureInterface
             ->setApplication($application)
             ->setConfigurationKey('quiz.module.configuration')
             ->setConfigurationValue(['shuffleQuestions' => true, 'timerSec' => 45])
-            ->setScope(ConfigurationScope::APPLICATION)
+            ->setScope(ConfigurationScope::PLATFORM)
             ->setPrivate(true);
         $manager->persist($configuration);
 

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -200,7 +200,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $johnAdmin = $this->getReference('User-john-admin', User::class);
 
         $johnRootRecruitApplication->setStatus(ApplicationStatus::WAITING);
-        $otherOwner = $johnRootRecruitApplication->getRecruit()?->getApplication()?->getUser();
+        $otherOwner = $johnRootRecruitApplication->getJob()->getOwner();
 
         if (!$otherOwner instanceof User) {
             return;


### PR DESCRIPTION
### Motivation

- Treat quiz module configuration as platform-wide rather than application-scoped so the quiz settings apply at the correct scope. 
- Adapt fixture/fixture-handling code to recent domain model changes for recruit ownership lookup.

### Description

- Replaced `ConfigurationScope::APPLICATION` with `ConfigurationScope::PLATFORM` when creating `Configuration` for the quiz in `CreateQuizQuestionCommandHandler.php` and `LoadQuizData.php`.
- Updated the owner retrieval in `LoadRecruitChatCalendarScenarioData.php` from `$johnRootRecruitApplication->getRecruit()?->getApplication()?->getUser()` to `$johnRootRecruitApplication->getJob()->getOwner()` to follow the updated domain accessors.
- Preserved existing persistence behavior for quiz questions, answers, and configuration creation.

### Testing

- Ran the test suite with `vendor/bin/phpunit` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adec1777288326b0f7812c4d84e51f)