### PR TITLE
feat(user): add authenticated endpoints for me/profile/sessions/password/delete

### DIFF
--- a/migrations/Version20260310110000.php
+++ b/migrations/Version20260310110000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Override;
+
+final class Version20260310110000 extends AbstractMigration
+{
+    #[Override]
+    public function getDescription(): string
+    {
+        return 'Create user profile and social tables.';
+    }
+
+    #[Override]
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on mysql.');
+
+        $this->addSql('CREATE TABLE user_profile (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", user_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title VARCHAR(255) DEFAULT NULL, information LONGTEXT DEFAULT NULL, gender VARCHAR(20) DEFAULT NULL, birthday DATE DEFAULT NULL, location VARCHAR(255) DEFAULT NULL, phone VARCHAR(50) DEFAULT NULL, created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, UNIQUE INDEX uq_user_profile_user (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE user_social (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", user_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", provider VARCHAR(50) NOT NULL, provider_id VARCHAR(255) NOT NULL, created_at DATETIME DEFAULT NULL, updated_at DATETIME DEFAULT NULL, UNIQUE INDEX uq_user_social_provider (user_id, provider), INDEX IDX_E4A7EE9CA76ED395 (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE user_profile ADD CONSTRAINT FK_3D82D22EA76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE user_social ADD CONSTRAINT FK_E4A7EE9CA76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+    }
+
+    #[Override]
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(!$this->connection->getDatabasePlatform() instanceof AbstractMySQLPlatform, 'Migration can only be executed safely on mysql.');
+
+        $this->addSql('DROP TABLE user_profile');
+        $this->addSql('DROP TABLE user_social');
+    }
+}

