### PR TITLE
Add v1 aggregate APIs for Shop/CRM/School with Elasticsearch projections

### DIFF
--- a/src/Crm/Application/Projection/CrmTaskProjection.php
+++ b/src/Crm/Application/Projection/CrmTaskProjection.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Projection;
+
+final class CrmTaskProjection
+{
+    public const string INDEX_NAME = 'crm_tasks';
+}

--- a/src/Crm/Application/Service/TaskListService.php
+++ b/src/Crm/Application/Service/TaskListService.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Application\Projection\CrmTaskProjection;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Throwable;
+
+readonly class TaskListService
+{
+    public function __construct(
+        private TaskRepository $taskRepository,
+        private CacheInterface $cache,
+        private ElasticsearchServiceInterface $elasticsearchService,
+        private CacheKeyConventionService $cacheKeyConventionService,
+    ) {
+    }
+
+    /** @return array<string,mixed> */
+    public function getList(Request $request): array
+    {
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = ['q' => trim((string) $request->query->get('q', '')), 'title' => trim((string) $request->query->get('title', ''))];
+        $cacheKey = $this->cacheKeyConventionService->buildCrmTaskListKey($page, $limit, $filters);
+
+        /** @var array<string,mixed> $result */
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit): array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->crmTaskListTag());
+            }
+
+            $esIds = $this->searchIdsFromElastic($filters);
+            if ($esIds === []) {
+                return ['items' => [], 'pagination' => ['page' => $page, 'limit' => $limit, 'totalItems' => 0, 'totalPages' => 0]];
+            }
+
+            $qb = $this->taskRepository->createQueryBuilder('task')->leftJoin('task.project', 'project')->leftJoin('task.sprint', 'sprint')
+                ->setFirstResult(($page - 1) * $limit)->setMaxResults($limit)->orderBy('task.createdAt', 'DESC');
+
+            if ($filters['title'] !== '') {
+                $qb->andWhere('LOWER(task.title) LIKE LOWER(:title)')->setParameter('title', '%' . $filters['title'] . '%');
+            }
+            if ($esIds !== null) {
+                $qb->andWhere('task.id IN (:ids)')->setParameter('ids', $esIds);
+            }
+
+            $items = array_map(static fn (Task $task): array => [
+                'id' => $task->getId(), 'title' => $task->getTitle(), 'projectId' => $task->getProject()?->getId(), 'projectName' => $task->getProject()?->getName(),
+                'sprintId' => $task->getSprint()?->getId(), 'sprintName' => $task->getSprint()?->getName(), 'updatedAt' => $task->getUpdatedAt()?->format(DATE_ATOM),
+            ], $qb->getQuery()->getResult());
+
+            $countQb = $this->taskRepository->createQueryBuilder('task')->select('COUNT(task.id)');
+            if ($filters['title'] !== '') {
+                $countQb->andWhere('LOWER(task.title) LIKE LOWER(:title)')->setParameter('title', '%' . $filters['title'] . '%');
+            }
+            if ($esIds !== null) {
+                $countQb->andWhere('task.id IN (:ids)')->setParameter('ids', $esIds);
+            }
+
+            $totalItems = (int) $countQb->getQuery()->getSingleScalarResult();
+            return ['items' => $items, 'pagination' => ['page' => $page, 'limit' => $limit, 'totalItems' => $totalItems, 'totalPages' => $totalItems > 0 ? (int) ceil($totalItems / $limit) : 0]];
+        });
+
+        $result['filters'] = array_filter($filters, static fn (string $value): bool => $value !== '');
+        return $result;
+    }
+
+    /** @param array<string,string> $filters
+     * @return array<int,string>|null
+     */
+    private function searchIdsFromElastic(array $filters): ?array
+    {
+        if ($filters['q'] === '') {
+            return null;
+        }
+
+        try {
+            $response = $this->elasticsearchService->search(CrmTaskProjection::INDEX_NAME, [
+                'query' => ['multi_match' => ['query' => $filters['q'], 'type' => 'phrase_prefix', 'fields' => ['title^3', 'projectName^2', 'sprintName', 'taskRequests']]],
+                '_source' => ['id'],
+            ], 0, 200);
+        } catch (Throwable) {
+            return null;
+        }
+
+        $hits = $response['hits']['hits'] ?? [];
+        return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/CrmController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CrmController.php
@@ -4,17 +4,240 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1;
 
+use App\Crm\Application\Service\TaskListService;
+use App\Crm\Domain\Entity\Company;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\Crm\Infrastructure\Repository\CrmRepository;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Crm\Infrastructure\Repository\TaskRequestRepository;
+use App\General\Application\Message\EntityCreated;
+use App\General\Application\Message\EntityDeleted;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
-final class CrmController
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class CrmController
 {
-    #[Route('/v1/crm', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    public function __construct(
+        private CompanyRepository $companyRepository,
+        private ProjectRepository $projectRepository,
+        private TaskRepository $taskRepository,
+        private TaskRequestRepository $taskRequestRepository,
+        private SprintRepository $sprintRepository,
+        private CrmRepository $crmRepository,
+        private TaskListService $taskListService,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    #[Route('/v1/crm/companies', methods: [Request::METHOD_GET])]
+    public function companies(): JsonResponse
     {
-        return new JsonResponse(['module' => 'crm', 'status' => 'ok']);
+        $items = array_map(static fn (Company $company): array => ['id' => $company->getId(), 'name' => $company->getName()], $this->companyRepository->findBy([], ['createdAt' => 'DESC'], 200));
+        return new JsonResponse(['items' => $items]);
+    }
+
+    #[Route('/v1/crm/companies', methods: [Request::METHOD_POST])]
+    public function createCompany(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $company = new Company();
+        $company->setName((string) ($payload['name'] ?? ''));
+        if (is_string($payload['crmId'] ?? null)) {
+            $company->setCrm($this->crmRepository->find($payload['crmId']));
+        }
+
+        $this->entityManager->persist($company);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('crm_company', $company->getId()));
+
+        return new JsonResponse(['id' => $company->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/crm/companies/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteCompany(string $id): JsonResponse
+    {
+        $company = $this->companyRepository->find($id);
+        if (!$company instanceof Company) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($company);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('crm_company', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/crm/projects', methods: [Request::METHOD_GET])]
+    public function projects(): JsonResponse
+    {
+        $items = array_map(static fn (Project $project): array => ['id' => $project->getId(), 'name' => $project->getName(), 'companyId' => $project->getCompany()?->getId()], $this->projectRepository->findBy([], ['createdAt' => 'DESC'], 200));
+        return new JsonResponse(['items' => $items]);
+    }
+
+    #[Route('/v1/crm/projects', methods: [Request::METHOD_POST])]
+    public function createProject(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $project = new Project();
+        $project->setName((string) ($payload['name'] ?? ''));
+        if (is_string($payload['companyId'] ?? null)) {
+            $project->setCompany($this->companyRepository->find($payload['companyId']));
+        }
+
+        $this->entityManager->persist($project);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('crm_project', $project->getId()));
+
+        return new JsonResponse(['id' => $project->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/crm/projects/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteProject(string $id): JsonResponse
+    {
+        $project = $this->projectRepository->find($id);
+        if (!$project instanceof Project) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($project);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('crm_project', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/crm/tasks', methods: [Request::METHOD_GET])]
+    public function tasks(Request $request): JsonResponse
+    {
+        return new JsonResponse($this->taskListService->getList($request));
+    }
+
+    #[Route('/v1/crm/tasks', methods: [Request::METHOD_POST])]
+    public function createTask(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $task = new Task();
+        $task->setTitle((string) ($payload['title'] ?? ''));
+        if (is_string($payload['projectId'] ?? null)) {
+            $task->setProject($this->projectRepository->find($payload['projectId']));
+        }
+        if (is_string($payload['sprintId'] ?? null)) {
+            $task->setSprint($this->sprintRepository->find($payload['sprintId']));
+        }
+
+        $this->entityManager->persist($task);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('crm_task', $task->getId()));
+
+        return new JsonResponse(['id' => $task->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/crm/tasks/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteTask(string $id): JsonResponse
+    {
+        $task = $this->taskRepository->find($id);
+        if (!$task instanceof Task) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($task);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('crm_task', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/crm/task-requests', methods: [Request::METHOD_GET])]
+    public function taskRequests(): JsonResponse
+    {
+        $items = array_map(static fn (TaskRequest $taskRequest): array => ['id' => $taskRequest->getId(), 'title' => $taskRequest->getTitle(), 'status' => $taskRequest->getStatus(), 'taskId' => $taskRequest->getTask()?->getId()], $this->taskRequestRepository->findBy([], ['createdAt' => 'DESC'], 200));
+        return new JsonResponse(['items' => $items]);
+    }
+
+    #[Route('/v1/crm/task-requests', methods: [Request::METHOD_POST])]
+    public function createTaskRequest(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $taskRequest = new TaskRequest();
+        $taskRequest->setTitle((string) ($payload['title'] ?? ''))->setStatus((string) ($payload['status'] ?? 'pending'));
+        if (is_string($payload['taskId'] ?? null)) {
+            $taskRequest->setTask($this->taskRepository->find($payload['taskId']));
+        }
+
+        $this->entityManager->persist($taskRequest);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('crm_task_request', $taskRequest->getId()));
+
+        return new JsonResponse(['id' => $taskRequest->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/crm/task-requests/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteTaskRequest(string $id): JsonResponse
+    {
+        $taskRequest = $this->taskRequestRepository->find($id);
+        if (!$taskRequest instanceof TaskRequest) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($taskRequest);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('crm_task_request', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/crm/sprints', methods: [Request::METHOD_GET])]
+    public function sprints(): JsonResponse
+    {
+        $items = array_map(static fn (Sprint $sprint): array => ['id' => $sprint->getId(), 'name' => $sprint->getName(), 'projectId' => $sprint->getProject()?->getId()], $this->sprintRepository->findBy([], ['createdAt' => 'DESC'], 200));
+        return new JsonResponse(['items' => $items]);
+    }
+
+    #[Route('/v1/crm/sprints', methods: [Request::METHOD_POST])]
+    public function createSprint(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $sprint = new Sprint();
+        $sprint->setName((string) ($payload['name'] ?? ''));
+        if (is_string($payload['projectId'] ?? null)) {
+            $sprint->setProject($this->projectRepository->find($payload['projectId']));
+        }
+
+        $this->entityManager->persist($sprint);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('crm_sprint', $sprint->getId()));
+
+        return new JsonResponse(['id' => $sprint->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/crm/sprints/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteSprint(string $id): JsonResponse
+    {
+        $sprint = $this->sprintRepository->find($id);
+        if (!$sprint instanceof Sprint) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($sprint);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('crm_sprint', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }
 }

--- a/src/General/Application/MessageHandler/EntityProjectionHandler.php
+++ b/src/General/Application/MessageHandler/EntityProjectionHandler.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\General\Application\MessageHandler;
 
+use App\Crm\Application\Projection\CrmTaskProjection;
+use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\General\Application\Message\EntityCreated;
 use App\General\Application\Message\EntityDeleted;
 use App\General\Application\Message\EntityMutationMessage;
@@ -16,6 +18,10 @@ use App\Platform\Application\Projection\ApplicationProjection;
 use App\Platform\Infrastructure\Repository\ApplicationRepository;
 use App\Recruit\Application\Projection\RecruitJobProjection;
 use App\Recruit\Infrastructure\Repository\JobRepository;
+use App\School\Application\Projection\SchoolExamProjection;
+use App\School\Infrastructure\Repository\ExamRepository;
+use App\Shop\Application\Projection\ShopProductProjection;
+use App\Shop\Infrastructure\Repository\ProductRepository;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 use function array_map;
@@ -25,10 +31,16 @@ final readonly class EntityProjectionHandler
 {
     private const string PLATFORM_APPLICATION = 'platform_application';
     private const string RECRUIT_JOB = 'recruit_job';
+    private const string SHOP_PRODUCT = 'shop_product';
+    private const string CRM_TASK = 'crm_task';
+    private const string SCHOOL_EXAM = 'school_exam';
 
     public function __construct(
         private ApplicationRepository $applicationRepository,
         private JobRepository $jobRepository,
+        private ProductRepository $productRepository,
+        private TaskRepository $taskRepository,
+        private ExamRepository $examRepository,
         private CacheInvalidationService $cacheInvalidationService,
         private CriticalViewWarmer $criticalViewWarmer,
         private ElasticsearchServiceInterface $elasticsearchService,
@@ -44,12 +56,26 @@ final readonly class EntityProjectionHandler
 
         if ($message->entityType === self::PLATFORM_APPLICATION) {
             $this->projectPlatformApplication($message);
-
             return;
         }
 
         if ($message->entityType === self::RECRUIT_JOB) {
             $this->projectRecruitJob($message);
+            return;
+        }
+
+        if ($message->entityType === self::SHOP_PRODUCT) {
+            $this->projectShopProduct($message);
+            return;
+        }
+
+        if ($message->entityType === self::CRM_TASK) {
+            $this->projectCrmTask($message);
+            return;
+        }
+
+        if ($message->entityType === self::SCHOOL_EXAM) {
+            $this->projectSchoolExam($message);
         }
     }
 
@@ -123,5 +149,81 @@ final readonly class EntityProjectionHandler
             $this->cacheInvalidationService->invalidateRecruitJobListCaches($applicationSlug);
             $this->criticalViewWarmer->warmRecruitJobList($applicationSlug);
         }
+    }
+
+    private function projectShopProduct(EntityMutationMessage $message): void
+    {
+        if ($message instanceof EntityDeleted) {
+            $this->elasticsearchService->delete(ShopProductProjection::INDEX_NAME, $message->entityId);
+            $this->cacheInvalidationService->invalidateShopProductListCaches();
+            return;
+        }
+
+        $product = $this->productRepository->find($message->entityId);
+        if ($product === null) {
+            return;
+        }
+
+        $this->elasticsearchService->index(ShopProductProjection::INDEX_NAME, $product->getId(), [
+            'id' => $product->getId(),
+            'name' => $product->getName(),
+            'price' => $product->getPrice(),
+            'categoryId' => $product->getCategory()?->getId(),
+            'categoryName' => $product->getCategory()?->getName() ?? '',
+            'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $product->getTags()->toArray()),
+            'updatedAt' => $product->getUpdatedAt()?->format(DATE_ATOM),
+        ]);
+
+        $this->cacheInvalidationService->invalidateShopProductListCaches();
+    }
+
+    private function projectCrmTask(EntityMutationMessage $message): void
+    {
+        if ($message instanceof EntityDeleted) {
+            $this->elasticsearchService->delete(CrmTaskProjection::INDEX_NAME, $message->entityId);
+            $this->cacheInvalidationService->invalidateCrmTaskListCaches();
+            return;
+        }
+
+        $task = $this->taskRepository->find($message->entityId);
+        if ($task === null) {
+            return;
+        }
+
+        $this->elasticsearchService->index(CrmTaskProjection::INDEX_NAME, $task->getId(), [
+            'id' => $task->getId(),
+            'title' => $task->getTitle(),
+            'projectName' => $task->getProject()?->getName() ?? '',
+            'sprintName' => $task->getSprint()?->getName() ?? '',
+            'taskRequests' => array_map(static fn ($request): string => $request->getTitle(), $task->getTaskRequests()->toArray()),
+            'updatedAt' => $task->getUpdatedAt()?->format(DATE_ATOM),
+        ]);
+
+        $this->cacheInvalidationService->invalidateCrmTaskListCaches();
+    }
+
+    private function projectSchoolExam(EntityMutationMessage $message): void
+    {
+        if ($message instanceof EntityDeleted) {
+            $this->elasticsearchService->delete(SchoolExamProjection::INDEX_NAME, $message->entityId);
+            $this->cacheInvalidationService->invalidateSchoolExamListCaches();
+            return;
+        }
+
+        $exam = $this->examRepository->find($message->entityId);
+        if ($exam === null) {
+            return;
+        }
+
+        $this->elasticsearchService->index(SchoolExamProjection::INDEX_NAME, $exam->getId(), [
+            'id' => $exam->getId(),
+            'title' => $exam->getTitle(),
+            'className' => $exam->getSchoolClass()?->getName() ?? '',
+            'teacherName' => $exam->getTeacher()?->getName() ?? '',
+            'grades' => array_map(static fn ($grade): float => $grade->getScore(), $exam->getGrades()->toArray()),
+            'updatedAt' => $exam->getUpdatedAt()?->format(DATE_ATOM),
+        ]);
+
+        $this->cacheInvalidationService->invalidateSchoolExamListCaches();
     }
 }

--- a/src/General/Application/Service/CacheInvalidationService.php
+++ b/src/General/Application/Service/CacheInvalidationService.php
@@ -38,6 +38,44 @@ class CacheInvalidationService
         }
     }
 
+
+    public function invalidateShopProductListCaches(): void
+    {
+        if ($this->cache instanceof TagAwareCacheInterface) {
+            $this->cache->invalidateTags([$this->cacheKeyConventionService->shopProductListTag()]);
+        }
+
+        $this->cache->delete($this->cacheKeyConventionService->buildShopProductListKey(1, 20, [
+            'q' => '',
+            'name' => '',
+            'category' => '',
+        ]));
+    }
+
+    public function invalidateCrmTaskListCaches(): void
+    {
+        if ($this->cache instanceof TagAwareCacheInterface) {
+            $this->cache->invalidateTags([$this->cacheKeyConventionService->crmTaskListTag()]);
+        }
+
+        $this->cache->delete($this->cacheKeyConventionService->buildCrmTaskListKey(1, 20, [
+            'q' => '',
+            'title' => '',
+        ]));
+    }
+
+    public function invalidateSchoolExamListCaches(): void
+    {
+        if ($this->cache instanceof TagAwareCacheInterface) {
+            $this->cache->invalidateTags([$this->cacheKeyConventionService->schoolExamListTag()]);
+        }
+
+        $this->cache->delete($this->cacheKeyConventionService->buildSchoolExamListKey(1, 20, [
+            'q' => '',
+            'title' => '',
+        ]));
+    }
+
     public function invalidateRecruitJobListCaches(string $applicationSlug): void
     {
         if ($this->cache instanceof TagAwareCacheInterface) {

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -36,6 +36,43 @@ class CacheKeyConventionService
         ], JSON_THROW_ON_ERROR));
     }
 
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    public function buildShopProductListKey(int $page, int $limit, array $filters): string
+    {
+        return 'shop_product_list_' . md5((string) json_encode([
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    public function buildCrmTaskListKey(int $page, int $limit, array $filters): string
+    {
+        return 'crm_task_list_' . md5((string) json_encode([
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    public function buildSchoolExamListKey(int $page, int $limit, array $filters): string
+    {
+        return 'school_exam_list_' . md5((string) json_encode([
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
     public function applicationListTag(): string
     {
         return 'cache:application:list';
@@ -44,5 +81,20 @@ class CacheKeyConventionService
     public function recruitJobListTag(string $applicationSlug): string
     {
         return 'cache:recruit:job:list:' . $applicationSlug;
+    }
+
+    public function shopProductListTag(): string
+    {
+        return 'cache:shop:product:list';
+    }
+
+    public function crmTaskListTag(): string
+    {
+        return 'cache:crm:task:list';
+    }
+
+    public function schoolExamListTag(): string
+    {
+        return 'cache:school:exam:list';
     }
 }

--- a/src/School/Application/Projection/SchoolExamProjection.php
+++ b/src/School/Application/Projection/SchoolExamProjection.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Projection;
+
+final class SchoolExamProjection
+{
+    public const string INDEX_NAME = 'school_exams';
+}

--- a/src/School/Application/Service/ExamListService.php
+++ b/src/School/Application/Service/ExamListService.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\School\Application\Projection\SchoolExamProjection;
+use App\School\Domain\Entity\Exam;
+use App\School\Infrastructure\Repository\ExamRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Throwable;
+
+readonly class ExamListService
+{
+    public function __construct(
+        private ExamRepository $examRepository,
+        private CacheInterface $cache,
+        private ElasticsearchServiceInterface $elasticsearchService,
+        private CacheKeyConventionService $cacheKeyConventionService,
+    ) {
+    }
+
+    /** @return array<string,mixed> */
+    public function getList(Request $request): array
+    {
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = ['q' => trim((string) $request->query->get('q', '')), 'title' => trim((string) $request->query->get('title', ''))];
+        $cacheKey = $this->cacheKeyConventionService->buildSchoolExamListKey($page, $limit, $filters);
+
+        /** @var array<string,mixed> $result */
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit): array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->schoolExamListTag());
+            }
+
+            $esIds = $this->searchIdsFromElastic($filters);
+            if ($esIds === []) {
+                return ['items' => [], 'pagination' => ['page' => $page, 'limit' => $limit, 'totalItems' => 0, 'totalPages' => 0]];
+            }
+
+            $qb = $this->examRepository->createQueryBuilder('exam')->leftJoin('exam.schoolClass', 'class')->leftJoin('exam.teacher', 'teacher')
+                ->setFirstResult(($page - 1) * $limit)->setMaxResults($limit)->orderBy('exam.createdAt', 'DESC');
+            if ($filters['title'] !== '') {
+                $qb->andWhere('LOWER(exam.title) LIKE LOWER(:title)')->setParameter('title', '%' . $filters['title'] . '%');
+            }
+            if ($esIds !== null) {
+                $qb->andWhere('exam.id IN (:ids)')->setParameter('ids', $esIds);
+            }
+
+            $items = array_map(static fn (Exam $exam): array => [
+                'id' => $exam->getId(), 'title' => $exam->getTitle(), 'classId' => $exam->getSchoolClass()?->getId(), 'className' => $exam->getSchoolClass()?->getName(),
+                'teacherId' => $exam->getTeacher()?->getId(), 'teacherName' => $exam->getTeacher()?->getName(), 'updatedAt' => $exam->getUpdatedAt()?->format(DATE_ATOM),
+            ], $qb->getQuery()->getResult());
+
+            $countQb = $this->examRepository->createQueryBuilder('exam')->select('COUNT(exam.id)');
+            if ($filters['title'] !== '') {
+                $countQb->andWhere('LOWER(exam.title) LIKE LOWER(:title)')->setParameter('title', '%' . $filters['title'] . '%');
+            }
+            if ($esIds !== null) {
+                $countQb->andWhere('exam.id IN (:ids)')->setParameter('ids', $esIds);
+            }
+
+            $totalItems = (int) $countQb->getQuery()->getSingleScalarResult();
+            return ['items' => $items, 'pagination' => ['page' => $page, 'limit' => $limit, 'totalItems' => $totalItems, 'totalPages' => $totalItems > 0 ? (int) ceil($totalItems / $limit) : 0]];
+        });
+
+        $result['filters'] = array_filter($filters, static fn (string $value): bool => $value !== '');
+        return $result;
+    }
+
+    /** @param array<string,string> $filters
+     * @return array<int,string>|null
+     */
+    private function searchIdsFromElastic(array $filters): ?array
+    {
+        if ($filters['q'] === '') {
+            return null;
+        }
+
+        try {
+            $response = $this->elasticsearchService->search(SchoolExamProjection::INDEX_NAME, [
+                'query' => ['multi_match' => ['query' => $filters['q'], 'type' => 'phrase_prefix', 'fields' => ['title^3', 'className^2', 'teacherName', 'grades']]],
+                '_source' => ['id'],
+            ], 0, 200);
+        } catch (Throwable) {
+            return null;
+        }
+
+        $hits = $response['hits']['hits'] ?? [];
+        return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/SchoolController.php
+++ b/src/School/Transport/Controller/Api/V1/SchoolController.php
@@ -4,17 +4,240 @@ declare(strict_types=1);
 
 namespace App\School\Transport\Controller\Api\V1;
 
+use App\General\Application\Message\EntityCreated;
+use App\General\Application\Message\EntityDeleted;
+use App\School\Application\Service\ExamListService;
+use App\School\Domain\Entity\Exam;
+use App\School\Domain\Entity\Grade;
+use App\School\Domain\Entity\SchoolClass;
+use App\School\Domain\Entity\Student;
+use App\School\Domain\Entity\Teacher;
+use App\School\Infrastructure\Repository\ExamRepository;
+use App\School\Infrastructure\Repository\GradeRepository;
+use App\School\Infrastructure\Repository\SchoolClassRepository;
+use App\School\Infrastructure\Repository\SchoolRepository;
+use App\School\Infrastructure\Repository\StudentRepository;
+use App\School\Infrastructure\Repository\TeacherRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
-final class SchoolController
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class SchoolController
 {
-    #[Route('/v1/school', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    public function __construct(
+        private SchoolClassRepository $classRepository,
+        private StudentRepository $studentRepository,
+        private TeacherRepository $teacherRepository,
+        private ExamRepository $examRepository,
+        private GradeRepository $gradeRepository,
+        private SchoolRepository $schoolRepository,
+        private ExamListService $examListService,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    #[Route('/v1/school/classes', methods: [Request::METHOD_GET])]
+    public function classes(): JsonResponse
     {
-        return new JsonResponse(['module' => 'school', 'status' => 'ok']);
+        $items = array_map(static fn (SchoolClass $schoolClass): array => ['id' => $schoolClass->getId(), 'name' => $schoolClass->getName(), 'schoolId' => $schoolClass->getSchool()?->getId()], $this->classRepository->findBy([], ['createdAt' => 'DESC'], 200));
+        return new JsonResponse(['items' => $items]);
+    }
+
+    #[Route('/v1/school/classes', methods: [Request::METHOD_POST])]
+    public function createClass(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $schoolClass = new SchoolClass();
+        $schoolClass->setName((string) ($payload['name'] ?? ''));
+        if (is_string($payload['schoolId'] ?? null)) {
+            $schoolClass->setSchool($this->schoolRepository->find($payload['schoolId']));
+        }
+
+        $this->entityManager->persist($schoolClass);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('school_class', $schoolClass->getId()));
+
+        return new JsonResponse(['id' => $schoolClass->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/school/classes/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteClass(string $id): JsonResponse
+    {
+        $schoolClass = $this->classRepository->find($id);
+        if (!$schoolClass instanceof SchoolClass) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($schoolClass);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('school_class', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/school/students', methods: [Request::METHOD_GET])]
+    public function students(): JsonResponse
+    {
+        $items = array_map(static fn (Student $student): array => ['id' => $student->getId(), 'name' => $student->getName(), 'classId' => $student->getSchoolClass()?->getId()], $this->studentRepository->findBy([], ['createdAt' => 'DESC'], 200));
+        return new JsonResponse(['items' => $items]);
+    }
+
+    #[Route('/v1/school/students', methods: [Request::METHOD_POST])]
+    public function createStudent(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $student = new Student();
+        $student->setName((string) ($payload['name'] ?? ''));
+        if (is_string($payload['classId'] ?? null)) {
+            $student->setSchoolClass($this->classRepository->find($payload['classId']));
+        }
+
+        $this->entityManager->persist($student);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('school_student', $student->getId()));
+
+        return new JsonResponse(['id' => $student->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/school/students/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteStudent(string $id): JsonResponse
+    {
+        $student = $this->studentRepository->find($id);
+        if (!$student instanceof Student) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($student);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('school_student', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/school/teachers', methods: [Request::METHOD_GET])]
+    public function teachers(): JsonResponse
+    {
+        $items = array_map(static fn (Teacher $teacher): array => ['id' => $teacher->getId(), 'name' => $teacher->getName()], $this->teacherRepository->findBy([], ['createdAt' => 'DESC'], 200));
+        return new JsonResponse(['items' => $items]);
+    }
+
+    #[Route('/v1/school/teachers', methods: [Request::METHOD_POST])]
+    public function createTeacher(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $teacher = new Teacher();
+        $teacher->setName((string) ($payload['name'] ?? ''));
+
+        $this->entityManager->persist($teacher);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('school_teacher', $teacher->getId()));
+
+        return new JsonResponse(['id' => $teacher->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/school/teachers/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteTeacher(string $id): JsonResponse
+    {
+        $teacher = $this->teacherRepository->find($id);
+        if (!$teacher instanceof Teacher) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($teacher);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('school_teacher', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/school/exams', methods: [Request::METHOD_GET])]
+    public function exams(Request $request): JsonResponse
+    {
+        return new JsonResponse($this->examListService->getList($request));
+    }
+
+    #[Route('/v1/school/exams', methods: [Request::METHOD_POST])]
+    public function createExam(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $exam = new Exam();
+        $exam->setTitle((string) ($payload['title'] ?? ''));
+        if (is_string($payload['classId'] ?? null)) {
+            $exam->setSchoolClass($this->classRepository->find($payload['classId']));
+        }
+        if (is_string($payload['teacherId'] ?? null)) {
+            $exam->setTeacher($this->teacherRepository->find($payload['teacherId']));
+        }
+
+        $this->entityManager->persist($exam);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('school_exam', $exam->getId()));
+
+        return new JsonResponse(['id' => $exam->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/school/exams/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteExam(string $id): JsonResponse
+    {
+        $exam = $this->examRepository->find($id);
+        if (!$exam instanceof Exam) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($exam);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('school_exam', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/school/grades', methods: [Request::METHOD_GET])]
+    public function grades(): JsonResponse
+    {
+        $items = array_map(static fn (Grade $grade): array => ['id' => $grade->getId(), 'score' => $grade->getScore(), 'studentId' => $grade->getStudent()?->getId(), 'examId' => $grade->getExam()?->getId()], $this->gradeRepository->findBy([], ['createdAt' => 'DESC'], 200));
+        return new JsonResponse(['items' => $items]);
+    }
+
+    #[Route('/v1/school/grades', methods: [Request::METHOD_POST])]
+    public function createGrade(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $grade = new Grade();
+        $grade->setScore((float) ($payload['score'] ?? 0));
+        if (is_string($payload['studentId'] ?? null)) {
+            $grade->setStudent($this->studentRepository->find($payload['studentId']));
+        }
+        if (is_string($payload['examId'] ?? null)) {
+            $grade->setExam($this->examRepository->find($payload['examId']));
+        }
+
+        $this->entityManager->persist($grade);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('school_grade', $grade->getId()));
+
+        return new JsonResponse(['id' => $grade->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/school/grades/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteGrade(string $id): JsonResponse
+    {
+        $grade = $this->gradeRepository->find($id);
+        if (!$grade instanceof Grade) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($grade);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('school_grade', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }
 }

--- a/src/Shop/Application/Projection/ShopProductProjection.php
+++ b/src/Shop/Application/Projection/ShopProductProjection.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Projection;
+
+final class ShopProductProjection
+{
+    public const string INDEX_NAME = 'shop_products';
+}

--- a/src/Shop/Application/Service/ProductListService.php
+++ b/src/Shop/Application/Service/ProductListService.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Service;
+
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\Shop\Application\Projection\ShopProductProjection;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Throwable;
+
+readonly class ProductListService
+{
+    public function __construct(
+        private ProductRepository $productRepository,
+        private CacheInterface $cache,
+        private ElasticsearchServiceInterface $elasticsearchService,
+        private CacheKeyConventionService $cacheKeyConventionService,
+    ) {
+    }
+
+    /** @return array<string, mixed> */
+    public function getList(Request $request): array
+    {
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'q' => trim((string) $request->query->get('q', '')),
+            'name' => trim((string) $request->query->get('name', '')),
+            'category' => trim((string) $request->query->get('category', '')),
+        ];
+
+        $cacheKey = $this->cacheKeyConventionService->buildShopProductListKey($page, $limit, $filters);
+
+        /** @var array<string,mixed> $result */
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit): array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->shopProductListTag());
+            }
+
+            $esIds = $this->searchIdsFromElastic($filters);
+            if ($esIds === []) {
+                return ['items' => [], 'pagination' => ['page' => $page, 'limit' => $limit, 'totalItems' => 0, 'totalPages' => 0]];
+            }
+
+            $qb = $this->productRepository->createQueryBuilder('product')
+                ->leftJoin('product.category', 'category')
+                ->setFirstResult(($page - 1) * $limit)
+                ->setMaxResults($limit)
+                ->orderBy('product.createdAt', 'DESC');
+
+            if ($filters['name'] !== '') {
+                $qb->andWhere('LOWER(product.name) LIKE LOWER(:name)')->setParameter('name', '%' . $filters['name'] . '%');
+            }
+
+            if ($filters['category'] !== '') {
+                $qb->andWhere('LOWER(category.name) LIKE LOWER(:category)')->setParameter('category', '%' . $filters['category'] . '%');
+            }
+
+            if ($esIds !== null) {
+                $qb->andWhere('product.id IN (:ids)')->setParameter('ids', $esIds);
+            }
+
+            $items = array_map(static fn (Product $product): array => [
+                'id' => $product->getId(),
+                'name' => $product->getName(),
+                'price' => $product->getPrice(),
+                'categoryId' => $product->getCategory()?->getId(),
+                'categoryName' => $product->getCategory()?->getName(),
+                'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $product->getTags()->toArray()),
+                'updatedAt' => $product->getUpdatedAt()?->format(DATE_ATOM),
+            ], $qb->getQuery()->getResult());
+
+            $countQb = $this->productRepository->createQueryBuilder('product')->select('COUNT(product.id)')
+                ->leftJoin('product.category', 'category');
+
+            if ($filters['name'] !== '') {
+                $countQb->andWhere('LOWER(product.name) LIKE LOWER(:name)')->setParameter('name', '%' . $filters['name'] . '%');
+            }
+            if ($filters['category'] !== '') {
+                $countQb->andWhere('LOWER(category.name) LIKE LOWER(:category)')->setParameter('category', '%' . $filters['category'] . '%');
+            }
+            if ($esIds !== null) {
+                $countQb->andWhere('product.id IN (:ids)')->setParameter('ids', $esIds);
+            }
+
+            $totalItems = (int) $countQb->getQuery()->getSingleScalarResult();
+
+            return ['items' => $items, 'pagination' => ['page' => $page, 'limit' => $limit, 'totalItems' => $totalItems, 'totalPages' => $totalItems > 0 ? (int) ceil($totalItems / $limit) : 0]];
+        });
+
+        $result['filters'] = array_filter($filters, static fn (string $value): bool => $value !== '');
+
+        return $result;
+    }
+
+    /** @param array<string, string> $filters
+     * @return array<int, string>|null
+     */
+    private function searchIdsFromElastic(array $filters): ?array
+    {
+        if ($filters['q'] === '') {
+            return null;
+        }
+
+        try {
+            $response = $this->elasticsearchService->search(ShopProductProjection::INDEX_NAME, [
+                'query' => ['multi_match' => ['query' => $filters['q'], 'type' => 'phrase_prefix', 'fields' => ['name^3', 'categoryName^2', 'tags']]],
+                '_source' => ['id'],
+            ], 0, 200);
+        } catch (Throwable) {
+            return null;
+        }
+
+        $hits = $response['hits']['hits'] ?? [];
+
+        return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/ShopController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ShopController.php
@@ -4,17 +4,159 @@ declare(strict_types=1);
 
 namespace App\Shop\Transport\Controller\Api\V1;
 
+use App\General\Application\Message\EntityCreated;
+use App\General\Application\Message\EntityDeleted;
+use App\Shop\Application\Service\ProductListService;
+use App\Shop\Domain\Entity\Category;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Domain\Entity\Tag;
+use App\Shop\Infrastructure\Repository\CategoryRepository;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Shop\Infrastructure\Repository\TagRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
-final class ShopController
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ShopController
 {
-    #[Route('/v1/shop', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    public function __construct(
+        private ProductRepository $productRepository,
+        private CategoryRepository $categoryRepository,
+        private TagRepository $tagRepository,
+        private ShopRepository $shopRepository,
+        private ProductListService $productListService,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    #[Route('/v1/shop/products', methods: [Request::METHOD_GET])]
+    public function products(Request $request): JsonResponse
     {
-        return new JsonResponse(['module' => 'shop', 'status' => 'ok']);
+        return new JsonResponse($this->productListService->getList($request));
+    }
+
+    #[Route('/v1/shop/products', methods: [Request::METHOD_POST])]
+    public function createProduct(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+
+        $product = new Product();
+        $product->setName((string) ($payload['name'] ?? ''))->setPrice((float) ($payload['price'] ?? 0));
+
+        if (is_string($payload['shopId'] ?? null)) {
+            $product->setShop($this->shopRepository->find($payload['shopId']));
+        }
+        if (is_string($payload['categoryId'] ?? null)) {
+            $product->setCategory($this->categoryRepository->find($payload['categoryId']));
+        }
+        foreach ((array) ($payload['tagIds'] ?? []) as $tagId) {
+            if (is_string($tagId) && ($tag = $this->tagRepository->find($tagId)) instanceof Tag) {
+                $product->addTag($tag);
+            }
+        }
+
+        $this->entityManager->persist($product);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('shop_product', $product->getId()));
+
+        return new JsonResponse(['id' => $product->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/shop/products/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteProduct(string $id): JsonResponse
+    {
+        $product = $this->productRepository->find($id);
+        if (!$product instanceof Product) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($product);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('shop_product', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/shop/categories', methods: [Request::METHOD_GET])]
+    public function categories(): JsonResponse
+    {
+        $items = array_map(static fn (Category $category): array => ['id' => $category->getId(), 'name' => $category->getName()], $this->categoryRepository->findBy([], ['createdAt' => 'DESC'], 200));
+        return new JsonResponse(['items' => $items]);
+    }
+
+    #[Route('/v1/shop/categories', methods: [Request::METHOD_POST])]
+    public function createCategory(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $category = new Category();
+        $category->setName((string) ($payload['name'] ?? ''));
+        if (is_string($payload['shopId'] ?? null)) {
+            $category->setShop($this->shopRepository->find($payload['shopId']));
+        }
+
+        $this->entityManager->persist($category);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('shop_category', $category->getId()));
+
+        return new JsonResponse(['id' => $category->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/shop/categories/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteCategory(string $id): JsonResponse
+    {
+        $category = $this->categoryRepository->find($id);
+        if (!$category instanceof Category) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($category);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('shop_category', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/shop/tags', methods: [Request::METHOD_GET])]
+    public function tags(): JsonResponse
+    {
+        $items = array_map(static fn (Tag $tag): array => ['id' => $tag->getId(), 'label' => $tag->getLabel()], $this->tagRepository->findBy([], ['createdAt' => 'DESC'], 200));
+        return new JsonResponse(['items' => $items]);
+    }
+
+    #[Route('/v1/shop/tags', methods: [Request::METHOD_POST])]
+    public function createTag(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $tag = new Tag();
+        $tag->setLabel((string) ($payload['label'] ?? ''));
+        $this->entityManager->persist($tag);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('shop_tag', $tag->getId()));
+
+        return new JsonResponse(['id' => $tag->getId()], JsonResponse::HTTP_CREATED);
+    }
+
+    #[Route('/v1/shop/tags/{id}', methods: [Request::METHOD_DELETE])]
+    public function deleteTag(string $id): JsonResponse
+    {
+        $tag = $this->tagRepository->find($id);
+        if (!$tag instanceof Tag) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($tag);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('shop_tag', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }
 }


### PR DESCRIPTION
### Motivation
- Provide REST API v1 endpoints for the Shop, CRM and School aggregates so clients can list/create/delete main entities.
- Emit entity mutation events so projections stay in sync with domain changes and search lists can be served from Elasticsearch.
- Support ES-backed listing/search for large result sets and invalidate Redis caches when relevant data changes.

### Description
- Add API controllers for v1: `ShopController` (endpoints: `products`, `categories`, `tags`), `CrmController` (endpoints: `companies`, `projects`, `tasks`, `task-requests`, `sprints`) and `SchoolController` (endpoints: `classes`, `students`, `teachers`, `exams`, `grades`) with create/delete flows dispatching `EntityCreated` / `EntityDeleted` messages and basic list endpoints. Files: `src/Shop/Transport/Controller/Api/V1/ShopController.php`, `src/Crm/Transport/Controller/Api/V1/CrmController.php`, `src/School/Transport/Controller/Api/V1/SchoolController.php`.
- Extend `EntityProjectionHandler` to handle new `entityType` values (`shop_product`, `crm_task`, `school_exam`) and to index / delete documents in Elasticsearch using new projection classes with `INDEX_NAME` constants (`ShopProductProjection`, `CrmTaskProjection`, `SchoolExamProjection`). File: `src/General/Application/MessageHandler/EntityProjectionHandler.php` and projection files under each domain's `Application/Projection` folder.
- Add ES-backed list/search services that integrate with cache tags and repository queries: `ProductListService`, `TaskListService`, `ExamListService`, each using the respective projection `INDEX_NAME` for searches and falling back to DB queries; files under `src/Shop/Application/Service`, `src/Crm/Application/Service`, `src/School/Application/Service`.
- Extend cache conventions and invalidation: add list key builders and cache tags for shop/crm/school lists in `CacheKeyConventionService` and add invalidation helpers in `CacheInvalidationService` to clear Redis keys/tags used by the new list services.

### Testing
- Ran PHP syntax checks with `php -l` on all modified/new PHP files including controllers, services, projections and the projection handler, and they reported no syntax errors. 
- Verified newly added files are syntactically valid: `ProductListService`, `TaskListService`, `ExamListService`, `ShopProductProjection`, `CrmTaskProjection`, `SchoolExamProjection`, updated `EntityProjectionHandler`, cache services and controllers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf4f17b648326acb6156944cac3ab)