### PR TITLE
feat(chat): return full user objects for participants and message sender

### DIFF
--- a/src/Chat/Application/Service/ConversationListService.php
+++ b/src/Chat/Application/Service/ConversationListService.php
@@ -118,7 +118,7 @@ final readonly class ConversationListService
             }
 
             return [
-                'items' => $this->normalizeConversations($conversations),
+                'items' => $this->normalizeConversations($conversations, $user),
                 'pagination' => [
                     'page' => $page,
                     'limit' => $limit,
@@ -183,23 +183,41 @@ final readonly class ConversationListService
      *
      * @return array<int, array<string, mixed>>
      */
-    private function normalizeConversations(array $conversations): array
+    private function normalizeConversations(array $conversations, ?User $connectedUser): array
     {
+        $connectedUserId = $connectedUser?->getId();
+
         return array_map(function (Conversation $conversation): array {
             return [
                 'id' => $conversation->getId(),
                 'chatId' => $conversation->getChat()->getId(),
-                'participants' => array_map(static function (ConversationParticipant $participant): array {
+                'participants' => array_map(function (ConversationParticipant $participant) use ($connectedUserId): array {
+                    $participantUser = $participant->getUser();
+
                     return [
                         'id' => $participant->getId(),
-                        'userId' => $participant?->getUser()?->getId(),
+                        'user' => [
+                            'id' => $participantUser->getId(),
+                            'firstName' => $participantUser->getFirstName(),
+                            'lastName' => $participantUser->getLastName(),
+                            'photo' => $participantUser->getPhoto(),
+                            'owner' => $connectedUserId !== null && $participantUser->getId() === $connectedUserId,
+                        ],
                     ];
                 }, $conversation->getParticipants()->toArray()),
-                'messages' => array_map(static function (ChatMessage $message): array {
+                'messages' => array_map(function (ChatMessage $message) use ($connectedUserId): array {
+                    $sender = $message->getSender();
+
                     return [
                         'id' => $message->getId(),
                         'content' => $message->getContent(),
-                        'senderId' => $message?->getSender()?->getId(),
+                        'sender' => [
+                            'id' => $sender->getId(),
+                            'firstName' => $sender->getFirstName(),
+                            'lastName' => $sender->getLastName(),
+                            'photo' => $sender->getPhoto(),
+                            'owner' => $connectedUserId !== null && $sender->getId() === $connectedUserId,
+                        ],
                         'attachments' => $message->getAttachments(),
                         'readAt' => $message->getReadAt()?->format(DATE_ATOM),
                         'createdAt' => $message->getCreatedAt()?->format(DATE_ATOM),


### PR DESCRIPTION
### Motivation

- Replace `userId`/`senderId` scalars with full user payloads and mark which entries belong to the connected user so clients receive richer user info and an `owner` flag.

### Description

- `ConversationListService::normalizeConversations` signature now accepts the connected `User` and computes a `connectedUserId` for owner checks.
- The call site was updated to pass the connected `$user` into `normalizeConversations` when building the list result.
- Participant entries now include a nested `user` object with `id`, `firstName`, `lastName`, `photo`, and `owner` instead of `userId`.
- Message entries now include a nested `sender` object with `id`, `firstName`, `lastName`, `photo`, and `owner` instead of `senderId`.
- Owner is set to `true` when the nested user id matches the connected user id; reactions payload was left unchanged.

### Testing

- Ran PHP lint on the modified file with `php -l src/Chat/Application/Service/ConversationListService.php`, which succeeded.
- Attempted to run unit tests `tests/Unit/Chat/Application/Service/ConversationListServiceTest.php` but no local PHPUnit binary was available (`vendor/bin/phpunit` and `bin/phpunit` not present), so unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af6c5f19fc8326888056ac931ada5a)