### PR TITLE
Enhance general blog fixtures (40 posts, nested comments & reactions) and include author details in blog tree

### DIFF
--- a/src/Blog/Application/Service/BlogReadService.php
+++ b/src/Blog/Application/Service/BlogReadService.php
@@ -8,6 +8,7 @@ use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Infrastructure\Repository\BlogRepository;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\User\Domain\Entity\User;
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -50,6 +51,7 @@ final readonly class BlogReadService
             'posts' => array_map(fn ($p): array => [
                 'id' => $p->getId(),
                 'authorId' => $p->getAuthor()->getId(),
+                'author' => $this->normalizeAuthor($p->getAuthor()),
                 'content' => $p->getContent(),
                 'filePath' => $p->getFilePath(),
                 'comments' => $this->normalizeComments($p->getComments()->toArray(), null),
@@ -66,11 +68,26 @@ final readonly class BlogReadService
             return [
                 'id' => $comment->getId(),
                 'authorId' => $comment->getAuthor()->getId(),
+                'author' => $this->normalizeAuthor($comment->getAuthor()),
                 'content' => $comment->getContent(),
                 'filePath' => $comment->getFilePath(),
-                'reactions' => array_map(static fn ($r): array => ['id' => $r->getId(), 'authorId' => $r->getAuthor()->getId(), 'type' => $r->getType()], $comment->getReactions()->toArray()),
+                'reactions' => array_map(fn ($r): array => [
+                    'id' => $r->getId(),
+                    'authorId' => $r->getAuthor()->getId(),
+                    'author' => $this->normalizeAuthor($r->getAuthor()),
+                    'type' => $r->getType(),
+                ], $comment->getReactions()->toArray()),
                 'children' => $this->normalizeComments($comments, $comment->getId()),
             ];
         }, array_values($filtered));
+    }
+
+    private function normalizeAuthor(User $author): array
+    {
+        return [
+            'firstName' => $author->getFirstName(),
+            'lastName' => $author->getLastName(),
+            'photo' => $author->getPhoto(),
+        ];
     }
 }

--- a/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
+++ b/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
@@ -56,7 +56,9 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
         $reactionTypes = ['like', 'heart', 'laugh'];
 
         foreach ($blogs as $blogIndex => $blog) {
-            for ($postIndex = 1; $postIndex <= 6; ++$postIndex) {
+            $postCount = $blog->getType() === BlogType::GENERAL ? 40 : 6;
+
+            for ($postIndex = 1; $postIndex <= $postCount; ++$postIndex) {
                 $author = $authors[($blogIndex + $postIndex) % count($authors)];
 
                 $post = (new BlogPost())
@@ -80,8 +82,14 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
                     ->setAuthor($authors[($blogIndex + $postIndex + 1) % count($authors)])
                     ->setContent('Child comment #' . $postIndex)
                     ->setParent($parent);
+                $subChild = (new BlogComment())
+                    ->setPost($post)
+                    ->setAuthor($authors[($blogIndex + $postIndex + 2) % count($authors)])
+                    ->setContent('Sub child comment #' . $postIndex)
+                    ->setParent($child);
                 $manager->persist($parent);
                 $manager->persist($child);
+                $manager->persist($subChild);
 
                 $manager->persist((new BlogReaction())
                     ->setComment($parent)
@@ -91,6 +99,10 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
                     ->setComment($child)
                     ->setAuthor($authors[($blogIndex + 2) % count($authors)])
                     ->setType($reactionTypes[($blogIndex + $postIndex + 1) % count($reactionTypes)]));
+                $manager->persist((new BlogReaction())
+                    ->setComment($subChild)
+                    ->setAuthor($authors[($blogIndex + $postIndex + 2) % count($authors)])
+                    ->setType($reactionTypes[($blogIndex + $postIndex + 2) % count($reactionTypes)]));
             }
         }
 

--- a/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
@@ -28,10 +28,16 @@ final readonly class BlogReadController
             'posts' => [[
                 'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e71',
                 'content' => 'Fixture post 1 for General Blog Root',
+                'author' => ['firstName' => 'John', 'lastName' => 'Root', 'photo' => 'https://...'],
                 'comments' => [[
                     'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e72',
                     'content' => 'Parent comment #1',
-                    'reactions' => [['type' => 'like', 'authorId' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e73']],
+                    'author' => ['firstName' => 'John', 'lastName' => 'Admin', 'photo' => 'https://...'],
+                    'reactions' => [[
+                        'type' => 'like',
+                        'authorId' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e73',
+                        'author' => ['firstName' => 'John', 'lastName' => 'User', 'photo' => 'https://...'],
+                    ]],
                 ]],
             ]],
         ]),


### PR DESCRIPTION
### Motivation
- Augmenter les fixtures du blog général pour générer beaucoup de posts (40) avec commentaires imbriqués et réactions afin d'obtenir des jeux de données réalistes pour le front et les tests.
- Retourner, dans l'API de lecture du blog, les informations d'auteur (`firstName`, `lastName`, `photo`) pour les posts, commentaires et réactions afin de simplifier l'affichage côté client.

### Description
- Modified `src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php` to generate `40` posts for `BlogType::GENERAL`, keep application blogs at `6`, and add nested comments (parent → child → sub-child) with reactions at each level.
- Updated `src/Blog/Application/Service/BlogReadService.php` to include an `author` object (`firstName`, `lastName`, `photo`) alongside existing `authorId` for posts, comments and reactions, and added a private `normalizeAuthor()` helper.
- Updated the OpenAPI example in `src/Blog/Transport/Controller/Api/V1/BlogReadController.php` to reflect the enriched response shape including `author` objects.
- Preserved existing `authorId` fields for backward compatibility while adding the richer `author` payload.

### Testing
- Ran PHP lint checks: `php -l src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php` and `php -l src/Blog/Application/Service/BlogReadService.php` and `php -l src/Blog/Transport/Controller/Api/V1/BlogReadController.php`, all reporting no syntax errors.
- Committed changes and created the PR after successful lint validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae1a4188808326bc9240c7beec49b6)