### PR TITLE
feat(page): add Page module with CRUD for Home/About/Contact/Faq

### DIFF
--- a/src/Page/Application/DTO/About/About.php
+++ b/src/Page/Application/DTO/About/About.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\About;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Enum\Language;
+use App\Page\Domain\Entity\About as Entity;
+use Override;
+
+class About extends RestDto
+{
+    protected string $language = Language::EN->value;
+    protected array $content = [];
+
+    public function getLanguage(): string { return $this->language; }
+    public function setLanguage(string $language): self { $this->setVisited('language'); $this->language = $language; return $this; }
+    public function getContent(): array { return $this->content; }
+    public function setContent(array $content): self { $this->setVisited('content'); $this->content = $content; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->language = $entity->getLanguage()->value;
+            $this->content = $entity->getContent();
+        }
+
+        return $this;
+    }
+}

--- a/src/Page/Application/DTO/About/AboutCreate.php
+++ b/src/Page/Application/DTO/About/AboutCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\About;
+
+class AboutCreate extends About
+{
+}

--- a/src/Page/Application/DTO/About/AboutPatch.php
+++ b/src/Page/Application/DTO/About/AboutPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\About;
+
+class AboutPatch extends About
+{
+}

--- a/src/Page/Application/DTO/About/AboutUpdate.php
+++ b/src/Page/Application/DTO/About/AboutUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\About;
+
+class AboutUpdate extends About
+{
+}

--- a/src/Page/Application/DTO/Contact/Contact.php
+++ b/src/Page/Application/DTO/Contact/Contact.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Contact;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Enum\Language;
+use App\Page\Domain\Entity\Contact as Entity;
+use Override;
+
+class Contact extends RestDto
+{
+    protected string $language = Language::EN->value;
+    protected array $content = [];
+
+    public function getLanguage(): string { return $this->language; }
+    public function setLanguage(string $language): self { $this->setVisited('language'); $this->language = $language; return $this; }
+    public function getContent(): array { return $this->content; }
+    public function setContent(array $content): self { $this->setVisited('content'); $this->content = $content; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->language = $entity->getLanguage()->value;
+            $this->content = $entity->getContent();
+        }
+
+        return $this;
+    }
+}

--- a/src/Page/Application/DTO/Contact/ContactCreate.php
+++ b/src/Page/Application/DTO/Contact/ContactCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Contact;
+
+class ContactCreate extends Contact
+{
+}

--- a/src/Page/Application/DTO/Contact/ContactPatch.php
+++ b/src/Page/Application/DTO/Contact/ContactPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Contact;
+
+class ContactPatch extends Contact
+{
+}

--- a/src/Page/Application/DTO/Contact/ContactUpdate.php
+++ b/src/Page/Application/DTO/Contact/ContactUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Contact;
+
+class ContactUpdate extends Contact
+{
+}

--- a/src/Page/Application/DTO/Faq/Faq.php
+++ b/src/Page/Application/DTO/Faq/Faq.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Faq;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Enum\Language;
+use App\Page\Domain\Entity\Faq as Entity;
+use Override;
+
+class Faq extends RestDto
+{
+    protected string $language = Language::EN->value;
+    protected array $content = [];
+
+    public function getLanguage(): string { return $this->language; }
+    public function setLanguage(string $language): self { $this->setVisited('language'); $this->language = $language; return $this; }
+    public function getContent(): array { return $this->content; }
+    public function setContent(array $content): self { $this->setVisited('content'); $this->content = $content; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->language = $entity->getLanguage()->value;
+            $this->content = $entity->getContent();
+        }
+
+        return $this;
+    }
+}

--- a/src/Page/Application/DTO/Faq/FaqCreate.php
+++ b/src/Page/Application/DTO/Faq/FaqCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Faq;
+
+class FaqCreate extends Faq
+{
+}

--- a/src/Page/Application/DTO/Faq/FaqPatch.php
+++ b/src/Page/Application/DTO/Faq/FaqPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Faq;
+
+class FaqPatch extends Faq
+{
+}

--- a/src/Page/Application/DTO/Faq/FaqUpdate.php
+++ b/src/Page/Application/DTO/Faq/FaqUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Faq;
+
+class FaqUpdate extends Faq
+{
+}