--- a/src/User/Application/Service/UserMeService.php
+++ b/src/User/Application/Service/UserMeService.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Service;
+
+use App\General\Application\Message\EntityDeleted;
+use App\General\Application\Message\EntityPatched;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\Log\Infrastructure\Repository\LogLoginRepository;
+use App\User\Application\Security\SecurityUser;
+use App\User\Domain\Entity\Social;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserProfile;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Throwable;
+
+use function array_key_exists;
+use function array_map;
+use function in_array;
+use function is_array;
+use function sprintf;
+use function trim;
+use function uniqid;
+
+readonly class UserMeService
+{
+    private const string USER_ENTITY_TYPE = 'user_user';
+
+    public function __construct(
+        private LogLoginRepository $logLoginRepository,
+        private EntityManagerInterface $entityManager,
+        private CacheInterface $cache,
+        private ElasticsearchServiceInterface $elasticsearchService,
+        private MessageBusInterface $messageBus,
+        private UserPasswordHasherInterface $passwordHasher,
+    ) {
+    }
+
+    /** @return array<int,array<string,string>> */
+    public function getSessions(User $user): array
+    {
+        $cacheKey = sprintf('user:sessions:%s', $user->getId());
+
+        /** @var array<int,array<string,string>> $sessions */
+        $sessions = $this->cache->get($cacheKey, function (ItemInterface $item) use ($user): array {
+            $item->expiresAfter(120);
+
+            $qb = $this->logLoginRepository->createQueryBuilder('log')
+                ->andWhere('log.user = :user')
+                ->setParameter('user', $user)
+                ->orderBy('log.date', 'DESC')
+                ->setMaxResults(10);
+
+            return array_map(static function ($log): array {
+                $device = $log->getDeviceName() ?? 'desktop';
+                $icon = $device === 'smartphone' ? 'mdi-cellphone' : 'mdi-desktop-classic';
+
+                return [
+                    'icon' => $icon,
+                    'title' => trim(($log->getClientName() ?? 'Unknown') . ' on ' . ($log->getOsName() ?? 'Unknown')),
+                    'description' => '',
+                    'badge' => 'Active',
+                    'city' => 'Unknown',
+                    'ip' => $log->getClientIp(),
+                ];
+            }, $qb->getQuery()->getResult());
+        });
+
+        return $sessions;
+    }
+
+    /** @return array<string,mixed> */
+    public function getMe(User $user): array
+    {
+        $profile = $this->ensureProfile($user);
+
+        return [
+            'id' => $user->getId(),
+            'username' => $user->getUsername(),
+            'email' => $user->getEmail(),
+            'firstName' => $user->getFirstName(),
+            'lastName' => $user->getLastName(),
+            'photo' => $user->getPhoto(),
+            'profile' => $this->normalizeProfile($profile),
+            'socials' => array_map(static fn (Social $social): array => [
+                'provider' => $social->getProvider(),
+                'providerId' => $social->getProviderId(),
+            ], $user->getSocials()->toArray()),
+            'sessions' => $this->getSessions($user),
+        ];
+    }
+
+    /** @param array<string,mixed> $payload */
+    public function patchProfile(User $user, array $payload): array
+    {
+        $profile = $this->ensureProfile($user);
+
+        if (array_key_exists('title', $payload)) { $profile->setTitle($this->nullableString($payload['title'])); }
+        if (array_key_exists('information', $payload)) { $profile->setInformation($this->nullableString($payload['information'])); }
+        if (array_key_exists('gender', $payload)) {
+            $gender = $this->nullableString($payload['gender']);
+            if ($gender !== null && in_array($gender, ['Female', 'Male'], true) === false) {
+                throw new BadRequestHttpException('gender must be Female or Male');
+            }
+            $profile->setGender($gender);
+        }
+        if (array_key_exists('birthday', $payload)) {
+            $profile->setBirthday($payload['birthday'] !== null && $payload['birthday'] !== '' ? new DateTimeImmutable((string) $payload['birthday']) : null);
+        }
+        if (array_key_exists('location', $payload)) { $profile->setLocation($this->nullableString($payload['location'])); }
+        if (array_key_exists('phone', $payload)) { $profile->setPhone($this->nullableString($payload['phone'])); }
+
+        if (array_key_exists('socials', $payload) && is_array($payload['socials'])) {
+            $user->getSocials()->clear();
+            foreach ($payload['socials'] as $socialData) {
+                if (!is_array($socialData) || !isset($socialData['provider'], $socialData['providerId'])) {
+                    continue;
+                }
+                $social = new Social();
+                $social->setProvider((string) $socialData['provider']);
+                $social->setProviderId((string) $socialData['providerId']);
+                $user->addSocial($social);
+                $this->entityManager->persist($social);
+            }
+        }
+
+        $this->entityManager->persist($profile);
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        $this->messageBus->dispatch(new EntityPatched(uniqid('op_', true), self::USER_ENTITY_TYPE, $user->getId()));
+        $this->indexUser($user, $profile);
+
+        return $this->normalizeProfile($profile);
+    }
+
+    /** @param array<string,mixed> $payload */
+    public function changePassword(User $user, array $payload): void
+    {
+        $currentPassword = (string) ($payload['currentPassword'] ?? '');
+        $newPassword = (string) ($payload['newPassword'] ?? '');
+
+        if ($this->passwordHasher->isPasswordValid(new SecurityUser($user, []), $currentPassword) === false) {
+            throw new BadRequestHttpException('Current password is invalid');
+        }
+
+        $user->setPlainPassword($newPassword);
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+    }
+
+    public function deleteMe(User $user): void
+    {
+        $userId = $user->getId();
+        $this->entityManager->remove($user);
+        $this->entityManager->flush();
+
+        $this->messageBus->dispatch(new EntityDeleted(uniqid('op_', true), self::USER_ENTITY_TYPE, $userId));
+
+        try {
+            $this->elasticsearchService->delete('users', $userId);
+        } catch (Throwable) {
+        }
+    }
+
+    private function ensureProfile(User $user): UserProfile
+    {
+        $profile = $user->getProfile();
+
+        if ($profile === null) {
+            $profile = new UserProfile();
+            $profile->setUser($user);
+            $user->setProfile($profile);
+            $this->entityManager->persist($profile);
+            $this->entityManager->flush();
+        }
+
+        return $profile;
+    }
+
+    /** @return array<string,mixed> */
+    private function normalizeProfile(UserProfile $profile): array
+    {
+        return [
+            'title' => $profile->getTitle(),
+            'information' => $profile->getInformation(),
+            'gender' => $profile->getGender(),
+            'birthday' => $profile->getBirthday()?->format('Y-m-d'),
+            'location' => $profile->getLocation(),
+            'phone' => $profile->getPhone(),
+        ];
+    }
+
+    private function indexUser(User $user, UserProfile $profile): void
+    {
+        try {
+            $this->elasticsearchService->index('users', $user->getId(), [
+                'id' => $user->getId(),
+                'username' => $user->getUsername(),
+                'email' => $user->getEmail(),
+                'firstName' => $user->getFirstName(),
+                'lastName' => $user->getLastName(),
+                'title' => $profile->getTitle(),
+                'information' => $profile->getInformation(),
+                'location' => $profile->getLocation(),
+                'updatedAt' => $user->getUpdatedAt()?->format(DATE_ATOM),
+            ]);
+        } catch (Throwable) {
+        }
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/src/User/Domain/Entity/Social.php
+++ b/src/User/Domain/Entity/Social.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Throwable;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'user_social')]
+#[ORM\UniqueConstraint(name: 'uq_user_social_provider', columns: ['user_id', 'provider'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Social implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class, inversedBy: 'socials')]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $user;
+
+    #[ORM\Column(name: 'provider', type: Types::STRING, length: 50, nullable: false)]
+    private string $provider = '';
+
+    #[ORM\Column(name: 'provider_id', type: Types::STRING, length: 255, nullable: false)]
+    private string $providerId = '';
+
+    /**
+     * @throws Throwable
+     */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getUser(): User { return $this->user; }
+    public function setUser(User $user): self { $this->user = $user; return $this; }
+    public function getProvider(): string { return $this->provider; }
+    public function setProvider(string $provider): self { $this->provider = $provider; return $this; }
+    public function getProviderId(): string { return $this->providerId; }
+    public function setProviderId(string $providerId): self { $this->providerId = $providerId; return $this; }
+}

