### PR TITLE
Notification: add read flag, unread count and mark-all-read endpoint

### DIFF
--- a/migrations/Version20260309161000.php
+++ b/migrations/Version20260309161000.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+// phpcs:ignoreFile
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260309161000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Add read flag to notification table.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+
+        $this->addSql('ALTER TABLE notification ADD is_read TINYINT(1) DEFAULT 0 NOT NULL');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform,
+            "Migration can only be executed safely on 'mysql'."
+        );
+
+        $this->addSql('ALTER TABLE notification DROP is_read');
+    }
+}

--- a/src/Notification/Application/Service/NotificationReadService.php
+++ b/src/Notification/Application/Service/NotificationReadService.php
@@ -25,6 +25,7 @@ final readonly class NotificationReadService
             'title' => $notification->getTitle(),
             'description' => $notification->getDescription(),
             'type' => $notification->getType(),
+            'read' => $notification->isRead(),
             'createdAt' => $notification->getCreatedAt()?->format(DATE_ATOM),
             'from' => $from === null ? null : [
                 'firstName' => $from->getFirstName(),

--- a/src/Notification/Domain/Entity/Notification.php
+++ b/src/Notification/Domain/Entity/Notification.php
@@ -34,6 +34,9 @@ class Notification implements EntityInterface
     #[ORM\Column(name: 'type', type: Types::STRING, length: 100)]
     private string $type = '';
 
+    #[ORM\Column(name: 'is_read', type: Types::BOOLEAN, options: ['default' => false])]
+    private bool $isRead = false;
+
     #[ORM\ManyToOne(targetEntity: User::class)]
     #[ORM\JoinColumn(name: 'from_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     private ?User $from = null;
@@ -50,6 +53,8 @@ class Notification implements EntityInterface
     public function setDescription(string $description): self { $this->description = $description; return $this; }
     public function getType(): string { return $this->type; }
     public function setType(string $type): self { $this->type = $type; return $this; }
+    public function isRead(): bool { return $this->isRead; }
+    public function setRead(bool $isRead): self { $this->isRead = $isRead; return $this; }
     public function getFrom(): ?User { return $this->from; }
     public function setFrom(?User $from): self { $this->from = $from; return $this; }
     public function getRecipient(): User { return $this->recipient; }

--- a/src/Notification/Infrastructure/DataFixtures/ORM/LoadNotificationData.php
+++ b/src/Notification/Infrastructure/DataFixtures/ORM/LoadNotificationData.php
@@ -17,7 +17,7 @@ use Throwable;
 final class LoadNotificationData extends Fixture implements OrderedFixtureInterface
 {
     /**
-     * @var array<int, array{uuid: non-empty-string, title: non-empty-string, description: non-empty-string, type: non-empty-string, recipientRef: non-empty-string, fromRef: non-empty-string|null}>
+     * @var array<int, array{uuid: non-empty-string, title: non-empty-string, description: non-empty-string, type: non-empty-string, recipientRef: non-empty-string, fromRef: non-empty-string|null, read: bool}>
      */
     private const array DATA = [
         [
@@ -27,6 +27,7 @@ final class LoadNotificationData extends Fixture implements OrderedFixtureInterf
             'type' => 'system',
             'recipientRef' => 'User-john-user',
             'fromRef' => null,
+            'read' => false,
         ],
         [
             'uuid' => '70000000-0000-1000-8000-000000000002',
@@ -35,6 +36,7 @@ final class LoadNotificationData extends Fixture implements OrderedFixtureInterf
             'type' => 'warning',
             'recipientRef' => 'User-john-admin',
             'fromRef' => 'User-john-root',
+            'read' => true,
         ],
         [
             'uuid' => '70000000-0000-1000-8000-000000000003',
@@ -43,7 +45,28 @@ final class LoadNotificationData extends Fixture implements OrderedFixtureInterf
             'type' => 'info',
             'recipientRef' => 'User-john-root',
             'fromRef' => 'User-john-admin',
+            'read' => false,
         ],
+
+        [
+            'uuid' => '70000000-0000-1000-8000-000000000004',
+            'title' => 'Team update',
+            'description' => 'A new update is available for your team.',
+            'type' => 'info',
+            'recipientRef' => 'User-john-root',
+            'fromRef' => 'User-john-user',
+            'read' => true,
+        ],
+        [
+            'uuid' => '70000000-0000-1000-8000-000000000005',
+            'title' => 'Security alert',
+            'description' => 'A login from a new device was detected.',
+            'type' => 'security',
+            'recipientRef' => 'User-john-root',
+            'fromRef' => null,
+            'read' => false,
+        ],
+
     ];
 
     /**
@@ -63,7 +86,8 @@ final class LoadNotificationData extends Fixture implements OrderedFixtureInterf
                 ->setDescription($item['description'])
                 ->setType($item['type'])
                 ->setRecipient($recipient)
-                ->setFrom($from);
+                ->setFrom($from)
+                ->setRead($item['read']);
 
             PhpUnitUtil::setProperty('id', UuidHelper::fromString($item['uuid']), $notification);
 

--- a/src/Notification/Infrastructure/Repository/NotificationRepository.php
+++ b/src/Notification/Infrastructure/Repository/NotificationRepository.php
@@ -34,4 +34,32 @@ class NotificationRepository extends BaseRepository
 
         return array_values(array_filter($result, static fn ($notification): bool => $notification instanceof Notification));
     }
+
+    public function countUnreadByRecipient(User $user): int
+    {
+        return (int) $this->createQueryBuilder('n')
+            ->select('COUNT(n.id)')
+            ->andWhere('n.recipient = :recipient')
+            ->andWhere('n.isRead = :isRead')
+            ->setParameter('recipient', $user->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->setParameter('isRead', false)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function markAllAsReadByRecipient(User $user): int
+    {
+        return $this->createQueryBuilder('n')
+            ->update()
+            ->set('n.isRead', ':isRead')
+            ->andWhere('n.recipient = :recipient')
+            ->andWhere('n.isRead = :currentState')
+            ->setParameter('isRead', true)
+            ->setParameter('currentState', false)
+            ->setParameter('recipient', $user->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->getQuery()
+            ->execute();
+    }
+
 }
+

--- a/src/Notification/Transport/Controller/Api/V1/NotificationController.php
+++ b/src/Notification/Transport/Controller/Api/V1/NotificationController.php
@@ -47,6 +47,7 @@ final readonly class NotificationController
                     new OA\Property(property: 'title', type: 'string', example: 'System maintenance'),
                     new OA\Property(property: 'description', type: 'string', example: 'A maintenance window is planned for tonight.'),
                     new OA\Property(property: 'type', type: 'string', example: 'system'),
+                    new OA\Property(property: 'read', type: 'boolean', example: false),
                     new OA\Property(property: 'createdAt', type: 'string', format: 'date-time'),
                     new OA\Property(
                         property: 'from',
@@ -72,6 +73,7 @@ final readonly class NotificationController
                     'title' => 'System maintenance',
                     'description' => 'A maintenance window is planned for tonight.',
                     'type' => 'system',
+                    'read' => false,
                     'createdAt' => '2026-03-10T10:00:00+00:00',
                     'from' => null,
                 ],
@@ -80,6 +82,7 @@ final readonly class NotificationController
                     'title' => 'Profile warning',
                     'description' => 'Your profile is missing a required document.',
                     'type' => 'warning',
+                    'read' => false,
                     'createdAt' => '2026-03-10T10:05:00+00:00',
                     'from' => [
                         'firstName' => 'John',
@@ -100,8 +103,33 @@ final readonly class NotificationController
 
         $notifications = $this->notificationRepository->findByRecipient($loggedInUser, $limit, $offset);
 
-        return new JsonResponse($this->notificationReadService->normalizeList($notifications));
+        return new JsonResponse([
+            'items' => $this->notificationReadService->normalizeList($notifications),
+            'unreadCount' => $this->notificationRepository->countUnreadByRecipient($loggedInUser),
+        ]);
     }
+
+    #[Route('/v1/notifications/read-all', methods: [Request::METHOD_PATCH])]
+    #[OA\Patch(summary: 'Mark all notifications as read for the logged-in user.')]
+    #[OA\Response(
+        response: 200,
+        description: 'Notifications updated.',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'updatedCount', type: 'integer', example: 3),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[OA\Response(response: 401, description: 'Authentication required.')]
+    #[OA\Response(response: 403, description: 'Access denied.')]
+    public function markAllAsRead(User $loggedInUser): JsonResponse
+    {
+        $updatedCount = $this->notificationRepository->markAllAsReadByRecipient($loggedInUser);
+
+        return new JsonResponse(['updatedCount' => $updatedCount]);
+    }
+
 
     #[Route('/v1/notifications/{id}', methods: [Request::METHOD_GET])]
     #[OA\Get(summary: 'Get a notification detail by id.')]

--- a/tests/Application/Controller/DocumentationSnapshotTest.php
+++ b/tests/Application/Controller/DocumentationSnapshotTest.php
@@ -35,6 +35,7 @@ class DocumentationSnapshotTest extends WebTestCase
             '/v1/calendar/private/events' => ['get', 'post'],
             '/v1/chat/private/messages/{messageId}' => ['patch', 'delete'],
             '/v1/notifications' => ['get', 'post'],
+            '/v1/notifications/read-all' => ['patch'],
             '/v1/notifications/{id}' => ['get'],
             '/v1/media/upload' => ['post'],
         ];

--- a/tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php
+++ b/tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php
@@ -49,13 +49,17 @@ class NotificationControllerTest extends WebTestCase
 
         $payload = JSON::decode($content, true);
         self::assertIsArray($payload);
+        self::assertArrayHasKey('items', $payload);
+        self::assertArrayHasKey('unreadCount', $payload);
+        self::assertIsArray($payload['items']);
+        self::assertIsInt($payload['unreadCount']);
 
-        $notificationIds = array_column($payload, 'id');
+        $notificationIds = array_column($payload['items'], 'id');
         self::assertContains($rootNotification['id'], $notificationIds);
         self::assertNotContains($otherUserNotification['id'], $notificationIds);
 
         $rootNotificationInList = null;
-        foreach ($payload as $item) {
+        foreach ($payload['items'] as $item) {
             if (($item['id'] ?? null) === $rootNotification['id']) {
                 $rootNotificationInList = $item;
                 break;
@@ -66,6 +70,8 @@ class NotificationControllerTest extends WebTestCase
         self::assertArrayHasKey('from', $rootNotificationInList);
         self::assertIsArray($rootNotificationInList['from']);
         self::assertSame(['firstName', 'lastName', 'photo'], array_keys($rootNotificationInList['from']));
+        self::assertArrayHasKey('read', $rootNotificationInList);
+        self::assertIsBool($rootNotificationInList['read']);
     }
 
     /** @throws Throwable */
@@ -81,6 +87,48 @@ class NotificationControllerTest extends WebTestCase
 
         $response = $client->getResponse();
         self::assertContains($response->getStatusCode(), [Response::HTTP_FORBIDDEN, Response::HTTP_NOT_FOUND], "Response:\n" . $response);
+    }
+
+
+
+    /** @throws Throwable */
+    #[TestDox('Test that `PATCH /v1/notifications/read-all` marks notifications as read for authenticated user only.')]
+    public function testThatMarkAllAsReadUpdatesOnlyCurrentUserNotifications(): void
+    {
+        $recipientId = LoadUserData::getUuidByKey('john-root');
+        $otherRecipientId = LoadUserData::getUuidByKey('john-admin');
+
+        $rootNotification = $this->createNotification('root-to-read', $recipientId);
+        $otherNotification = $this->createNotification('other-stays-unread', $otherRecipientId);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('PATCH', $this->baseUrl . '/read-all');
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:
+" . $response);
+
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('updatedCount', $payload);
+        self::assertGreaterThanOrEqual(1, $payload['updatedCount']);
+
+        $client->request('GET', $this->baseUrl . '/' . $rootNotification['id']);
+        $rootDetailContent = $client->getResponse()->getContent();
+        self::assertNotFalse($rootDetailContent);
+        $rootDetail = JSON::decode($rootDetailContent, true);
+        self::assertIsArray($rootDetail);
+        self::assertTrue($rootDetail['read']);
+
+        $adminClient = $this->getTestClient('john-admin', 'password-admin');
+        $adminClient->request('GET', $this->baseUrl . '/' . $otherNotification['id']);
+        $otherDetailContent = $adminClient->getResponse()->getContent();
+        self::assertNotFalse($otherDetailContent);
+        $otherDetail = JSON::decode($otherDetailContent, true);
+        self::assertIsArray($otherDetail);
+        self::assertFalse($otherDetail['read']);
     }
 
     /** @throws Throwable */
@@ -114,6 +162,8 @@ class NotificationControllerTest extends WebTestCase
         self::assertArrayHasKey('from', $payload);
         self::assertIsArray($payload['from']);
         self::assertSame(['firstName', 'lastName', 'photo'], array_keys($payload['from']));
+        self::assertArrayHasKey('read', $payload);
+        self::assertFalse($payload['read']);
     }
 
     /** @throws Throwable */


