### PR TITLE
Add john-root private/direct conversation fixtures with messages and reactions

### DIFF
--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -64,7 +64,82 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             }
         }
 
+        $this->createJohnRootPrivateDirectMessageScenarios($manager);
+
         $manager->flush();
+    }
+
+    private function createJohnRootPrivateDirectMessageScenarios(ObjectManager $manager): void
+    {
+        /** @var User $johnRoot */
+        $johnRoot = $this->getReference('User-john-root', User::class);
+        /** @var User $johnAdmin */
+        $johnAdmin = $this->getReference('User-john-admin', User::class);
+        /** @var User $johnUser */
+        $johnUser = $this->getReference('User-john-user', User::class);
+        /** @var User $johnApi */
+        $johnApi = $this->getReference('User-john-api', User::class);
+
+        $privateConversationSetups = [
+            [
+                'application' => $this->getReference('Application-crm-pipeline-pro', PlatformApplication::class),
+                'partner' => $johnAdmin,
+                'firstMessage' => 'Hello John Admin, on peut échanger en privé sur les prochaines étapes ?',
+                'replyMessage' => 'Oui, je te confirme le plan et je garde cette conversation en direct.',
+                'rootReaction' => '🤝',
+                'partnerReaction' => '✅',
+            ],
+            [
+                'application' => $this->getReference('Application-shop-orders-watch', PlatformApplication::class),
+                'partner' => $johnUser,
+                'firstMessage' => 'Salut John User, je te partage ici les points sensibles côté commandes.',
+                'replyMessage' => 'Parfait, je m’en occupe et je te fais un retour rapidement.',
+                'rootReaction' => '👍',
+                'partnerReaction' => '👀',
+            ],
+            [
+                'application' => $this->getReference('Application-school-course-flow', PlatformApplication::class),
+                'partner' => $johnApi,
+                'firstMessage' => 'Hello John API, on valide ensemble la synchro de ce soir en privé ?',
+                'replyMessage' => 'Oui, je lance la synchro et je confirme dès que c’est terminé.',
+                'rootReaction' => '🚀',
+                'partnerReaction' => '👌',
+            ],
+        ];
+
+        foreach ($privateConversationSetups as $index => $setup) {
+            /** @var PlatformApplication $application */
+            $application = $setup['application'];
+            /** @var User $partner */
+            $partner = $setup['partner'];
+
+            $chat = $this->ensureChat($manager, $application);
+            $conversation = $this->ensureConversation($manager, $chat);
+
+            $this->ensureParticipant($manager, $conversation, $johnRoot);
+            $this->ensureParticipant($manager, $conversation, $partner);
+
+            $firstMessage = $this->ensureMessage(
+                $manager,
+                $conversation,
+                $johnRoot,
+                $setup['firstMessage'],
+                []
+            );
+
+            $replyMessage = $this->ensureMessage(
+                $manager,
+                $conversation,
+                $partner,
+                $setup['replyMessage'],
+                []
+            );
+
+            $this->ensureReaction($manager, $firstMessage, $partner, $setup['partnerReaction']);
+            $this->ensureReaction($manager, $replyMessage, $johnRoot, $setup['rootReaction']);
+
+            $this->addReference('Recruit-Conversation-john-root-private-' . ($index + 1), $conversation);
+        }
     }
 
     private function ensurePluginAttached(ObjectManager $manager, PlatformApplication $application, Plugin $plugin): void


### PR DESCRIPTION
### Motivation
- Seed private/direct chat scenarios so the `john-root` user has private conversations with other users for functional tests and fixtures. 
- Provide example bilateral messages and reactions to cover chat message and reaction flows in fixtures. 
- Keep scenarios reusable by using existing helper methods (`ensureChat`, `ensureConversation`, `ensureParticipant`, `ensureMessage`, `ensureReaction`).

### Description
- Call the new helper `createJohnRootPrivateDirectMessageScenarios()` from `load()` in `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` to create the fixtures during load. 
- Implement `createJohnRootPrivateDirectMessageScenarios()` to seed three private conversations between `john-root` and `john-admin`, `john-user`, and `john-api`, each with a first message, a reply, and reactions from both sides. 
- Add references for each created conversation as `Recruit-Conversation-john-root-private-1`, `-2`, and `-3` for downstream tests. 
- Reuse existing fixture helpers (`ensureChat`, `ensureConversation`, `ensureParticipant`, `ensureMessage`, `ensureReaction`) and persist via the existing `load()` flush.

### Testing
- Ran `php -l src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af532abf1c8326bd8428f523c2bd4e)