--- a/src/User/Domain/Entity/Traits/UserRelations.php
+++ b/src/User/Domain/Entity/Traits/UserRelations.php
@@ -8,8 +8,10 @@ use App\Log\Domain\Entity\LogLogin;
 use App\Log\Domain\Entity\LogLoginFailure;
 use App\Configuration\Domain\Entity\Configuration;
 use App\Log\Domain\Entity\LogRequest;
+use App\User\Domain\Entity\Social;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Entity\UserGroup;
+use App\User\Domain\Entity\UserProfile;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -81,6 +83,15 @@ trait UserRelations
         'User.configurations',
     ])]
     protected Collection | ArrayCollection $configurations;
+
+    #[ORM\OneToOne(targetEntity: UserProfile::class, mappedBy: 'user')]
+    protected ?UserProfile $profile = null;
+
+    /**
+     * @var Collection<int, Social>|ArrayCollection<int, Social>
+     */
+    #[ORM\OneToMany(targetEntity: Social::class, mappedBy: 'user')]
+    protected Collection | ArrayCollection $socials;
 
     /**
      * Getter for roles.
@@ -154,6 +165,47 @@ trait UserRelations
     public function getConfigurations(): Collection | ArrayCollection
     {
         return $this->configurations;
+    }
+
+    public function getProfile(): ?UserProfile
+    {
+        return $this->profile;
+    }
+
+    public function setProfile(?UserProfile $profile): self
+    {
+        $this->profile = $profile;
+
+        if ($profile !== null && $profile->getUser() !== $this) {
+            $profile->setUser($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Social>|ArrayCollection<int, Social>
+     */
+    public function getSocials(): Collection | ArrayCollection
+    {
+        return $this->socials;
+    }
+
+    public function addSocial(Social $social): self
+    {
+        if ($this->socials->contains($social) === false) {
+            $this->socials->add($social);
+            $social->setUser($this);
+        }
+
+        return $this;
+    }
+
+    public function removeSocial(Social $social): self
+    {
+        $this->socials->removeElement($social);
+
+        return $this;
     }
 
     public function addConfiguration(Configuration $configuration): self

--- a/src/User/Domain/Entity/User.php
+++ b/src/User/Domain/Entity/User.php
@@ -268,6 +268,7 @@ class User implements EntityInterface, UserInterface, UserGroupAwareInterface
         $this->logsLogin = new ArrayCollection();
         $this->logsLoginFailure = new ArrayCollection();
         $this->configurations = new ArrayCollection();
+        $this->socials = new ArrayCollection();
     }
 
     /**

--- a/src/User/Domain/Entity/UserProfile.php
+++ b/src/User/Domain/Entity/UserProfile.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Throwable;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'user_profile')]
+#[ORM\UniqueConstraint(name: 'uq_user_profile_user', columns: ['user_id'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class UserProfile implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\OneToOne(targetEntity: User::class, inversedBy: 'profile')]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?User $user = null;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $title = null;
+
+    #[ORM\Column(name: 'information', type: Types::TEXT, nullable: true)]
+    private ?string $information = null;
+
+    #[ORM\Column(name: 'gender', type: Types::STRING, length: 20, nullable: true)]
+    private ?string $gender = null;
+
+    #[ORM\Column(name: 'birthday', type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $birthday = null;
+
+    #[ORM\Column(name: 'location', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $location = null;
+
+    #[ORM\Column(name: 'phone', type: Types::STRING, length: 50, nullable: true)]
+    private ?string $phone = null;
+
+    /**
+     * @throws Throwable
+     */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getTitle(): ?string { return $this->title; }
+    public function setTitle(?string $title): self { $this->title = $title; return $this; }
+    public function getInformation(): ?string { return $this->information; }
+    public function setInformation(?string $information): self { $this->information = $information; return $this; }
+    public function getGender(): ?string { return $this->gender; }
+    public function setGender(?string $gender): self { $this->gender = $gender; return $this; }
+    public function getBirthday(): ?DateTimeImmutable { return $this->birthday; }
+    public function setBirthday(?DateTimeImmutable $birthday): self { $this->birthday = $birthday; return $this; }
+    public function getLocation(): ?string { return $this->location; }
+    public function setLocation(?string $location): self { $this->location = $location; return $this; }
+    public function getPhone(): ?string { return $this->phone; }
+    public function setPhone(?string $phone): self { $this->phone = $phone; return $this; }
+}

