### PR TITLE
Add UserRelationship entity and repository for user-to-user relations

### DIFF
--- a/src/User/Domain/Entity/UserRelationship.php
+++ b/src/User/Domain/Entity/UserRelationship.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Enum\UserRelationshipStatus;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+use function sprintf;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'user_relationship')]
+#[ORM\UniqueConstraint(name: 'uq_user_relationship_key', columns: ['relationship_key'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class UserRelationship implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true, nullable: false)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'requester_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $requester;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'addressee_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $addressee;
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 20, enumType: UserRelationshipStatus::class)]
+    private UserRelationshipStatus $status = UserRelationshipStatus::PENDING;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'blocked_by_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?User $blockedBy = null;
+
+    #[ORM\Column(name: 'relationship_key', type: Types::STRING, length: 73, nullable: false)]
+    private string $relationshipKey = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getRequester(): User
+    {
+        return $this->requester;
+    }
+
+    public function setRequester(User $requester): self
+    {
+        $this->requester = $requester;
+        $this->refreshRelationshipKey();
+
+        return $this;
+    }
+
+    public function getAddressee(): User
+    {
+        return $this->addressee;
+    }
+
+    public function setAddressee(User $addressee): self
+    {
+        $this->addressee = $addressee;
+        $this->refreshRelationshipKey();
+
+        return $this;
+    }
+
+    public function getStatus(): UserRelationshipStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(UserRelationshipStatus $status): self
+    {
+        $this->status = $status;
+
+        if ($status !== UserRelationshipStatus::BLOCKED) {
+            $this->blockedBy = null;
+        }
+
+        return $this;
+    }
+
+    public function getBlockedBy(): ?User
+    {
+        return $this->blockedBy;
+    }
+
+    public function setBlockedBy(?User $blockedBy): self
+    {
+        $this->blockedBy = $blockedBy;
+
+        return $this;
+    }
+
+    public function getRelationshipKey(): string
+    {
+        return $this->relationshipKey;
+    }
+
+    private function refreshRelationshipKey(): void
+    {
+        if (!isset($this->requester, $this->addressee)) {
+            return;
+        }
+
+        $requesterId = $this->requester->getId();
+        $addresseeId = $this->addressee->getId();
+
+        if ($requesterId <= $addresseeId) {
+            $this->relationshipKey = sprintf('%s:%s', $requesterId, $addresseeId);
+
+            return;
+        }
+
+        $this->relationshipKey = sprintf('%s:%s', $addresseeId, $requesterId);
+    }
+}

--- a/src/User/Domain/Enum/UserRelationshipStatus.php
+++ b/src/User/Domain/Enum/UserRelationshipStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Domain\Enum;
+
+enum UserRelationshipStatus: string
+{
+    case PENDING = 'PENDING';
+    case ACCEPTED = 'ACCEPTED';
+    case REJECTED = 'REJECTED';
+    case BLOCKED = 'BLOCKED';
+}

--- a/src/User/Domain/Repository/Interfaces/UserRelationshipRepositoryInterface.php
+++ b/src/User/Domain/Repository/Interfaces/UserRelationshipRepositoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Domain\Repository\Interfaces;
+
+use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserRelationship;
+
+/**
+ * @package App\User
+ */
+interface UserRelationshipRepositoryInterface
+{
+    public function findRelationBetweenUsers(User $firstUser, User $secondUser): ?UserRelationship;
+
+    /**
+     * @return array<int, UserRelationship>
+     */
+    public function findIncomingRequests(User $user): array;
+
+    /**
+     * @return array<int, UserRelationship>
+     */
+    public function findOutgoingRequests(User $user): array;
+
+    public function hasActiveBlock(User $firstUser, User $secondUser): bool;
+}

