### PR TITLE
Fix page resource lifecycle overrides to match RestResource contract

### DIFF
--- a/src/Page/Application/Resource/AboutResource.php
+++ b/src/Page/Application/Resource/AboutResource.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\Page\Application\DTO\About\About as AboutDto;
 use App\Page\Domain\Entity\About;
 use App\Page\Domain\Entity\PageLanguage;
@@ -19,12 +21,16 @@ class AboutResource extends RestResource
         parent::__construct($repository);
     }
 
-    protected function beforeCreate($dto, $entity): void { $this->applyLanguage($dto, $entity); }
-    protected function beforeUpdate(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
-    protected function beforePatch(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforeCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforeUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforePatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
 
-    private function applyLanguage(AboutDto $dto, About $entity): void
+    private function applyLanguage(RestDtoInterface $dto, EntityInterface $entity): void
     {
+        if (!$dto instanceof AboutDto || !$entity instanceof About) {
+            return;
+        }
+
         /** @var PageLanguage|null $language */
         $language = $this->pageLanguageRepository->find($dto->getLanguageId());
 

--- a/src/Page/Application/Resource/ContactResource.php
+++ b/src/Page/Application/Resource/ContactResource.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\Page\Application\DTO\Contact\Contact as ContactDto;
 use App\Page\Domain\Entity\Contact;
 use App\Page\Domain\Entity\PageLanguage;
@@ -19,12 +21,16 @@ class ContactResource extends RestResource
         parent::__construct($repository);
     }
 
-    protected function beforeCreate($dto, $entity): void { $this->applyLanguage($dto, $entity); }
-    protected function beforeUpdate(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
-    protected function beforePatch(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforeCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforeUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforePatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
 
-    private function applyLanguage(ContactDto $dto, Contact $entity): void
+    private function applyLanguage(RestDtoInterface $dto, EntityInterface $entity): void
     {
+        if (!$dto instanceof ContactDto || !$entity instanceof Contact) {
+            return;
+        }
+
         /** @var PageLanguage|null $language */
         $language = $this->pageLanguageRepository->find($dto->getLanguageId());
 

--- a/src/Page/Application/Resource/FaqResource.php
+++ b/src/Page/Application/Resource/FaqResource.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\Page\Application\DTO\Faq\Faq as FaqDto;
 use App\Page\Domain\Entity\Faq;
 use App\Page\Domain\Entity\PageLanguage;
@@ -19,12 +21,16 @@ class FaqResource extends RestResource
         parent::__construct($repository);
     }
 
-    protected function beforeCreate($dto, $entity): void { $this->applyLanguage($dto, $entity); }
-    protected function beforeUpdate(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
-    protected function beforePatch(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforeCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforeUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforePatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
 
-    private function applyLanguage(FaqDto $dto, Faq $entity): void
+    private function applyLanguage(RestDtoInterface $dto, EntityInterface $entity): void
     {
+        if (!$dto instanceof FaqDto || !$entity instanceof Faq) {
+            return;
+        }
+
         /** @var PageLanguage|null $language */
         $language = $this->pageLanguageRepository->find($dto->getLanguageId());
 

--- a/src/Page/Application/Resource/HomeResource.php
+++ b/src/Page/Application/Resource/HomeResource.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\Page\Application\DTO\Home\Home as HomeDto;
 use App\Page\Domain\Entity\Home;
 use App\Page\Domain\Repository\Interfaces\PageLanguageRepositoryInterface;
@@ -19,12 +21,16 @@ class HomeResource extends RestResource
         parent::__construct($repository);
     }
 
-    protected function beforeCreate($dto, $entity): void { $this->applyLanguage($dto, $entity); }
-    protected function beforeUpdate(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
-    protected function beforePatch(string $id, $dto, $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforeCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforeUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function beforePatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
 
-    private function applyLanguage(HomeDto $dto, Home $entity): void
+    private function applyLanguage(RestDtoInterface $dto, EntityInterface $entity): void
     {
+        if (!$dto instanceof HomeDto || !$entity instanceof Home) {
+            return;
+        }
+
         /** @var PageLanguage|null $language */
         $language = $this->pageLanguageRepository->find($dto->getLanguageId());
 


### PR DESCRIPTION
### Motivation
- Child resource classes had lifecycle methods with more restrictive visibility and incompatible signatures which caused a PHP fatal compile error about `beforeCreate()` visibility/signature mismatch.
- The goal is to align resource overrides with the `RestResource` lifecycle contract so the app can compile and run lifecycle hooks safely.

### Description
- Updated `AboutResource`, `ContactResource`, `FaqResource`, and `HomeResource` to make `beforeCreate`, `beforeUpdate`, and `beforePatch` `public` and match the parent signatures, including `RestDtoInterface`, `EntityInterface`, and `string &$id` where required.
- Added `use` imports for `RestDtoInterface` and `EntityInterface` in each resource file.
- Changed each `applyLanguage` helper to accept interface types and added `instanceof` guards to narrow to the concrete DTO/entity types before performing language lookup and assignment.
- Files modified: `src/Page/Application/Resource/AboutResource.php`, `src/Page/Application/Resource/ContactResource.php`, `src/Page/Application/Resource/FaqResource.php`, `src/Page/Application/Resource/HomeResource.php`.

### Testing
- Ran syntax checks with `php -l` on the modified files: `php -l src/Page/Application/Resource/AboutResource.php`, `php -l src/Page/Application/Resource/ContactResource.php`, `php -l src/Page/Application/Resource/FaqResource.php`, `php -l src/Page/Application/Resource/HomeResource.php`, and all returned "No syntax errors detected."

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af50e096ac83268c79cf30044d615a)