### PR DESCRIPTION
### Motivation

- Persist a per-notification read status and expose it in API responses so clients can show read/unread state. 
- Provide an efficient way to count unread items and to mark all notifications as read for the authenticated user. 
- Add realistic fixtures to cover read/unread scenarios and update API docs/tests for the new behaviour.

### Description

- Add a persistent `is_read` boolean column and `isRead`/`setRead` methods on the `Notification` entity (`src/Notification/Domain/Entity/Notification.php`).
- Return `read` in normalized notification payloads via `NotificationReadService` (`src/Notification/Application/Service/NotificationReadService.php`).
- Add repository methods `countUnreadByRecipient` and `markAllAsReadByRecipient` on `NotificationRepository` (`src/Notification/Infrastructure/Repository/NotificationRepository.php`).
- Change `GET /v1/notifications` to return an object with `items` and `unreadCount`, and add `PATCH /v1/notifications/read-all` to mark all notifications as read (`src/Notification/Transport/Controller/Api/V1/NotificationController.php`).
- Extend notification fixtures with a `read` value and add extra fixture records (`src/Notification/Infrastructure/DataFixtures/ORM/LoadNotificationData.php`).
- Add a migration to add the `is_read` column (`migrations/Version20260309161000.php`).
- Update API documentation snapshot and controller tests to cover the new response shape and the mark-all-read behaviour (`tests/Application/Controller/DocumentationSnapshotTest.php`, `tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php`).

### Testing

- Ran PHP linting on modified files with `php -l` and all updated PHP files passed lint checks. 
- Ran `php -l migrations/Version20260309161000.php` and the migration file passed syntax check. 
- Attempted to run unit/integration tests with `./vendor/bin/phpunit tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php --testdox` but `./vendor/bin/phpunit` is not available in this environment so the PHPUnit suite was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae171decac8326b26d3f59f8bc3135)