### PR TITLE
Add notification fixtures and extend OpenAPI documentation coverage

### DIFF
--- a/src/Media/Transport/Controller/Api/V1/MediaUploadController.php
+++ b/src/Media/Transport/Controller/Api/V1/MediaUploadController.php
@@ -40,14 +40,51 @@ class MediaUploadController
                 type: 'object',
                 properties: [
                     new OA\Property(property: 'file', type: 'string', format: 'binary'),
-                    new OA\Property(property: 'files', type: 'array', items: new OA\Items(type: 'string', format: 'binary')),
+                    new OA\Property(property: 'files[]', type: 'array', items: new OA\Items(type: 'string', format: 'binary')),
                 ],
             ),
         ),
     )]
-    #[OA\Response(response: 201, description: 'Fichiers uploadés')]
+    #[OA\Response(
+        response: 201,
+        description: 'Fichiers uploadés',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'files',
+                    type: 'array',
+                    items: new OA\Items(
+                        type: 'object',
+                        properties: [
+                            new OA\Property(property: 'url', type: 'string', example: '/uploads/media/3fa85f64.jpg'),
+                            new OA\Property(property: 'originalName', type: 'string', example: 'document.pdf'),
+                            new OA\Property(property: 'mimeType', type: 'string', example: 'application/pdf'),
+                            new OA\Property(property: 'size', type: 'integer', example: 24576),
+                        ],
+                    ),
+                ),
+            ],
+            example: [
+                'files' => [
+                    [
+                        'url' => '/uploads/media/photo-1.jpg',
+                        'originalName' => 'photo-1.jpg',
+                        'mimeType' => 'image/jpeg',
+                        'size' => 125631,
+                    ],
+                    [
+                        'url' => '/uploads/media/cv.pdf',
+                        'originalName' => 'cv.pdf',
+                        'mimeType' => 'application/pdf',
+                        'size' => 84521,
+                    ],
+                ],
+            ],
+        ),
+    )]
     #[OA\Response(response: 400, description: 'Aucun fichier ou fichier invalide. Stratégie all-or-nothing: si un fichier est invalide, aucun n\'est enregistré.')]
     #[OA\Response(response: 401, description: 'Authentication required')]
+    #[OA\Response(response: 403, description: 'Access denied')]
     public function __invoke(Request $request): JsonResponse
     {
         $files = $this->extractFiles($request);

--- a/src/Notification/Infrastructure/DataFixtures/ORM/LoadNotificationData.php
+++ b/src/Notification/Infrastructure/DataFixtures/ORM/LoadNotificationData.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Infrastructure\DataFixtures\ORM;
+
+use App\General\Domain\Rest\UuidHelper;
+use App\Notification\Domain\Entity\Notification;
+use App\Tests\Utils\PhpUnitUtil;
+use App\User\Domain\Entity\User;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+use Throwable;
+
+final class LoadNotificationData extends Fixture implements OrderedFixtureInterface
+{
+    /**
+     * @var array<int, array{uuid: non-empty-string, title: non-empty-string, description: non-empty-string, type: non-empty-string, recipientRef: non-empty-string, fromRef: non-empty-string|null}>
+     */
+    private const array DATA = [
+        [
+            'uuid' => '70000000-0000-1000-8000-000000000001',
+            'title' => 'System maintenance',
+            'description' => 'A maintenance window is planned for tonight.',
+            'type' => 'system',
+            'recipientRef' => 'User-john-user',
+            'fromRef' => null,
+        ],
+        [
+            'uuid' => '70000000-0000-1000-8000-000000000002',
+            'title' => 'Profile warning',
+            'description' => 'Your profile is missing a required document.',
+            'type' => 'warning',
+            'recipientRef' => 'User-john-admin',
+            'fromRef' => 'User-john-root',
+        ],
+        [
+            'uuid' => '70000000-0000-1000-8000-000000000003',
+            'title' => 'Welcome',
+            'description' => 'Welcome to the notification module.',
+            'type' => 'info',
+            'recipientRef' => 'User-john-root',
+            'fromRef' => 'User-john-admin',
+        ],
+    ];
+
+    /**
+     * @throws Throwable
+     */
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        foreach (self::DATA as $item) {
+            /** @var User $recipient */
+            $recipient = $this->getReference($item['recipientRef'], User::class);
+            /** @var User|null $from */
+            $from = $item['fromRef'] !== null ? $this->getReference($item['fromRef'], User::class) : null;
+
+            $notification = (new Notification())
+                ->setTitle($item['title'])
+                ->setDescription($item['description'])
+                ->setType($item['type'])
+                ->setRecipient($recipient)
+                ->setFrom($from);
+
+            PhpUnitUtil::setProperty('id', UuidHelper::fromString($item['uuid']), $notification);
+
+            $manager->persist($notification);
+            $this->addReference('Notification-' . $item['uuid'], $notification);
+        }
+
+        $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 4;
+    }
+}

