### PR TITLE
Add Shop, Crm and School module wiring in Symfony config

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -118,6 +118,24 @@ doctrine:
                         dir: '%kernel.project_dir%/src/Quiz/Domain/Entity'
                         prefix: 'App\Quiz\Domain\Entity'
                         alias: Quiz
+                    Shop:
+                        type: attribute
+                        is_bundle: false
+                        dir: '%kernel.project_dir%/src/Shop/Domain/Entity'
+                        prefix: 'App\Shop\Domain\Entity'
+                        alias: Shop
+                    Crm:
+                        type: attribute
+                        is_bundle: false
+                        dir: '%kernel.project_dir%/src/Crm/Domain/Entity'
+                        prefix: 'App\Crm\Domain\Entity'
+                        alias: Crm
+                    School:
+                        type: attribute
+                        is_bundle: false
+                        dir: '%kernel.project_dir%/src/School/Domain/Entity'
+                        prefix: 'App\School\Domain\Entity'
+                        alias: School
                 dql:
                     datetime_functions:
                         datesub: DoctrineExtensions\Query\Mysql\DateSub

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -94,3 +94,30 @@ quiz-controllers:
     prefix: /api
     defaults:
         _format: json
+
+shop-controllers:
+    resource:
+        path: ../src/Shop/Transport/Controller/Api/
+        namespace: App\Shop\Transport\Controller\Api
+    type: attribute
+    prefix: /api
+    defaults:
+        _format: json
+
+crm-controllers:
+    resource:
+        path: ../src/Crm/Transport/Controller/Api/
+        namespace: App\Crm\Transport\Controller\Api
+    type: attribute
+    prefix: /api
+    defaults:
+        _format: json
+
+school-controllers:
+    resource:
+        path: ../src/School/Transport/Controller/Api/
+        namespace: App\School\Transport\Controller\Api
+    type: attribute
+    prefix: /api
+    defaults:
+        _format: json

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -158,6 +158,13 @@ when@dev:
         App\Quiz\Infrastructure\DataFixtures\:
             resource: '../src/Quiz/Infrastructure/DataFixtures/*'
 
+        App\Shop\Infrastructure\DataFixtures\:
+            resource: '../src/Shop/Infrastructure/DataFixtures/*'
+        App\Crm\Infrastructure\DataFixtures\:
+            resource: '../src/Crm/Infrastructure/DataFixtures/*'
+        App\School\Infrastructure\DataFixtures\:
+            resource: '../src/School/Infrastructure/DataFixtures/*'
+
         App\Tests\TestCase\:
             resource: '../tests/TestCase/*'
 
@@ -200,6 +207,13 @@ when@test:
 
         App\User\Infrastructure\DataFixtures\:
             resource: '../src/User/Infrastructure/DataFixtures/*'
+
+        App\Shop\Infrastructure\DataFixtures\:
+            resource: '../src/Shop/Infrastructure/DataFixtures/*'
+        App\Crm\Infrastructure\DataFixtures\:
+            resource: '../src/Crm/Infrastructure/DataFixtures/*'
+        App\School\Infrastructure\DataFixtures\:
+            resource: '../src/School/Infrastructure/DataFixtures/*'
 
         App\Tests\TestCase\:
             resource: '../tests/TestCase/*'


### PR DESCRIPTION
### Motivation

- Register the new `Shop`, `Crm` and `School` modules so their entities, controllers and fixtures are discovered by the application. 
- Ensure API controllers from those modules are imported with attribute routes under the `/api` prefix and default to JSON. 
- Make fixtures for these modules available in development and test environments for data loading.

### Description

- Added Doctrine ORM mappings for `Shop`, `Crm` and `School` in `config/packages/doctrine.yaml` with `dir`, `prefix`, `type: attribute` and `alias` for each module. 
- Added route imports `shop-controllers`, `crm-controllers` and `school-controllers` to `config/routes.yaml` pointing to `../src/<Module>/Transport/Controller/Api/` with `type: attribute`, `prefix: /api` and `defaults: { _format: json }`. 
- Registered fixtures namespaces `App\Shop\Infrastructure\DataFixtures\`, `App\Crm\Infrastructure\DataFixtures\` and `App\School\Infrastructure\DataFixtures\` in both the `when@dev` and `when@test` sections of `config/services.yaml` with resources at `../src/<Module>/Infrastructure/DataFixtures/*`.

### Testing

- Ran `php bin/console lint:yaml config/packages/doctrine.yaml config/routes.yaml config/services.yaml` which failed due to missing project dependencies and recommends running `composer install` (environmental failure, configuration changes themselves were not validated by the linter).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf38d4e1c832689a583402d8897e2)