--- a/src/Page/Application/DTO/Home/Home.php
+++ b/src/Page/Application/DTO/Home/Home.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Home;
+
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Enum\Language;
+use App\Page\Domain\Entity\Home as Entity;
+use Override;
+
+class Home extends RestDto
+{
+    protected string $language = Language::EN->value;
+    protected array $content = [];
+
+    public function getLanguage(): string { return $this->language; }
+    public function setLanguage(string $language): self { $this->setVisited('language'); $this->language = $language; return $this; }
+    public function getContent(): array { return $this->content; }
+    public function setContent(array $content): self { $this->setVisited('content'); $this->content = $content; return $this; }
+
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->language = $entity->getLanguage()->value;
+            $this->content = $entity->getContent();
+        }
+
+        return $this;
+    }
+}

--- a/src/Page/Application/DTO/Home/HomeCreate.php
+++ b/src/Page/Application/DTO/Home/HomeCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Home;
+
+class HomeCreate extends Home
+{
+}

--- a/src/Page/Application/DTO/Home/HomePatch.php
+++ b/src/Page/Application/DTO/Home/HomePatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Home;
+
+class HomePatch extends Home
+{
+}

--- a/src/Page/Application/DTO/Home/HomeUpdate.php
+++ b/src/Page/Application/DTO/Home/HomeUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\DTO\Home;
+
+class HomeUpdate extends Home
+{
+}

--- a/src/Page/Application/Resource/AboutResource.php
+++ b/src/Page/Application/Resource/AboutResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Page\Domain\Repository\Interfaces\AboutRepositoryInterface as Repository;
+
+class AboutResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Page/Application/Resource/ContactResource.php
+++ b/src/Page/Application/Resource/ContactResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Page\Domain\Repository\Interfaces\ContactRepositoryInterface as Repository;
+
+class ContactResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Page/Application/Resource/FaqResource.php
+++ b/src/Page/Application/Resource/FaqResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Page\Domain\Repository\Interfaces\FaqRepositoryInterface as Repository;
+
+class FaqResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Page/Application/Resource/HomeResource.php
+++ b/src/Page/Application/Resource/HomeResource.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\Resource;
+
+use App\General\Application\Rest\RestResource;
+use App\Page\Domain\Repository\Interfaces\HomeRepositoryInterface as Repository;
+
+class HomeResource extends RestResource
+{
+    public function __construct(Repository $repository)
+    {
+        parent::__construct($repository);
+    }
+}

--- a/src/Page/Domain/Entity/About.php
+++ b/src/Page/Domain/Entity/About.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\General\Domain\Enum\Language;
+use App\General\Domain\Doctrine\DBAL\Types\Types as AppTypes;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'page_about')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class About implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['About', 'About.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'language', type: AppTypes::ENUM_LANGUAGE, nullable: false)]
+    #[Groups(['About', 'About.language'])]
+    private Language $language = Language::EN;
+
+    #[ORM\Column(name: 'content', type: Types::JSON)]
+    #[Groups(['About', 'About.content'])]
+    private array $content = [];
+
+    public function __construct() { $this->id = $this->createUuid(); }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getLanguage(): Language { return $this->language; }
+    public function setLanguage(Language|string $language): self { $this->language = $language instanceof Language ? $language : Language::from($language); return $this; }
+    public function getContent(): array { return $this->content; }
+    public function setContent(array $content): self { $this->content = $content; return $this; }
+}

--- a/src/Page/Domain/Entity/Contact.php
+++ b/src/Page/Domain/Entity/Contact.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\General\Domain\Enum\Language;
+use App\General\Domain\Doctrine\DBAL\Types\Types as AppTypes;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'page_contact')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Contact implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['Contact', 'Contact.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'language', type: AppTypes::ENUM_LANGUAGE, nullable: false)]
+    #[Groups(['Contact', 'Contact.language'])]
+    private Language $language = Language::EN;
+
+    #[ORM\Column(name: 'content', type: Types::JSON)]
+    #[Groups(['Contact', 'Contact.content'])]
+    private array $content = [];
+
+    public function __construct() { $this->id = $this->createUuid(); }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getLanguage(): Language { return $this->language; }
+    public function setLanguage(Language|string $language): self { $this->language = $language instanceof Language ? $language : Language::from($language); return $this; }
+    public function getContent(): array { return $this->content; }
+    public function setContent(array $content): self { $this->content = $content; return $this; }
+}

