### PR TITLE
Capture upload metadata before file move to avoid temp-file errors

### DIFF
--- a/src/Media/Application/Service/MediaUploaderService.php
+++ b/src/Media/Application/Service/MediaUploaderService.php
@@ -43,6 +43,9 @@ class MediaUploaderService
 
         $uploadedFiles = [];
         foreach ($files as $file) {
+            $originalName = $file->getClientOriginalName();
+            $mimeType = (string) ($file->getMimeType() ?? $file->getClientMimeType() ?? 'application/octet-stream');
+            $size = $this->extractSize($file);
             $extension = strtolower($file->guessExtension() ?? $file->getClientOriginalExtension() ?: 'bin');
             $fileName = bin2hex(random_bytes(16)) . '.' . $extension;
 
@@ -50,9 +53,9 @@ class MediaUploaderService
 
             $uploadedFiles[] = [
                 'url' => $request->getSchemeAndHttpHost() . $normalizedDirectory . '/' . $fileName,
-                'originalName' => $file->getClientOriginalName(),
-                'mimeType' => (string) ($file->getMimeType() ?? $file->getClientMimeType() ?? 'application/octet-stream'),
-                'size' => $this->extractSize($file),
+                'originalName' => $originalName,
+                'mimeType' => $mimeType,
+                'size' => $size,
                 'extension' => $extension,
             ];
         }


### PR DESCRIPTION
### Motivation
- Reading MIME type and size after calling `UploadedFile::move()` can trigger fileinfo lookups on the original temporary path which may no longer exist, causing errors like: `The "/tmp/php..." file does not exist or is not readable.`

### Description
- Capture `originalName`, `mimeType`, and `size` from the `UploadedFile` before calling `move()` in `src/Media/Application/Service/MediaUploaderService.php`.
- Preserve the existing response contract (`url`, `originalName`, `mimeType`, `size`, `extension`) while avoiding post-move reads from the temp path.
- No public API changes were introduced; only internal ordering of metadata extraction was adjusted.

### Testing
- Ran `php -l src/Media/Application/Service/MediaUploaderService.php` which reported no syntax errors and succeeded.
- Attempted to run `vendor/bin/phpunit tests/Application/User/Transport/Controller/Api/V1/Profile/UploadPhotoControllerTest.php` but it failed to run because `vendor/bin/phpunit` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af2e0eeccc8326baea1a7066090dd0)