### PR TITLE
Add UserFriendController and UserFriendService for friendship workflows

### DIFF
--- a/src/User/Application/Service/UserFriendService.php
+++ b/src/User/Application/Service/UserFriendService.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Service;
+
+use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserRelationship;
+use App\User\Domain\Enum\UserRelationshipStatus;
+use App\User\Domain\Repository\Interfaces\UserRelationshipRepositoryInterface;
+use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+readonly class UserFriendService
+{
+    public function __construct(
+        private UserRepository $userRepository,
+        private UserRelationshipRepositoryInterface $userRelationshipRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /** @return array<string,mixed> */
+    public function requestFriend(string $targetUserId, User $loggedInUser): array
+    {
+        $targetUser = $this->getTargetUser($targetUserId);
+        $this->assertNotSameUser($loggedInUser, $targetUser);
+
+        $relationship = $this->userRelationshipRepository->findRelationBetweenUsers($loggedInUser, $targetUser);
+
+        if ($relationship === null) {
+            $relationship = new UserRelationship();
+            $relationship
+                ->setRequester($loggedInUser)
+                ->setAddressee($targetUser)
+                ->setStatus(UserRelationshipStatus::PENDING);
+
+            $this->entityManager->persist($relationship);
+            $this->entityManager->flush();
+
+            return ['status' => 'ok', 'data' => $this->normalizeRelationship($relationship)];
+        }
+
+        if ($relationship->getStatus() === UserRelationshipStatus::ACCEPTED) {
+            throw new BadRequestHttpException('You are already friends with this user.');
+        }
+
+        if ($relationship->getStatus() === UserRelationshipStatus::BLOCKED) {
+            throw new BadRequestHttpException('Cannot send a friend request while one of you has blocked the other.');
+        }
+
+        if ($relationship->getStatus() === UserRelationshipStatus::PENDING && $relationship->getRequester() === $loggedInUser) {
+            throw new BadRequestHttpException('Friend request already sent.');
+        }
+
+        $relationship
+            ->setRequester($loggedInUser)
+            ->setAddressee($targetUser)
+            ->setStatus(UserRelationshipStatus::PENDING);
+
+        $this->entityManager->flush();
+
+        return ['status' => 'ok', 'data' => $this->normalizeRelationship($relationship)];
+    }
+
+    /** @return array<string,mixed> */
+    public function acceptFriendRequest(string $targetUserId, User $loggedInUser): array
+    {
+        $targetUser = $this->getTargetUser($targetUserId);
+        $this->assertNotSameUser($loggedInUser, $targetUser);
+
+        $relationship = $this->userRelationshipRepository->findRelationBetweenUsers($loggedInUser, $targetUser);
+
+        if ($relationship === null || $relationship->getStatus() !== UserRelationshipStatus::PENDING) {
+            throw new BadRequestHttpException('No pending friend request found.');
+        }
+
+        if ($relationship->getAddressee() !== $loggedInUser) {
+            throw new BadRequestHttpException('Only the addressee can accept this friend request.');
+        }
+
+        $relationship->setStatus(UserRelationshipStatus::ACCEPTED);
+        $this->entityManager->flush();
+
+        return ['status' => 'ok', 'data' => $this->normalizeRelationship($relationship)];
+    }
+
+    /** @return array<string,mixed> */
+    public function rejectFriendRequest(string $targetUserId, User $loggedInUser): array
+    {
+        $targetUser = $this->getTargetUser($targetUserId);
+        $this->assertNotSameUser($loggedInUser, $targetUser);
+
+        $relationship = $this->userRelationshipRepository->findRelationBetweenUsers($loggedInUser, $targetUser);
+
+        if ($relationship === null || $relationship->getStatus() !== UserRelationshipStatus::PENDING) {
+            throw new BadRequestHttpException('No pending friend request found.');
+        }
+
+        if ($relationship->getAddressee() !== $loggedInUser) {
+            throw new BadRequestHttpException('Only the addressee can reject this friend request.');
+        }
+
+        $relationship->setStatus(UserRelationshipStatus::REJECTED);
+        $this->entityManager->flush();
+
+        return ['status' => 'ok', 'data' => $this->normalizeRelationship($relationship)];
+    }
+
+    /** @return array<string,mixed> */
+    public function blockUser(string $targetUserId, User $loggedInUser): array
+    {
+        $targetUser = $this->getTargetUser($targetUserId);
+        $this->assertNotSameUser($loggedInUser, $targetUser);
+
+        $relationship = $this->userRelationshipRepository->findRelationBetweenUsers($loggedInUser, $targetUser);
+
+        if ($relationship === null) {
+            $relationship = new UserRelationship();
+            $relationship
+                ->setRequester($loggedInUser)
+                ->setAddressee($targetUser);
+
+            $this->entityManager->persist($relationship);
+        }
+
+        $relationship
+            ->setStatus(UserRelationshipStatus::BLOCKED)
+            ->setBlockedBy($loggedInUser);
+
+        $this->entityManager->flush();
+
+        return ['status' => 'ok', 'data' => $this->normalizeRelationship($relationship)];
+    }
+
+    /** @return array<string,mixed> */
+    public function unblockUser(string $targetUserId, User $loggedInUser): array
+    {
+        $targetUser = $this->getTargetUser($targetUserId);
+        $this->assertNotSameUser($loggedInUser, $targetUser);
+
+        $relationship = $this->userRelationshipRepository->findRelationBetweenUsers($loggedInUser, $targetUser);
+
+        if ($relationship === null || $relationship->getStatus() !== UserRelationshipStatus::BLOCKED) {
+            throw new BadRequestHttpException('No block relationship found.');
+        }
+
+        if ($relationship->getBlockedBy() !== $loggedInUser) {
+            throw new BadRequestHttpException('Only the user who created the block can remove it.');
+        }
+
+        $relationship->setStatus(UserRelationshipStatus::REJECTED);
+        $this->entityManager->flush();
+
+        return ['status' => 'ok', 'data' => $this->normalizeRelationship($relationship)];
+    }
+
+    /** @return array<string,mixed> */
+    public function getFriends(User $loggedInUser): array
+    {
+        $friends = $this->userRelationshipRepository->findAcceptedRelationships($loggedInUser);
+
+        return [
+            'status' => 'ok',
+            'data' => [
+                'friends' => array_map(fn (UserRelationship $relationship): array => $this->normalizeFriend($relationship, $loggedInUser), $friends),
+            ],
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    public function getFriendRequests(User $loggedInUser): array
+    {
+        $incoming = $this->userRelationshipRepository->findIncomingRequests($loggedInUser);
+        $outgoing = $this->userRelationshipRepository->findOutgoingRequests($loggedInUser);
+
+        return [
+            'status' => 'ok',
+            'data' => [
+                'incoming' => array_map(fn (UserRelationship $relationship): array => $this->normalizeRelationship($relationship), $incoming),
+                'outgoing' => array_map(fn (UserRelationship $relationship): array => $this->normalizeRelationship($relationship), $outgoing),
+            ],
+        ];
+    }
+
+    private function getTargetUser(string $targetUserId): User
+    {
+        $targetUser = $this->userRepository->find($targetUserId);
+
+        if (!$targetUser instanceof User) {
+            throw new NotFoundHttpException('User not found.');
+        }
+
+        return $targetUser;
+    }
+
+    private function assertNotSameUser(User $loggedInUser, User $targetUser): void
+    {
+        if ($loggedInUser === $targetUser) {
+            throw new BadRequestHttpException('Cannot perform this action on yourself.');
+        }
+    }
+
+    /** @return array<string,mixed> */
+    private function normalizeRelationship(UserRelationship $relationship): array
+    {
+        return [
+            'id' => $relationship->getId(),
+            'status' => $relationship->getStatus()->value,
+            'requesterId' => $relationship->getRequester()->getId(),
+            'addresseeId' => $relationship->getAddressee()->getId(),
+            'blockedById' => $relationship->getBlockedBy()?->getId(),
+            'createdAt' => $relationship->getCreatedAt()?->format(DATE_ATOM),
+            'updatedAt' => $relationship->getUpdatedAt()?->format(DATE_ATOM),
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function normalizeFriend(UserRelationship $relationship, User $loggedInUser): array
+    {
+        $friend = $relationship->getRequester() === $loggedInUser
+            ? $relationship->getAddressee()
+            : $relationship->getRequester();
+
+        return [
+            'id' => $friend->getId(),
+            'username' => $friend->getUsername(),
+            'firstName' => $friend->getFirstName(),
+            'lastName' => $friend->getLastName(),
+            'photo' => $friend->getPhoto(),
+            'relationship' => $this->normalizeRelationship($relationship),
+        ];
+    }
+}

--- a/src/User/Domain/Repository/Interfaces/UserRelationshipRepositoryInterface.php
+++ b/src/User/Domain/Repository/Interfaces/UserRelationshipRepositoryInterface.php
@@ -24,5 +24,11 @@ interface UserRelationshipRepositoryInterface
      */
     public function findOutgoingRequests(User $user): array;
 
+
+    /**
+     * @return array<int, UserRelationship>
+     */
+    public function findAcceptedRelationships(User $user): array;
+
     public function hasActiveBlock(User $firstUser, User $secondUser): bool;
 }

--- a/src/User/Infrastructure/Repository/UserRelationshipRepository.php
+++ b/src/User/Infrastructure/Repository/UserRelationshipRepository.php
@@ -82,6 +82,19 @@ class UserRelationshipRepository extends BaseRepository implements UserRelations
             ->getResult();
     }
 
+    public function findAcceptedRelationships(User $user): array
+    {
+        return $this
+            ->createQueryBuilder('ur')
+            ->where('(ur.requester = :user OR ur.addressee = :user)')
+            ->andWhere('ur.status = :status')
+            ->setParameter('user', $user)
+            ->setParameter('status', UserRelationshipStatus::ACCEPTED)
+            ->orderBy('ur.updatedAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
     public function hasActiveBlock(User $firstUser, User $secondUser): bool
     {
         $result = $this

--- a/src/User/Transport/Controller/Api/V1/User/UserFriendController.php
+++ b/src/User/Transport/Controller/Api/V1/User/UserFriendController.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Transport\Controller\Api\V1\User;
+
+use App\User\Application\Service\UserFriendService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'User Friends')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class UserFriendController
+{
+    public function __construct(private readonly UserFriendService $userFriendService)
+    {
+    }
+
+    #[Route(path: '/v1/users/{id}/friends/request', methods: [Request::METHOD_POST])]
+    public function requestFriend(string $id, User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userFriendService->requestFriend($id, $loggedInUser));
+    }
+
+    #[Route(path: '/v1/users/{id}/friends/accept', methods: [Request::METHOD_POST])]
+    public function acceptFriend(string $id, User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userFriendService->acceptFriendRequest($id, $loggedInUser));
+    }
+
+    #[Route(path: '/v1/users/{id}/friends/reject', methods: [Request::METHOD_POST])]
+    public function rejectFriend(string $id, User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userFriendService->rejectFriendRequest($id, $loggedInUser));
+    }
+
+    #[Route(path: '/v1/users/{id}/block', methods: [Request::METHOD_POST])]
+    public function block(string $id, User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userFriendService->blockUser($id, $loggedInUser));
+    }
+
+    #[Route(path: '/v1/users/{id}/block', methods: [Request::METHOD_DELETE])]
+    public function unblock(string $id, User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userFriendService->unblockUser($id, $loggedInUser));
+    }
+
+    #[Route(path: '/v1/users/me/friends', methods: [Request::METHOD_GET])]
+    public function friends(User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userFriendService->getFriends($loggedInUser));
+    }
+
+    #[Route(path: '/v1/users/me/friends/requests', methods: [Request::METHOD_GET])]
+    public function friendRequests(User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userFriendService->getFriendRequests($loggedInUser));
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose explicit, authenticated endpoints to manage user relationships (friend requests, accept/reject, block/unblock, list friends/requests) and centralize the business logic in the application layer. 
- Provide homogeneous JSON responses for these operations and reuse existing `UserRelationship`/status model.