--- a/src/Page/Domain/Entity/Faq.php
+++ b/src/Page/Domain/Entity/Faq.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\General\Domain\Enum\Language;
+use App\General\Domain\Doctrine\DBAL\Types\Types as AppTypes;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'page_faq')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Faq implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['Faq', 'Faq.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'language', type: AppTypes::ENUM_LANGUAGE, nullable: false)]
+    #[Groups(['Faq', 'Faq.language'])]
+    private Language $language = Language::EN;
+
+    #[ORM\Column(name: 'content', type: Types::JSON)]
+    #[Groups(['Faq', 'Faq.content'])]
+    private array $content = [];
+
+    public function __construct() { $this->id = $this->createUuid(); }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getLanguage(): Language { return $this->language; }
+    public function setLanguage(Language|string $language): self { $this->language = $language instanceof Language ? $language : Language::from($language); return $this; }
+    public function getContent(): array { return $this->content; }
+    public function setContent(array $content): self { $this->content = $content; return $this; }
+}

--- a/src/Page/Domain/Entity/Home.php
+++ b/src/Page/Domain/Entity/Home.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\General\Domain\Enum\Language;
+use App\General\Domain\Doctrine\DBAL\Types\Types as AppTypes;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'page_home')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Home implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['Home', 'Home.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'language', type: AppTypes::ENUM_LANGUAGE, nullable: false)]
+    #[Groups(['Home', 'Home.language'])]
+    private Language $language = Language::EN;
+
+    #[ORM\Column(name: 'content', type: Types::JSON)]
+    #[Groups(['Home', 'Home.content'])]
+    private array $content = [];
+
+    public function __construct() { $this->id = $this->createUuid(); }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getLanguage(): Language { return $this->language; }
+    public function setLanguage(Language|string $language): self { $this->language = $language instanceof Language ? $language : Language::from($language); return $this; }
+    public function getContent(): array { return $this->content; }
+    public function setContent(array $content): self { $this->content = $content; return $this; }
+}

--- a/src/Page/Domain/Repository/Interfaces/AboutRepositoryInterface.php
+++ b/src/Page/Domain/Repository/Interfaces/AboutRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Domain\Repository\Interfaces;
+
+interface AboutRepositoryInterface
+{
+}

--- a/src/Page/Domain/Repository/Interfaces/ContactRepositoryInterface.php
+++ b/src/Page/Domain/Repository/Interfaces/ContactRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Domain\Repository\Interfaces;
+
+interface ContactRepositoryInterface
+{
+}

--- a/src/Page/Domain/Repository/Interfaces/FaqRepositoryInterface.php
+++ b/src/Page/Domain/Repository/Interfaces/FaqRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Domain\Repository\Interfaces;
+
+interface FaqRepositoryInterface
+{
+}

--- a/src/Page/Domain/Repository/Interfaces/HomeRepositoryInterface.php
+++ b/src/Page/Domain/Repository/Interfaces/HomeRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Domain\Repository\Interfaces;
+
+interface HomeRepositoryInterface
+{
+}

--- a/src/Page/Infrastructure/Repository/AboutRepository.php
+++ b/src/Page/Infrastructure/Repository/AboutRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Page\Domain\Entity\About as Entity;
+use App\Page\Domain\Repository\Interfaces\AboutRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class AboutRepository extends BaseRepository implements AboutRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Page/Infrastructure/Repository/ContactRepository.php
+++ b/src/Page/Infrastructure/Repository/ContactRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Page\Domain\Entity\Contact as Entity;
+use App\Page\Domain\Repository\Interfaces\ContactRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ContactRepository extends BaseRepository implements ContactRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Page/Infrastructure/Repository/FaqRepository.php
+++ b/src/Page/Infrastructure/Repository/FaqRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Page\Domain\Entity\Faq as Entity;
+use App\Page\Domain\Repository\Interfaces\FaqRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class FaqRepository extends BaseRepository implements FaqRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Page/Infrastructure/Repository/HomeRepository.php
+++ b/src/Page/Infrastructure/Repository/HomeRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Page\Domain\Entity\Home as Entity;
+use App\Page\Domain\Repository\Interfaces\HomeRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class HomeRepository extends BaseRepository implements HomeRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Page/Transport/AutoMapper/About/AutoMapperConfiguration.php
+++ b/src/Page/Transport/AutoMapper/About/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\AutoMapper\About;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Page\Application\DTO\About\AboutCreate;
+use App\Page\Application\DTO\About\AboutPatch;
+use App\Page\Application\DTO\About\AboutUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        AboutCreate::class,
+        AboutUpdate::class,
+        AboutPatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Page/Transport/AutoMapper/About/RequestMapper.php
+++ b/src/Page/Transport/AutoMapper/About/RequestMapper.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\AutoMapper\About;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = ['language', 'content'];
+}

