### PR TITLE
Add dedicated page language entity and require languageId in CMS page CRUD

### DIFF
--- a/migrations/Version20260311130000.php
+++ b/migrations/Version20260311130000.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260311130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Introduce dedicated page language table and connect CMS pages to it';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE page_language (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", code VARCHAR(10) NOT NULL, label VARCHAR(64) NOT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, UNIQUE INDEX uq_page_language_code (code), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE page_home DROP language, ADD language_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)"');
+        $this->addSql('CREATE INDEX idx_page_home_language_id ON page_home (language_id)');
+        $this->addSql('CREATE UNIQUE INDEX uq_page_home_language_id ON page_home (language_id)');
+        $this->addSql('ALTER TABLE page_home ADD CONSTRAINT FK_4BF8D00482F1BAF4 FOREIGN KEY (language_id) REFERENCES page_language (id)');
+
+        $this->addSql('ALTER TABLE page_about DROP language, ADD language_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)"');
+        $this->addSql('CREATE INDEX idx_page_about_language_id ON page_about (language_id)');
+        $this->addSql('CREATE UNIQUE INDEX uq_page_about_language_id ON page_about (language_id)');
+        $this->addSql('ALTER TABLE page_about ADD CONSTRAINT FK_7AFC3D8282F1BAF4 FOREIGN KEY (language_id) REFERENCES page_language (id)');
+
+        $this->addSql('ALTER TABLE page_contact DROP language, ADD language_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)"');
+        $this->addSql('CREATE INDEX idx_page_contact_language_id ON page_contact (language_id)');
+        $this->addSql('CREATE UNIQUE INDEX uq_page_contact_language_id ON page_contact (language_id)');
+        $this->addSql('ALTER TABLE page_contact ADD CONSTRAINT FK_C8EE6D4782F1BAF4 FOREIGN KEY (language_id) REFERENCES page_language (id)');
+
+        $this->addSql('ALTER TABLE page_faq DROP language, ADD language_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)"');
+        $this->addSql('CREATE INDEX idx_page_faq_language_id ON page_faq (language_id)');
+        $this->addSql('CREATE UNIQUE INDEX uq_page_faq_language_id ON page_faq (language_id)');
+        $this->addSql('ALTER TABLE page_faq ADD CONSTRAINT FK_C743A75C82F1BAF4 FOREIGN KEY (language_id) REFERENCES page_language (id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE page_home DROP FOREIGN KEY FK_4BF8D00482F1BAF4');
+        $this->addSql('DROP INDEX uq_page_home_language_id ON page_home');
+        $this->addSql('DROP INDEX idx_page_home_language_id ON page_home');
+        $this->addSql('ALTER TABLE page_home DROP language_id, ADD language VARCHAR(2) NOT NULL COMMENT "(DC2Type:EnumLanguage)"');
+
+        $this->addSql('ALTER TABLE page_about DROP FOREIGN KEY FK_7AFC3D8282F1BAF4');
+        $this->addSql('DROP INDEX uq_page_about_language_id ON page_about');
+        $this->addSql('DROP INDEX idx_page_about_language_id ON page_about');
+        $this->addSql('ALTER TABLE page_about DROP language_id, ADD language VARCHAR(2) NOT NULL COMMENT "(DC2Type:EnumLanguage)"');
+
+        $this->addSql('ALTER TABLE page_contact DROP FOREIGN KEY FK_C8EE6D4782F1BAF4');
+        $this->addSql('DROP INDEX uq_page_contact_language_id ON page_contact');
+        $this->addSql('DROP INDEX idx_page_contact_language_id ON page_contact');
+        $this->addSql('ALTER TABLE page_contact DROP language_id, ADD language VARCHAR(2) NOT NULL COMMENT "(DC2Type:EnumLanguage)"');
+
+        $this->addSql('ALTER TABLE page_faq DROP FOREIGN KEY FK_C743A75C82F1BAF4');
+        $this->addSql('DROP INDEX uq_page_faq_language_id ON page_faq');
+        $this->addSql('DROP INDEX idx_page_faq_language_id ON page_faq');
+        $this->addSql('ALTER TABLE page_faq DROP language_id, ADD language VARCHAR(2) NOT NULL COMMENT "(DC2Type:EnumLanguage)"');
+
+        $this->addSql('DROP TABLE page_language');
+    }
+}

