### PR TITLE
Fix invalid Symfony cache key in user sessions endpoint

### DIFF
--- a/src/User/Application/Service/UserMeService.php
+++ b/src/User/Application/Service/UserMeService.php
@@ -47,7 +47,7 @@ readonly class UserMeService
     /** @return array<int,array<string,string>> */
     public function getSessions(User $user): array
     {
-        $cacheKey = sprintf('user:sessions:%s', $user->getId());
+        $cacheKey = sprintf('user_sessions_%s', $user->getId());
 
         /** @var array<int,array<string,string>> $sessions */
         $sessions = $this->cache->get($cacheKey, function (ItemInterface $item) use ($user): array {


### PR DESCRIPTION
### Motivation
- The Symfony cache was rejecting keys containing reserved characters which caused a 500 error when fetching `/api/v1/users/me` sessions, so the cache key format needed to be changed to avoid those characters.

### Description
- Replace the cache key in `UserMeService::getSessions` from `user:sessions:%s` to `user_sessions_%s` in `src/User/Application/Service/UserMeService.php` to eliminate reserved characters (`{}()/\\@:`) in cache keys.

### Testing
- Ran `php -l src/User/Application/Service/UserMeService.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae55974f988326a7d585feaf517775)