--- a/src/Page/Transport/AutoMapper/Contact/AutoMapperConfiguration.php
+++ b/src/Page/Transport/AutoMapper/Contact/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\AutoMapper\Contact;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Page\Application\DTO\Contact\ContactCreate;
+use App\Page\Application\DTO\Contact\ContactPatch;
+use App\Page\Application\DTO\Contact\ContactUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        ContactCreate::class,
+        ContactUpdate::class,
+        ContactPatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Page/Transport/AutoMapper/Contact/RequestMapper.php
+++ b/src/Page/Transport/AutoMapper/Contact/RequestMapper.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\AutoMapper\Contact;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = ['language', 'content'];
+}

--- a/src/Page/Transport/AutoMapper/Faq/AutoMapperConfiguration.php
+++ b/src/Page/Transport/AutoMapper/Faq/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\AutoMapper\Faq;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Page\Application\DTO\Faq\FaqCreate;
+use App\Page\Application\DTO\Faq\FaqPatch;
+use App\Page\Application\DTO\Faq\FaqUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        FaqCreate::class,
+        FaqUpdate::class,
+        FaqPatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Page/Transport/AutoMapper/Faq/RequestMapper.php
+++ b/src/Page/Transport/AutoMapper/Faq/RequestMapper.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\AutoMapper\Faq;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = ['language', 'content'];
+}

--- a/src/Page/Transport/AutoMapper/Home/AutoMapperConfiguration.php
+++ b/src/Page/Transport/AutoMapper/Home/AutoMapperConfiguration.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\AutoMapper\Home;
+
+use App\General\Transport\AutoMapper\RestAutoMapperConfiguration;
+use App\Page\Application\DTO\Home\HomeCreate;
+use App\Page\Application\DTO\Home\HomePatch;
+use App\Page\Application\DTO\Home\HomeUpdate;
+
+class AutoMapperConfiguration extends RestAutoMapperConfiguration
+{
+    protected static array $requestMapperClasses = [
+        HomeCreate::class,
+        HomeUpdate::class,
+        HomePatch::class,
+    ];
+
+    public function __construct(RequestMapper $requestMapper)
+    {
+        parent::__construct($requestMapper);
+    }
+}

--- a/src/Page/Transport/AutoMapper/Home/RequestMapper.php
+++ b/src/Page/Transport/AutoMapper/Home/RequestMapper.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\AutoMapper\Home;
+
+use App\General\Transport\AutoMapper\RestRequestMapper;
+
+class RequestMapper extends RestRequestMapper
+{
+    protected static array $properties = ['language', 'content'];
+}

--- a/src/Page/Transport/Controller/Api/V1/About/AboutController.php
+++ b/src/Page/Transport/Controller/Api/V1/About/AboutController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\Controller\Api\V1\About;
+
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\Traits\Actions;
+use App\Page\Application\DTO\About\AboutCreate;
+use App\Page\Application\DTO\About\AboutPatch;
+use App\Page\Application\DTO\About\AboutUpdate;
+use App\Page\Application\Resource\AboutResource;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[Route(path: '/v1/page/about')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Page About Management')]
+class AboutController extends Controller
+{
+    use Actions\Root\CountAction;
+    use Actions\Root\FindAction;
+    use Actions\Root\FindOneAction;
+    use Actions\Root\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => AboutCreate::class,
+        Controller::METHOD_UPDATE => AboutUpdate::class,
+        Controller::METHOD_PATCH => AboutPatch::class,
+    ];
+
+    public function __construct(AboutResource $resource)
+    {
+        parent::__construct($resource);
+    }
+}

--- a/src/Page/Transport/Controller/Api/V1/Contact/ContactController.php
+++ b/src/Page/Transport/Controller/Api/V1/Contact/ContactController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\Controller\Api\V1\Contact;
+
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\Traits\Actions;
+use App\Page\Application\DTO\Contact\ContactCreate;
+use App\Page\Application\DTO\Contact\ContactPatch;
+use App\Page\Application\DTO\Contact\ContactUpdate;
+use App\Page\Application\Resource\ContactResource;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[Route(path: '/v1/page/contact')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Page Contact Management')]
+class ContactController extends Controller
+{
+    use Actions\Root\CountAction;
+    use Actions\Root\FindAction;
+    use Actions\Root\FindOneAction;
+    use Actions\Root\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => ContactCreate::class,
+        Controller::METHOD_UPDATE => ContactUpdate::class,
+        Controller::METHOD_PATCH => ContactPatch::class,
+    ];
+
+    public function __construct(ContactResource $resource)
+    {
+        parent::__construct($resource);
+    }
+}