--- a/src/Page/Application/DTO/About/About.php
+++ b/src/Page/Application/DTO/About/About.php
@@ -6,17 +6,20 @@ namespace App\Page\Application\DTO\About;
 
 use App\General\Application\DTO\RestDto;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
-use App\General\Domain\Enum\Language;
 use App\Page\Domain\Entity\About as Entity;
 use Override;
 
 class About extends RestDto
 {
-    protected string $language = Language::EN->value;
+    protected static array $mappings = [
+        'languageId' => 'mapLanguageId',
+    ];
+
+    protected string $languageId = '';
     protected array $content = [];
 
-    public function getLanguage(): string { return $this->language; }
-    public function setLanguage(string $language): self { $this->setVisited('language'); $this->language = $language; return $this; }
+    public function getLanguageId(): string { return $this->languageId; }
+    public function setLanguageId(string $languageId): self { $this->setVisited('languageId'); $this->languageId = $languageId; return $this; }
     public function getContent(): array { return $this->content; }
     public function setContent(array $content): self { $this->setVisited('content'); $this->content = $content; return $this; }
 
@@ -25,10 +28,12 @@ class About extends RestDto
     {
         if ($entity instanceof Entity) {
             $this->id = $entity->getId();
-            $this->language = $entity->getLanguage()->value;
+            $this->languageId = $entity->getLanguageId();
             $this->content = $entity->getContent();
         }
 
         return $this;
     }
+
+    protected function mapLanguageId(EntityInterface $entity, string $languageId): void {}
 }

--- a/src/Page/Application/DTO/Contact/Contact.php
+++ b/src/Page/Application/DTO/Contact/Contact.php
@@ -6,17 +6,20 @@ namespace App\Page\Application\DTO\Contact;
 
 use App\General\Application\DTO\RestDto;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
-use App\General\Domain\Enum\Language;
 use App\Page\Domain\Entity\Contact as Entity;
 use Override;
 
 class Contact extends RestDto
 {
-    protected string $language = Language::EN->value;
+    protected static array $mappings = [
+        'languageId' => 'mapLanguageId',
+    ];
+
+    protected string $languageId = '';
     protected array $content = [];
 
-    public function getLanguage(): string { return $this->language; }
-    public function setLanguage(string $language): self { $this->setVisited('language'); $this->language = $language; return $this; }
+    public function getLanguageId(): string { return $this->languageId; }
+    public function setLanguageId(string $languageId): self { $this->setVisited('languageId'); $this->languageId = $languageId; return $this; }
     public function getContent(): array { return $this->content; }
     public function setContent(array $content): self { $this->setVisited('content'); $this->content = $content; return $this; }
 
@@ -25,10 +28,12 @@ class Contact extends RestDto
     {
         if ($entity instanceof Entity) {
             $this->id = $entity->getId();
-            $this->language = $entity->getLanguage()->value;
+            $this->languageId = $entity->getLanguageId();
             $this->content = $entity->getContent();
         }
 
         return $this;
     }
+
+    protected function mapLanguageId(EntityInterface $entity, string $languageId): void {}
 }

--- a/src/Page/Application/DTO/Faq/Faq.php
+++ b/src/Page/Application/DTO/Faq/Faq.php
@@ -6,17 +6,20 @@ namespace App\Page\Application\DTO\Faq;
 
 use App\General\Application\DTO\RestDto;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
-use App\General\Domain\Enum\Language;
 use App\Page\Domain\Entity\Faq as Entity;
 use Override;
 
 class Faq extends RestDto
 {
-    protected string $language = Language::EN->value;
+    protected static array $mappings = [
+        'languageId' => 'mapLanguageId',
+    ];
+
+    protected string $languageId = '';
     protected array $content = [];
 
-    public function getLanguage(): string { return $this->language; }
-    public function setLanguage(string $language): self { $this->setVisited('language'); $this->language = $language; return $this; }
+    public function getLanguageId(): string { return $this->languageId; }
+    public function setLanguageId(string $languageId): self { $this->setVisited('languageId'); $this->languageId = $languageId; return $this; }
     public function getContent(): array { return $this->content; }
     public function setContent(array $content): self { $this->setVisited('content'); $this->content = $content; return $this; }
 
@@ -25,10 +28,12 @@ class Faq extends RestDto
     {
         if ($entity instanceof Entity) {
             $this->id = $entity->getId();
-            $this->language = $entity->getLanguage()->value;
+            $this->languageId = $entity->getLanguageId();
             $this->content = $entity->getContent();
         }
 
         return $this;
     }
+
+    protected function mapLanguageId(EntityInterface $entity, string $languageId): void {}
 }

