### PR TITLE
Add Elasticsearch reindex commands and 30-minute scheduled job for blogs, crms, shops, platforms and notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,7 @@ migrate-cron-jobs: ## Creates cron job tasks (cleanup logs, failed old messenger
 	@make exec cmd="php bin/console scheduler:cleanup-logs"
 	@make exec cmd="php bin/console scheduler:cleanup-messenger-messages"
 	@make exec cmd="php bin/console scheduler:recruit-index-similar-jobs"
+	@make exec cmd="php bin/console scheduler:elastic-reindex-domains"
 
 fixtures: ## Runs all fixtures for test database without --append option (tables will be dropped and recreated)
 	@make exec cmd="php bin/console doctrine:fixtures:load --env=test --no-interaction"

--- a/src/Blog/Application/Projection/BlogProjection.php
+++ b/src/Blog/Application/Projection/BlogProjection.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Projection;
+
+final class BlogProjection
+{
+    public const string INDEX_NAME = 'blogs';
+}
+

--- a/src/Notification/Application/Projection/NotificationProjection.php
+++ b/src/Notification/Application/Projection/NotificationProjection.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\Projection;
+
+final class NotificationProjection
+{
+    public const string INDEX_NAME = 'notifications';
+}
+

--- a/src/Tool/Transport/Command/Elastic/ReindexAllDomainsCommand.php
+++ b/src/Tool/Transport/Command/Elastic/ReindexAllDomainsCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Command\Elastic;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Index blogs, CRMs, shops, platforms and notifications in Elasticsearch.',
+)]
+final class ReindexAllDomainsCommand extends Command
+{
+    final public const string NAME = 'elastic:reindex:all-domains';
+
+    public function __construct(
+        private readonly ReindexBlogsCommand $reindexBlogsCommand,
+        private readonly ReindexCrmTasksCommand $reindexCrmTasksCommand,
+        private readonly ReindexShopProductsCommand $reindexShopProductsCommand,
+        private readonly ReindexPlatformsCommand $reindexPlatformsCommand,
+        private readonly ReindexNotificationsCommand $reindexNotificationsCommand,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->reindexBlogsCommand->run($input, $output);
+        $this->reindexCrmTasksCommand->run($input, $output);
+        $this->reindexShopProductsCommand->run($input, $output);
+        $this->reindexPlatformsCommand->run($input, $output);
+        $this->reindexNotificationsCommand->run($input, $output);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Tool/Transport/Command/Elastic/ReindexBlogsCommand.php
+++ b/src/Tool/Transport/Command/Elastic/ReindexBlogsCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Command\Elastic;
+
+use App\Blog\Application\Projection\BlogProjection;
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function array_map;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Index blogs in Elasticsearch.',
+)]
+final class ReindexBlogsCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'elastic:reindex:blogs';
+
+    public function __construct(
+        private readonly BlogRepository $blogRepository,
+        private readonly ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $indexed = 0;
+
+        /** @var Blog $blog */
+        foreach ($this->blogRepository->findBy([], ['createdAt' => 'DESC']) as $blog) {
+            $this->elasticsearchService->index(BlogProjection::INDEX_NAME, $blog->getId(), [
+                'id' => $blog->getId(),
+                'title' => $blog->getTitle(),
+                'type' => $blog->getType()->value,
+                'postStatus' => $blog->getPostStatus()->value,
+                'commentStatus' => $blog->getCommentStatus()->value,
+                'applicationSlug' => $blog->getApplication()?->getSlug(),
+                'ownerId' => $blog->getOwner()->getId(),
+                'postsCount' => $blog->getPosts()->count(),
+                'postContents' => array_map(
+                    static fn ($post): string => (string) $post->getContent(),
+                    $blog->getPosts()->toArray(),
+                ),
+                'updatedAt' => $blog->getUpdatedAt()?->format(DATE_ATOM),
+            ]);
+            ++$indexed;
+        }
+
+        if ($input->isInteractive()) {
+            $this->getSymfonyStyle($input, $output)->success('Blogs indexed: ' . $indexed);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Tool/Transport/Command/Elastic/ReindexCrmTasksCommand.php
+++ b/src/Tool/Transport/Command/Elastic/ReindexCrmTasksCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Command\Elastic;
+
+use App\Crm\Application\Projection\CrmTaskProjection;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function array_map;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Index CRM tasks in Elasticsearch.',
+)]
+final class ReindexCrmTasksCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'elastic:reindex:crms';
+
+    public function __construct(
+        private readonly TaskRepository $taskRepository,
+        private readonly ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $indexed = 0;
+
+        /** @var Task $task */
+        foreach ($this->taskRepository->findBy([], ['createdAt' => 'DESC']) as $task) {
+            $this->elasticsearchService->index(CrmTaskProjection::INDEX_NAME, $task->getId(), [
+                'id' => $task->getId(),
+                'title' => $task->getTitle(),
+                'projectName' => $task->getProject()?->getName() ?? '',
+                'sprintName' => $task->getSprint()?->getName() ?? '',
+                'taskRequests' => array_map(static fn ($request): string => $request->getTitle(), $task->getTaskRequests()->toArray()),
+                'updatedAt' => $task->getUpdatedAt()?->format(DATE_ATOM),
+            ]);
+            ++$indexed;
+        }
+
+        if ($input->isInteractive()) {
+            $this->getSymfonyStyle($input, $output)->success('CRM tasks indexed: ' . $indexed);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Tool/Transport/Command/Elastic/ReindexNotificationsCommand.php
+++ b/src/Tool/Transport/Command/Elastic/ReindexNotificationsCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Command\Elastic;
+
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Notification\Application\Projection\NotificationProjection;
+use App\Notification\Domain\Entity\Notification;
+use App\Notification\Infrastructure\Repository\NotificationRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Index notifications in Elasticsearch.',
+)]
+final class ReindexNotificationsCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'elastic:reindex:notifications';
+
+    public function __construct(
+        private readonly NotificationRepository $notificationRepository,
+        private readonly ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $indexed = 0;
+
+        /** @var Notification $notification */
+        foreach ($this->notificationRepository->findBy([], ['createdAt' => 'DESC']) as $notification) {
+            $this->elasticsearchService->index(NotificationProjection::INDEX_NAME, $notification->getId(), [
+                'id' => $notification->getId(),
+                'title' => $notification->getTitle(),
+                'description' => $notification->getDescription(),
+                'type' => $notification->getType(),
+                'read' => $notification->isRead(),
+                'recipientId' => $notification->getRecipient()->getId(),
+                'fromId' => $notification->getFrom()?->getId(),
+                'updatedAt' => $notification->getUpdatedAt()?->format(DATE_ATOM),
+            ]);
+            ++$indexed;
+        }
+
+        if ($input->isInteractive()) {
+            $this->getSymfonyStyle($input, $output)->success('Notifications indexed: ' . $indexed);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Tool/Transport/Command/Elastic/ReindexPlatformsCommand.php
+++ b/src/Tool/Transport/Command/Elastic/ReindexPlatformsCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Command\Elastic;
+
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Platform\Application\Projection\ApplicationProjection;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Infrastructure\Repository\ApplicationRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Index platform applications in Elasticsearch.',
+)]
+final class ReindexPlatformsCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'elastic:reindex:platforms';
+
+    public function __construct(
+        private readonly ApplicationRepository $applicationRepository,
+        private readonly ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $indexed = 0;
+
+        /** @var Application $application */
+        foreach ($this->applicationRepository->findBy([], ['createdAt' => 'DESC']) as $application) {
+            $this->elasticsearchService->index(ApplicationProjection::INDEX_NAME, $application->getId(), [
+                'id' => $application->getId(),
+                'title' => $application->getTitle(),
+                'description' => $application->getDescription(),
+                'slug' => $application->getSlug(),
+                'platformName' => $application->getPlatform()?->getName() ?? '',
+                'platformKey' => $application->getPlatform()?->getPlatformKeyValue() ?? '',
+                'status' => $application->getStatus()->value,
+                'private' => $application->isPrivate(),
+                'updatedAt' => $application->getUpdatedAt()?->format(DATE_ATOM),
+            ]);
+            ++$indexed;
+        }
+
+        if ($input->isInteractive()) {
+            $this->getSymfonyStyle($input, $output)->success('Platform applications indexed: ' . $indexed);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Tool/Transport/Command/Elastic/ReindexShopProductsCommand.php
+++ b/src/Tool/Transport/Command/Elastic/ReindexShopProductsCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Command\Elastic;
+
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Shop\Application\Projection\ShopProductProjection;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function array_map;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Index shop products in Elasticsearch.',
+)]
+final class ReindexShopProductsCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'elastic:reindex:shops';
+
+    public function __construct(
+        private readonly ProductRepository $productRepository,
+        private readonly ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $indexed = 0;
+
+        /** @var Product $product */
+        foreach ($this->productRepository->findBy([], ['createdAt' => 'DESC']) as $product) {
+            $this->elasticsearchService->index(ShopProductProjection::INDEX_NAME, $product->getId(), [
+                'id' => $product->getId(),
+                'name' => $product->getName(),
+                'price' => $product->getPrice(),
+                'categoryId' => $product->getCategory()?->getId(),
+                'categoryName' => $product->getCategory()?->getName() ?? '',
+                'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $product->getTags()->toArray()),
+                'updatedAt' => $product->getUpdatedAt()?->format(DATE_ATOM),
+            ]);
+            ++$indexed;
+        }
+
+        if ($input->isInteractive()) {
+            $this->getSymfonyStyle($input, $output)->success('Shop products indexed: ' . $indexed);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Tool/Transport/Command/Scheduler/ReindexElasticDomainsScheduledCommand.php
+++ b/src/Tool/Transport/Command/Scheduler/ReindexElasticDomainsScheduledCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Command\Scheduler;
+
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Tool\Application\Service\Scheduler\Interfaces\ScheduledCommandServiceInterface;
+use App\Tool\Transport\Command\Elastic\ReindexAllDomainsCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Command to create a cron job to reindex blogs, crms, shops, platforms and notifications in Elasticsearch every 30 minutes.',
+)]
+final class ReindexElasticDomainsScheduledCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'scheduler:elastic-reindex-domains';
+
+    public function __construct(
+        private readonly ScheduledCommandServiceInterface $scheduledCommandService,
+    ) {
+        parent::__construct();
+    }
+
+    /** @throws Throwable */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $message = $this->createScheduledCommand();
+
+        if ($input->isInteractive()) {
+            $this->getSymfonyStyle($input, $output)->success($message);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /** @throws Throwable */
+    private function createScheduledCommand(): string
+    {
+        $entity = $this->scheduledCommandService->findByCommand(ReindexAllDomainsCommand::NAME);
+
+        if ($entity !== null) {
+            return "The job ElasticReindexDomains is already present [id='{$entity->getId()}']";
+        }
+
+        $this->scheduledCommandService->create(
+            'Reindex blogs, crms, shops, platforms and notifications in Elasticsearch',
+            ReindexAllDomainsCommand::NAME,
+            '*/30 * * * *',
+            '/elastic-reindex-domains.log'
+        );
+
+        return 'The job ElasticReindexDomains is created';
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide console commands to (re)index `blogs`, `crms` (tasks), `shops` (products), `platforms` (applications) and `notifications` into Elasticsearch. 
- Automate periodic reindexing by creating a cron entry that runs every 30 minutes and integrate it into the Docker cron bootstrap flow.

### Description
- Added projection constants `BlogProjection::INDEX_NAME` and `NotificationProjection::INDEX_NAME` in `src/Blog/Application/Projection/BlogProjection.php` and `src/Notification/Application/Projection/NotificationProjection.php` respectively to standardize index names used by the reindexers.
- Added dedicated reindex console commands under `src/Tool/Transport/Command/Elastic/`:
  - `elastic:reindex:blogs` (`ReindexBlogsCommand`) which indexes `Blog` entities.
  - `elastic:reindex:crms` (`ReindexCrmTasksCommand`) which indexes CRM `Task` entities.
  - `elastic:reindex:shops` (`ReindexShopProductsCommand`) which indexes shop `Product` entities.
  - `elastic:reindex:platforms` (`ReindexPlatformsCommand`) which indexes platform `Application` entities.
  - `elastic:reindex:notifications` (`ReindexNotificationsCommand`) which indexes `Notification` entities.
- Added a composite command `elastic:reindex:all-domains` (`ReindexAllDomainsCommand`) that runs all reindex commands sequentially.
- Added a scheduler command `scheduler:elastic-reindex-domains` (`ReindexElasticDomainsScheduledCommand`) which creates a scheduled command entry with cron expression `*/30 * * * *` (every 30 minutes) using the existing scheduled-command service and is idempotent (checks for existing entry).
- Integrated scheduler creation into Docker cron bootstrap by updating `Makefile` (`migrate-cron-jobs`) to run `php bin/console scheduler:elastic-reindex-domains` along with existing scheduled-job creation steps.

### Testing
- Ran PHP syntax checks on all new/modified files with `php -l` and all files reported `No syntax errors detected` (files checked: new projection and command files and the scheduler file).
- Attempted to list console commands via `php bin/console list` to validate registration, but this failed in the environment with `LogicException: Dependencies are missing. Try running "composer install".` and therefore command registration could not be exercised here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae44947714832683cd6951662eecf2)