### Description
- Add `UserFriendController` at `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` protected by `#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]` and providing routes: `POST /v1/users/{id}/friends/request`, `POST /v1/users/{id}/friends/accept`, `POST /v1/users/{id}/friends/reject`, `POST /v1/users/{id}/block`, `DELETE /v1/users/{id}/block`, `GET /v1/users/me/friends`, and `GET /v1/users/me/friends/requests`.
- Implement `UserFriendService` at `src/User/Application/Service/UserFriendService.php` with core workflows: `requestFriend`, `acceptFriendRequest`, `rejectFriendRequest`, `blockUser`, `unblockUser`, `getFriends`, `getFriendRequests`, and consistent `status`+`data` JSON payloads.
- Extend repository contract and implementation with `findAcceptedRelationships()` to fetch accepted friend relations; files modified: `src/User/Domain/Repository/Interfaces/UserRelationshipRepositoryInterface.php` and `src/User/Infrastructure/Repository/UserRelationshipRepository.php`.
- Use existing `UserRelationship` entity and `UserRelationshipStatus` enum for state management and validation (self-action, role of requester/addressee, block ownership).

### Testing
- Ran PHP lint checks: `php -l` on `src/User/Application/Service/UserFriendService.php`, `src/User/Transport/Controller/Api/V1/User/UserFriendController.php`, `src/User/Infrastructure/Repository/UserRelationshipRepository.php`, and `src/User/Domain/Repository/Interfaces/UserRelationshipRepositoryInterface.php` — all reported no syntax errors (passed).
- Attempted project test commands: `composer test` failed because the `test` script is not defined (failed), and `vendor/bin/phpunit` is not installed in this environment (not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af43dc6b308326aac33cea4ce8b41d)