### PR TITLE
Fix fixture interface conflict in LoadUserFriendRelationData

### DIFF
--- a/src/User/Infrastructure/DataFixtures/ORM/LoadUserFriendRelationData.php
+++ b/src/User/Infrastructure/DataFixtures/ORM/LoadUserFriendRelationData.php
@@ -9,12 +9,11 @@ use App\User\Domain\Entity\UserFriendRelation;
 use App\User\Domain\Enum\FriendStatus;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Override;
 use Throwable;
 
-final class LoadUserFriendRelationData extends Fixture implements OrderedFixtureInterface, DependentFixtureInterface
+final class LoadUserFriendRelationData extends Fixture implements DependentFixtureInterface
 {
     /**
      * @throws Throwable
@@ -50,12 +49,6 @@ final class LoadUserFriendRelationData extends Fixture implements OrderedFixture
         $manager->persist($accepted);
         $manager->persist($blocked);
         $manager->flush();
-    }
-
-    #[Override]
-    public function getOrder(): int
-    {
-        return 4;
     }
 
     /** @return array<int, class-string> */


### PR DESCRIPTION
### Motivation
- Resolve a runtime error where `LoadUserFriendRelationData` declared both `OrderedFixtureInterface` and `DependentFixtureInterface`, which are incompatible when used together.

### Description
- Remove the `OrderedFixtureInterface` import and its implementation from `src/User/Infrastructure/DataFixtures/ORM/LoadUserFriendRelationData.php` and drop the obsolete `getOrder()` method so ordering relies on `DependentFixtureInterface::getDependencies()` only.

### Testing
- Ran `php -l src/User/Infrastructure/DataFixtures/ORM/LoadUserFriendRelationData.php` which reported no syntax errors.
- Attempted `php bin/console doctrine:fixtures:load -n` but it failed in this environment due to missing project dependencies (error suggests running `composer install`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4c48aab08326a3491c16c07dc979)