### PR TITLE
Add user friend endpoints for blocked/sent requests and cancellation

### DIFF
--- a/src/User/Application/Service/UserFriendService.php
+++ b/src/User/Application/Service/UserFriendService.php
@@ -80,6 +80,22 @@ readonly class UserFriendService
     }
 
     /** @return array<string,string> */
+    public function cancelRequest(User $loggedInUser, User $targetUser): array
+    {
+        $this->guardNotSelf($loggedInUser, $targetUser);
+
+        $relation = $this->findDirectRelation($loggedInUser, $targetUser);
+        if ($relation === null || $relation->getStatus() !== FriendStatus::PENDING) {
+            throw new NotFoundHttpException('Pending sent friend request not found.');
+        }
+
+        $this->entityManager->remove($relation);
+        $this->entityManager->flush();
+
+        return ['status' => 'request_cancelled'];
+    }
+
+    /** @return array<string,string> */
     public function block(User $loggedInUser, User $targetUser): array
     {
         $this->guardNotSelf($loggedInUser, $targetUser);
@@ -166,6 +182,54 @@ readonly class UserFriendService
             'firstName' => $relation->getRequester()->getFirstName(),
             'lastName' => $relation->getRequester()->getLastName(),
             'photo' => $relation->getRequester()->getPhoto(),
+        ], $relations);
+    }
+
+    /** @return array<int,array<string,string>> */
+    public function getMySentRequests(User $loggedInUser): array
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('r, addressee')
+            ->from(UserFriendRelation::class, 'r')
+            ->join('r.addressee', 'addressee')
+            ->where('r.requester = :me')
+            ->andWhere('r.status = :status')
+            ->setParameter('me', $loggedInUser->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->setParameter('status', FriendStatus::PENDING->value);
+
+        /** @var array<int,UserFriendRelation> $relations */
+        $relations = $qb->getQuery()->getResult();
+
+        return array_map(static fn (UserFriendRelation $relation): array => [
+            'id' => $relation->getAddressee()->getId(),
+            'username' => $relation->getAddressee()->getUsername(),
+            'firstName' => $relation->getAddressee()->getFirstName(),
+            'lastName' => $relation->getAddressee()->getLastName(),
+            'photo' => $relation->getAddressee()->getPhoto(),
+        ], $relations);
+    }
+
+    /** @return array<int,array<string,string>> */
+    public function getMyBlockedUsers(User $loggedInUser): array
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('r, addressee')
+            ->from(UserFriendRelation::class, 'r')
+            ->join('r.addressee', 'addressee')
+            ->where('r.requester = :me')
+            ->andWhere('r.status = :status')
+            ->setParameter('me', $loggedInUser->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->setParameter('status', FriendStatus::BLOCKED->value);
+
+        /** @var array<int,UserFriendRelation> $relations */
+        $relations = $qb->getQuery()->getResult();
+
+        return array_map(static fn (UserFriendRelation $relation): array => [
+            'id' => $relation->getAddressee()->getId(),
+            'username' => $relation->getAddressee()->getUsername(),
+            'firstName' => $relation->getAddressee()->getFirstName(),
+            'lastName' => $relation->getAddressee()->getLastName(),
+            'photo' => $relation->getAddressee()->getPhoto(),
         ], $relations);
     }
 

--- a/src/User/Transport/Controller/Api/V1/User/UserFriendController.php
+++ b/src/User/Transport/Controller/Api/V1/User/UserFriendController.php
@@ -34,6 +34,16 @@ class UserFriendController
         return new JsonResponse($this->userFriendService->sendRequest($loggedInUser, $user));
     }
 
+
+
+    #[Route(path: '/v1/users/{user}/friends/request', requirements: ['user' => Requirement::UUID_V1], methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'user', description: 'Target user UUID', in: 'path', required: true)]
+    #[OA\Response(response: 200, description: 'Request cancelled', content: new JsonContent(example: ['status' => 'request_cancelled']))]
+    public function cancelRequest(User $user, User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userFriendService->cancelRequest($loggedInUser, $user));
+    }
+
     #[Route(path: '/v1/users/{user}/friends/accept', requirements: ['user' => Requirement::UUID_V1], methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'user', description: 'Requester user UUID', in: 'path', required: true)]
     #[OA\Response(response: 200, description: 'Request accepted', content: new JsonContent(example: ['status' => 'accepted']))]
@@ -109,4 +119,49 @@ class UserFriendController
     {
         return new JsonResponse($this->userFriendService->getMyIncomingRequests($loggedInUser));
     }
