### PR TITLE
Add application-scoped endpoints, repository lookups and OpenAPI docs; link Shop/School to Application and enrich fixtures

### DIFF
--- a/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
+++ b/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
@@ -10,12 +10,14 @@ use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Domain\Entity\BlogReaction;
 use App\Blog\Domain\Entity\BlogTag;
 use App\Blog\Domain\Enum\BlogType;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use App\Platform\Domain\Entity\Application;
 use App\User\Domain\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Override;
+
+use function sprintf;
 
 final class LoadBlogData extends Fixture implements OrderedFixtureInterface
 {
@@ -23,25 +25,72 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
     public function load(ObjectManager $manager): void
     {
         $johnRoot = $this->getReference('User-john-root', User::class);
-        $application = $this->getReference('Application-shop-ops-center', Application::class);
+        $johnAdmin = $this->getReference('User-john-admin', User::class);
+        $johnUser = $this->getReference('User-john-user', User::class);
 
-        $generalBlog = (new Blog())->setTitle('General Blog Root')->setOwner($johnRoot)->setType(BlogType::GENERAL);
-        $applicationBlog = (new Blog())->setTitle('Shop Blog')->setOwner($johnRoot)->setType(BlogType::APPLICATION)->setApplication($application);
-        $manager->persist($generalBlog); $manager->persist($applicationBlog);
+        $applications = [
+            $this->getReference('Application-shop-ops-center', Application::class),
+            $this->getReference('Application-crm-sales-hub', Application::class),
+            $this->getReference('Application-school-campus-core', Application::class),
+        ];
 
-        foreach ([$generalBlog, $applicationBlog] as $i => $blog) {
-            for ($p = 1; $p <= 4; ++$p) {
-                $post = (new BlogPost())->setBlog($blog)->setAuthor($johnRoot)->setContent(sprintf('Fixture post %d for %s', $p, $blog->getTitle()));
+        $generalBlog = (new Blog())
+            ->setTitle('General Blog Root')
+            ->setOwner($johnRoot)
+            ->setType(BlogType::GENERAL);
+        $manager->persist($generalBlog);
+
+        /** @var list<Blog> $blogs */
+        $blogs = [$generalBlog];
+        foreach ($applications as $index => $application) {
+            $blog = (new Blog())
+                ->setTitle(sprintf('Application Blog %d', $index + 1))
+                ->setOwner($johnRoot)
+                ->setType(BlogType::APPLICATION)
+                ->setApplication($application);
+            $manager->persist($blog);
+            $blogs[] = $blog;
+        }
+
+        $authors = [$johnRoot, $johnAdmin, $johnUser];
+        $reactionTypes = ['like', 'heart', 'laugh'];
+
+        foreach ($blogs as $blogIndex => $blog) {
+            for ($postIndex = 1; $postIndex <= 6; ++$postIndex) {
+                $author = $authors[($blogIndex + $postIndex) % count($authors)];
+
+                $post = (new BlogPost())
+                    ->setBlog($blog)
+                    ->setAuthor($author)
+                    ->setContent(sprintf('Fixture post %d for %s', $postIndex, $blog->getTitle()));
                 $manager->persist($post);
-                $tag = (new BlogTag())->setBlog($blog)->setLabel(sprintf('tag-%d-%d', $i + 1, $p));
-                $manager->persist($tag);
 
-                $parent = (new BlogComment())->setPost($post)->setAuthor($johnRoot)->setContent('Parent comment #' . $p);
-                $child = (new BlogComment())->setPost($post)->setAuthor($johnRoot)->setContent('Child comment #' . $p)->setParent($parent);
-                $manager->persist($parent); $manager->persist($child);
+                for ($tagIndex = 1; $tagIndex <= 2; ++$tagIndex) {
+                    $manager->persist((new BlogTag())
+                        ->setBlog($blog)
+                        ->setLabel(sprintf('tag-%d-%d-%d', $blogIndex + 1, $postIndex, $tagIndex)));
+                }
 
-                $manager->persist((new BlogReaction())->setComment($parent)->setAuthor($johnRoot)->setType('like'));
-                $manager->persist((new BlogReaction())->setComment($child)->setAuthor($johnRoot)->setType('heart'));
+                $parent = (new BlogComment())
+                    ->setPost($post)
+                    ->setAuthor($author)
+                    ->setContent('Parent comment #' . $postIndex);
+                $child = (new BlogComment())
+                    ->setPost($post)
+                    ->setAuthor($authors[($blogIndex + $postIndex + 1) % count($authors)])
+                    ->setContent('Child comment #' . $postIndex)
+                    ->setParent($parent);
+                $manager->persist($parent);
+                $manager->persist($child);
+
+                $manager->persist((new BlogReaction())
+                    ->setComment($parent)
+                    ->setAuthor($authors[($blogIndex + 1) % count($authors)])
+                    ->setType($reactionTypes[($blogIndex + $postIndex) % count($reactionTypes)]));
+                $manager->persist((new BlogReaction())
+                    ->setComment($child)
+                    ->setAuthor($authors[($blogIndex + 2) % count($authors)])
+                    ->setType($reactionTypes[($blogIndex + $postIndex + 1) % count($reactionTypes)]));
             }
         }
 

--- a/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
@@ -15,6 +15,7 @@ use App\Blog\Application\Message\PatchBlogCommentCommand;
 use App\Blog\Application\Message\PatchBlogPostCommand;
 use App\Blog\Application\Message\PatchBlogReactionCommand;
 use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -26,11 +27,14 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Blog')]
 final readonly class BlogMutationController
 {
     public function __construct(private MessageBusInterface $messageBus) {}
 
     #[Route('/v1/blogs/general', methods: [Request::METHOD_POST])]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['title' => 'General Blog']))]
+    #[OA\Response(response: 202, description: 'General blog creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createGeneral(Request $request): JsonResponse
     {
         $user = $request->getUser();
@@ -45,6 +49,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blogs/{blogId}/posts', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'blogId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e77')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Nouveau post produit', 'filePath' => '/uploads/blog/post.png']))]
+    #[OA\Response(response: 202, description: 'Post creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createPost(string $blogId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request);
@@ -55,6 +62,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/posts/{postId}', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'postId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e78')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Mise a jour du post', 'filePath' => '/uploads/blog/new-file.png']))]
+    #[OA\Response(response: 204, description: 'Post updated.')]
     public function patchPost(string $postId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
@@ -63,6 +73,8 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/posts/{postId}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'postId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e78')]
+    #[OA\Response(response: 204, description: 'Post deleted.')]
     public function deletePost(string $postId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $this->messageBus->dispatch(new DeleteBlogPostCommand((string) uniqid('op_', true), $user->getId(), $postId));
@@ -70,6 +82,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/posts/{postId}/comments', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'postId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e79')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Je valide ce point', 'parentCommentId' => null]))]
+    #[OA\Response(response: 202, description: 'Comment creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createComment(string $postId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
@@ -78,6 +93,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/comments/{commentId}', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'commentId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e90')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Commentaire corrige']))]
+    #[OA\Response(response: 204, description: 'Comment updated.')]
     public function patchComment(string $commentId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
@@ -86,6 +104,8 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/comments/{commentId}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'commentId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e90')]
+    #[OA\Response(response: 204, description: 'Comment deleted.')]
     public function deleteComment(string $commentId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $this->messageBus->dispatch(new DeleteBlogCommentCommand((string) uniqid('op_', true), $user->getId(), $commentId));
@@ -93,6 +113,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/comments/{commentId}/reactions', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'commentId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e90')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['type' => 'heart']))]
+    #[OA\Response(response: 202, description: 'Reaction creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createReaction(string $commentId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
@@ -101,6 +124,9 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/reactions/{reactionId}', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'reactionId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e91')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['type' => 'laugh']))]
+    #[OA\Response(response: 204, description: 'Reaction updated.')]
     public function patchReaction(string $reactionId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $payload = (array) json_decode((string) $request->getContent(), true);
@@ -109,6 +135,8 @@ final readonly class BlogMutationController
     }
 
     #[Route('/v1/blog/reactions/{reactionId}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'reactionId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e91')]
+    #[OA\Response(response: 204, description: 'Reaction deleted.')]
     public function deleteReaction(string $reactionId, Request $request): JsonResponse
     {
         $user = $this->requireUser($request); $this->messageBus->dispatch(new DeleteBlogReactionCommand((string) uniqid('op_', true), $user->getId(), $reactionId));

--- a/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Api\V1;
 
 use App\Blog\Application\Service\BlogReadService;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -16,12 +17,45 @@ final readonly class BlogReadController
     public function __construct(private BlogReadService $blogReadService) {}
 
     #[Route('/v1/blogs/general', methods: [Request::METHOD_GET])]
+    #[OA\Tag(name: 'Blog')]
+    #[OA\Response(
+        response: 200,
+        description: 'General blog with nested posts, comments and reactions.',
+        content: new OA\JsonContent(example: [
+            'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e70',
+            'title' => 'General Blog Root',
+            'type' => 'general',
+            'posts' => [[
+                'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e71',
+                'content' => 'Fixture post 1 for General Blog Root',
+                'comments' => [[
+                    'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e72',
+                    'content' => 'Parent comment #1',
+                    'reactions' => [['type' => 'like', 'authorId' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e73']],
+                ]],
+            ]],
+        ]),
+    )]
     public function general(): JsonResponse
     {
         return new JsonResponse($this->blogReadService->getGeneralBlogWithTree());
     }
 
     #[Route('/v1/blogs/application/{applicationSlug}', methods: [Request::METHOD_GET])]
+    #[OA\Tag(name: 'Blog')]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'shop-ops-center')]
+    #[OA\Response(
+        response: 200,
+        description: 'Application blog tree.',
+        content: new OA\JsonContent(example: [
+            'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e80',
+            'title' => 'Shop Blog',
+            'type' => 'application',
+            'applicationSlug' => 'shop-ops-center',
+            'posts' => [],
+            'tags' => [['label' => 'tag-2-1']],
+        ]),
+    )]
     public function byApplication(string $applicationSlug): JsonResponse
     {
         return new JsonResponse($this->blogReadService->getByApplicationSlug($applicationSlug));

--- a/src/Crm/Infrastructure/Repository/CrmRepository.php
+++ b/src/Crm/Infrastructure/Repository/CrmRepository.php
@@ -24,4 +24,18 @@ class CrmRepository extends BaseRepository
     public function __construct(protected ManagerRegistry $managerRegistry)
     {
     }
+
+    public function findOneByApplicationSlug(string $applicationSlug): ?Entity
+    {
+        $entity = $this->createQueryBuilder('module')
+            ->innerJoin('module.application', 'application')
+            ->addSelect('application')
+            ->where('application.slug = :applicationSlug')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $entity instanceof Entity ? $entity : null;
+    }
 }
