### PR TITLE
feat(crm): relier Crm à Application et peupler fixtures CRM

### DIFF
--- a/src/Crm/Domain/Entity/Crm.php
+++ b/src/Crm/Domain/Entity/Crm.php
@@ -7,13 +7,14 @@ namespace App\Crm\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\Platform\Domain\Entity\Application as PlatformApplication;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
+use Throwable;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'crm')]
@@ -27,13 +28,15 @@ class Crm implements EntityInterface
     #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
     private UuidInterface $id;
 
-    #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
-    private string $name = '';
+    #[ORM\OneToOne(targetEntity: PlatformApplication::class)]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: false, unique: true, onDelete: 'CASCADE')]
+    private ?PlatformApplication $application = null;
 
     /** @var Collection<int, Company>|ArrayCollection<int, Company> */
     #[ORM\OneToMany(targetEntity: Company::class, mappedBy: 'crm')]
     private Collection|ArrayCollection $companies;
 
+    /** @throws Throwable */
     public function __construct()
     {
         $this->id = $this->createUuid();
@@ -41,10 +44,26 @@ class Crm implements EntityInterface
     }
 
     #[Override]
-    public function getId(): string { return $this->id->toString(); }
-    public function getName(): string { return $this->name; }
-    public function setName(string $name): self { $this->name = $name; return $this; }
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getApplication(): ?PlatformApplication
+    {
+        return $this->application;
+    }
+
+    public function setApplication(?PlatformApplication $application): self
+    {
+        $this->application = $application;
+
+        return $this;
+    }
 
     /** @return Collection<int, Company>|ArrayCollection<int, Company> */
-    public function getCompanies(): Collection|ArrayCollection { return $this->companies; }
+    public function getCompanies(): Collection|ArrayCollection
+    {
+        return $this->companies;
+    }
 }

--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -4,15 +4,133 @@ declare(strict_types=1);
 
 namespace App\Crm\Infrastructure\DataFixtures\ORM;
 
+use App\Crm\Domain\Entity\Company;
+use App\Crm\Domain\Entity\Crm;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PlatformKey;
 use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Override;
 
