### PR TITLE
feat(notification): add notification module and v1 API

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -121,3 +121,12 @@ school-controllers:
     prefix: /api
     defaults:
         _format: json
+
+notification-controllers:
+    resource:
+        path: ../src/Notification/Transport/Controller/Api/
+        namespace: App\Notification\Transport\Controller\Api
+    type: attribute
+    prefix: /api
+    defaults:
+        _format: json

--- a/migrations/Version20260309150000.php
+++ b/migrations/Version20260309150000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260309150000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Create notification table linked to user sender and recipient.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('CREATE TABLE notification (id BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid_binary_ordered_time)\', from_id BINARY(16) DEFAULT NULL COMMENT \'(DC2Type:uuid_binary_ordered_time)\', recipient_id BINARY(16) NOT NULL COMMENT \'(DC2Type:uuid_binary_ordered_time)\', title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, type VARCHAR(100) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', updated_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', INDEX idx_notification_from_id (from_id), INDEX idx_notification_recipient_id (recipient_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE notification ADD CONSTRAINT fk_notification_from_id FOREIGN KEY (from_id) REFERENCES user (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE notification ADD CONSTRAINT fk_notification_recipient_id FOREIGN KEY (recipient_id) REFERENCES user (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            'Migration can only be executed safely on \'mysql\'.'
+        );
+
+        $this->addSql('ALTER TABLE notification DROP FOREIGN KEY fk_notification_from_id');
+        $this->addSql('ALTER TABLE notification DROP FOREIGN KEY fk_notification_recipient_id');
+        $this->addSql('DROP TABLE notification');
+    }
+}

--- a/src/Notification/Application/Service/NotificationReadService.php
+++ b/src/Notification/Application/Service/NotificationReadService.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\Service;
+
+use App\Notification\Domain\Entity\Notification;
+
+use function array_map;
+
+final readonly class NotificationReadService
+{
+    /** @param Notification[] $notifications */
+    public function normalizeList(array $notifications): array
+    {
+        return array_map(fn (Notification $notification): array => $this->normalize($notification), $notifications);
+    }
+
+    public function normalize(Notification $notification): array
+    {
+        $from = $notification->getFrom();
+
+        return [
+            'id' => $notification->getId(),
+            'title' => $notification->getTitle(),
+            'description' => $notification->getDescription(),
+            'type' => $notification->getType(),
+            'createdAt' => $notification->getCreatedAt()?->format(DATE_ATOM),
+            'from' => $from === null ? null : [
+                'firstName' => $from->getFirstName(),
+                'lastName' => $from->getLastName(),
+                'photo' => $from->getPhoto(),
+            ],
+        ];
+    }
+}

--- a/src/Notification/Domain/Entity/Notification.php
+++ b/src/Notification/Domain/Entity/Notification.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'notification')]
+class Notification implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
+    private string $title = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT)]
+    private string $description = '';
+
+    #[ORM\Column(name: 'type', type: Types::STRING, length: 100)]
+    private string $type = '';
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'from_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?User $from = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'recipient_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $recipient;
+
+    public function __construct() { $this->id = $this->createUuid(); }
+    #[Override] public function getId(): string { return $this->id->toString(); }
+    public function getTitle(): string { return $this->title; }
+    public function setTitle(string $title): self { $this->title = $title; return $this; }
+    public function getDescription(): string { return $this->description; }
+    public function setDescription(string $description): self { $this->description = $description; return $this; }
+    public function getType(): string { return $this->type; }
+    public function setType(string $type): self { $this->type = $type; return $this; }
+    public function getFrom(): ?User { return $this->from; }
+    public function setFrom(?User $from): self { $this->from = $from; return $this; }
+    public function getRecipient(): User { return $this->recipient; }
+    public function setRecipient(User $recipient): self { $this->recipient = $recipient; return $this; }
+}

