### PR TITLE
Add Notification API tests and clean up temp files in Media upload tests

### DIFF
--- a/tests/Application/Media/Transport/Controller/Api/V1/MediaUploadControllerTest.php
+++ b/tests/Application/Media/Transport/Controller/Api/V1/MediaUploadControllerTest.php
@@ -58,6 +58,10 @@ class MediaUploadControllerTest extends WebTestCase
         self::assertCount(1, $payload['files']);
 
         $this->assertValidUploadedMediaPayload($payload['files'][0]);
+
+        if (file_exists($tmpFile)) {
+            unlink($tmpFile);
+        }
     }
 
     /** @throws Throwable */
@@ -90,6 +94,12 @@ class MediaUploadControllerTest extends WebTestCase
         foreach ($payload['files'] as $item) {
             self::assertIsArray($item);
             $this->assertValidUploadedMediaPayload($item);
+        }
+
+        foreach ([$tmpPngA, $tmpPngB] as $tempFile) {
+            if (file_exists($tempFile)) {
+                unlink($tempFile);
+            }
         }
     }
 

--- a/tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php
+++ b/tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Notification\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Infrastructure\DataFixtures\ORM\LoadUserData;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+use function array_keys;
+
+class NotificationControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/notifications';
+
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/notifications` requires authentication.')]
+    public function testThatListRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', $this->baseUrl);
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
+    }
+
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/notifications` returns only notifications for the authenticated user.')]
+    public function testThatListReturnsOnlyCurrentUserNotifications(): void
+    {
+        $recipientId = LoadUserData::getUuidByKey('john-root');
+        $otherRecipientId = LoadUserData::getUuidByKey('john-admin');
+        $fromId = LoadUserData::getUuidByKey('john-user');
+
+        $rootNotification = $this->createNotification('root-visible', $recipientId, $fromId);
+        $otherUserNotification = $this->createNotification('admin-hidden', $otherRecipientId, $fromId);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', $this->baseUrl);
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload);
+
+        $notificationIds = array_column($payload, 'id');
+        self::assertContains($rootNotification['id'], $notificationIds);
+        self::assertNotContains($otherUserNotification['id'], $notificationIds);
+
+        $rootNotificationInList = null;
+        foreach ($payload as $item) {
+            if (($item['id'] ?? null) === $rootNotification['id']) {
+                $rootNotificationInList = $item;
+                break;
+            }
+        }
+
+        self::assertIsArray($rootNotificationInList);
+        self::assertArrayHasKey('from', $rootNotificationInList);
+        self::assertIsArray($rootNotificationInList['from']);
+        self::assertSame(['firstName', 'lastName', 'photo'], array_keys($rootNotificationInList['from']));
+    }
+
+    /** @throws Throwable */
+    #[TestDox('Test that `GET /v1/notifications/{id}` for another user notification is denied.')]
+    public function testThatDetailForOtherUserNotificationIsDenied(): void
+    {
+        $otherRecipientId = LoadUserData::getUuidByKey('john-admin');
+
+        $notification = $this->createNotification('other-user-detail', $otherRecipientId);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', $this->baseUrl . '/' . $notification['id']);
+
+        $response = $client->getResponse();
+        self::assertContains($response->getStatusCode(), [Response::HTTP_FORBIDDEN, Response::HTTP_NOT_FOUND], "Response:\n" . $response);
+    }
+
+    /** @throws Throwable */
+    #[TestDox('Test that `POST /v1/notifications` with valid payload returns 201 and normalized from fields only.')]
+    public function testThatCreateWithValidPayloadReturnsCreated(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            'POST',
+            $this->baseUrl,
+            [],
+            [],
+            [],
+            JSON::encode([
+                'title' => 'valid-notification',
+                'description' => 'description',
+                'type' => 'system',
+                'toId' => LoadUserData::getUuidByKey('john-root'),
+                'fromId' => LoadUserData::getUuidByKey('john-user'),
+            ])
+        );
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('id', $payload);
+        self::assertArrayHasKey('from', $payload);
+        self::assertIsArray($payload['from']);
+        self::assertSame(['firstName', 'lastName', 'photo'], array_keys($payload['from']));
+    }
+
+    /** @throws Throwable */
+    #[TestDox('Test that `POST /v1/notifications` with invalid payload returns 400.')]
+    public function testThatCreateWithInvalidPayloadReturnsBadRequest(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            'POST',
+            $this->baseUrl,
+            [],
+            [],
+            [],
+            JSON::encode([
+                'title' => '',
+                'type' => 'system',
+                'toId' => LoadUserData::getUuidByKey('john-root'),
+            ])
+        );
+
+        $response = $client->getResponse();
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @throws Throwable
+     */
+    private function createNotification(string $title, string $toId, ?string $fromId = null): array
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $payload = [
+            'title' => $title,
+            'description' => 'seed for tests',
+            'type' => 'system',
+            'toId' => $toId,
+        ];
+
+        if ($fromId !== null) {
+            $payload['fromId'] = $fromId;
+        }
+
+        $client->request('POST', $this->baseUrl, [], [], [], JSON::encode($payload));
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responsePayload = JSON::decode($content, true);
+        self::assertIsArray($responsePayload);
+
+        return $responsePayload;
+    }
+}


### PR DESCRIPTION
### Motivation
- Add API tests for Notification endpoints covering the requested minimal scenarios (auth, listing, detail access, create success/failure and `from` shape). 
- Ensure `MediaUploadControllerTest` does not leave temporary source files on disk after single and multiple upload tests.
- Keep tests compatible with the current test bootstrap which runs migrations and loads fixtures, relying on existing fixture UUIDs.

### Description
- Added `tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php` with tests for: GET list without auth (401), GET list with auth (200 + only recipient notifications), GET detail for another user (403/404 policy-compatible assertion), POST valid payload (201), POST invalid payload (400), and verification that `from` contains only `firstName`, `lastName`, `photo`.
- Updated `tests/Application/Media/Transport/Controller/Api/V1/MediaUploadControllerTest.php` to unlink the temporary source PNGs created for single and multiple upload tests after use, matching the existing cleanup pattern for uploaded files.
- Tests use fixture UUIDs from `LoadUserData` and create notifications via the API helper `createNotification` so they remain compatible with the existing `tests/bootstrap.php` migrations and fixtures.

### Testing
- Ran PHP syntax checks with `php -l tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php` which succeeded.
- Ran PHP syntax checks with `php -l tests/Application/Media/Transport/Controller/Api/V1/MediaUploadControllerTest.php` which succeeded.
- Ran PHP syntax check with `php -l tests/bootstrap.php` which succeeded.
- Attempted to run the tests via `vendor/bin/phpunit ...` but the environment lacks `vendor/bin/phpunit`, so the PHPUnit run could not be executed (failure due to missing binary).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae108d2da083268a24541f3f244b0d)