### PR TITLE
Add ownership flags for posts/comments/reactions in blog listing

### DIFF
--- a/src/Blog/Application/Service/BlogReadService.php
+++ b/src/Blog/Application/Service/BlogReadService.php
@@ -18,28 +18,32 @@ final readonly class BlogReadService
     public function __construct(private BlogRepository $blogRepository, private CacheInterface $cache, private ElasticsearchServiceInterface $elasticsearchService) {}
 
     /** @throws InvalidArgumentException */
-    public function getGeneralBlogWithTree(): array
+    public function getGeneralBlogWithTree(?User $currentUser = null): array
     {
-        return $this->cache->get('blog_general_tree', function (ItemInterface $item): array {
+        $userId = $currentUser?->getId() ?? 'anonymous';
+
+        return $this->cache->get('blog_general_tree_' . $userId, function (ItemInterface $item) use ($currentUser): array {
             $item->expiresAfter(120);
             $blog = $this->blogRepository->findGeneralBlog();
 
-            return $blog instanceof Blog ? $this->normalizeBlog($blog) : [];
+            return $blog instanceof Blog ? $this->normalizeBlog($blog, $currentUser) : [];
         });
     }
 
     /** @throws InvalidArgumentException */
-    public function getByApplicationSlug(string $applicationSlug): array
+    public function getByApplicationSlug(string $applicationSlug, ?User $currentUser = null): array
     {
-        return $this->cache->get('blog_app_' . $applicationSlug, function (ItemInterface $item) use ($applicationSlug): array {
+        $userId = $currentUser?->getId() ?? 'anonymous';
+
+        return $this->cache->get('blog_app_' . $applicationSlug . '_' . $userId, function (ItemInterface $item) use ($applicationSlug, $currentUser): array {
             $item->expiresAfter(120);
             $blog = $this->blogRepository->findOneByApplicationSlug($applicationSlug);
 
-            return $blog instanceof Blog ? $this->normalizeBlog($blog) : [];
+            return $blog instanceof Blog ? $this->normalizeBlog($blog, $currentUser) : [];
         });
     }
 
-    private function normalizeBlog(Blog $blog): array
+    private function normalizeBlog(Blog $blog, ?User $currentUser): array
     {
         return [
             'id' => $blog->getId(),
@@ -51,35 +55,43 @@ final readonly class BlogReadService
             'posts' => array_map(fn ($p): array => [
                 'id' => $p->getId(),
                 'authorId' => $p->getAuthor()->getId(),
+                'isAuthor' => $this->isAuthor($p->getAuthor(), $currentUser),
                 'author' => $this->normalizeAuthor($p->getAuthor()),
                 'content' => $p->getContent(),
                 'filePath' => $p->getFilePath(),
-                'comments' => $this->normalizeComments($p->getComments()->toArray(), null),
+                'comments' => $this->normalizeComments($p->getComments()->toArray(), null, $currentUser),
             ], $blog->getPosts()->toArray()),
         ];
     }
 
     /** @param array<int, BlogComment> $comments */
-    private function normalizeComments(array $comments, ?string $parentId): array
+    private function normalizeComments(array $comments, ?string $parentId, ?User $currentUser): array
     {
         $filtered = array_filter($comments, static fn (BlogComment $comment): bool => $comment->getParent()?->getId() === $parentId);
 
-        return array_map(function (BlogComment $comment) use ($comments): array {
+        return array_map(function (BlogComment $comment) use ($comments, $currentUser): array {
             return [
                 'id' => $comment->getId(),
                 'authorId' => $comment->getAuthor()->getId(),
+                'isAuthor' => $this->isAuthor($comment->getAuthor(), $currentUser),
                 'author' => $this->normalizeAuthor($comment->getAuthor()),
                 'content' => $comment->getContent(),
                 'filePath' => $comment->getFilePath(),
                 'reactions' => array_map(fn ($r): array => [
                     'id' => $r->getId(),
                     'authorId' => $r->getAuthor()->getId(),
+                    'isAuthor' => $this->isAuthor($r->getAuthor(), $currentUser),
                     'author' => $this->normalizeAuthor($r->getAuthor()),
                     'type' => $r->getType(),
                 ], $comment->getReactions()->toArray()),
-                'children' => $this->normalizeComments($comments, $comment->getId()),
+                'children' => $this->normalizeComments($comments, $comment->getId(), $currentUser),
             ];
         }, array_values($filtered));
+    }
+
+    private function isAuthor(User $author, ?User $currentUser): bool
+    {
+        return null !== $currentUser && $author->getId() === $currentUser->getId();
     }
 
     private function normalizeAuthor(User $author): array

--- a/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Api\V1;
 
 use App\Blog\Application\Service\BlogReadService;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,24 +28,29 @@ final readonly class BlogReadController
             'type' => 'general',
             'posts' => [[
                 'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e71',
+                'isAuthor' => true,
                 'content' => 'Fixture post 1 for General Blog Root',
                 'author' => ['firstName' => 'John', 'lastName' => 'Root', 'photo' => 'https://...'],
                 'comments' => [[
                     'id' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e72',
+                    'isAuthor' => false,
                     'content' => 'Parent comment #1',
                     'author' => ['firstName' => 'John', 'lastName' => 'Admin', 'photo' => 'https://...'],
                     'reactions' => [[
                         'type' => 'like',
                         'authorId' => '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e73',
+                        'isAuthor' => false,
                         'author' => ['firstName' => 'John', 'lastName' => 'User', 'photo' => 'https://...'],
                     ]],
                 ]],
             ]],
         ]),
     )]
-    public function general(): JsonResponse
+    public function general(Request $request): JsonResponse
     {
-        return new JsonResponse($this->blogReadService->getGeneralBlogWithTree());
+        $user = $this->getCurrentUserFromRequest($request);
+
+        return new JsonResponse($this->blogReadService->getGeneralBlogWithTree($user));
     }
 
     #[Route('/v1/blogs/application/{applicationSlug}', methods: [Request::METHOD_GET])]
@@ -62,8 +68,17 @@ final readonly class BlogReadController
             'tags' => [['label' => 'tag-2-1']],
         ]),
     )]
-    public function byApplication(string $applicationSlug): JsonResponse
+    public function byApplication(string $applicationSlug, Request $request): JsonResponse
     {
-        return new JsonResponse($this->blogReadService->getByApplicationSlug($applicationSlug));
+        $user = $this->getCurrentUserFromRequest($request);
+
+        return new JsonResponse($this->blogReadService->getByApplicationSlug($applicationSlug, $user));
+    }
+
+    private function getCurrentUserFromRequest(Request $request): ?User
+    {
+        $user = $request->getUser();
+
+        return $user instanceof User ? $user : null;
     }
 }


### PR DESCRIPTION
## Summary
- pass current authenticated user (if any) from `BlogReadController` to `BlogReadService`
- enrich `/v1/blogs/general` and `/v1/blogs/application/{applicationSlug}` payloads with `isAuthor` booleans for:
  - each post
  - each comment
  - each comment reaction
- split cache keys by user id (or `anonymous`) so ownership flags are not mixed across users
- update OpenAPI example for the general blog endpoint to include new `isAuthor` fields

## Notes
- no runtime tests were executed in this environment

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae2bff463883268c4e0ed4cbc7b5e7)