--- a/src/Page/Application/DTO/Home/Home.php
+++ b/src/Page/Application/DTO/Home/Home.php
@@ -6,17 +6,20 @@ namespace App\Page\Application\DTO\Home;
 
 use App\General\Application\DTO\RestDto;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
-use App\General\Domain\Enum\Language;
 use App\Page\Domain\Entity\Home as Entity;
 use Override;
 
 class Home extends RestDto
 {
-    protected string $language = Language::EN->value;
+    protected static array $mappings = [
+        'languageId' => 'mapLanguageId',
+    ];
+
+    protected string $languageId = '';
     protected array $content = [];
 
-    public function getLanguage(): string { return $this->language; }
-    public function setLanguage(string $language): self { $this->setVisited('language'); $this->language = $language; return $this; }
+    public function getLanguageId(): string { return $this->languageId; }
+    public function setLanguageId(string $languageId): self { $this->setVisited('languageId'); $this->languageId = $languageId; return $this; }
     public function getContent(): array { return $this->content; }
     public function setContent(array $content): self { $this->setVisited('content'); $this->content = $content; return $this; }
 
@@ -25,10 +28,12 @@ class Home extends RestDto
     {
         if ($entity instanceof Entity) {
             $this->id = $entity->getId();
-            $this->language = $entity->getLanguage()->value;
+            $this->languageId = $entity->getLanguageId();
             $this->content = $entity->getContent();
         }
 
         return $this;
     }
+
+    protected function mapLanguageId(EntityInterface $entity, string $languageId): void {}
 }

--- a/src/Page/Application/Resource/AboutResource.php
+++ b/src/Page/Application/Resource/AboutResource.php
@@ -5,12 +5,33 @@ declare(strict_types=1);
 namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
+use App\Page\Application\DTO\About\About as AboutDto;
+use App\Page\Domain\Entity\About;
+use App\Page\Domain\Entity\PageLanguage;
 use App\Page\Domain\Repository\Interfaces\AboutRepositoryInterface as Repository;