--- a/src/Notification/Transport/Controller/Api/V1/NotificationController.php
+++ b/src/Notification/Transport/Controller/Api/V1/NotificationController.php
@@ -33,6 +33,66 @@ final readonly class NotificationController
     ) {}
 
     #[Route('/v1/notifications', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'List notifications for the logged-in user.')]
+    #[OA\Parameter(name: 'limit', in: 'query', required: false, description: 'Max number of items to return (default: 50).', schema: new OA\Schema(type: 'integer', minimum: 1, example: 20))]
+    #[OA\Parameter(name: 'offset', in: 'query', required: false, description: 'Pagination offset (default: 0).', schema: new OA\Schema(type: 'integer', minimum: 0, example: 0))]
+    #[OA\Response(
+        response: 200,
+        description: 'Notifications list.',
+        content: new OA\JsonContent(
+            type: 'array',
+            items: new OA\Items(
+                type: 'object',
+                properties: [
+                    new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                    new OA\Property(property: 'title', type: 'string', example: 'System maintenance'),
+                    new OA\Property(property: 'description', type: 'string', example: 'A maintenance window is planned for tonight.'),
+                    new OA\Property(property: 'type', type: 'string', example: 'system'),
+                    new OA\Property(property: 'createdAt', type: 'string', format: 'date-time'),
+                    new OA\Property(
+                        property: 'from',
+                        nullable: true,
+                        oneOf: [
+                            new OA\Schema(type: 'null', example: null),
+                            new OA\Schema(
+                                type: 'object',
+                                properties: [
+                                    new OA\Property(property: 'firstName', type: 'string', example: 'John'),
+                                    new OA\Property(property: 'lastName', type: 'string', example: 'Doe'),
+                                    new OA\Property(property: 'photo', type: 'string', nullable: true, example: '/uploads/profile/avatar.jpg'),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            example: [
+                [
+                    'id' => '70000000-0000-1000-8000-000000000001',
+                    'title' => 'System maintenance',
+                    'description' => 'A maintenance window is planned for tonight.',
+                    'type' => 'system',
+                    'createdAt' => '2026-03-10T10:00:00+00:00',
+                    'from' => null,
+                ],
+                [
+                    'id' => '70000000-0000-1000-8000-000000000002',
+                    'title' => 'Profile warning',
+                    'description' => 'Your profile is missing a required document.',
+                    'type' => 'warning',
+                    'createdAt' => '2026-03-10T10:05:00+00:00',
+                    'from' => [
+                        'firstName' => 'John',
+                        'lastName' => 'Doe',
+                        'photo' => '/uploads/profile/avatar.jpg',
+                    ],
+                ],
+            ],
+        ),
+    )]
+    #[OA\Response(response: 400, description: 'Invalid query parameters.')]
+    #[OA\Response(response: 401, description: 'Authentication required.')]
+    #[OA\Response(response: 403, description: 'Access denied.')]
     public function list(Request $request, User $loggedInUser): JsonResponse
     {
         $limit = max(1, (int) $request->query->get('limit', 50));
@@ -44,6 +104,12 @@ final readonly class NotificationController
     }
 
     #[Route('/v1/notifications/{id}', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Get a notification detail by id.')]
+    #[OA\Parameter(name: 'id', in: 'path', required: true, description: 'Notification UUID.', schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Response(response: 200, description: 'Notification detail.')]
+    #[OA\Response(response: 401, description: 'Authentication required.')]
+    #[OA\Response(response: 403, description: 'You cannot access this notification.')]
+    #[OA\Response(response: 404, description: 'Notification not found.')]
     public function detail(string $id, User $loggedInUser): JsonResponse
     {
         $notification = $this->notificationRepository->find($id);
@@ -59,6 +125,33 @@ final readonly class NotificationController
     }
 
     #[Route('/v1/notifications', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Create a notification.')]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['title', 'type', 'toId'],
+            properties: [
+                new OA\Property(property: 'title', type: 'string', example: 'System maintenance'),
+                new OA\Property(property: 'description', type: 'string', example: 'A maintenance window is planned for tonight.'),
+                new OA\Property(property: 'type', type: 'string', example: 'system'),
+                new OA\Property(property: 'toId', type: 'string', format: 'uuid', example: '20000000-0000-1000-8000-000000000004'),
+                new OA\Property(property: 'recipientId', type: 'string', format: 'uuid', nullable: true, example: null),
+                new OA\Property(property: 'fromId', type: 'string', format: 'uuid', nullable: true, example: '20000000-0000-1000-8000-000000000006'),
+            ],
+            example: [
+                'title' => 'Profile warning',
+                'description' => 'Your profile is missing a required document.',
+                'type' => 'warning',
+                'toId' => '20000000-0000-1000-8000-000000000005',
+                'fromId' => '20000000-0000-1000-8000-000000000006',
+            ],
+        ),
+    )]
+    #[OA\Response(response: 201, description: 'Notification created.')]
+    #[OA\Response(response: 400, description: 'Validation error or unknown users.')]
+    #[OA\Response(response: 401, description: 'Authentication required.')]
+    #[OA\Response(response: 403, description: 'Access denied.')]
+    #[OA\Response(response: 404, description: 'Related resource not found.')]
     public function create(Request $request): JsonResponse
     {
         $payload = $request->toArray();

--- a/tests/Application/Controller/DocumentationSnapshotTest.php
+++ b/tests/Application/Controller/DocumentationSnapshotTest.php
@@ -34,6 +34,9 @@ class DocumentationSnapshotTest extends WebTestCase
             '/v1/recruit/company' => ['get', 'post'],
             '/v1/calendar/private/events' => ['get', 'post'],
             '/v1/chat/private/messages/{messageId}' => ['patch', 'delete'],
+            '/v1/notifications' => ['get', 'post'],
+            '/v1/notifications/{id}' => ['get'],
+            '/v1/media/upload' => ['post'],
         ];
 
         foreach ($snapshot as $path => $methods) {


### PR DESCRIPTION
### Motivation
- Provide deterministic notification fixtures to allow integration and module tests to rely on known Notification entities and relationships to existing users.
- Improve OpenAPI documentation for notification endpoints and media upload so generated docs include query/path parameters, request bodies, response schemas and practical examples (including `from: null`).
- Ensure the documentation snapshot test covers newly documented API paths so documentation regressions are detected automatically.

### Description
- Added `src/Notification/Infrastructure/DataFixtures/ORM/LoadNotificationData.php` which creates three notifications with deterministic UUIDs and reuses `User-john-user`, `User-john-admin`, and `User-john-root`, covering `from = null`, populated `from`, and multiple types, and sets `getOrder()` to `4` so it runs after user fixtures.
- Enriched `src/Notification/Transport/Controller/Api/V1/NotificationController.php` with OpenAPI attributes for listing (`limit`, `offset`), detail (`id` path param) and create (`POST` request body), documented responses (200/201/400/401/403/404) and examples showing both `from: null` and a `from` object with `firstName`, `lastName`, `photo`.
- Updated `src/Media/Transport/Controller/Api/V1/MediaUploadController.php` OpenAPI annotations to explicitly document `multipart/form-data` fields `file` and `files[]` and added a 201 response schema and multi-file example.
- Extended `tests/Application/Controller/DocumentationSnapshotTest.php` to assert presence of `/v1/notifications`, `/v1/notifications/{id}`, and `/v1/media/upload` in the generated OpenAPI paths.

### Testing
- Ran PHP syntax checks with `php -l` on the modified files which returned no syntax errors.
- Attempted to run the documentation snapshot test with PHPUnit via `./vendor/bin/phpunit tests/Application/Controller/DocumentationSnapshotTest.php` but the PHPUnit binary was not available in this environment, so the PHPUnit run could not be executed.
- Attempted `php bin/phpunit tests/Application/Controller/DocumentationSnapshotTest.php` which also failed because the project PHPUnit entry was not present in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae0cd929b4832682376a86f5eb205d)