--- a/src/User/Infrastructure/Repository/UserRelationshipRepository.php
+++ b/src/User/Infrastructure/Repository/UserRelationshipRepository.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserRelationship as Entity;
+use App\User\Domain\Enum\UserRelationshipStatus;
+use App\User\Domain\Repository\Interfaces\UserRelationshipRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @package App\User
+ *
+ * @psalm-suppress LessSpecificImplementedReturnType
+ * @codingStandardsIgnoreStart
+ *
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity|null findAdvanced(string $id, string|int|null $hydrationMode = null, string|null $entityManagerName = null)
+ * @method Entity|null findOneBy(array $criteria, ?array $orderBy = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ * @method Entity[] findByAdvanced(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?array $search = null, ?string $entityManagerName = null)
+ * @method Entity[] findAll(?string $entityManagerName = null)
+ *
+ * @codingStandardsIgnoreEnd
+ */
+class UserRelationshipRepository extends BaseRepository implements UserRelationshipRepositoryInterface
+{
+    /**
+     * @psalm-var class-string
+     */
+    protected static string $entityName = Entity::class;
+
+    /**
+     * @var array<int, string>
+     */
+    protected static array $searchColumns = ['status'];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+
+    public function findRelationBetweenUsers(User $firstUser, User $secondUser): ?Entity
+    {
+        return $this
+            ->createQueryBuilder('ur')
+            ->where('(ur.requester = :firstUser AND ur.addressee = :secondUser) OR (ur.requester = :secondUser AND ur.addressee = :firstUser)')
+            ->setParameter('firstUser', $firstUser)
+            ->setParameter('secondUser', $secondUser)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findIncomingRequests(User $user): array
+    {
+        return $this
+            ->createQueryBuilder('ur')
+            ->where('ur.addressee = :user')
+            ->andWhere('ur.status = :status')
+            ->setParameter('user', $user)
+            ->setParameter('status', UserRelationshipStatus::PENDING)
+            ->orderBy('ur.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findOutgoingRequests(User $user): array
+    {
+        return $this
+            ->createQueryBuilder('ur')
+            ->where('ur.requester = :user')
+            ->andWhere('ur.status = :status')
+            ->setParameter('user', $user)
+            ->setParameter('status', UserRelationshipStatus::PENDING)
+            ->orderBy('ur.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function hasActiveBlock(User $firstUser, User $secondUser): bool
+    {
+        $result = $this
+            ->createQueryBuilder('ur')
+            ->select('ur.id')
+            ->where('(ur.requester = :firstUser AND ur.addressee = :secondUser) OR (ur.requester = :secondUser AND ur.addressee = :firstUser)')
+            ->andWhere('ur.status = :status')
+            ->setParameter('firstUser', $firstUser)
+            ->setParameter('secondUser', $secondUser)
+            ->setParameter('status', UserRelationshipStatus::BLOCKED)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $result !== null;
+    }
+}


### PR DESCRIPTION
### Motivation
- Add domain model and data access to represent user-to-user relationships (friend requests, accepts, rejects, blocks) and provide business queries for incoming/outgoing requests and block detection.
- Prevent duplicate relations between the same pair of users regardless of request direction by canonicalizing pairs.

### Description
- Added enum `UserRelationshipStatus` with values `PENDING`, `ACCEPTED`, `REJECTED`, `BLOCKED` at `src/User/Domain/Enum/UserRelationshipStatus.php`.
- Introduced `UserRelationship` Doctrine entity at `src/User/Domain/Entity/UserRelationship.php` with `requester` and `addressee` (`ManyToOne` to `User`), `status` (enum), optional `blockedBy` (`ManyToOne`), timestamps via `Timestampable`, and a canonical `relationship_key` with a unique constraint to avoid duplicate relations.
- Added repository interface `UserRelationshipRepositoryInterface` at `src/User/Domain/Repository/Interfaces/UserRelationshipRepositoryInterface.php` declaring methods to find a relation between two users, list incoming/outgoing requests, and check active blocks.
- Implemented `UserRelationshipRepository` in `src/User/Infrastructure/Repository/UserRelationshipRepository.php` with Doctrine QueryBuilder logic for bidirectional lookups, `PENDING` request queries, and `BLOCKED` checks.

### Testing
- Ran PHP lint checks: `php -l` on `src/User/Domain/Enum/UserRelationshipStatus.php`, `src/User/Domain/Entity/UserRelationship.php`, `src/User/Domain/Repository/Interfaces/UserRelationshipRepositoryInterface.php`, and `src/User/Infrastructure/Repository/UserRelationshipRepository.php`, and they reported no syntax errors.
- Attempted to run `vendor/bin/phpunit tests/Unit/ExampleTest.php` but the PHPUnit binary is not present in the environment, so unit tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af42e71bf48326910f4aaeb28a4d50)