+use App\Page\Domain\Repository\Interfaces\PageLanguageRepositoryInterface;
+use RuntimeException;
 
 class AboutResource extends RestResource
 {
-    public function __construct(Repository $repository)
+    public function __construct(Repository $repository, private readonly PageLanguageRepositoryInterface $pageLanguageRepository)
     {
         parent::__construct($repository);
+    }
+
+    protected function beforeCreate($dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    protected function beforeUpdate(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    protected function beforePatch(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+
+    private function applyLanguage(AboutDto $dto, About $entity): void
+    {
+        /** @var PageLanguage|null $language */
+        $language = $this->pageLanguageRepository->find($dto->getLanguageId());
+
+        if ($language === null) {
+            throw new RuntimeException('Invalid page language id provided.');
+        }
+
+        $entity->setLanguage($language);
     }
 }

--- a/src/Page/Application/Resource/ContactResource.php
+++ b/src/Page/Application/Resource/ContactResource.php
@@ -5,12 +5,33 @@ declare(strict_types=1);
 namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
+use App\Page\Application\DTO\Contact\Contact as ContactDto;
+use App\Page\Domain\Entity\Contact;
+use App\Page\Domain\Entity\PageLanguage;
 use App\Page\Domain\Repository\Interfaces\ContactRepositoryInterface as Repository;
+use App\Page\Domain\Repository\Interfaces\PageLanguageRepositoryInterface;
+use RuntimeException;
 
 class ContactResource extends RestResource
 {
-    public function __construct(Repository $repository)
+    public function __construct(Repository $repository, private readonly PageLanguageRepositoryInterface $pageLanguageRepository)
     {
         parent::__construct($repository);
+    }
+
+    protected function beforeCreate($dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    protected function beforeUpdate(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    protected function beforePatch(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+
+    private function applyLanguage(ContactDto $dto, Contact $entity): void
+    {
+        /** @var PageLanguage|null $language */
+        $language = $this->pageLanguageRepository->find($dto->getLanguageId());
+
+        if ($language === null) {
+            throw new RuntimeException('Invalid page language id provided.');
+        }
+
+        $entity->setLanguage($language);
     }
 }

--- a/src/Page/Application/Resource/FaqResource.php
+++ b/src/Page/Application/Resource/FaqResource.php
@@ -5,12 +5,33 @@ declare(strict_types=1);
 namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
+use App\Page\Application\DTO\Faq\Faq as FaqDto;
+use App\Page\Domain\Entity\Faq;
+use App\Page\Domain\Entity\PageLanguage;
 use App\Page\Domain\Repository\Interfaces\FaqRepositoryInterface as Repository;
+use App\Page\Domain\Repository\Interfaces\PageLanguageRepositoryInterface;
+use RuntimeException;
 
 class FaqResource extends RestResource
 {
-    public function __construct(Repository $repository)
+    public function __construct(Repository $repository, private readonly PageLanguageRepositoryInterface $pageLanguageRepository)
     {
         parent::__construct($repository);
+    }
+
+    protected function beforeCreate($dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    protected function beforeUpdate(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    protected function beforePatch(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+
+    private function applyLanguage(FaqDto $dto, Faq $entity): void
+    {
+        /** @var PageLanguage|null $language */
+        $language = $this->pageLanguageRepository->find($dto->getLanguageId());
+
+        if ($language === null) {
+            throw new RuntimeException('Invalid page language id provided.');
+        }
+
+        $entity->setLanguage($language);
     }
 }

--- a/src/Page/Application/Resource/HomeResource.php
+++ b/src/Page/Application/Resource/HomeResource.php
@@ -5,12 +5,33 @@ declare(strict_types=1);
 namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
+use App\Page\Application\DTO\Home\Home as HomeDto;
+use App\Page\Domain\Entity\Home;
+use App\Page\Domain\Repository\Interfaces\PageLanguageRepositoryInterface;
 use App\Page\Domain\Repository\Interfaces\HomeRepositoryInterface as Repository;
+use App\Page\Domain\Entity\PageLanguage;
+use RuntimeException;
 
 class HomeResource extends RestResource
 {
-    public function __construct(Repository $repository)
+    public function __construct(Repository $repository, private readonly PageLanguageRepositoryInterface $pageLanguageRepository)
     {
         parent::__construct($repository);
+    }
+
+    protected function beforeCreate($dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    protected function beforeUpdate(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    protected function beforePatch(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+
+    private function applyLanguage(HomeDto $dto, Home $entity): void
+    {
+        /** @var PageLanguage|null $language */
+        $language = $this->pageLanguageRepository->find($dto->getLanguageId());
+
+        if ($language === null) {
+            throw new RuntimeException('Invalid page language id provided.');
+        }
+
+        $entity->setLanguage($language);
     }
 }

--- a/src/Page/Domain/Entity/About.php
+++ b/src/Page/Domain/Entity/About.php
@@ -7,8 +7,6 @@ namespace App\Page\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
-use App\General\Domain\Enum\Language;
-use App\General\Domain\Doctrine\DBAL\Types\Types as AppTypes;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
@@ -18,6 +16,8 @@ use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'page_about')]
+#[ORM\Index(name: 'idx_page_about_language_id', columns: ['language_id'])]
+#[ORM\UniqueConstraint(name: 'uq_page_about_language_id', columns: ['language_id'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class About implements EntityInterface
 {
@@ -29,9 +29,10 @@ class About implements EntityInterface
     #[Groups(['About', 'About.id'])]
     private UuidInterface $id;
 
-    #[ORM\Column(name: 'language', type: AppTypes::ENUM_LANGUAGE, nullable: false)]
-    #[Groups(['About', 'About.language'])]
-    private Language $language = Language::EN;
+    #[ORM\ManyToOne(targetEntity: PageLanguage::class)]
+    #[ORM\JoinColumn(name: 'language_id', referencedColumnName: 'id', nullable: false)]
+    #[Groups(['About', 'About.languageId'])]
+    private PageLanguage $language;
 
     #[ORM\Column(name: 'content', type: Types::JSON)]
     #[Groups(['About', 'About.content'])]
@@ -41,8 +42,9 @@ class About implements EntityInterface
 
     #[Override]
     public function getId(): string { return $this->id->toString(); }
-    public function getLanguage(): Language { return $this->language; }
-    public function setLanguage(Language|string $language): self { $this->language = $language instanceof Language ? $language : Language::from($language); return $this; }
+    public function getLanguage(): PageLanguage { return $this->language; }
+    public function getLanguageId(): string { return $this->language->getId(); }
+    public function setLanguage(PageLanguage $language): self { $this->language = $language; return $this; }
     public function getContent(): array { return $this->content; }
     public function setContent(array $content): self { $this->content = $content; return $this; }
 }

--- a/src/Page/Domain/Entity/Contact.php
+++ b/src/Page/Domain/Entity/Contact.php
@@ -7,8 +7,6 @@ namespace App\Page\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
-use App\General\Domain\Enum\Language;
-use App\General\Domain\Doctrine\DBAL\Types\Types as AppTypes;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
@@ -18,6 +16,8 @@ use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'page_contact')]
+#[ORM\Index(name: 'idx_page_contact_language_id', columns: ['language_id'])]
+#[ORM\UniqueConstraint(name: 'uq_page_contact_language_id', columns: ['language_id'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Contact implements EntityInterface
 {
@@ -29,9 +29,10 @@ class Contact implements EntityInterface
     #[Groups(['Contact', 'Contact.id'])]
     private UuidInterface $id;
 
-    #[ORM\Column(name: 'language', type: AppTypes::ENUM_LANGUAGE, nullable: false)]
-    #[Groups(['Contact', 'Contact.language'])]
-    private Language $language = Language::EN;
+    #[ORM\ManyToOne(targetEntity: PageLanguage::class)]
+    #[ORM\JoinColumn(name: 'language_id', referencedColumnName: 'id', nullable: false)]
+    #[Groups(['Contact', 'Contact.languageId'])]
+    private PageLanguage $language;
 
     #[ORM\Column(name: 'content', type: Types::JSON)]
     #[Groups(['Contact', 'Contact.content'])]
@@ -41,8 +42,9 @@ class Contact implements EntityInterface
 
     #[Override]
     public function getId(): string { return $this->id->toString(); }
-    public function getLanguage(): Language { return $this->language; }
-    public function setLanguage(Language|string $language): self { $this->language = $language instanceof Language ? $language : Language::from($language); return $this; }
+    public function getLanguage(): PageLanguage { return $this->language; }
+    public function getLanguageId(): string { return $this->language->getId(); }
+    public function setLanguage(PageLanguage $language): self { $this->language = $language; return $this; }
     public function getContent(): array { return $this->content; }
     public function setContent(array $content): self { $this->content = $content; return $this; }
 }

--- a/src/Page/Domain/Entity/Faq.php
+++ b/src/Page/Domain/Entity/Faq.php
@@ -7,8 +7,6 @@ namespace App\Page\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
-use App\General\Domain\Enum\Language;
-use App\General\Domain\Doctrine\DBAL\Types\Types as AppTypes;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
@@ -18,6 +16,8 @@ use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'page_faq')]
+#[ORM\Index(name: 'idx_page_faq_language_id', columns: ['language_id'])]
+#[ORM\UniqueConstraint(name: 'uq_page_faq_language_id', columns: ['language_id'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Faq implements EntityInterface
 {
@@ -29,9 +29,10 @@ class Faq implements EntityInterface
     #[Groups(['Faq', 'Faq.id'])]
     private UuidInterface $id;
 
-    #[ORM\Column(name: 'language', type: AppTypes::ENUM_LANGUAGE, nullable: false)]
-    #[Groups(['Faq', 'Faq.language'])]
-    private Language $language = Language::EN;
+    #[ORM\ManyToOne(targetEntity: PageLanguage::class)]
+    #[ORM\JoinColumn(name: 'language_id', referencedColumnName: 'id', nullable: false)]
+    #[Groups(['Faq', 'Faq.languageId'])]
+    private PageLanguage $language;
 
     #[ORM\Column(name: 'content', type: Types::JSON)]
     #[Groups(['Faq', 'Faq.content'])]
@@ -41,8 +42,9 @@ class Faq implements EntityInterface
 
     #[Override]
     public function getId(): string { return $this->id->toString(); }
-    public function getLanguage(): Language { return $this->language; }
-    public function setLanguage(Language|string $language): self { $this->language = $language instanceof Language ? $language : Language::from($language); return $this; }
+    public function getLanguage(): PageLanguage { return $this->language; }
+    public function getLanguageId(): string { return $this->language->getId(); }
+    public function setLanguage(PageLanguage $language): self { $this->language = $language; return $this; }
     public function getContent(): array { return $this->content; }
     public function setContent(array $content): self { $this->content = $content; return $this; }
 }

--- a/src/Page/Domain/Entity/Home.php
+++ b/src/Page/Domain/Entity/Home.php
@@ -7,8 +7,6 @@ namespace App\Page\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
-use App\General\Domain\Enum\Language;
-use App\General\Domain\Doctrine\DBAL\Types\Types as AppTypes;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
@@ -18,6 +16,8 @@ use Symfony\Component\Serializer\Attribute\Groups;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'page_home')]
+#[ORM\Index(name: 'idx_page_home_language_id', columns: ['language_id'])]
+#[ORM\UniqueConstraint(name: 'uq_page_home_language_id', columns: ['language_id'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Home implements EntityInterface
 {
@@ -29,9 +29,10 @@ class Home implements EntityInterface
     #[Groups(['Home', 'Home.id'])]
     private UuidInterface $id;
 
-    #[ORM\Column(name: 'language', type: AppTypes::ENUM_LANGUAGE, nullable: false)]
-    #[Groups(['Home', 'Home.language'])]
-    private Language $language = Language::EN;
+    #[ORM\ManyToOne(targetEntity: PageLanguage::class)]
+    #[ORM\JoinColumn(name: 'language_id', referencedColumnName: 'id', nullable: false)]
+    #[Groups(['Home', 'Home.languageId'])]
+    private PageLanguage $language;
 
     #[ORM\Column(name: 'content', type: Types::JSON)]
     #[Groups(['Home', 'Home.content'])]
@@ -41,8 +42,9 @@ class Home implements EntityInterface
 
     #[Override]
     public function getId(): string { return $this->id->toString(); }
-    public function getLanguage(): Language { return $this->language; }
-    public function setLanguage(Language|string $language): self { $this->language = $language instanceof Language ? $language : Language::from($language); return $this; }
+    public function getLanguage(): PageLanguage { return $this->language; }
+    public function getLanguageId(): string { return $this->language->getId(); }
+    public function setLanguage(PageLanguage $language): self { $this->language = $language; return $this; }
     public function getContent(): array { return $this->content; }
     public function setContent(array $content): self { $this->content = $content; return $this; }
 }

--- a/src/Page/Domain/Entity/PageLanguage.php
+++ b/src/Page/Domain/Entity/PageLanguage.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'page_language')]
+#[ORM\UniqueConstraint(name: 'uq_page_language_code', columns: ['code'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class PageLanguage implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    #[Groups(['PageLanguage', 'PageLanguage.id'])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'code', type: Types::STRING, length: 10)]
+    #[Groups(['PageLanguage', 'PageLanguage.code'])]
+    private string $code;
+
+    #[ORM\Column(name: 'label', type: Types::STRING, length: 64)]
+    #[Groups(['PageLanguage', 'PageLanguage.label'])]
+    private string $label;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->code = '';
+        $this->label = '';
+    }
+
+    #[Override]
+    public function getId(): string { return $this->id->toString(); }
+    public function getCode(): string { return $this->code; }
+    public function setCode(string $code): self { $this->code = $code; return $this; }
+    public function getLabel(): string { return $this->label; }
+    public function setLabel(string $label): self { $this->label = $label; return $this; }
+}

