### PR TITLE
Add functional tests for user friend request, decision and block endpoints

### DIFF
--- a/tests/Application/User/Transport/Controller/Api/V1/User/UserBlockControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/User/UserBlockControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\User;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Infrastructure\DataFixtures\ORM\LoadUserData;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class UserBlockControllerTest extends WebTestCase
+{
+    private const string BASE_URL = self::API_URL_PREFIX . '/v1/users';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that block prevents friend request, then unblock allows valid friend flow again.')]
+    public function testThatBlockThenUnblockControlsFriendFlow(): void
+    {
+        $userId = LoadUserData::getUuidByKey('john-user');
+        $adminId = LoadUserData::getUuidByKey('john-admin');
+
+        $userClient = $this->getTestClient('john-user', 'password-user');
+        $adminClient = $this->getTestClient('john-admin', 'password-admin');
+
+        $userClient->request('POST', self::BASE_URL . '/' . $adminId . '/block');
+        $blockResponse = $userClient->getResponse();
+        $blockContent = $blockResponse->getContent();
+        self::assertNotFalse($blockContent);
+        self::assertSame(Response::HTTP_OK, $blockResponse->getStatusCode(), "Response:\n" . $blockResponse);
+        $blockData = JSON::decode($blockContent, true);
+        self::assertSame('BLOCKED', $blockData['data']['status']);
+        self::assertSame($userId, $blockData['data']['blockedById']);
+
+        $adminClient->request('POST', self::BASE_URL . '/' . $userId . '/friends/request');
+        $requestWhileBlockedResponse = $adminClient->getResponse();
+        $requestWhileBlockedContent = $requestWhileBlockedResponse->getContent();
+        self::assertNotFalse($requestWhileBlockedContent);
+        self::assertSame(Response::HTTP_FORBIDDEN, $requestWhileBlockedResponse->getStatusCode(), "Response:\n" . $requestWhileBlockedResponse);
+        $requestWhileBlockedData = JSON::decode($requestWhileBlockedContent, true);
+        self::assertSame(
+            'Cannot send a friend request while a block is active between both users.',
+            $requestWhileBlockedData['message']
+        );
+
+        $userClient->request('DELETE', self::BASE_URL . '/' . $adminId . '/block');
+        $unblockResponse = $userClient->getResponse();
+        $unblockContent = $unblockResponse->getContent();
+        self::assertNotFalse($unblockContent);
+        self::assertSame(Response::HTTP_OK, $unblockResponse->getStatusCode(), "Response:\n" . $unblockResponse);
+        $unblockData = JSON::decode($unblockContent, true);
+        self::assertSame('REJECTED', $unblockData['data']['status']);
+
+        $adminClient->request('POST', self::BASE_URL . '/' . $userId . '/friends/request');
+        $newRequestResponse = $adminClient->getResponse();
+        $newRequestContent = $newRequestResponse->getContent();
+        self::assertNotFalse($newRequestContent);
+        self::assertSame(Response::HTTP_OK, $newRequestResponse->getStatusCode(), "Response:\n" . $newRequestResponse);
+        $newRequestData = JSON::decode($newRequestContent, true);
+        self::assertSame('PENDING', $newRequestData['data']['status']);
+
+        $userClient->request('POST', self::BASE_URL . '/' . $adminId . '/friends/accept');
+        $acceptResponse = $userClient->getResponse();
+        $acceptContent = $acceptResponse->getContent();
+        self::assertNotFalse($acceptContent);
+        self::assertSame(Response::HTTP_OK, $acceptResponse->getStatusCode(), "Response:\n" . $acceptResponse);
+        $acceptData = JSON::decode($acceptContent, true);
+        self::assertSame('ACCEPTED', $acceptData['data']['status']);
+    }
+}