+

--- a/src/Crm/Transport/Controller/Api/V1/CrmController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CrmController.php
@@ -10,6 +10,7 @@ use App\Crm\Domain\Entity\Project;
 use App\Crm\Domain\Entity\Sprint;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Domain\Entity\Crm;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Infrastructure\Repository\CrmRepository;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
@@ -18,16 +19,21 @@ use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\Crm\Infrastructure\Repository\TaskRequestRepository;
 use App\General\Application\Message\EntityCreated;
 use App\General\Application\Message\EntityDeleted;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PlatformKey;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class CrmController
 {
@@ -240,4 +246,55 @@ final readonly class CrmController
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/companies', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
+    #[OA\Response(response: 200, description: 'Companies list scoped to CRM application.')]
+    public function companiesByApplication(string $applicationSlug): JsonResponse
+    {
+        $crm = $this->resolveOrCreateCrmByApplicationSlug($applicationSlug);
+        $items = array_map(static fn (Company $company): array => ['id' => $company->getId(), 'name' => $company->getName()], $this->companyRepository->findBy(['crm' => $crm], ['createdAt' => 'DESC'], 200));
+
+        return new JsonResponse(['applicationSlug' => $applicationSlug, 'crmId' => $crm->getId(), 'items' => $items]);
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/companies', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['name' => 'Acme Europe']))]
+    #[OA\Response(response: 201, description: 'Company created under CRM application.', content: new OA\JsonContent(example: ['id' => 'uuid', 'crmId' => 'uuid', 'applicationSlug' => 'crm-sales-hub']))]
+    public function createCompanyByApplication(string $applicationSlug, Request $request): JsonResponse
+    {
+        $crm = $this->resolveOrCreateCrmByApplicationSlug($applicationSlug);
+        $payload = (array) json_decode((string) $request->getContent(), true);
+
+        $company = (new Company())
+            ->setCrm($crm)
+            ->setName((string) ($payload['name'] ?? ''));
+
+        $this->entityManager->persist($company);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('crm_company', $company->getId(), context: ['applicationSlug' => $applicationSlug]));
+
+        return new JsonResponse(['id' => $company->getId(), 'crmId' => $crm->getId(), 'applicationSlug' => $applicationSlug], JsonResponse::HTTP_CREATED);
+    }
+
+    private function resolveOrCreateCrmByApplicationSlug(string $applicationSlug): Crm
+    {
+        $crm = $this->crmRepository->findOneByApplicationSlug($applicationSlug);
+        if ($crm instanceof Crm) {
+            return $crm;
+        }
+
+        $application = $this->entityManager->getRepository(Application::class)->findOneBy(['slug' => $applicationSlug]);
+        if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== PlatformKey::CRM) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicationSlug" for CRM platform.');
+        }
+
+        $crm = (new Crm())->setApplication($application);
+        $this->entityManager->persist($crm);
+        $this->entityManager->flush();
+
+        return $crm;
+    }
+
 }