--- a/src/User/Transport/Controller/Api/V1/User/UserMeController.php
+++ b/src/User/Transport/Controller/Api/V1/User/UserMeController.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Transport\Controller\Api\V1\User;
+
+use App\User\Application\Service\UserMeService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'User Me')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class UserMeController
+{
+    public function __construct(private readonly UserMeService $userMeService)
+    {
+    }
+
+    #[Route(path: '/v1/users/me', methods: [Request::METHOD_GET])]
+    public function me(User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userMeService->getMe($loggedInUser));
+    }
+
+    #[Route(path: '/v1/users/me/sessions', methods: [Request::METHOD_GET])]
+    public function sessions(User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userMeService->getSessions($loggedInUser));
+    }
+
+    #[Route(path: '/v1/users/me/profile', methods: [Request::METHOD_GET])]
+    public function profile(User $loggedInUser): JsonResponse
+    {
+        $me = $this->userMeService->getMe($loggedInUser);
+
+        return new JsonResponse($me['profile'] ?? []);
+    }
+
+    #[Route(path: '/v1/users/me/profile', methods: [Request::METHOD_PATCH])]
+    public function patchProfile(Request $request, User $loggedInUser): JsonResponse
+    {
+        /** @var array<string,mixed> $payload */
+        $payload = json_decode($request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        return new JsonResponse($this->userMeService->patchProfile($loggedInUser, $payload));
+    }
+
+    #[Route(path: '/v1/users/me/password', methods: [Request::METHOD_PATCH])]
+    public function changePassword(Request $request, User $loggedInUser): JsonResponse
+    {
+        /** @var array<string,mixed> $payload */
+        $payload = json_decode($request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->userMeService->changePassword($loggedInUser, $payload);
+
+        return new JsonResponse(['status' => 'ok']);
+    }
+
+    #[Route(path: '/v1/users/me', methods: [Request::METHOD_DELETE])]
+    public function delete(User $loggedInUser): JsonResponse
+    {
+        $this->userMeService->deleteMe($loggedInUser);
+
+        return new JsonResponse(null, 204);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide authenticated users with endpoints to read their profile and sessions, patch profile (including socials), change password and delete their account, and aggregate all user-related info in a single `me` response. 
- Use existing platform services for caching (Redis via `CacheInterface`), full-text indexing (`ElasticsearchServiceInterface`) and async notifications/invalidations (`MessageBusInterface`).

### Description
- Added a new `UserProfile` entity (1:1 to `User`) with fields `title`, `information`, `gender`, `birthday`, `location` and `phone` (`src/User/Domain/Entity/UserProfile.php`).
- Added a new `Social` entity to store `(provider, providerId)` per user and a uniqueness constraint per `(user, provider)` (`src/User/Domain/Entity/Social.php`).
- Extended user relations to include `profile` and `socials` and initialized `socials` collection in `User` (`src/User/Domain/Entity/Traits/UserRelations.php`, `src/User/Domain/Entity/User.php`).
- Implemented `UserMeService` to centralize logic for `getMe`, `getSessions`, `patchProfile`, `changePassword` and `deleteMe`, using `CacheInterface` for sessions, `ElasticsearchServiceInterface` for indexing, and `MessageBusInterface` for entity mutation messages (`src/User/Application/Service/UserMeService.php`).
- Added authenticated controller `UserMeController` exposing endpoints: `GET /v1/users/me`, `GET /v1/users/me/sessions`, `GET /v1/users/me/profile`, `PATCH /v1/users/me/profile`, `PATCH /v1/users/me/password`, and `DELETE /v1/users/me` (`src/User/Transport/Controller/Api/V1/User/UserMeController.php`).
- Added Doctrine migration to create `user_profile` and `user_social` tables with FK constraints and uniqueness indexes (`migrations/Version20260310110000.php`).

### Testing
- Ran PHP syntax checks with `php -l` for touched files (`src/User/Domain/Entity/UserProfile.php`, `src/User/Domain/Entity/Social.php`, `src/User/Application/Service/UserMeService.php`, `src/User/Transport/Controller/Api/V1/User/UserMeController.php`, `src/User/Domain/Entity/Traits/UserRelations.php`, `src/User/Domain/Entity/User.php`, `migrations/Version20260310110000.php`) and they all succeeded.
- Confirmed code compiles at a basic level (no syntax errors) after changes via the lint step above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae4f04d4d88326a95ec34316893047)