### PR TITLE
Add public page endpoints, fixtures and API tests

### DIFF
--- a/src/Page/Infrastructure/DataFixtures/ORM/LoadPageData.php
+++ b/src/Page/Infrastructure/DataFixtures/ORM/LoadPageData.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Infrastructure\DataFixtures\ORM;
+
+use App\Page\Domain\Entity\About;
+use App\Page\Domain\Entity\Contact;
+use App\Page\Domain\Entity\Faq;
+use App\Page\Domain\Entity\Home;
+use App\Page\Domain\Entity\PageLanguage;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+
+final class LoadPageData extends Fixture implements OrderedFixtureInterface
+{
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        $language = (new PageLanguage())
+            ->setCode('fr')
+            ->setLabel('Français');
+
+        $manager->persist($language);
+
+        $manager->persist((new Home())
+            ->setLanguage($language)
+            ->setContent([
+                'hero' => [
+                    'title' => 'Bienvenue sur Bro World',
+                    'subtitle' => 'Une plateforme unifiée pour vos applications.',
+                    'cta' => [
+                        'label' => 'Commencer',
+                        'url' => '/signup',
+                    ],
+                ],
+                'highlights' => [
+                    ['title' => 'Rapide', 'description' => 'Mise en route en quelques minutes.'],
+                    ['title' => 'Sécurisé', 'description' => 'Protection des données de bout en bout.'],
+                    ['title' => 'Flexible', 'description' => 'S’adapte à vos besoins métier.'],
+                ],
+            ]));
+
+        $manager->persist((new About())
+            ->setLanguage($language)
+            ->setContent([
+                'title' => 'À propos',
+                'mission' => 'Aider les équipes à livrer plus vite avec une expérience cohérente.',
+                'values' => [
+                    'Qualité',
+                    'Transparence',
+                    'Innovation',
+                ],
+            ]));
+
+        $manager->persist((new Contact())
+            ->setLanguage($language)
+            ->setContent([
+                'title' => 'Contact',
+                'email' => 'contact@bro-world.dev',
+                'phone' => '+33 1 23 45 67 89',
+                'address' => '10 Rue de la Paix, 75002 Paris, France',
+            ]));
+
+        $manager->persist((new Faq())
+            ->setLanguage($language)
+            ->setContent([
+                'title' => 'FAQ',
+                'items' => [
+                    [
+                        'question' => 'Comment créer un compte ?',
+                        'answer' => 'Cliquez sur "Commencer" puis suivez les étapes d’inscription.',
+                    ],
+                    [
+                        'question' => 'Puis-je changer de langue ?',
+                        'answer' => 'Oui, vous pouvez sélectionner votre langue depuis les paramètres.',
+                    ],
+                ],
+            ]));
+
+        $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 10;
+    }
+}

--- a/src/Page/Transport/Controller/Api/V1/Public/PublicPageController.php
+++ b/src/Page/Transport/Controller/Api/V1/Public/PublicPageController.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Transport\Controller\Api\V1\Public;
+
+use App\Page\Domain\Entity\About;
+use App\Page\Domain\Entity\Contact;
+use App\Page\Domain\Entity\Faq;
+use App\Page\Domain\Entity\Home;
+use App\Page\Domain\Entity\PageLanguage;
+use App\Page\Infrastructure\Repository\AboutRepository;
+use App\Page\Infrastructure\Repository\ContactRepository;
+use App\Page\Infrastructure\Repository\FaqRepository;
+use App\Page\Infrastructure\Repository\HomeRepository;
+use App\Page\Infrastructure\Repository\PageLanguageRepository;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Page Public')]
+final class PublicPageController
+{
+    public function __construct(
+        private readonly PageLanguageRepository $pageLanguageRepository,
+        private readonly HomeRepository $homeRepository,
+        private readonly AboutRepository $aboutRepository,
+        private readonly ContactRepository $contactRepository,
+        private readonly FaqRepository $faqRepository,
+    ) {
+    }
+
+    #[Route(path: '/v1/page/public/home/{languageCode}', methods: [Request::METHOD_GET])]
+    #[OA\Get(security: [])]
+    public function home(string $languageCode): JsonResponse
+    {
+        $language = $this->resolveLanguage($languageCode);
+
+        /** @var Home|null $entity */
+        $entity = $this->homeRepository->findOneBy(['language' => $language]);
+
+        return $this->jsonContentOr404($entity?->getContent());
+    }
+
+    #[Route(path: '/v1/page/public/about/{languageCode}', methods: [Request::METHOD_GET])]
+    #[OA\Get(security: [])]
+    public function about(string $languageCode): JsonResponse
+    {
+        $language = $this->resolveLanguage($languageCode);
+
+        /** @var About|null $entity */
+        $entity = $this->aboutRepository->findOneBy(['language' => $language]);
+
+        return $this->jsonContentOr404($entity?->getContent());
+    }
+
+    #[Route(path: '/v1/page/public/contact/{languageCode}', methods: [Request::METHOD_GET])]
+    #[OA\Get(security: [])]
+    public function contact(string $languageCode): JsonResponse
+    {
+        $language = $this->resolveLanguage($languageCode);
+
+        /** @var Contact|null $entity */
+        $entity = $this->contactRepository->findOneBy(['language' => $language]);
+
+        return $this->jsonContentOr404($entity?->getContent());
+    }
+
+    #[Route(path: '/v1/page/public/faq/{languageCode}', methods: [Request::METHOD_GET])]
+    #[OA\Get(security: [])]
+    public function faq(string $languageCode): JsonResponse
+    {
+        $language = $this->resolveLanguage($languageCode);
+
+        /** @var Faq|null $entity */
+        $entity = $this->faqRepository->findOneBy(['language' => $language]);
+
+        return $this->jsonContentOr404($entity?->getContent());
+    }
+
+    private function resolveLanguage(string $languageCode): PageLanguage
+    {
+        /** @var PageLanguage|null $language */
+        $language = $this->pageLanguageRepository->findOneBy(['code' => $languageCode]);
+
+        if ($language === null) {
+            throw new NotFoundHttpException('Language not found.');
+        }
+
+        return $language;
+    }
+
+    /** @param array<string, mixed>|null $content */
+    private function jsonContentOr404(?array $content): JsonResponse
+    {
+        if ($content === null) {
+            throw new NotFoundHttpException('Page content not found.');
+        }
+
+        return new JsonResponse($content);
+    }
+}

