### PR TITLE
Harden user relationship operations and HTTP error semantics

### DIFF
--- a/src/User/Application/Service/UserFriendService.php
+++ b/src/User/Application/Service/UserFriendService.php
@@ -11,6 +11,8 @@ use App\User\Domain\Repository\Interfaces\UserRelationshipRepositoryInterface;
 use App\User\Infrastructure\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\ForbiddenHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 readonly class UserFriendService
@@ -27,6 +29,7 @@ readonly class UserFriendService
     {
         $targetUser = $this->getTargetUser($targetUserId);
         $this->assertNotSameUser($loggedInUser, $targetUser);
+        $this->assertNoActiveBlock($loggedInUser, $targetUser, 'Cannot send a friend request while a block is active between both users.');
 
         $relationship = $this->userRelationshipRepository->findRelationBetweenUsers($loggedInUser, $targetUser);
 
@@ -44,15 +47,19 @@ readonly class UserFriendService
         }
 
         if ($relationship->getStatus() === UserRelationshipStatus::ACCEPTED) {
-            throw new BadRequestHttpException('You are already friends with this user.');
+            throw new ConflictHttpException('You are already friends with this user.');
         }
 
         if ($relationship->getStatus() === UserRelationshipStatus::BLOCKED) {
-            throw new BadRequestHttpException('Cannot send a friend request while one of you has blocked the other.');
+            throw new ForbiddenHttpException('Cannot send a friend request while one of you has blocked the other.');
         }
 
