### PR TITLE
Fix Doctrine fixture identity collision for users

### DIFF
--- a/src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php
+++ b/src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php
@@ -139,11 +139,6 @@ final class LoadUserData extends Fixture implements OrderedFixtureInterface
     {
         $users = [
             [
-                'username' => 'alice',
-                'firstName' => 'Alice',
-                'lastName' => 'Martin',
-            ],
-            [
                 'username' => 'bob',
                 'firstName' => 'Bob',
                 'lastName' => 'Durand',


### PR DESCRIPTION
### Motivation
- Prevent `EntityIdentityCollisionException` when loading fixtures by avoiding creating two distinct `User` objects with the same static UUID (`20000000-0000-1000-8000-000000000007`).

### Description
- Removed the duplicate `alice` entry from `createAdditionalUsers()` in `src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php` so `alice` is only created once via `createNamedUser()`.
- Kept other additional users (`bob`, `charlie`, `diana`) intact and preserved the existing UUID assignment logic using `PhpUnitUtil::setProperty` and `UuidHelper::fromString`.
- Committed the fix with a descriptive message to the current branch.

### Testing
- Ran `php -l src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php` and it returned no syntax errors (passed).
- Attempted `php bin/console doctrine:fixtures:load -n` but the run was blocked by missing project dependencies (`composer install` required), so fixtures execution could not be validated in this environment (blocked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4d5112f483268daec021a330d347)