--- a/src/Page/Domain/Repository/Interfaces/PageLanguageRepositoryInterface.php
+++ b/src/Page/Domain/Repository/Interfaces/PageLanguageRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Domain\Repository\Interfaces;
+
+interface PageLanguageRepositoryInterface
+{
+}

--- a/src/Page/Infrastructure/Repository/PageLanguageRepository.php
+++ b/src/Page/Infrastructure/Repository/PageLanguageRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Page\Domain\Entity\PageLanguage as Entity;
+use App\Page\Domain\Repository\Interfaces\PageLanguageRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class PageLanguageRepository extends BaseRepository implements PageLanguageRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+        'code',
+        'label',
+    ];
+
+    public function __construct(protected ManagerRegistry $managerRegistry)
+    {
+    }
+}

--- a/src/Page/Transport/AutoMapper/About/RequestMapper.php
+++ b/src/Page/Transport/AutoMapper/About/RequestMapper.php
@@ -8,5 +8,5 @@ use App\General\Transport\AutoMapper\RestRequestMapper;
 
 class RequestMapper extends RestRequestMapper
 {
-    protected static array $properties = ['language', 'content'];
+    protected static array $properties = ['languageId', 'content'];
 }

--- a/src/Page/Transport/AutoMapper/Contact/RequestMapper.php
+++ b/src/Page/Transport/AutoMapper/Contact/RequestMapper.php
@@ -8,5 +8,5 @@ use App\General\Transport\AutoMapper\RestRequestMapper;
 
 class RequestMapper extends RestRequestMapper
 {
-    protected static array $properties = ['language', 'content'];
+    protected static array $properties = ['languageId', 'content'];
 }