--- a/tests/Application/User/Transport/Controller/Api/V1/User/UserFriendDecisionControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/User/UserFriendDecisionControllerTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\User;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Infrastructure\DataFixtures\ORM\LoadUserData;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class UserFriendDecisionControllerTest extends WebTestCase
+{
+    private const string BASE_URL = self::API_URL_PREFIX . '/v1/users';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that addressee can accept pending friend request.')]
+    public function testThatAcceptFriendRequestSucceeds(): void
+    {
+        $requesterId = LoadUserData::getUuidByKey('john-user');
+        $addresseeId = LoadUserData::getUuidByKey('john-admin');
+
+        $requesterClient = $this->getTestClient('john-user', 'password-user');
+        $requesterClient->request('POST', self::BASE_URL . '/' . $addresseeId . '/friends/request');
+        self::assertSame(Response::HTTP_OK, $requesterClient->getResponse()->getStatusCode());
+
+        $addresseeClient = $this->getTestClient('john-admin', 'password-admin');
+        $addresseeClient->request('POST', self::BASE_URL . '/' . $requesterId . '/friends/accept');
+        $response = $addresseeClient->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertSame('ok', $responseData['status']);
+        self::assertSame('ACCEPTED', $responseData['data']['status']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that addressee can reject pending friend request.')]
+    public function testThatRejectFriendRequestSucceeds(): void
+    {
+        $requesterId = LoadUserData::getUuidByKey('john-user');
+        $addresseeId = LoadUserData::getUuidByKey('john-admin');
+
+        $requesterClient = $this->getTestClient('john-user', 'password-user');
+        $requesterClient->request('POST', self::BASE_URL . '/' . $addresseeId . '/friends/request');
+        self::assertSame(Response::HTTP_OK, $requesterClient->getResponse()->getStatusCode());
+
+        $addresseeClient = $this->getTestClient('john-admin', 'password-admin');
+        $addresseeClient->request('POST', self::BASE_URL . '/' . $requesterId . '/friends/reject');
+        $response = $addresseeClient->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertSame('ok', $responseData['status']);
+        self::assertSame('REJECTED', $responseData['data']['status']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that only addressee can accept or reject a pending friend request.')]
+    public function testThatOnlyAddresseeCanAcceptOrReject(): void
+    {
+        $requesterId = LoadUserData::getUuidByKey('john-user');
+        $addresseeId = LoadUserData::getUuidByKey('john-admin');
+
+        $requesterClient = $this->getTestClient('john-user', 'password-user');
+        $requesterClient->request('POST', self::BASE_URL . '/' . $addresseeId . '/friends/request');
+        self::assertSame(Response::HTTP_OK, $requesterClient->getResponse()->getStatusCode());
+
+        $requesterClient->request('POST', self::BASE_URL . '/' . $addresseeId . '/friends/accept');
+        $acceptResponse = $requesterClient->getResponse();
+        $acceptContent = $acceptResponse->getContent();
+        self::assertNotFalse($acceptContent);
+        self::assertSame(Response::HTTP_FORBIDDEN, $acceptResponse->getStatusCode(), "Response:\n" . $acceptResponse);
+        $acceptResponseData = JSON::decode($acceptContent, true);
+        self::assertSame('Only the addressee can accept this friend request.', $acceptResponseData['message']);
+
+        $requesterClient->request('POST', self::BASE_URL . '/' . $addresseeId . '/friends/reject');
+        $rejectResponse = $requesterClient->getResponse();
+        $rejectContent = $rejectResponse->getContent();
+        self::assertNotFalse($rejectContent);
+        self::assertSame(Response::HTTP_FORBIDDEN, $rejectResponse->getStatusCode(), "Response:\n" . $rejectResponse);
+        $rejectResponseData = JSON::decode($rejectContent, true);
+        self::assertSame('Only the addressee can reject this friend request.', $rejectResponseData['message']);
+
+        // Ensure request is still pending and can be accepted by addressee.
+        $addresseeClient = $this->getTestClient('john-admin', 'password-admin');
+        $addresseeClient->request('POST', self::BASE_URL . '/' . $requesterId . '/friends/accept');
+        self::assertSame(Response::HTTP_OK, $addresseeClient->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Application/User/Transport/Controller/Api/V1/User/UserFriendRequestControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/User/UserFriendRequestControllerTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\User;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Infrastructure\DataFixtures\ORM\LoadUserData;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class UserFriendRequestControllerTest extends WebTestCase
+{
+    private const string BASE_URL = self::API_URL_PREFIX . '/v1/users';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that friend request can be created.')]
+    public function testThatFriendRequestSucceeds(): void
+    {
+        $requesterId = LoadUserData::getUuidByKey('john-user');
+        $addresseeId = LoadUserData::getUuidByKey('john-admin');
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request('POST', self::BASE_URL . '/' . $addresseeId . '/friends/request');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertSame('ok', $responseData['status']);
+        self::assertSame('PENDING', $responseData['data']['status']);
+        self::assertSame($requesterId, $responseData['data']['requesterId']);
+        self::assertSame($addresseeId, $responseData['data']['addresseeId']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that user cannot send a friend request to himself.')]
+    public function testThatSelfFriendRequestIsForbidden(): void
+    {
+        $loggedUserId = LoadUserData::getUuidByKey('john-user');
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request('POST', self::BASE_URL . '/' . $loggedUserId . '/friends/request');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertSame('Cannot perform this action on yourself.', $responseData['message']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that duplicate friend request returns conflict.')]
+    public function testThatDuplicateFriendRequestReturnsConflict(): void
+    {
+        $addresseeId = LoadUserData::getUuidByKey('john-admin');
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request('POST', self::BASE_URL . '/' . $addresseeId . '/friends/request');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request('POST', self::BASE_URL . '/' . $addresseeId . '/friends/request');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_CONFLICT, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertSame('Friend request already sent.', $responseData['message']);
+    }
+}


### PR DESCRIPTION
### Motivation

- Add end-to-end API tests to cover user friendship and blocking behaviours (request, accept, reject, block/unblock) and validate permission checks and edge cases.

### Description

- Add `tests/Application/User/Transport/Controller/Api/V1/User/UserFriendRequestControllerTest.php` to cover successful friend request creation, self-request forbidden, and duplicate request conflict.
- Add `tests/Application/User/Transport/Controller/Api/V1/User/UserFriendDecisionControllerTest.php` to cover accept/reject flows and verify that only the addressee can accept or reject a pending request.
- Add `tests/Application/User/Transport/Controller/Api/V1/User/UserBlockControllerTest.php` to cover block flow, prevention of friend requests while blocked, unblock flow, and subsequent valid request+accept flow.
- All tests reuse the existing `WebTestCase` setup and authentication helpers and rely on the `LoadUserData` fixtures to reference test users.

### Testing

- Ran syntax checks with `php -l` on the three new test files and they returned no syntax errors.
- Attempted to run PHPUnit via `./vendor/bin/phpunit` (and `bin/phpunit`) but the executable is not present in this environment so full test execution could not be performed.
- The new tests were added and are ready to run in CI or a local environment with project dependencies installed (running `vendor/bin/phpunit` will execute them).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4798b4948326917d5284c5b6be8b)