--- a/src/Notification/Infrastructure/Repository/NotificationRepository.php
+++ b/src/Notification/Infrastructure/Repository/NotificationRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Notification\Domain\Entity\Notification;
+use App\User\Domain\Entity\User;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Notification|null find(string $id, $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ */
+class NotificationRepository extends BaseRepository
+{
+    protected static string $entityName = Notification::class;
+    protected static array $searchColumns = ['id', 'title', 'description', 'type'];
+
+    public function __construct(protected ManagerRegistry $managerRegistry) {}
+
+    /** @return Notification[] */
+    public function findByRecipient(User $user, int $limit = 50, int $offset = 0): array
+    {
+        $result = $this->createQueryBuilder('n')
+            ->andWhere('n.recipient = :recipient')
+            ->setParameter('recipient', $user)
+            ->orderBy('n.createdAt', 'DESC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return array_values(array_filter($result, static fn ($notification): bool => $notification instanceof Notification));
+    }
+}

--- a/src/Notification/Transport/Controller/Api/V1/NotificationController.php
+++ b/src/Notification/Transport/Controller/Api/V1/NotificationController.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Transport\Controller\Api\V1;
+
+use App\Notification\Application\Service\NotificationReadService;
+use App\Notification\Domain\Entity\Notification;
+use App\Notification\Infrastructure\Repository\NotificationRepository;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_string;
+use function trim;
+
+#[AsController]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Notification')]
+final readonly class NotificationController
+{
+    public function __construct(
+        private NotificationRepository $notificationRepository,
+        private UserRepository $userRepository,
+        private NotificationReadService $notificationReadService,
+    ) {}
+
+    #[Route('/v1/notifications', methods: [Request::METHOD_GET])]
+    public function list(Request $request, User $loggedInUser): JsonResponse
+    {
+        $limit = max(1, (int) $request->query->get('limit', 50));
+        $offset = max(0, (int) $request->query->get('offset', 0));
+
+        $notifications = $this->notificationRepository->findByRecipient($loggedInUser, $limit, $offset);
+
+        return new JsonResponse($this->notificationReadService->normalizeList($notifications));
+    }
+
+    #[Route('/v1/notifications/{id}', methods: [Request::METHOD_GET])]
+    public function detail(string $id, User $loggedInUser): JsonResponse
+    {
+        $notification = $this->notificationRepository->find($id);
+        if (!$notification instanceof Notification) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Notification not found.');
+        }
+
+        if ($notification->getRecipient()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot access this notification.');
+        }
+
+        return new JsonResponse($this->notificationReadService->normalize($notification));
+    }
+
+    #[Route('/v1/notifications', methods: [Request::METHOD_POST])]
+    public function create(Request $request): JsonResponse
+    {
+        $payload = $request->toArray();
+
+        $title = $payload['title'] ?? null;
+        $description = $payload['description'] ?? '';
+        $type = $payload['type'] ?? null;
+        $toId = $payload['toId'] ?? $payload['recipientId'] ?? null;
+        $fromId = $payload['fromId'] ?? null;
+
+        if (!is_string($title) || trim($title) === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "title" must be a non-empty string.');
+        }
+
+        if (!is_string($description)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "description" must be a string.');
+        }
+
+        if (!is_string($type) || trim($type) === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "type" must be a non-empty string.');
+        }
+
+        if (!is_string($toId) || trim($toId) === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "toId" (or "recipientId") is required and must be a non-empty string.');
+        }
+
+        $recipient = $this->userRepository->find($toId);
+        if (!$recipient instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Recipient user not found.');
+        }
+
+        $from = null;
+        if ($fromId !== null) {
+            if (!is_string($fromId) || trim($fromId) === '') {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "fromId" must be a non-empty string when provided.');
+            }
+
+            $from = $this->userRepository->find($fromId);
+            if (!$from instanceof User) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Sender user not found.');
+            }
+        }
+
+        $notification = (new Notification())
+            ->setTitle(trim($title))
+            ->setDescription(trim($description))
+            ->setType(trim($type))
+            ->setRecipient($recipient)
+            ->setFrom($from);
+
+        $this->notificationRepository->save($notification);
+
+        return new JsonResponse($this->notificationReadService->normalize($notification), JsonResponse::HTTP_CREATED);
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduire un module de notifications pour permettre l’envoi et la consultation de notifications liées à des utilisateurs avec les mêmes conventions que les modules existants (Blog/Quiz).
- Fournir des endpoints API sécurisés pour lister, consulter et créer des notifications destinées à un utilisateur authentifié.

### Description
- Ajout de l’entity `App\Notification\Domain\Entity\Notification` avec traits `Uuid` et `Timestampable` et champs `id`, `title`, `description`, `type`, `createdAt`, `updatedAt`, relation `from` nullable vers `App\User\Domain\Entity\User` et relation `recipient` non-null vers `User` (fichier `src/Notification/Domain/Entity/Notification.php`).
- Ajout du repository `NotificationRepository` (hérite de `BaseRepository`) avec la méthode `findByRecipient(User $user, int $limit = 50, int $offset = 0): array` triée par `createdAt` décroissant (fichier `src/Notification/Infrastructure/Repository/NotificationRepository.php`).
- Ajout du service de lecture/formatage `NotificationReadService` qui retourne la projection API attendue (`id`, `title`, `description`, `type`, `createdAt`, `from` minimal) (fichier `src/Notification/Application/Service/NotificationReadService.php`).
- Ajout du contrôleur API v1 `NotificationController` protégé par `#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]` avec endpoints `GET /v1/notifications`, `GET /v1/notifications/{id}` (ownership recipient vérifié) et `POST /v1/notifications` (validation du payload, résolution optionnelle de `fromId` et exigence de `toId`/`recipientId`) (fichier `src/Notification/Transport/Controller/Api/V1/NotificationController.php`).
- Ajout d’une migration Doctrine `migrations/Version20260309150000.php` qui crée la table `notification` avec FK `from_id` (nullable, ON DELETE SET NULL) et `recipient_id` (non-null, ON DELETE CASCADE).
- Enregistrement des routes du module dans `config/routes.yaml` sous la section `notification-controllers` avec préfixe `/api` et `_format: json`.

### Testing
- `php -l` a été exécuté sur les nouveaux fichiers `src/Notification/*` et sur la migration et n’a révélé aucune erreur de syntaxe.
- `php bin/console lint:yaml config/routes.yaml` n’a pas pu être exécuté dans cet environnement car les dépendances ne sont pas installées (message: `Dependencies are missing. Try running "composer install"`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae0952dfb08326977f6bdc8e88a226)