### PR TITLE
Ajout des fixtures Shop/Crm/School liées aux références Application

### DIFF
--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -17,111 +17,67 @@ use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Override;
 
-use function sprintf;
-
 final class LoadCrmData extends Fixture implements OrderedFixtureInterface
 {
-    private const int COMPANY_COUNT_PER_APPLICATION = 2;
-    private const int PROJECT_COUNT_PER_COMPANY = 2;
-    private const int TASK_COUNT_PER_PROJECT = 3;
+    /** @var array<non-empty-string, array<int, non-empty-string>> */
+    private const array APPLICATION_KEYS_BY_PLATFORM = [
+        PlatformKey::CRM->value => [
+            'crm-sales-hub',
+            'crm-pipeline-pro',
+            'crm-support-desk',
+        ],
+    ];
 
     #[Override]
     public function load(ObjectManager $manager): void
     {
-        $crmApplications = $manager->getRepository(Application::class)
-            ->createQueryBuilder('application')
-            ->innerJoin('application.platform', 'platform')
-            ->andWhere('platform.platformKey = :platformKey')
-            ->setParameter('platformKey', PlatformKey::CRM)
-            ->orderBy('application.title', 'ASC')
-            ->getQuery()
-            ->getResult();
+        foreach ($this->getApplicationsByPlatform(PlatformKey::CRM) as $application) {
+            $crm = (new Crm())->setApplication($application);
+            $manager->persist($crm);
 
-        foreach ($crmApplications as $applicationIndex => $application) {
-            if (!$application instanceof Application) {
-                continue;
-            }
+            $companies = [
+                (new Company())->setCrm($crm)->setName($application->getTitle() . ' - Acme Corp'),
+                (new Company())->setCrm($crm)->setName($application->getTitle() . ' - Globex'),
+            ];
 
-            $crm = $manager->getRepository(Crm::class)->findOneBy([
-                'application' => $application,
-            ]);
+            foreach ($companies as $companyIndex => $company) {
+                $manager->persist($company);
 
-            if (!$crm instanceof Crm) {
-                $crm = (new Crm())->setApplication($application);
-                $manager->persist($crm);
-            }
+                $project = (new Project())
+                    ->setCompany($company)
+                    ->setName($company->getName() . ' - Projet Transformation');
+                $manager->persist($project);
 
-            for ($companyIndex = 1; $companyIndex <= self::COMPANY_COUNT_PER_APPLICATION; ++$companyIndex) {
-                $companyName = sprintf('%s - Company %d', $application->getTitle(), $companyIndex);
-                $company = $manager->getRepository(Company::class)->findOneBy([
-                    'crm' => $crm,
-                    'name' => $companyName,
-                ]);
+                $sprint = (new Sprint())
+                    ->setProject($project)
+                    ->setName('Sprint ' . (string) ($companyIndex + 1));
+                $manager->persist($sprint);
 
-                if (!$company instanceof Company) {
-                    $company = (new Company())
-                        ->setCrm($crm)
-                        ->setName($companyName);
-                    $manager->persist($company);
-                }
+                $taskBacklog = (new Task())
+                    ->setProject($project)
+                    ->setSprint($sprint)
+                    ->setTitle('Consolider le backlog');
+                $taskAutomation = (new Task())
+                    ->setProject($project)
+                    ->setSprint($sprint)
+                    ->setTitle('Automatiser les relances');
 
-                for ($projectIndex = 1; $projectIndex <= self::PROJECT_COUNT_PER_COMPANY; ++$projectIndex) {
-                    $projectName = sprintf('%s - Project %d', $companyName, $projectIndex);
-                    $project = $manager->getRepository(Project::class)->findOneBy([
-                        'company' => $company,
-                        'name' => $projectName,
-                    ]);
+                $manager->persist($taskBacklog);
+                $manager->persist($taskAutomation);
 
-                    if (!$project instanceof Project) {
-                        $project = (new Project())
-                            ->setCompany($company)
-                            ->setName($projectName);
-                        $manager->persist($project);
-                    }
+                $manager->persist(
+                    (new TaskRequest())
+                        ->setTask($taskBacklog)
+                        ->setTitle('Prioriser les leads chauds')
+                        ->setStatus('pending'),
+                );
 
-                    $sprintName = sprintf('%s - Sprint 1', $projectName);
-                    $sprint = $manager->getRepository(Sprint::class)->findOneBy([
-                        'project' => $project,
-                        'name' => $sprintName,
-                    ]);
-
-                    if (!$sprint instanceof Sprint) {
-                        $sprint = (new Sprint())
-                            ->setProject($project)
-                            ->setName($sprintName);
-                        $manager->persist($sprint);
-                    }
-
-                    for ($taskIndex = 1; $taskIndex <= self::TASK_COUNT_PER_PROJECT; ++$taskIndex) {
-                        $taskTitle = sprintf('%s - Task %d', $projectName, $taskIndex);
-                        $task = $manager->getRepository(Task::class)->findOneBy([
-                            'project' => $project,
-                            'title' => $taskTitle,
-                        ]);
-
-                        if (!$task instanceof Task) {
-                            $task = (new Task())
-                                ->setProject($project)
-                                ->setSprint($sprint)
-                                ->setTitle($taskTitle);
-                            $manager->persist($task);
-                        }
-
-                        $taskRequestTitle = sprintf('%s - Request 1', $taskTitle);
-                        $taskRequest = $manager->getRepository(TaskRequest::class)->findOneBy([
-                            'task' => $task,
-                            'title' => $taskRequestTitle,
-                        ]);
-
-                        if (!$taskRequest instanceof TaskRequest) {
-                            $taskRequest = (new TaskRequest())
-                                ->setTask($task)
-                                ->setTitle($taskRequestTitle)
-                                ->setStatus(($applicationIndex + $taskIndex) % 2 === 0 ? 'pending' : 'approved');
-                            $manager->persist($taskRequest);
-                        }
-                    }
-                }
+                $manager->persist(
+                    (new TaskRequest())
+                        ->setTask($taskAutomation)
+                        ->setTitle('Valider le workflow de notifications')
+                        ->setStatus('approved'),
+                );
             }
         }
 
@@ -131,6 +87,18 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
     #[Override]
     public function getOrder(): int
     {
-        return 8;
+        return 9;
+    }
+
+    /** @return array<int, Application> */
+    private function getApplicationsByPlatform(PlatformKey $platformKey): array
+    {
+        $applications = [];
+
+        foreach (self::APPLICATION_KEYS_BY_PLATFORM[$platformKey->value] ?? [] as $applicationKey) {
+            $applications[] = $this->getReference('Application-' . $applicationKey, Application::class);
+        }
+
+        return $applications;
     }
 }

--- a/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
+++ b/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
@@ -4,15 +4,95 @@ declare(strict_types=1);
 
 namespace App\School\Infrastructure\DataFixtures\ORM;
 
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PlatformKey;
+use App\School\Domain\Entity\Exam;
+use App\School\Domain\Entity\Grade;
+use App\School\Domain\Entity\School;
+use App\School\Domain\Entity\SchoolClass;
+use App\School\Domain\Entity\Student;
+use App\School\Domain\Entity\Teacher;
 use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Override;
 
-final class LoadSchoolData extends Fixture
+final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
 {
+    /** @var array<non-empty-string, array<int, non-empty-string>> */
+    private const array APPLICATION_KEYS_BY_PLATFORM = [
+        PlatformKey::SCHOOL->value => [
+            'school-campus-core',
+            'school-course-flow',
+            'school-grade-track',
+        ],
+    ];
+
     #[Override]
     public function load(ObjectManager $manager): void
     {
+        foreach ($this->getApplicationsByPlatform(PlatformKey::SCHOOL) as $application) {
+            $school = (new School())
+                ->setName($application->getTitle() . ' Academy');
+            $manager->persist($school);
+
+            $classA = (new SchoolClass())->setSchool($school)->setName('Classe A - Sciences');
+            $classB = (new SchoolClass())->setSchool($school)->setName('Classe B - Langues');
+            $manager->persist($classA);
+            $manager->persist($classB);
+
+            $teacherMath = (new Teacher())->setName('Mme Martin');
+            $teacherFrench = (new Teacher())->setName('M. Dubois');
+            $teacherMath->getClasses()->add($classA);
+            $teacherFrench->getClasses()->add($classA);
+            $teacherFrench->getClasses()->add($classB);
+            $manager->persist($teacherMath);
+            $manager->persist($teacherFrench);
+
+            $students = [
+                (new Student())->setSchoolClass($classA)->setName('Alice Bernard'),
+                (new Student())->setSchoolClass($classA)->setName('Lucas Petit'),
+                (new Student())->setSchoolClass($classB)->setName('Emma Laurent'),
+            ];
+
+            foreach ($students as $student) {
+                $manager->persist($student);
+            }
+
+            $examMath = (new Exam())
+                ->setSchoolClass($classA)
+                ->setTeacher($teacherMath)
+                ->setTitle('Examen Mathematiques - Trimestre 1');
+            $examFrench = (new Exam())
+                ->setSchoolClass($classB)
+                ->setTeacher($teacherFrench)
+                ->setTitle('Examen Francais - Trimestre 1');
+            $manager->persist($examMath);
+            $manager->persist($examFrench);
+
+            $manager->persist((new Grade())->setStudent($students[0])->setExam($examMath)->setScore(16.5));
+            $manager->persist((new Grade())->setStudent($students[1])->setExam($examMath)->setScore(14.0));
+            $manager->persist((new Grade())->setStudent($students[2])->setExam($examFrench)->setScore(17.0));
+        }
+
         $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 11;
+    }
+
+    /** @return array<int, Application> */
+    private function getApplicationsByPlatform(PlatformKey $platformKey): array
+    {
+        $applications = [];
+
+        foreach (self::APPLICATION_KEYS_BY_PLATFORM[$platformKey->value] ?? [] as $applicationKey) {
+            $applications[] = $this->getReference('Application-' . $applicationKey, Application::class);
+        }
+
+        return $applications;
     }
 }

--- a/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
+++ b/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
@@ -4,15 +4,86 @@ declare(strict_types=1);
 
 namespace App\Shop\Infrastructure\DataFixtures\ORM;
 
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PlatformKey;
+use App\Shop\Domain\Entity\Category;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Domain\Entity\Tag;
 use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Override;
 
-final class LoadShopData extends Fixture
+final class LoadShopData extends Fixture implements OrderedFixtureInterface
 {
+    /** @var array<non-empty-string, array<int, non-empty-string>> */
+    private const array APPLICATION_KEYS_BY_PLATFORM = [
+        PlatformKey::SHOP->value => [
+            'shop-ops-center',
+            'shop-catalog-lab',
+            'shop-orders-watch',
+        ],
+    ];
+
     #[Override]
     public function load(ObjectManager $manager): void
     {
+        foreach ($this->getApplicationsByPlatform(PlatformKey::SHOP) as $application) {
+            $catalog = (new Shop())
+                ->setName($application->getTitle() . ' Catalog');
+            $manager->persist($catalog);
+
+            $categories = [
+                'Electronique' => (new Category())->setShop($catalog)->setName('Electronique'),
+                'Maison' => (new Category())->setShop($catalog)->setName('Maison'),
+                'Bureau' => (new Category())->setShop($catalog)->setName('Bureau'),
+            ];
+
+            foreach ($categories as $category) {
+                $manager->persist($category);
+            }
+
+            $tags = [
+                'Nouveau' => (new Tag())->setLabel('Nouveau'),
+                'Promo' => (new Tag())->setLabel('Promo'),
+                'Eco' => (new Tag())->setLabel('Eco'),
+            ];
+
+            foreach ($tags as $tag) {
+                $manager->persist($tag);
+            }
+
+            $products = [
+                (new Product())->setShop($catalog)->setCategory($categories['Electronique'])->setName('Casque Bluetooth')->setPrice(89.99)->addTag($tags['Nouveau'])->addTag($tags['Promo']),
+                (new Product())->setShop($catalog)->setCategory($categories['Maison'])->setName('Lampe LED connectee')->setPrice(59.90)->addTag($tags['Eco']),
+                (new Product())->setShop($catalog)->setCategory($categories['Bureau'])->setName('Chaise ergonomique')->setPrice(229.00)->addTag($tags['Promo']),
+                (new Product())->setShop($catalog)->setCategory($categories['Electronique'])->setName('Souris sans fil')->setPrice(34.50)->addTag($tags['Nouveau'])->addTag($tags['Eco']),
+            ];
+
+            foreach ($products as $product) {
+                $manager->persist($product);
+            }
+        }
+
         $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 10;
+    }
+
+    /** @return array<int, Application> */
+    private function getApplicationsByPlatform(PlatformKey $platformKey): array
+    {
+        $applications = [];
+
+        foreach (self::APPLICATION_KEYS_BY_PLATFORM[$platformKey->value] ?? [] as $applicationKey) {
+            $applications[] = $this->getReference('Application-' . $applicationKey, Application::class);
+        }
+
+        return $applications;
     }
 }


### PR DESCRIPTION
### Motivation
- Ajouter des jeux de données cohérents pour les modules Shop, Crm et School afin de faciliter le développement et les tests locaux. 
- Attacher ces données aux bonnes applications en réutilisant les références `Application-*` créées par la fixture `LoadApplicationData`. 
- Garantir l'ordre de chargement des fixtures pour qu'elles s'exécutent après les fixtures de `Platform`/`Application`.

### Description
- Réécriture/implémentation des fichiers de fixtures `src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php`, `src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php` et `src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php` pour semer des jeux de données cohérents. 
- Chaque fixture utilise un tableau de clés d'application groupées par `PlatformKey` et une méthode `getApplicationsByPlatform()` pour récupérer les références `Application-<key>` via `getReference()`. 
- Jeux de données ajoutés : Shop crée des `Shop`, `Category`, `Tag` et `Product`; Crm crée `Crm`, `Company`, `Project`, `Sprint`, `Task` et `TaskRequest`; School crée `School`, `SchoolClass`, `Teacher`, `Student`, `Exam` et `Grade`. 
- `LoadShopData` et `LoadSchoolData` implémentent désormais `OrderedFixtureInterface` et les trois fixtures définissent `getOrder()` pour s'exécuter après les fixtures de plateforme (`Crm => 9`, `Shop => 10`, `School => 11`).

### Testing
- Vérification de syntaxe PHP avec `php -l` sur les trois fichiers de fixtures (`src/Shop/.../LoadShopData.php`, `src/Crm/.../LoadCrmData.php`, `src/School/.../LoadSchoolData.php`) et aucune erreur de syntaxe détectée. 
- Les fixtures ont été relues localement pour s'assurer que les entités et relations créées correspondent aux entités du domaine et aux références `Application-*` existantes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adf722a974832690eb60fd2375084e)