-        if ($relationship->getStatus() === UserRelationshipStatus::PENDING && $relationship->getRequester() === $loggedInUser) {
-            throw new BadRequestHttpException('Friend request already sent.');
+        if ($relationship->getStatus() === UserRelationshipStatus::PENDING) {
+            if ($relationship->getRequester() === $loggedInUser) {
+                throw new ConflictHttpException('Friend request already sent.');
+            }
+
+            throw new ConflictHttpException('You already have an incoming pending friend request from this user.');
         }
 
         $relationship
@@ -70,15 +77,20 @@ readonly class UserFriendService
     {
         $targetUser = $this->getTargetUser($targetUserId);
         $this->assertNotSameUser($loggedInUser, $targetUser);
+        $this->assertNoActiveBlock($loggedInUser, $targetUser, 'Cannot accept a friend request while a block is active between both users.');
 
         $relationship = $this->userRelationshipRepository->findRelationBetweenUsers($loggedInUser, $targetUser);
 
-        if ($relationship === null || $relationship->getStatus() !== UserRelationshipStatus::PENDING) {
-            throw new BadRequestHttpException('No pending friend request found.');
+        if ($relationship === null) {
+            throw new NotFoundHttpException('No friend request found between both users.');
+        }
+
+        if ($relationship->getStatus() !== UserRelationshipStatus::PENDING) {
+            throw new ConflictHttpException('Cannot accept a friend request that is not pending.');
         }
 
         if ($relationship->getAddressee() !== $loggedInUser) {
-            throw new BadRequestHttpException('Only the addressee can accept this friend request.');
+            throw new ForbiddenHttpException('Only the addressee can accept this friend request.');
         }
 
         $relationship->setStatus(UserRelationshipStatus::ACCEPTED);
@@ -95,12 +107,16 @@ readonly class UserFriendService
 
         $relationship = $this->userRelationshipRepository->findRelationBetweenUsers($loggedInUser, $targetUser);
 
-        if ($relationship === null || $relationship->getStatus() !== UserRelationshipStatus::PENDING) {
-            throw new BadRequestHttpException('No pending friend request found.');
+        if ($relationship === null) {
+            throw new NotFoundHttpException('No friend request found between both users.');
+        }
+
+        if ($relationship->getStatus() !== UserRelationshipStatus::PENDING) {
+            throw new ConflictHttpException('Cannot reject a friend request that is not pending.');
         }
 
         if ($relationship->getAddressee() !== $loggedInUser) {
-            throw new BadRequestHttpException('Only the addressee can reject this friend request.');
+            throw new ForbiddenHttpException('Only the addressee can reject this friend request.');
         }
 
         $relationship->setStatus(UserRelationshipStatus::REJECTED);
@@ -126,6 +142,14 @@ readonly class UserFriendService
             $this->entityManager->persist($relationship);
         }
 
+        if ($relationship->getStatus() === UserRelationshipStatus::BLOCKED) {
+            if ($relationship->getBlockedBy() === $loggedInUser) {
+                throw new ConflictHttpException('This user is already blocked.');
+            }
+
+            throw new ForbiddenHttpException('Cannot override an active block created by the other user.');
+        }
+
         $relationship
             ->setStatus(UserRelationshipStatus::BLOCKED)
             ->setBlockedBy($loggedInUser);
@@ -144,11 +168,11 @@ readonly class UserFriendService
         $relationship = $this->userRelationshipRepository->findRelationBetweenUsers($loggedInUser, $targetUser);
 
         if ($relationship === null || $relationship->getStatus() !== UserRelationshipStatus::BLOCKED) {
-            throw new BadRequestHttpException('No block relationship found.');
+            throw new NotFoundHttpException('No block relationship found.');
         }
 
         if ($relationship->getBlockedBy() !== $loggedInUser) {
-            throw new BadRequestHttpException('Only the user who created the block can remove it.');
+            throw new ForbiddenHttpException('Only the user who created the block can remove it.');
         }
 
         $relationship->setStatus(UserRelationshipStatus::REJECTED);
@@ -198,8 +222,15 @@ readonly class UserFriendService
 
     private function assertNotSameUser(User $loggedInUser, User $targetUser): void
     {
-        if ($loggedInUser === $targetUser) {
+        if ($loggedInUser->getId() === $targetUser->getId()) {
             throw new BadRequestHttpException('Cannot perform this action on yourself.');
+        }
+    }
+
+    private function assertNoActiveBlock(User $loggedInUser, User $targetUser, string $message): void
+    {
+        if ($this->userRelationshipRepository->hasActiveBlock($loggedInUser, $targetUser)) {
+            throw new ForbiddenHttpException($message);
         }
     }
 

--- a/tests/Unit/User/Application/Service/UserFriendServiceTest.php
+++ b/tests/Unit/User/Application/Service/UserFriendServiceTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\User\Application\Service;
+
+use App\User\Application\Service\UserFriendService;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserRelationship;
+use App\User\Domain\Enum\UserRelationshipStatus;
+use App\User\Domain\Repository\Interfaces\UserRelationshipRepositoryInterface;
+use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
+use Symfony\Component\HttpKernel\Exception\ForbiddenHttpException;
+
+final class UserFriendServiceTest extends TestCase
+{
+    public function testRequestFriendRejectsSelfAction(): void
+    {
+        $loggedInUser = new User();
+
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->method('find')->willReturn($loggedInUser);
+
+        $relationshipRepository = $this->createMock(UserRelationshipRepositoryInterface::class);
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $service = new UserFriendService($userRepository, $relationshipRepository, $entityManager);
+
+        $this->expectException(BadRequestHttpException::class);
+        $service->requestFriend($loggedInUser->getId(), $loggedInUser);
+    }
+
+    public function testRequestFriendRejectsWhenBlockIsActive(): void
+    {
+        $loggedInUser = new User();
+        $targetUser = new User();
+
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->method('find')->willReturn($targetUser);
+
+        $relationshipRepository = $this->createMock(UserRelationshipRepositoryInterface::class);
+        $relationshipRepository->expects(self::once())
+            ->method('hasActiveBlock')
+            ->with($loggedInUser, $targetUser)
+            ->willReturn(true);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $service = new UserFriendService($userRepository, $relationshipRepository, $entityManager);
+
+        $this->expectException(ForbiddenHttpException::class);
+        $service->requestFriend($targetUser->getId(), $loggedInUser);
+    }
+
+    public function testRequestFriendRejectsDuplicateOutgoingPendingRequest(): void
+    {
+        $loggedInUser = new User();
+        $targetUser = new User();
+
+        $relationship = (new UserRelationship())
+            ->setRequester($loggedInUser)
+            ->setAddressee($targetUser)
+            ->setStatus(UserRelationshipStatus::PENDING);
+
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->method('find')->willReturn($targetUser);
+
+        $relationshipRepository = $this->createMock(UserRelationshipRepositoryInterface::class);
+        $relationshipRepository->method('hasActiveBlock')->willReturn(false);
+        $relationshipRepository->method('findRelationBetweenUsers')->willReturn($relationship);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $service = new UserFriendService($userRepository, $relationshipRepository, $entityManager);
+
+        $this->expectException(ConflictHttpException::class);
+        $service->requestFriend($targetUser->getId(), $loggedInUser);
+    }
+
+    public function testAcceptFriendRequestIsForbiddenForNonAddressee(): void
+    {
+        $loggedInUser = new User();
+        $targetUser = new User();
+
+        $relationship = (new UserRelationship())
+            ->setRequester($loggedInUser)
+            ->setAddressee($targetUser)
+            ->setStatus(UserRelationshipStatus::PENDING);
+
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->method('find')->willReturn($targetUser);
+
+        $relationshipRepository = $this->createMock(UserRelationshipRepositoryInterface::class);
+        $relationshipRepository->method('hasActiveBlock')->willReturn(false);
+        $relationshipRepository->method('findRelationBetweenUsers')->willReturn($relationship);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $service = new UserFriendService($userRepository, $relationshipRepository, $entityManager);
+
+        $this->expectException(ForbiddenHttpException::class);
+        $service->acceptFriendRequest($targetUser->getId(), $loggedInUser);
+    }
+
+    public function testRejectFriendRequestWithInvalidStatusThrowsConflict(): void
+    {
+        $loggedInUser = new User();
+        $targetUser = new User();
+
+        $relationship = (new UserRelationship())
+            ->setRequester($targetUser)
+            ->setAddressee($loggedInUser)
+            ->setStatus(UserRelationshipStatus::ACCEPTED);
+
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->method('find')->willReturn($targetUser);
+
+        $relationshipRepository = $this->createMock(UserRelationshipRepositoryInterface::class);
+        $relationshipRepository->method('findRelationBetweenUsers')->willReturn($relationship);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $service = new UserFriendService($userRepository, $relationshipRepository, $entityManager);
+
+        $this->expectException(ConflictHttpException::class);
+        $service->rejectFriendRequest($targetUser->getId(), $loggedInUser);
+    }
+}


### PR DESCRIPTION
### Motivation
- Appliquer les règles métier pour les relations utilisateur : interdire les opérations sur soi, empêcher les doublons et transitions d'état invalides, et restreindre l'acceptation/refus aux destinataires.
- Bloquer la création/acceptation d'amitié lorsqu'un blocage actif existe entre deux utilisateurs et préserver le comportement de blocage en basculant/dissolvant les relations existantes.
- Uniformiser les erreurs HTTP renvoyées par le service en utilisant les exceptions Symfony existantes pour refléter correctement `400`, `403`, `404` et `409`.

### Description
- Renforcement de la logique dans `src/User/Application/Service/UserFriendService.php` : vérification par `getId()` pour refuser les actions sur soi et ajout de `assertNoActiveBlock()` pour interdire certaines opérations quand `hasActiveBlock()` est vrai.
- Ajustement des transitions d'état et des gardes : utilisation de `ConflictHttpException`, `ForbiddenHttpException` et `NotFoundHttpException` pour représenter respectivement les conflits (`409`), les accès interdits (`403`) et les entités introuvables (`404`), et clarification des règles pour `PENDING`/`ACCEPTED`/`BLOCKED`.
- Gestion de `blockUser` durcie pour interdire l'écrasement d'un blocage existant et renvoyer des erreurs cohérentes si l'auteur du blocage diffère.
- Ajout d'un fichier de tests unitaires ciblés `tests/Unit/User/Application/Service/UserFriendServiceTest.php` couvrant les cas : action sur soi, blocage actif, doublon de demande sortante en `PENDING`, acceptation par un non-destinataire, et rejet quand le statut est invalide.

### Testing
- Exécution des vérifications de syntaxe PHP avec `php -l` sur `src/User/Application/Service/UserFriendService.php` et sur le nouveau test, les deux ont réussi.
- Création et ajout du test unitaire `tests/Unit/User/Application/Service/UserFriendServiceTest.php` (tests présents mais non exécutés ici).
- Tentative d'exécution de `vendor/bin/phpunit tests/Unit/User/Application/Service/UserFriendServiceTest.php` non réalisable dans cet environnement car `vendor/bin/phpunit` est absent (dépendances non installées), donc les tests unitaires n'ont pas été exécutés ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af45369f5083269dc7ca702b26135e)