+
+    #[Route(path: '/v1/users/me/friends/requests/sent', methods: [Request::METHOD_GET])]
+    #[OA\Response(
+        response: 200,
+        description: 'My outgoing pending requests',
+        content: new JsonContent(
+            type: 'array',
+            items: new OA\Items(
+                properties: [
+                    new Property(property: 'id', type: 'string'),
+                    new Property(property: 'username', type: 'string'),
+                    new Property(property: 'firstName', type: 'string'),
+                    new Property(property: 'lastName', type: 'string'),
+                ],
+                type: 'object',
+            ),
+        ),
+    )]
+    public function myOutgoingRequests(User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userFriendService->getMySentRequests($loggedInUser));
+    }
+
+    #[Route(path: '/v1/users/me/friends/blocked', methods: [Request::METHOD_GET])]
+    #[OA\Response(
+        response: 200,
+        description: 'My blocked users',
+        content: new JsonContent(
+            type: 'array',
+            items: new OA\Items(
+                properties: [
+                    new Property(property: 'id', type: 'string'),
+                    new Property(property: 'username', type: 'string'),
+                    new Property(property: 'firstName', type: 'string'),
+                    new Property(property: 'lastName', type: 'string'),
+                ],
+                type: 'object',
+            ),
+        ),
+    )]
+    public function myBlockedUsers(User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userFriendService->getMyBlockedUsers($loggedInUser));
+    }
+
 }

--- a/tests/Application/User/Transport/Controller/Api/V1/User/UserFriendMeEndpointsControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/User/UserFriendMeEndpointsControllerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\User;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Infrastructure\DataFixtures\ORM\LoadUserData;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class UserFriendMeEndpointsControllerTest extends WebTestCase
+{
+    private const string BASE_URL = self::API_URL_PREFIX . '/v1/users';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that user can list blocked users from me endpoint.')]
+    public function testThatMyBlockedUsersListSucceeds(): void
+    {
+        $adminId = LoadUserData::getUuidByKey('john-admin');
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request('POST', self::BASE_URL . '/' . $adminId . '/block');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', self::BASE_URL . '/me/friends/blocked');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertSame('ok', $responseData['status']);
+        self::assertCount(1, $responseData['data']);
+        self::assertSame($adminId, $responseData['data'][0]['id']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that user can list sent requests and cancel own pending request.')]
+    public function testThatMySentRequestsAndCancelSucceeds(): void
+    {
+        $adminId = LoadUserData::getUuidByKey('john-admin');
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request('POST', self::BASE_URL . '/' . $adminId . '/friends/request');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', self::BASE_URL . '/me/friends/requests/sent');
+        $sentResponse = $client->getResponse();
+        $sentContent = $sentResponse->getContent();
+        self::assertNotFalse($sentContent);
+        self::assertSame(Response::HTTP_OK, $sentResponse->getStatusCode(), "Response:\n" . $sentResponse);
+
+        $sentData = JSON::decode($sentContent, true);
+        self::assertSame('ok', $sentData['status']);
+        self::assertCount(1, $sentData['data']);
+        self::assertSame($adminId, $sentData['data'][0]['id']);
+
+        $client->request('DELETE', self::BASE_URL . '/' . $adminId . '/friends/request');
+        $cancelResponse = $client->getResponse();
+        $cancelContent = $cancelResponse->getContent();
+        self::assertNotFalse($cancelContent);
+        self::assertSame(Response::HTTP_OK, $cancelResponse->getStatusCode(), "Response:\n" . $cancelResponse);
+
+        $cancelData = JSON::decode($cancelContent, true);
+        self::assertSame('ok', $cancelData['status']);
+
+        $client->request('GET', self::BASE_URL . '/me/friends/requests/sent');
+        $afterResponse = $client->getResponse();
+        $afterContent = $afterResponse->getContent();
+        self::assertNotFalse($afterContent);
+        self::assertSame(Response::HTTP_OK, $afterResponse->getStatusCode(), "Response:\n" . $afterResponse);
+
+        $afterData = JSON::decode($afterContent, true);
+        self::assertSame('ok', $afterData['status']);
+        self::assertCount(0, $afterData['data']);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide endpoints to manage friend-related states from the current user context: see who the current user has blocked, see outgoing pending friend requests, and allow cancelling a sent friend request.

### Description
- Added service methods in `UserFriendService`: `cancelRequest`, `getMySentRequests`, and `getMyBlockedUsers` to implement the new behaviors. (`src/User/Application/Service/UserFriendService.php`).
- Exposed three API routes in the user friends controller: `DELETE /v1/users/{user}/friends/request`, `GET /v1/users/me/friends/requests/sent`, and `GET /v1/users/me/friends/blocked` (`src/User/Transport/Controller/Api/V1/User/UserFriendController.php`).
- Added functional tests that cover listing blocked users, listing sent requests, and cancelling a sent request, and verifying the sent list is updated (`tests/Application/User/Transport/Controller/Api/V1/User/UserFriendMeEndpointsControllerTest.php`).

### Testing
- Ran syntax checks: `php -l src/User/Application/Service/UserFriendService.php`, `php -l src/User/Transport/Controller/Api/V1/User/UserFriendController.php`, and `php -l tests/Application/User/Transport/Controller/Api/V1/User/UserFriendMeEndpointsControllerTest.php`, all succeeded.
- Attempted to run the new functional test with `./vendor/bin/phpunit tests/Application/User/Transport/Controller/Api/V1/User/UserFriendMeEndpointsControllerTest.php`, but it could not be executed in this environment because `vendor/bin/phpunit` is not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af585778c08326b25645e9f976f1fc)