--- a/src/Page/Transport/AutoMapper/Faq/RequestMapper.php
+++ b/src/Page/Transport/AutoMapper/Faq/RequestMapper.php
@@ -8,5 +8,5 @@ use App\General\Transport\AutoMapper\RestRequestMapper;
 
 class RequestMapper extends RestRequestMapper
 {
-    protected static array $properties = ['language', 'content'];
+    protected static array $properties = ['languageId', 'content'];
 }

--- a/src/Page/Transport/AutoMapper/Home/RequestMapper.php
+++ b/src/Page/Transport/AutoMapper/Home/RequestMapper.php
@@ -8,5 +8,5 @@ use App\General\Transport\AutoMapper\RestRequestMapper;
 
 class RequestMapper extends RestRequestMapper
 {
-    protected static array $properties = ['language', 'content'];
+    protected static array $properties = ['languageId', 'content'];
 }


### PR DESCRIPTION
### Motivation

- Séparer le besoin CMS de la `Language` du domaine Recruit pour éviter de réutiliser l'entité couplée à `Resume` et permettre une gestion centralisée des langues pour les pages.
- Supporter un contenu CMS par langue en rendant la langue d'une page une relation vers une entité dédiée plutôt qu'un enum primitif.
- Préparer le terrain pour mutualiser ou étendre la gestion des langues côté Page sans impacter le domaine Recruit.