--- a/tests/Application/Page/Transport/Controller/Api/V1/Public/PublicPageControllerTest.php
+++ b/tests/Application/Page/Transport/Controller/Api/V1/Public/PublicPageControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Page\Transport\Controller\Api\V1\Public;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+final class PublicPageControllerTest extends WebTestCase
+{
+    #[TestDox('Public page endpoint returns expected JSON payload for existing language.')]
+    #[DataProvider('providePublicPageRoutes')]
+    public function testPublicPageEndpointReturns200(string $route, array $expectedSubset): void
+    {
+        $client = $this->getTestClient();
+        $client->request('GET', self::API_URL_PREFIX . $route . '/fr');
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload);
+
+        foreach ($expectedSubset as $key => $value) {
+            self::assertArrayHasKey($key, $payload);
+            self::assertSame($value, $payload[$key]);
+        }
+    }
+
+    #[TestDox('Public page endpoint returns 404 for missing language.')]
+    #[DataProvider('providePublicPageRoutes')]
+    public function testPublicPageEndpointReturns404WhenLanguageIsMissing(string $route): void
+    {
+        $client = $this->getTestClient();
+        $client->request('GET', self::API_URL_PREFIX . $route . '/xx');
+
+        $response = $client->getResponse();
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: array<string, mixed>}>
+     */
+    public static function providePublicPageRoutes(): iterable
+    {
+        yield 'home' => ['/v1/page/public/home', ['hero' => ['title' => 'Bienvenue sur Bro World', 'subtitle' => 'Une plateforme unifiée pour vos applications.', 'cta' => ['label' => 'Commencer', 'url' => '/signup']]]];
+        yield 'about' => ['/v1/page/public/about', ['title' => 'À propos', 'mission' => 'Aider les équipes à livrer plus vite avec une expérience cohérente.']];
+        yield 'contact' => ['/v1/page/public/contact', ['title' => 'Contact', 'email' => 'contact@bro-world.dev']];
+        yield 'faq' => ['/v1/page/public/faq', ['title' => 'FAQ']];
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide unauthenticated public endpoints to expose page content (home/about/contact/faq) per language so frontends can retrieve localized page JSON.
- Seed a default French language and page records so tests and development environments have predictable page content.

### Description
- Added `src/Page/Infrastructure/DataFixtures/ORM/LoadPageData.php` which creates a `PageLanguage` (`fr`) and persists `Home`, `About`, `Contact`, and `Faq` entities with the requested JSON `content` payloads and implements `OrderedFixtureInterface` (`getOrder(): 10`).
- Introduced `src/Page/Transport/Controller/Api/V1/Public/PublicPageController.php` exposing four public routes: `GET /v1/page/public/home/{languageCode}`, `GET /v1/page/public/about/{languageCode}`, `GET /v1/page/public/contact/{languageCode}`, and `GET /v1/page/public/faq/{languageCode}`; each route resolves the language by code, fetches the entity by language, returns the raw `content` JSON, and throws `404` when not found.
- Added OpenAPI annotations (`security: []`) to the public endpoints for documentation parity with other public controllers.
- Added application tests at `tests/Application/Page/Transport/Controller/Api/V1/Public/PublicPageControllerTest.php` that assert `200` responses and payload structure for `fr`, and `404` when the language is missing.

### Testing
- Ran `php -l` syntax checks on `src/Page/Infrastructure/DataFixtures/ORM/LoadPageData.php`, `src/Page/Transport/Controller/Api/V1/Public/PublicPageController.php`, and `tests/Application/Page/Transport/Controller/Api/V1/Public/PublicPageControllerTest.php`, all of which passed.
- Attempted to run `phpunit` for the new tests but the test runner (`vendor/bin/phpunit`) is not available in this environment, so the full test suite could not be executed.
- Added automated API tests covering success (`200`) and missing-language (`404`) scenarios and simple payload assertions (these tests are included in the repository and ready to run when dependencies are present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af4e2a59848326aa2e5ed4d84913bb)