### PR TITLE
Enhance Blog/Quiz fixtures and add OpenAPI documentation to Blog and Quiz controllers

### DIFF
--- a/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
+++ b/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
@@ -10,12 +10,14 @@ use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Domain\Entity\BlogReaction;
 use App\Blog\Domain\Entity\BlogTag;
 use App\Blog\Domain\Enum\BlogType;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use App\Platform\Domain\Entity\Application;
 use App\User\Domain\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Override;
+
+use function sprintf;
 
 final class LoadBlogData extends Fixture implements OrderedFixtureInterface
 {
@@ -23,25 +25,72 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
     public function load(ObjectManager $manager): void
     {
         $johnRoot = $this->getReference('User-john-root', User::class);
-        $application = $this->getReference('Application-shop-ops-center', Application::class);
+        $johnAdmin = $this->getReference('User-john-admin', User::class);
+        $johnUser = $this->getReference('User-john-user', User::class);
 
-        $generalBlog = (new Blog())->setTitle('General Blog Root')->setOwner($johnRoot)->setType(BlogType::GENERAL);
-        $applicationBlog = (new Blog())->setTitle('Shop Blog')->setOwner($johnRoot)->setType(BlogType::APPLICATION)->setApplication($application);
-        $manager->persist($generalBlog); $manager->persist($applicationBlog);
+        $applications = [
+            $this->getReference('Application-shop-ops-center', Application::class),
+            $this->getReference('Application-crm-sales-hub', Application::class),
+            $this->getReference('Application-school-campus-core', Application::class),
+        ];
 
-        foreach ([$generalBlog, $applicationBlog] as $i => $blog) {
-            for ($p = 1; $p <= 4; ++$p) {
-                $post = (new BlogPost())->setBlog($blog)->setAuthor($johnRoot)->setContent(sprintf('Fixture post %d for %s', $p, $blog->getTitle()));
+        $generalBlog = (new Blog())
+            ->setTitle('General Blog Root')
+            ->setOwner($johnRoot)
+            ->setType(BlogType::GENERAL);
+        $manager->persist($generalBlog);
+
+        /** @var list<Blog> $blogs */
+        $blogs = [$generalBlog];
+        foreach ($applications as $index => $application) {
+            $blog = (new Blog())
+                ->setTitle(sprintf('Application Blog %d', $index + 1))
+                ->setOwner($johnRoot)
+                ->setType(BlogType::APPLICATION)
+                ->setApplication($application);
+            $manager->persist($blog);
+            $blogs[] = $blog;
+        }
+
+        $authors = [$johnRoot, $johnAdmin, $johnUser];
+        $reactionTypes = ['like', 'heart', 'laugh'];
+
+        foreach ($blogs as $blogIndex => $blog) {
+            for ($postIndex = 1; $postIndex <= 6; ++$postIndex) {
+                $author = $authors[($blogIndex + $postIndex) % count($authors)];
+
+                $post = (new BlogPost())
+                    ->setBlog($blog)
+                    ->setAuthor($author)
+                    ->setContent(sprintf('Fixture post %d for %s', $postIndex, $blog->getTitle()));
                 $manager->persist($post);
-                $tag = (new BlogTag())->setBlog($blog)->setLabel(sprintf('tag-%d-%d', $i + 1, $p));
-                $manager->persist($tag);
 
-                $parent = (new BlogComment())->setPost($post)->setAuthor($johnRoot)->setContent('Parent comment #' . $p);
-                $child = (new BlogComment())->setPost($post)->setAuthor($johnRoot)->setContent('Child comment #' . $p)->setParent($parent);
-                $manager->persist($parent); $manager->persist($child);
+                for ($tagIndex = 1; $tagIndex <= 2; ++$tagIndex) {
+                    $manager->persist((new BlogTag())
+                        ->setBlog($blog)
+                        ->setLabel(sprintf('tag-%d-%d-%d', $blogIndex + 1, $postIndex, $tagIndex)));
+                }
 
-                $manager->persist((new BlogReaction())->setComment($parent)->setAuthor($johnRoot)->setType('like'));
-                $manager->persist((new BlogReaction())->setComment($child)->setAuthor($johnRoot)->setType('heart'));
+                $parent = (new BlogComment())
+                    ->setPost($post)
+                    ->setAuthor($author)
+                    ->setContent('Parent comment #' . $postIndex);
+                $child = (new BlogComment())
+                    ->setPost($post)
+                    ->setAuthor($authors[($blogIndex + $postIndex + 1) % count($authors)])
+                    ->setContent('Child comment #' . $postIndex)
+                    ->setParent($parent);
+                $manager->persist($parent);
+                $manager->persist($child);
+
+                $manager->persist((new BlogReaction())
+                    ->setComment($parent)
+                    ->setAuthor($authors[($blogIndex + 1) % count($authors)])
+                    ->setType($reactionTypes[($blogIndex + $postIndex) % count($reactionTypes)]));
+                $manager->persist((new BlogReaction())
+                    ->setComment($child)
+                    ->setAuthor($authors[($blogIndex + 2) % count($authors)])
+                    ->setType($reactionTypes[($blogIndex + $postIndex + 1) % count($reactionTypes)]));
             }
         }
 

--- a/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
@@ -15,6 +15,7 @@ use App\Blog\Application\Message\PatchBlogCommentCommand;
 use App\Blog\Application\Message\PatchBlogPostCommand;
 use App\Blog\Application\Message\PatchBlogReactionCommand;
 use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -26,11 +27,14 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Blog')]
 final readonly class BlogMutationController
 {
     public function __construct(private MessageBusInterface $messageBus) {}
 
     #[Route('/v1/blogs/general', methods: [Request::METHOD_POST])]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['title' => 'General Blog']))]
+    #[OA\Response(response: 202, description: 'General blog creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createGeneral(Request $request): JsonResponse
     {
         $user = $request->getUser();
@@ -45,6 +49,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blogs/{blogId}/posts', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'blogId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e77')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Nouveau post produit', 'filePath' => '/uploads/blog/post.png']))]
+    #[OA\Response(response: 202, description: 'Post creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createPost(string $blogId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request);
@@ -55,6 +62,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/posts/{postId}', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'postId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e78')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Mise a jour du post', 'filePath' => '/uploads/blog/new-file.png']))]
+    #[OA\Response(response: 204, description: 'Post updated.')]
     public function patchPost(string $postId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
@@ -63,6 +73,8 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/posts/{postId}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'postId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e78')]
+    #[OA\Response(response: 204, description: 'Post deleted.')]
     public function deletePost(string $postId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $this->messageBus->dispatch(new DeleteBlogPostCommand((string) uniqid('op_', true), $user->getId(), $postId));
@@ -70,6 +82,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/posts/{postId}/comments', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'postId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e79')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Je valide ce point', 'parentCommentId' => null]))]
+    #[OA\Response(response: 202, description: 'Comment creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createComment(string $postId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
@@ -78,6 +93,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/comments/{commentId}', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'commentId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e90')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Commentaire corrige']))]
+    #[OA\Response(response: 204, description: 'Comment updated.')]
     public function patchComment(string $commentId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
@@ -86,6 +104,8 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/comments/{commentId}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'commentId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e90')]
+    #[OA\Response(response: 204, description: 'Comment deleted.')]
     public function deleteComment(string $commentId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $this->messageBus->dispatch(new DeleteBlogCommentCommand((string) uniqid('op_', true), $user->getId(), $commentId));
@@ -93,6 +113,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/comments/{commentId}/reactions', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'commentId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e90')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['type' => 'heart']))]
+    #[OA\Response(response: 202, description: 'Reaction creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createReaction(string $commentId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
@@ -101,6 +124,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/reactions/{reactionId}', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'reactionId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e91')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['type' => 'laugh']))]
+    #[OA\Response(response: 204, description: 'Reaction updated.')]
     public function patchReaction(string $reactionId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
@@ -109,6 +135,8 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/reactions/{reactionId}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'reactionId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e91')]
+    #[OA\Response(response: 204, description: 'Reaction deleted.')]
     public function deleteReaction(string $reactionId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $this->messageBus->dispatch(new DeleteBlogReactionCommand((string) uniqid('op_', true), $user->getId(), $reactionId));

--- a/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Api\V1;
 
 use App\Blog\Application\Service\BlogReadService;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -16,12 +17,45 @@ final readonly class BlogReadController
     public function __construct(private BlogReadService $blogReadService) {}
 
     #[Route('/v1/blogs/general', methods: [Request::METHOD_GET])]
+    #[OA\Tag(name: 'Blog')]
+    #[OA\Response(
+        response: 200,
+        description: 'General blog with nested posts, comments and reactions.',
+        content: new OA\JsonContent(example: [
+            'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e70',
+            'title' => 'General Blog Root',
+            'type' => 'general',
+            'posts' => [[
+                'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e71',
+                'content' => 'Fixture post 1 for General Blog Root',
+                'comments' => [[
+                    'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e72',
+                    'content' => 'Parent comment #1',
+                    'reactions' => [['type' => 'like', 'authorId' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e73']],
+                ]],
+            ]],
+        ]),
+    )]
     public function general(): JsonResponse
     {
         return new JsonResponse($this->blogReadService->getGeneralBlogWithTree());
     }
 
     #[Route('/v1/blogs/application/{applicationSlug}', methods: [Request::METHOD_GET])]
+    #[OA\Tag(name: 'Blog')]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'shop-ops-center')]
+    #[OA\Response(
+        response: 200,
+        description: 'Application blog tree.',
+        content: new OA\JsonContent(example: [
+            'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e80',
+            'title' => 'Shop Blog',
+            'type' => 'application',
+            'applicationSlug' => 'shop-ops-center',
+            'posts' => [],
+            'tags' => [['label' => 'tag-2-1']],
+        ]),
+    )]
     public function byApplication(string $applicationSlug): JsonResponse
     {
         return new JsonResponse($this->blogReadService->getByApplicationSlug($applicationSlug));

--- a/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
+++ b/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
@@ -6,12 +6,12 @@ namespace App\Quiz\Infrastructure\DataFixtures\ORM;
 
 use App\Configuration\Domain\Entity\Configuration;
 use App\Configuration\Domain\Enum\ConfigurationScope;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use App\Platform\Domain\Entity\Application;
 use App\Quiz\Domain\Entity\Quiz;
 use App\Quiz\Domain\Entity\QuizAnswer;
 use App\Quiz\Domain\Entity\QuizQuestion;
 use App\User\Domain\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Override;
@@ -21,31 +21,50 @@ final class LoadQuizData extends Fixture implements OrderedFixtureInterface
     #[Override]
     public function load(ObjectManager $manager): void
     {
-        $johnRoot = $this->getReference('User-john-root', User::class);
-        $application = $this->getReference('Application-shop-ops-center', Application::class);
+        $users = [
+            $this->getReference('User-john-root', User::class),
+            $this->getReference('User-john-admin', User::class),
+            $this->getReference('User-john-user', User::class),
+        ];
 
-        $configuration = (new Configuration())
-            ->setApplication($application)
-            ->setConfigurationKey('quiz.module.configuration')
-            ->setConfigurationValue(['shuffleQuestions' => true, 'timerSec' => 45])
-            ->setScope(ConfigurationScope::PLATFORM)
-            ->setPrivate(true);
-        $manager->persist($configuration);
+        $applications = [
+            $this->getReference('Application-shop-ops-center', Application::class),
+            $this->getReference('Application-crm-sales-hub', Application::class),
+            $this->getReference('Application-school-campus-core', Application::class),
+        ];
 
-        $quiz = (new Quiz())->setApplication($application)->setOwner($johnRoot)->setConfiguration($configuration);
-        $manager->persist($quiz);
+        foreach ($applications as $applicationIndex => $application) {
+            $configuration = (new Configuration())
+                ->setApplication($application)
+                ->setConfigurationKey('quiz.module.configuration')
+                ->setConfigurationValue([
+                    'shuffleQuestions' => true,
+                    'timerSec' => 30 + ($applicationIndex * 15),
+                    'showInstantCorrection' => $applicationIndex % 2 === 0,
+                ])
+                ->setScope(ConfigurationScope::PLATFORM)
+                ->setPrivate(true);
+            $manager->persist($configuration);
 
-        for ($i = 1; $i <= 8; ++$i) {
-            $question = (new QuizQuestion())
-                ->setQuiz($quiz)
-                ->setTitle('Question fixture #' . $i)
-                ->setLevel($i % 3 === 0 ? 'hard' : ($i % 2 === 0 ? 'medium' : 'easy'))
-                ->setCategory($i % 2 === 0 ? 'backend' : 'frontend');
-            $manager->persist($question);
+            $quiz = (new Quiz())
+                ->setApplication($application)
+                ->setOwner($users[$applicationIndex % count($users)])
+                ->setConfiguration($configuration);
+            $manager->persist($quiz);
 
-            $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Right answer ' . $i)->setCorrect(true));
-            $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer A ' . $i)->setCorrect(false));
-            $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer B ' . $i)->setCorrect(false));
+            for ($questionIndex = 1; $questionIndex <= 12; ++$questionIndex) {
+                $question = (new QuizQuestion())
+                    ->setQuiz($quiz)
+                    ->setTitle('Question fixture #' . $questionIndex . ' app #' . ($applicationIndex + 1))
+                    ->setLevel($questionIndex % 3 === 0 ? 'hard' : ($questionIndex % 2 === 0 ? 'medium' : 'easy'))
+                    ->setCategory($questionIndex % 2 === 0 ? 'backend' : 'frontend');
+                $manager->persist($question);
+
+                $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Right answer ' . $questionIndex)->setCorrect(true));
+                $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer A ' . $questionIndex)->setCorrect(false));
+                $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer B ' . $questionIndex)->setCorrect(false));
+                $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer C ' . $questionIndex)->setCorrect(false));
+            }
         }
 
         $manager->flush();

--- a/src/Quiz/Transport/Controller/Api/V1/QuizController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/QuizController.php
@@ -7,6 +7,7 @@ namespace App\Quiz\Transport\Controller\Api\V1;
 use App\Quiz\Application\Message\CreateQuizQuestionCommand;
 use App\Quiz\Application\Service\QuizReadService;
 use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -18,17 +19,23 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Quiz')]
 final readonly class QuizController
 {
     public function __construct(private MessageBusInterface $messageBus, private QuizReadService $quizReadService) {}
 
     #[Route('/v1/quiz/application/{applicationSlug}', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'shop-ops-center')]
+    #[OA\Response(response: 200, description: 'Quiz with questions and answers by application.', content: new OA\JsonContent(example: ['id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e90', 'applicationSlug' => 'shop-ops-center', 'questions' => [['title' => 'Question fixture #1', 'answers' => [['label' => 'Right answer 1', 'correct' => true]]]]]))]
     public function getByApplication(string $applicationSlug): JsonResponse
     {
         return new JsonResponse($this->quizReadService->getByApplicationSlug($applicationSlug));
     }
 
     #[Route('/v1/quiz/application/{applicationSlug}/questions', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'shop-ops-center')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['title' => 'What is Symfony Messenger?', 'level' => 'medium', 'category' => 'backend', 'answers' => [['label' => 'Message bus component', 'correct' => true], ['label' => 'Template engine', 'correct' => false]], 'configuration' => ['shuffleAnswers' => true, 'timeLimitSec' => 40]]))]
+    #[OA\Response(response: 202, description: 'Question creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createQuestion(string $applicationSlug, Request $request): JsonResponse
     {
         $user = $request->getUser();


### PR DESCRIPTION
### Motivation
- Provide richer, more realistic data fixtures across Blog and Quiz modules to cover multiple applications, users and varied content for development and local testing.
- Improve API discoverability by adding OpenAPI attributes to Blog and Quiz controllers so endpoints, parameters and example payloads/responses are documented.

### Description
- Expanded `LoadBlogData` to reference multiple applications and users, create multiple application blogs, increase posts per blog, add tags, nested comments and varied reactions, and cleaned up imports and small refactors (added `sprintf`).
- Expanded `LoadQuizData` to generate quizzes for multiple applications with per-application configuration, more questions and additional answers, and cleaned up imports.
- Annotated `BlogMutationController`, `BlogReadController` and `QuizController` with OpenAPI (`OpenApi\Attributes`) metadata including tags, path parameters, request body and response examples to improve generated API docs.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adef20892c8326b1109b78e222ee61)