### Description

- Ajout de l'entité `PageLanguage` (`code`, `label`) et de son dépôt `PageLanguageRepository` dans le bounded context `Page`, plus l'interface `PageLanguageRepositoryInterface`.
- Transformation des champs `language` de `Home`, `About`, `Contact`, `Faq` en `ManyToOne` vers `PageLanguage` avec `language_id` SQL, index et contrainte d'unicité (un seul enregistrement par langue et par type de page).
- Mise à jour des DTOs pour exposer et exiger `languageId` (`language` retiré), et adaptation des mappers request (`RequestMapper`) pour accepter `languageId` dans le payload.
- Mise à jour des `Resource` de Page pour résoudre `languageId` en entité `PageLanguage` avant `create/update/patch` et lever une erreur si l'ID est invalide.
- Ajout d'une migration Doctrine `migrations/Version20260311130000.php` créant `page_language` et modifiant les tables de pages (FK, index, contraintes d'unicité) ainsi que la méthode `down` pour rollback.

### Testing

- Vérification statique PHP : `php -l` sur tous les fichiers modifiés (tous réussis).
- Tentative d'exécution de `php bin/console doctrine:migrations:diff` a échoué en environnement d'exécution à cause de dépendances manquantes (voir note ci‑dessous).
- Tentatives d'installation des dépendances avec `composer install` ont échoué en local CI/tooling à cause d'extensions PHP manquantes (`ext-amqp`, `ext-sodium`) et de restrictions réseau lors du fetch des paquets, empêchant la génération automatique de la migration (la migration a été ajoutée manuellement pour la PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4c182d4c8326b4bc3a566ba689fa)