### PR TITLE
Add fixture users and expand john-root friend relations

### DIFF
--- a/src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php
+++ b/src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php
@@ -42,6 +42,9 @@ final class LoadUserData extends Fixture implements OrderedFixtureInterface
         'bob' => '20000000-0000-1000-8000-000000000010',
         'charlie' => '20000000-0000-1000-8000-000000000011',
         'diana' => '20000000-0000-1000-8000-000000000012',
+        'emma' => '20000000-0000-1000-8000-000000000013',
+        'felix' => '20000000-0000-1000-8000-000000000014',
+        'grace' => '20000000-0000-1000-8000-000000000015',
     ];
 
     public function __construct(
@@ -152,6 +155,21 @@ final class LoadUserData extends Fixture implements OrderedFixtureInterface
                 'username' => 'diana',
                 'firstName' => 'Diana',
                 'lastName' => 'Moreau',
+            ],
+            [
+                'username' => 'emma',
+                'firstName' => 'Emma',
+                'lastName' => 'Petit',
+            ],
+            [
+                'username' => 'felix',
+                'firstName' => 'Félix',
+                'lastName' => 'Renaud',
+            ],
+            [
+                'username' => 'grace',
+                'firstName' => 'Grace',
+                'lastName' => 'Lambert',
             ],
         ];
 

--- a/src/User/Infrastructure/DataFixtures/ORM/LoadUserFriendRelationData.php
+++ b/src/User/Infrastructure/DataFixtures/ORM/LoadUserFriendRelationData.php
@@ -21,33 +21,70 @@ final class LoadUserFriendRelationData extends Fixture implements DependentFixtu
     #[Override]
     public function load(ObjectManager $manager): void
     {
-        /** @var User $john */
-        $john = $this->getReference('User-john', User::class);
+        /** @var User $johnRoot */
+        $johnRoot = $this->getReference('User-john-root', User::class);
         /** @var User $alice */
         $alice = $this->getReference('User-alice', User::class);
         /** @var User $bruno */
         $bruno = $this->getReference('User-bruno', User::class);
         /** @var User $clara */
         $clara = $this->getReference('User-clara', User::class);
+        /** @var User $bob */
+        $bob = $this->getReference('User-bob', User::class);
+        /** @var User $charlie */
+        $charlie = $this->getReference('User-charlie', User::class);
+        /** @var User $diana */
+        $diana = $this->getReference('User-diana', User::class);
+        /** @var User $emma */
+        $emma = $this->getReference('User-emma', User::class);
+        /** @var User $felix */
+        $felix = $this->getReference('User-felix', User::class);
+        /** @var User $grace */
+        $grace = $this->getReference('User-grace', User::class);
 
-        $pending = (new UserFriendRelation())
-            ->setRequester($alice)
-            ->setAddressee($john)
-            ->setStatus(FriendStatus::PENDING);
+        $relations = [
+            (new UserFriendRelation())
+                ->setRequester($alice)
+                ->setAddressee($johnRoot)
+                ->setStatus(FriendStatus::PENDING),
+            (new UserFriendRelation())
+                ->setRequester($johnRoot)
+                ->setAddressee($bruno)
+                ->setStatus(FriendStatus::PENDING),
+            (new UserFriendRelation())
+                ->setRequester($johnRoot)
+                ->setAddressee($clara)
+                ->setStatus(FriendStatus::REJECTED),
+            (new UserFriendRelation())
+                ->setRequester($diana)
+                ->setAddressee($johnRoot)
+                ->setStatus(FriendStatus::REJECTED),
+            (new UserFriendRelation())
+                ->setRequester($johnRoot)
+                ->setAddressee($emma)
+                ->setStatus(FriendStatus::ACCEPTED),
+            (new UserFriendRelation())
+                ->setRequester($felix)
+                ->setAddressee($johnRoot)
+                ->setStatus(FriendStatus::ACCEPTED),
+            (new UserFriendRelation())
+                ->setRequester($johnRoot)
+                ->setAddressee($grace)
+                ->setStatus(FriendStatus::ACCEPTED),
+            (new UserFriendRelation())
+                ->setRequester($charlie)
+                ->setAddressee($johnRoot)
+                ->setStatus(FriendStatus::BLOCKED),
+            (new UserFriendRelation())
+                ->setRequester($bob)
+                ->setAddressee($alice)
+                ->setStatus(FriendStatus::PENDING),
+        ];
 
-        $accepted = (new UserFriendRelation())
-            ->setRequester($john)
-            ->setAddressee($bruno)
-            ->setStatus(FriendStatus::ACCEPTED);
+        foreach ($relations as $relation) {
+            $manager->persist($relation);
+        }
 
-        $blocked = (new UserFriendRelation())
-            ->setRequester($clara)
-            ->setAddressee($john)
-            ->setStatus(FriendStatus::BLOCKED);
-
-        $manager->persist($pending);
-        $manager->persist($accepted);
-        $manager->persist($blocked);
         $manager->flush();
     }
 


### PR DESCRIPTION
### Motivation
- Enrich test fixtures so `john-root` participates in multiple friend scenarios to cover incoming/outgoing requests and different statuses.
- Provide additional users to act as diverse peers in friend relations and requests.

### Description
- Added three fixture users with stable UUIDs in `src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php`: `emma`, `felix`, and `grace`.
- Replaced the previous simple relations fixture with a richer set in `src/User/Infrastructure/DataFixtures/ORM/LoadUserFriendRelationData.php` centered on `john-root`, including multiple incoming and outgoing requests and relations with statuses `PENDING`, `REJECTED`, `ACCEPTED`, and `BLOCKED`.
- Persisted the new relations in a loop for clarity and maintainability.

### Testing
- Ran `php -l src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php` and it reported no syntax errors.
- Ran `php -l src/User/Infrastructure/DataFixtures/ORM/LoadUserFriendRelationData.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af52d261448326a0bb84337d137dc2)