--- a/src/Page/Transport/Controller/Api/V1/Faq/FaqController.php
+++ b/src/Page/Transport/Controller/Api/V1/Faq/FaqController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\Controller\Api\V1\Faq;
+
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\Traits\Actions;
+use App\Page\Application\DTO\Faq\FaqCreate;
+use App\Page\Application\DTO\Faq\FaqPatch;
+use App\Page\Application\DTO\Faq\FaqUpdate;
+use App\Page\Application\Resource\FaqResource;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[Route(path: '/v1/page/faq')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Page Faq Management')]
+class FaqController extends Controller
+{
+    use Actions\Root\CountAction;
+    use Actions\Root\FindAction;
+    use Actions\Root\FindOneAction;
+    use Actions\Root\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => FaqCreate::class,
+        Controller::METHOD_UPDATE => FaqUpdate::class,
+        Controller::METHOD_PATCH => FaqPatch::class,
+    ];
+
+    public function __construct(FaqResource $resource)
+    {
+        parent::__construct($resource);
+    }
+}

--- a/src/Page/Transport/Controller/Api/V1/Home/HomeController.php
+++ b/src/Page/Transport/Controller/Api/V1/Home/HomeController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\Controller\Api\V1\Home;
+
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\Traits\Actions;
+use App\Page\Application\DTO\Home\HomeCreate;
+use App\Page\Application\DTO\Home\HomePatch;
+use App\Page\Application\DTO\Home\HomeUpdate;
+use App\Page\Application\Resource\HomeResource;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[Route(path: '/v1/page/home')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Page Home Management')]
+class HomeController extends Controller
+{
+    use Actions\Root\CountAction;
+    use Actions\Root\FindAction;
+    use Actions\Root\FindOneAction;
+    use Actions\Root\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => HomeCreate::class,
+        Controller::METHOD_UPDATE => HomeUpdate::class,
+        Controller::METHOD_PATCH => HomePatch::class,
+    ];
+
+    public function __construct(HomeResource $resource)
+    {
+        parent::__construct($resource);
+    }
+}


### PR DESCRIPTION
### Motivation
- Fournir un module `Page` pour gérer le contenu statique (Home/About/Contact/Faq) en réutilisant le pattern existant des entités REST du projet.
- Stocker la structure complète du contenu dans un champ JSON et associer chaque page à une `language` pour la gestion multilingue.
- Exposer des endpoints CRUD sécurisés pour la gestion backend via les mêmes traits REST déjà utilisés.

### Description
- Ajout de l’arborescence `src/Page/` avec `Domain/Entity`, `Domain/Repository/Interfaces`, `Infrastructure/Repository`, `Application/Resource`, `Application/DTO/<Entity>/` et `Transport/Controller/Api/V1/<Entity>/` pour `Home`, `About`, `Contact`, `Faq`.
- Création de 4 entités (`Home`, `About`, `Contact`, `Faq`) avec `UUID` + `Timestampable`, un champ JSON `content` et le champ `language` utilisant le type DBAL `ENUM_LANGUAGE`.
- Ajout des repository interfaces et des repositories d’infrastructure, des resources REST, des arbres de DTO (`base`, `Create`, `Update`, `Patch`) et des configurations `AutoMapper` pour chaque entité.
- Création des contrôleurs CRUD pour chaque entité avec les routes `'/v1/page/home'`, `'/v1/page/about'`, `'/v1/page/contact'`, `'/v1/page/faq'` et protection `IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)`; l’autowiring Symfony existant est utilisé pour l’injection des services.

### Testing
- Exécution de `php -l` sur tous les fichiers créés dans `src/Page` : aucune erreur de syntaxe détectée (succès).
- Exécution de `php bin/console lint:container` impossible dans cet environnement car les dépendances manquent et `composer install` est requis (échec pour cause d’environnement, pas d’erreur de code liée aux fichiers ajoutés).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4a7b4e308326856f6cdfe9e9f9b4)