--- a/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
+++ b/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
@@ -6,12 +6,12 @@ namespace App\Quiz\Infrastructure\DataFixtures\ORM;
 
 use App\Configuration\Domain\Entity\Configuration;
 use App\Configuration\Domain\Enum\ConfigurationScope;
-use Doctrine\Bundle\FixturesBundle\Fixture;
 use App\Platform\Domain\Entity\Application;
 use App\Quiz\Domain\Entity\Quiz;
 use App\Quiz\Domain\Entity\QuizAnswer;
 use App\Quiz\Domain\Entity\QuizQuestion;
 use App\User\Domain\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Override;
@@ -21,31 +21,50 @@ final class LoadQuizData extends Fixture implements OrderedFixtureInterface
     #[Override]
     public function load(ObjectManager $manager): void
     {
-        $johnRoot = $this->getReference('User-john-root', User::class);
-        $application = $this->getReference('Application-shop-ops-center', Application::class);
+        $users = [
+            $this->getReference('User-john-root', User::class),
+            $this->getReference('User-john-admin', User::class),
+            $this->getReference('User-john-user', User::class),
+        ];
 
-        $configuration = (new Configuration())
-            ->setApplication($application)
-            ->setConfigurationKey('quiz.module.configuration')
-            ->setConfigurationValue(['shuffleQuestions' => true, 'timerSec' => 45])
-            ->setScope(ConfigurationScope::PLATFORM)
-            ->setPrivate(true);
-        $manager->persist($configuration);
+        $applications = [
+            $this->getReference('Application-shop-ops-center', Application::class),
+            $this->getReference('Application-crm-sales-hub', Application::class),
+            $this->getReference('Application-school-campus-core', Application::class),
+        ];
 
-        $quiz = (new Quiz())->setApplication($application)->setOwner($johnRoot)->setConfiguration($configuration);
-        $manager->persist($quiz);
+        foreach ($applications as $applicationIndex => $application) {
+            $configuration = (new Configuration())
+                ->setApplication($application)
+                ->setConfigurationKey('quiz.module.configuration')
+                ->setConfigurationValue([
+                    'shuffleQuestions' => true,
+                    'timerSec' => 30 + ($applicationIndex * 15),
+                    'showInstantCorrection' => $applicationIndex % 2 === 0,
+                ])
+                ->setScope(ConfigurationScope::PLATFORM)
+                ->setPrivate(true);
+            $manager->persist($configuration);
 
-        for ($i = 1; $i <= 8; ++$i) {
-            $question = (new QuizQuestion())
-                ->setQuiz($quiz)
-                ->setTitle('Question fixture #' . $i)
-                ->setLevel($i % 3 === 0 ? 'hard' : ($i % 2 === 0 ? 'medium' : 'easy'))
-                ->setCategory($i % 2 === 0 ? 'backend' : 'frontend');
-            $manager->persist($question);
+            $quiz = (new Quiz())
+                ->setApplication($application)
+                ->setOwner($users[$applicationIndex % count($users)])
+                ->setConfiguration($configuration);
+            $manager->persist($quiz);
 
-            $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Right answer ' . $i)->setCorrect(true));
-            $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer A ' . $i)->setCorrect(false));
-            $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer B ' . $i)->setCorrect(false));
+            for ($questionIndex = 1; $questionIndex <= 12; ++$questionIndex) {
+                $question = (new QuizQuestion())
+                    ->setQuiz($quiz)
+                    ->setTitle('Question fixture #' . $questionIndex . ' app #' . ($applicationIndex + 1))
+                    ->setLevel($questionIndex % 3 === 0 ? 'hard' : ($questionIndex % 2 === 0 ? 'medium' : 'easy'))
+                    ->setCategory($questionIndex % 2 === 0 ? 'backend' : 'frontend');
+                $manager->persist($question);
+
+                $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Right answer ' . $questionIndex)->setCorrect(true));
+                $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer A ' . $questionIndex)->setCorrect(false));
+                $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer B ' . $questionIndex)->setCorrect(false));
+                $manager->persist((new QuizAnswer())->setQuestion($question)->setLabel('Wrong answer C ' . $questionIndex)->setCorrect(false));
+            }
         }
 
         $manager->flush();

--- a/src/Quiz/Transport/Controller/Api/V1/QuizController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/QuizController.php
@@ -7,6 +7,7 @@ namespace App\Quiz\Transport\Controller\Api\V1;
 use App\Quiz\Application\Message\CreateQuizQuestionCommand;
 use App\Quiz\Application\Service\QuizReadService;
 use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -18,17 +19,23 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Quiz')]
 final readonly class QuizController
 {
     public function __construct(private MessageBusInterface $messageBus, private QuizReadService $quizReadService) {}
 
     #[Route('/v1/quiz/application/{applicationSlug}', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'shop-ops-center')]
+    #[OA\Response(response: 200, description: 'Quiz with questions and answers by application.', content: new OA\JsonContent(example: ['id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e90', 'applicationSlug' => 'shop-ops-center', 'questions' => [['title' => 'Question fixture #1', 'answers' => [['label' => 'Right answer 1', 'correct' => true]]]]]))]
     public function getByApplication(string $applicationSlug): JsonResponse
     {
         return new JsonResponse($this->quizReadService->getByApplicationSlug($applicationSlug));
     }
 
     #[Route('/v1/quiz/application/{applicationSlug}/questions', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'shop-ops-center')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['title' => 'What is Symfony Messenger?', 'level' => 'medium', 'category' => 'backend', 'answers' => [['label' => 'Message bus component', 'correct' => true], ['label' => 'Template engine', 'correct' => false]], 'configuration' => ['shuffleAnswers' => true, 'timeLimitSec' => 40]]))]
+    #[OA\Response(response: 202, description: 'Question creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createQuestion(string $applicationSlug, Request $request): JsonResponse
     {
         $user = $request->getUser();

--- a/src/School/Domain/Entity/School.php
+++ b/src/School/Domain/Entity/School.php
@@ -7,6 +7,7 @@ namespace App\School\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\Platform\Domain\Entity\Application as PlatformApplication;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -30,6 +31,10 @@ class School implements EntityInterface
     #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
     private string $name = '';
 
+    #[ORM\OneToOne(targetEntity: PlatformApplication::class)]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: false, unique: true, onDelete: 'CASCADE')]
+    private ?PlatformApplication $application = null;
+
     /** @var Collection<int, SchoolClass>|ArrayCollection<int, SchoolClass> */
     #[ORM\OneToMany(targetEntity: SchoolClass::class, mappedBy: 'school')]
     private Collection|ArrayCollection $classes;
@@ -44,6 +49,8 @@ class School implements EntityInterface
     public function getId(): string { return $this->id->toString(); }
     public function getName(): string { return $this->name; }
     public function setName(string $name): self { $this->name = $name; return $this; }
+    public function getApplication(): ?PlatformApplication { return $this->application; }
+    public function setApplication(?PlatformApplication $application): self { $this->application = $application; return $this; }
 
     /** @return Collection<int, SchoolClass>|ArrayCollection<int, SchoolClass> */
     public function getClasses(): Collection|ArrayCollection { return $this->classes; }

--- a/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
+++ b/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
@@ -33,7 +33,8 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
     {
         foreach ($this->getApplicationsByPlatform(PlatformKey::SCHOOL) as $application) {
             $school = (new School())
-                ->setName($application->getTitle() . ' Academy');
+                ->setName($application->getTitle() . ' Academy')
+                ->setApplication($application);
             $manager->persist($school);
 
             $classA = (new SchoolClass())->setSchool($school)->setName('Classe A - Sciences');

--- a/src/School/Infrastructure/Repository/SchoolRepository.php
+++ b/src/School/Infrastructure/Repository/SchoolRepository.php
@@ -24,4 +24,18 @@ class SchoolRepository extends BaseRepository
     public function __construct(protected ManagerRegistry $managerRegistry)
     {
     }
+
+    public function findOneByApplicationSlug(string $applicationSlug): ?Entity
+    {
+        $entity = $this->createQueryBuilder('module')
+            ->innerJoin('module.application', 'application')
+            ->addSelect('application')
+            ->where('application.slug = :applicationSlug')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $entity instanceof Entity ? $entity : null;
+    }
 }
+

--- a/src/School/Transport/Controller/Api/V1/SchoolController.php
+++ b/src/School/Transport/Controller/Api/V1/SchoolController.php
@@ -6,12 +6,15 @@ namespace App\School\Transport\Controller\Api\V1;
 
 use App\General\Application\Message\EntityCreated;
 use App\General\Application\Message\EntityDeleted;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PlatformKey;
 use App\School\Application\Service\ExamListService;
 use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\Grade;
 use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Student;
 use App\School\Domain\Entity\Teacher;
+use App\School\Domain\Entity\School;
 use App\School\Infrastructure\Repository\ExamRepository;
 use App\School\Infrastructure\Repository\GradeRepository;
 use App\School\Infrastructure\Repository\SchoolClassRepository;
@@ -21,13 +24,16 @@ use App\School\Infrastructure\Repository\TeacherRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'School')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class SchoolController
 {
@@ -240,4 +246,58 @@ final readonly class SchoolController
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }
+
+    #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'school-campus-core')]
+    #[OA\Response(response: 200, description: 'Classes list scoped to school application.')]
+    public function classesByApplication(string $applicationSlug): JsonResponse
+    {
+        $school = $this->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
+        $items = array_map(static fn (SchoolClass $class): array => ['id' => $class->getId(), 'name' => $class->getName()], $this->classRepository->findBy(['school' => $school], ['createdAt' => 'DESC'], 200));
+
+        return new JsonResponse(['applicationSlug' => $applicationSlug, 'schoolId' => $school->getId(), 'items' => $items]);
+    }
+
+    #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'school-campus-core')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['name' => 'Classe C - Informatique']))]
+    #[OA\Response(response: 201, description: 'Class created under school application.', content: new OA\JsonContent(example: ['id' => 'uuid', 'schoolId' => 'uuid', 'applicationSlug' => 'school-campus-core']))]
+    public function createClassByApplication(string $applicationSlug, Request $request): JsonResponse
+    {
+        $school = $this->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
+        $payload = (array) json_decode((string) $request->getContent(), true);
+
+        $class = (new SchoolClass())
+            ->setSchool($school)
+            ->setName((string) ($payload['name'] ?? ''));
+
+        $this->entityManager->persist($class);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('school_class', $class->getId(), context: ['applicationSlug' => $applicationSlug]));
+
+        return new JsonResponse(['id' => $class->getId(), 'schoolId' => $school->getId(), 'applicationSlug' => $applicationSlug], JsonResponse::HTTP_CREATED);
+    }
+
+    private function resolveOrCreateSchoolByApplicationSlug(string $applicationSlug): School
+    {
+        $school = $this->schoolRepository->findOneByApplicationSlug($applicationSlug);
+        if ($school instanceof School) {
+            return $school;
+        }
+
+        $application = $this->entityManager->getRepository(Application::class)->findOneBy(['slug' => $applicationSlug]);
+        if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== PlatformKey::SCHOOL) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicationSlug" for School platform.');
+        }
+
+        $school = (new School())
+            ->setApplication($application)
+            ->setName($application->getTitle() . ' Academy');
+
+        $this->entityManager->persist($school);
+        $this->entityManager->flush();
+
+        return $school;
+    }
+
 }