-final class LoadCrmData extends Fixture
+use function sprintf;
+
+final class LoadCrmData extends Fixture implements OrderedFixtureInterface
 {
+    private const int COMPANY_COUNT_PER_APPLICATION = 2;
+    private const int PROJECT_COUNT_PER_COMPANY = 2;
+    private const int TASK_COUNT_PER_PROJECT = 3;
+
     #[Override]
     public function load(ObjectManager $manager): void
     {
+        $crmApplications = $manager->getRepository(Application::class)
+            ->createQueryBuilder('application')
+            ->innerJoin('application.platform', 'platform')
+            ->andWhere('platform.platformKey = :platformKey')
+            ->setParameter('platformKey', PlatformKey::CRM)
+            ->orderBy('application.title', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        foreach ($crmApplications as $applicationIndex => $application) {
+            if (!$application instanceof Application) {
+                continue;
+            }
+
+            $crm = $manager->getRepository(Crm::class)->findOneBy([
+                'application' => $application,
+            ]);
+
+            if (!$crm instanceof Crm) {
+                $crm = (new Crm())->setApplication($application);
+                $manager->persist($crm);
+            }
+
+            for ($companyIndex = 1; $companyIndex <= self::COMPANY_COUNT_PER_APPLICATION; ++$companyIndex) {
+                $companyName = sprintf('%s - Company %d', $application->getTitle(), $companyIndex);
+                $company = $manager->getRepository(Company::class)->findOneBy([
+                    'crm' => $crm,
+                    'name' => $companyName,
+                ]);
+
+                if (!$company instanceof Company) {
+                    $company = (new Company())
+                        ->setCrm($crm)
+                        ->setName($companyName);
+                    $manager->persist($company);
+                }
+
+                for ($projectIndex = 1; $projectIndex <= self::PROJECT_COUNT_PER_COMPANY; ++$projectIndex) {
+                    $projectName = sprintf('%s - Project %d', $companyName, $projectIndex);
+                    $project = $manager->getRepository(Project::class)->findOneBy([
+                        'company' => $company,
+                        'name' => $projectName,
+                    ]);
+
+                    if (!$project instanceof Project) {
+                        $project = (new Project())
+                            ->setCompany($company)
+                            ->setName($projectName);
+                        $manager->persist($project);
+                    }
+
+                    $sprintName = sprintf('%s - Sprint 1', $projectName);
+                    $sprint = $manager->getRepository(Sprint::class)->findOneBy([
+                        'project' => $project,
+                        'name' => $sprintName,
+                    ]);
+
+                    if (!$sprint instanceof Sprint) {
+                        $sprint = (new Sprint())
+                            ->setProject($project)
+                            ->setName($sprintName);
+                        $manager->persist($sprint);
+                    }
+
+                    for ($taskIndex = 1; $taskIndex <= self::TASK_COUNT_PER_PROJECT; ++$taskIndex) {
+                        $taskTitle = sprintf('%s - Task %d', $projectName, $taskIndex);
+                        $task = $manager->getRepository(Task::class)->findOneBy([
+                            'project' => $project,
+                            'title' => $taskTitle,
+                        ]);
+
+                        if (!$task instanceof Task) {
+                            $task = (new Task())
+                                ->setProject($project)
+                                ->setSprint($sprint)
+                                ->setTitle($taskTitle);
+                            $manager->persist($task);
+                        }
+
+                        $taskRequestTitle = sprintf('%s - Request 1', $taskTitle);
+                        $taskRequest = $manager->getRepository(TaskRequest::class)->findOneBy([
+                            'task' => $task,
+                            'title' => $taskRequestTitle,
+                        ]);
+
+                        if (!$taskRequest instanceof TaskRequest) {
+                            $taskRequest = (new TaskRequest())
+                                ->setTask($task)
+                                ->setTitle($taskRequestTitle)
+                                ->setStatus(($applicationIndex + $taskIndex) % 2 === 0 ? 'pending' : 'approved');
+                            $manager->persist($taskRequest);
+                        }
+                    }
+                }
+            }
+        }
+
         $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 8;
     }
 }


### PR DESCRIPTION
### Motivation
- Aligner la racine CRM sur le pattern existant pour `Recruit` afin que chaque `Crm` soit lié de façon unique à une `Application` de plateforme;
- Fournir des fixtures idempotentes pour peupler un arbre métier de test `Company -> Project -> Sprint -> Task -> TaskRequest` pour les applications CRM.

### Description
- Mise à jour de l'entité `Crm` (`src/Crm/Domain/Entity/Crm.php`) pour ajouter une relation `OneToOne` vers `App\Platform\Domain\Entity\Application` via la colonne `application_id` avec `nullable=false`, `unique=true` et `onDelete=CASCADE`, et ajout des accesseurs `getApplication()`/`setApplication()`.
- Implémentation du fixture `LoadCrmData` (`src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php`) qui récupère les applications dont la plateforme est `PlatformKey::CRM`, crée ou retrouve une entité `Crm` par application, et peuple de manière idempotente les entités `Company`, `Project`, `Sprint`, `Task` et `TaskRequest` en utilisant des constantes de taille (`COMPANY_COUNT_PER_APPLICATION`, `PROJECT_COUNT_PER_COMPANY`, `TASK_COUNT_PER_PROJECT`).
- Aucun listener Doctrine spécifique au CRM n’a été ajouté car les entités CRM actuelles n’exigent pas de génération automatique de `slug`/`owner` comme pour `Recruit/Job`.

### Testing
- Vérification de la syntaxe PHP avec `php -l src/Crm/Domain/Entity/Crm.php` qui a renvoyé « No syntax errors detected ». 
- Vérification de la syntaxe PHP avec `php -l src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php` qui a renvoyé « No syntax errors detected ».

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf42f539c8326bc27b9306fd3c174)