### PR TITLE
Fix blog lookup by application slug

### DIFF
--- a/src/Blog/Application/Service/BlogReadService.php
+++ b/src/Blog/Application/Service/BlogReadService.php
@@ -32,15 +32,7 @@ final readonly class BlogReadService
     {
         return $this->cache->get('blog_app_' . $applicationSlug, function (ItemInterface $item) use ($applicationSlug): array {
             $item->expiresAfter(120);
-            $blog = $this->blogRepository->findOneBy(['application.slug' => $applicationSlug]);
-            if (!$blog instanceof Blog) {
-                $blog = $this->blogRepository->createQueryBuilder('b')
-                    ->leftJoin('b.application', 'a')
-                    ->andWhere('a.slug = :slug')
-                    ->setParameter('slug', $applicationSlug)
-                    ->getQuery()
-                    ->getOneOrNullResult();
-            }
+            $blog = $this->blogRepository->findOneByApplicationSlug($applicationSlug);
 
             return $blog instanceof Blog ? $this->normalizeBlog($blog) : [];
         });

--- a/src/Blog/Infrastructure/Repository/BlogRepository.php
+++ b/src/Blog/Infrastructure/Repository/BlogRepository.php
@@ -30,4 +30,17 @@ class BlogRepository extends BaseRepository
 
         return $result instanceof Blog ? $result : null;
     }
+
+    public function findOneByApplicationSlug(string $applicationSlug): ?Blog
+    {
+        $result = $this->createQueryBuilder('blog')
+            ->innerJoin('blog.application', 'application')
+            ->addSelect('application')
+            ->where('application.slug = :applicationSlug')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $result instanceof Blog ? $result : null;
+    }
 }


### PR DESCRIPTION
### Motivation
- Prevent Doctrine `UnrecognizedField` errors caused by using nested criteria like `['application.slug' => ...]` when resolving a `Blog` by application slug.
- Provide a single, explicit repository query that reliably joins the `application` relation and filters on `application.slug`.

### Description
- Added `BlogRepository::findOneByApplicationSlug(string $applicationSlug): ?Blog` that performs an `innerJoin` on `blog.application` and filters by `application.slug` returning a typed `Blog` or `null`.
- Simplified `BlogReadService::getByApplicationSlug()` to call the new `findOneByApplicationSlug()` repository method and removed the previous invalid nested criteria and duplicated query builder logic.
- Kept existing cache key and normalization behavior unchanged.

### Testing
- Ran `php -l src/Blog/Application/Service/BlogReadService.php` and it reported no syntax errors (success).
- Ran `php -l src/Blog/Infrastructure/Repository/BlogRepository.php` and it reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf03c1ed88326bc5ce9755a2a547c)