--- a/src/Shop/Domain/Entity/Shop.php
+++ b/src/Shop/Domain/Entity/Shop.php
@@ -7,6 +7,7 @@ namespace App\Shop\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\Platform\Domain\Entity\Application as PlatformApplication;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -30,6 +31,10 @@ class Shop implements EntityInterface
     #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
     private string $name = '';
 
+    #[ORM\OneToOne(targetEntity: PlatformApplication::class)]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: false, unique: true, onDelete: 'CASCADE')]
+    private ?PlatformApplication $application = null;
+
     /** @var Collection<int, Category>|ArrayCollection<int, Category> */
     #[ORM\OneToMany(targetEntity: Category::class, mappedBy: 'shop')]
     private Collection|ArrayCollection $categories;
@@ -50,6 +55,8 @@ class Shop implements EntityInterface
 
     public function getName(): string { return $this->name; }
     public function setName(string $name): self { $this->name = $name; return $this; }
+    public function getApplication(): ?PlatformApplication { return $this->application; }
+    public function setApplication(?PlatformApplication $application): self { $this->application = $application; return $this; }
 
     /** @return Collection<int, Category>|ArrayCollection<int, Category> */
     public function getCategories(): Collection|ArrayCollection { return $this->categories; }

--- a/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
+++ b/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
@@ -31,7 +31,8 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
     {
         foreach ($this->getApplicationsByPlatform(PlatformKey::SHOP) as $application) {
             $catalog = (new Shop())
-                ->setName($application->getTitle() . ' Catalog');
+                ->setName($application->getTitle() . ' Catalog')
+                ->setApplication($application);
             $manager->persist($catalog);
 
             $categories = [

--- a/src/Shop/Infrastructure/Repository/ShopRepository.php
+++ b/src/Shop/Infrastructure/Repository/ShopRepository.php
@@ -24,4 +24,18 @@ class ShopRepository extends BaseRepository
     public function __construct(protected ManagerRegistry $managerRegistry)
     {
     }
+
+    public function findOneByApplicationSlug(string $applicationSlug): ?Entity
+    {
+        $entity = $this->createQueryBuilder('module')
+            ->innerJoin('module.application', 'application')
+            ->addSelect('application')
+            ->where('application.slug = :applicationSlug')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $entity instanceof Entity ? $entity : null;
+    }
 }
+

--- a/src/Shop/Transport/Controller/Api/V1/ShopController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ShopController.php
@@ -6,10 +6,13 @@ namespace App\Shop\Transport\Controller\Api\V1;
 
 use App\General\Application\Message\EntityCreated;
 use App\General\Application\Message\EntityDeleted;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PlatformKey;
 use App\Shop\Application\Service\ProductListService;
 use App\Shop\Domain\Entity\Category;
 use App\Shop\Domain\Entity\Product;
 use App\Shop\Domain\Entity\Tag;
+use App\Shop\Domain\Entity\Shop;
 use App\Shop\Infrastructure\Repository\CategoryRepository;
 use App\Shop\Infrastructure\Repository\ProductRepository;
 use App\Shop\Infrastructure\Repository\ShopRepository;
@@ -17,13 +20,16 @@ use App\Shop\Infrastructure\Repository\TagRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Shop')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class ShopController
 {
@@ -159,4 +165,77 @@ final readonly class ShopController
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }
+
+    #[Route('/v1/shop/applications/{applicationSlug}/products', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'shop-ops-center')]
+    #[OA\Response(response: 200, description: 'Products list scoped to one application/shop.')]
+    public function productsByApplication(string $applicationSlug, Request $request): JsonResponse
+    {
+        $shop = $this->resolveOrCreateShopByApplicationSlug($applicationSlug);
+        $items = array_map(static fn (Product $product): array => [
+            'id' => $product->getId(),
+            'name' => $product->getName(),
+            'price' => $product->getPrice(),
+            'categoryId' => $product->getCategory()?->getId(),
+        ], $this->productRepository->findBy(['shop' => $shop], ['createdAt' => 'DESC'], max(1, min(200, $request->query->getInt('limit', 50)))));
+
+        return new JsonResponse(['applicationSlug' => $applicationSlug, 'shopId' => $shop->getId(), 'items' => $items]);
+    }
+
+    #[Route('/v1/shop/applications/{applicationSlug}/products', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'shop-ops-center')]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['name' => 'Clavier mecanique', 'price' => 129.9, 'categoryId' => null, 'tagIds' => []]))]
+    #[OA\Response(response: 201, description: 'Product created for the application shop.', content: new OA\JsonContent(example: ['id' => 'uuid', 'shopId' => 'uuid', 'applicationSlug' => 'shop-ops-center']))]
+    public function createProductByApplication(string $applicationSlug, Request $request): JsonResponse
+    {
+        $shop = $this->resolveOrCreateShopByApplicationSlug($applicationSlug);
+        $payload = (array) json_decode((string) $request->getContent(), true);
+
+        $product = (new Product())
+            ->setShop($shop)
+            ->setName((string) ($payload['name'] ?? ''))
+            ->setPrice((float) ($payload['price'] ?? 0));
+
+        if (is_string($payload['categoryId'] ?? null)) {
+            $category = $this->categoryRepository->find($payload['categoryId']);
+            if ($category instanceof Category && $category->getShop()?->getId() === $shop->getId()) {
+                $product->setCategory($category);
+            }
+        }
+
+        foreach ((array) ($payload['tagIds'] ?? []) as $tagId) {
+            if (is_string($tagId) && ($tag = $this->tagRepository->find($tagId)) instanceof Tag) {
+                $product->addTag($tag);
+            }
+        }
+
+        $this->entityManager->persist($product);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('shop_product', $product->getId(), context: ['applicationSlug' => $applicationSlug]));
+
+        return new JsonResponse(['id' => $product->getId(), 'shopId' => $shop->getId(), 'applicationSlug' => $applicationSlug], JsonResponse::HTTP_CREATED);
+    }
+
+    private function resolveOrCreateShopByApplicationSlug(string $applicationSlug): Shop
+    {
+        $shop = $this->shopRepository->findOneByApplicationSlug($applicationSlug);
+        if ($shop instanceof Shop) {
+            return $shop;
+        }
+
+        $application = $this->entityManager->getRepository(Application::class)->findOneBy(['slug' => $applicationSlug]);
+        if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== PlatformKey::SHOP) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicationSlug" for Shop platform.');
+        }
+
+        $shop = (new Shop())
+            ->setApplication($application)
+            ->setName($application->getTitle() . ' Catalog');
+
+        $this->entityManager->persist($shop);
+        $this->entityManager->flush();
+
+        return $shop;
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Provide per-application resource APIs so Shop, School and CRM data can be scoped to an `Application` and created-on-demand. 
- Allow lookups by `applicationSlug` and automatic creation of domain containers when missing to simplify multi-tenant seeding and client workflows. 
- Improve API documentation with OpenAPI attributes and realistic examples for mutation and read endpoints. 
- Enrich fixtures to produce multi-application sample data and more realistic posts/questions/comments/reactions for development and testing.

### Description
- Added a one-to-one `application` relation with accessor methods to `Shop` and `School` entities to associate those domain objects to `Application` instances. 
- Implemented `findOneByApplicationSlug` in `ShopRepository`, `SchoolRepository` and `CrmRepository` to query modules by linked application slug. 
- Added application-scoped endpoints and resolver helpers in `ShopController`, `SchoolController` and `CrmController` (routes under `/v1/.../applications/{applicationSlug}/...`) with `resolveOrCreate...ByApplicationSlug` logic that validates the `PlatformKey`, creates the module if absent, and throws `HttpException` for invalid slugs. 
- Enhanced multiple controllers (`BlogMutationController`, `BlogReadController`, `QuizController`, `ShopController`, `SchoolController`, `CrmController`) with `OpenApi\\Attributes` tags, parameters, request/response examples and additional routes for application-scoped operations. 
- Updated data fixtures (`LoadBlogData`, `LoadQuizData`, `LoadShopData`, `LoadSchoolData`) to generate richer sample data across several applications and users, including more posts, comments, reactions, quiz questions/answers and application-specific catalogs/classes. 
- Minor code cleanup: import `sprintf`, refactor loops and author selection in blog fixture, and small formatting adjustments.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adef20892c8326b1109b78e222ee61)