### PR TITLE
Add richer user and relationship fixtures for API demos

### DIFF
--- a/src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php
+++ b/src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php
@@ -36,6 +36,10 @@ final class LoadUserData extends Fixture implements OrderedFixtureInterface
         'john-user' => '20000000-0000-1000-8000-000000000004',
         'john-admin' => '20000000-0000-1000-8000-000000000005',
         'john-root' => '20000000-0000-1000-8000-000000000006',
+        'alice' => '20000000-0000-1000-8000-000000000007',
+        'bob' => '20000000-0000-1000-8000-000000000008',
+        'charlie' => '20000000-0000-1000-8000-000000000009',
+        'diana' => '20000000-0000-1000-8000-00000000000a',
     ];
 
     public function __construct(
@@ -59,6 +63,9 @@ final class LoadUserData extends Fixture implements OrderedFixtureInterface
                 ...$this->rolesService->getRoles(),
             ],
         );
+
+        $this->createAdditionalUsers($manager);
+
         // Flush database changes
         $manager->flush();
     }
@@ -113,5 +120,54 @@ final class LoadUserData extends Fixture implements OrderedFixtureInterface
         $this->addReference('User-' . $entity->getUsername(), $entity);
 
         return true;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function createAdditionalUsers(ObjectManager $manager): void
+    {
+        $users = [
+            [
+                'username' => 'alice',
+                'firstName' => 'Alice',
+                'lastName' => 'Martin',
+            ],
+            [
+                'username' => 'bob',
+                'firstName' => 'Bob',
+                'lastName' => 'Durand',
+            ],
+            [
+                'username' => 'charlie',
+                'firstName' => 'Charlie',
+                'lastName' => 'Bernard',
+            ],
+            [
+                'username' => 'diana',
+                'firstName' => 'Diana',
+                'lastName' => 'Moreau',
+            ],
+        ];
+
+        foreach ($users as $userData) {
+            $entity = new User()
+                ->setUsername($userData['username'])
+                ->setFirstName($userData['firstName'])
+                ->setLastName($userData['lastName'])
+                ->setEmail($userData['username'] . '@test.com')
+                ->setLanguage(Language::EN)
+                ->setLocale(Locale::EN)
+                ->setPlainPassword('password-' . $userData['username']);
+
+            PhpUnitUtil::setProperty(
+                'id',
+                UuidHelper::fromString(self::$uuids[$userData['username']]),
+                $entity
+            );
+
+            $manager->persist($entity);
+            $this->addReference('User-' . $entity->getUsername(), $entity);
+        }
     }
 }

--- a/src/User/Infrastructure/DataFixtures/ORM/LoadUserRelationshipData.php
+++ b/src/User/Infrastructure/DataFixtures/ORM/LoadUserRelationshipData.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\DataFixtures\ORM;
+
+use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserRelationship;
+use App\User\Domain\Enum\UserRelationshipStatus;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+
+final class LoadUserRelationshipData extends Fixture implements OrderedFixtureInterface
+{
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        $alice = $this->getReference('User-alice', User::class);
+        $bob = $this->getReference('User-bob', User::class);
+        $charlie = $this->getReference('User-charlie', User::class);
+        $diana = $this->getReference('User-diana', User::class);
+
+        $pendingRelationship = (new UserRelationship())
+            ->setRequester($alice)
+            ->setAddressee($bob)
+            ->setStatus(UserRelationshipStatus::PENDING);
+
+        $acceptedRelationship = (new UserRelationship())
+            ->setRequester($bob)
+            ->setAddressee($charlie)
+            ->setStatus(UserRelationshipStatus::ACCEPTED);
+
+        $blockedRelationship = (new UserRelationship())
+            ->setRequester($charlie)
+            ->setAddressee($diana)
+            ->setStatus(UserRelationshipStatus::BLOCKED)
+            ->setBlockedBy($diana);
+
+        $manager->persist($pendingRelationship);
+        $manager->persist($acceptedRelationship);
+        $manager->persist($blockedRelationship);
+
+        $this->addReference('UserRelationship-pending', $pendingRelationship);
+        $this->addReference('UserRelationship-accepted', $acceptedRelationship);
+        $this->addReference('UserRelationship-blocked', $blockedRelationship);
+
+        $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 5;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide more realistic and varied user data for API demos and tests by adding multiple users with different first/last names. 
- Make fixture references deterministic by extending `self::$uuids` with explicit keys for new users. 
- Seed example relationship states to facilitate testing of friend/relationship flows (`PENDING`, `ACCEPTED`, `BLOCKED`).

### Description

- Extended `LoadUserData::$uuids` with explicit keys and UUIDs for `alice`, `bob`, `charlie`, and `diana`. 
- Added a `createAdditionalUsers` method that creates the new users, sets deterministic IDs with `UuidHelper`, persists them and keeps the reference pattern `addReference('User-' . $entity->getUsername(), $entity)`. 
- Kept existing John-based users and role-based user creation logic unchanged. 
- Added a new fixture `src/User/Infrastructure/DataFixtures/ORM/LoadUserRelationshipData.php` that creates and persists three relationships (one `PENDING`, one `ACCEPTED`, and one `BLOCKED` with `blockedBy`) and exposes them via `UserRelationship-<status>` references, with fixture order set to `5`.

### Testing

- Ran `php -l src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php` which returned no syntax errors. 
- Ran `php -l src/User/Infrastructure/DataFixtures/ORM/LoadUserRelationshipData.php` which returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af46915cac8326aecc4f694c551e73)