### PR TITLE
docs(chat): add Swagger documentation for conversation listing endpoints

### DIFF
--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
@@ -13,6 +13,21 @@ use Symfony\Component\Routing\Attribute\Route;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
+#[OA\Get(
+    path: '/v1/chat/chats/{chatId}/conversations',
+    operationId: 'chat_conversation_public_chat_list',
+    summary: "Lister les conversations d'un chat",
+    tags: ['Chat Conversation'],
+    parameters: [
+        new OA\Parameter(name: 'chatId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
+        new OA\Parameter(name: 'page', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, default: 1)),
+        new OA\Parameter(name: 'limit', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20)),
+        new OA\Parameter(name: 'message', in: 'query', required: false, schema: new OA\Schema(type: 'string', example: 'bonjour')),
+    ],
+    responses: [
+        new OA\Response(response: 200, description: 'Liste paginée des conversations'),
+    ]
+)]
 class ApplicationConversationListController
 {
     public function __construct(private readonly ConversationListService $conversationListService)

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
@@ -16,6 +16,21 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
+#[OA\Get(
+    path: '/v1/chat/private/chats/{chatId}/conversations',
+    operationId: 'chat_conversation_private_chat_list',
+    summary: "Lister les conversations privées d'un chat pour l'utilisateur connecté",
+    tags: ['Chat Conversation'],
+    parameters: [
+        new OA\Parameter(name: 'chatId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
+        new OA\Parameter(name: 'page', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, default: 1)),
+        new OA\Parameter(name: 'limit', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20)),
+        new OA\Parameter(name: 'message', in: 'query', required: false, schema: new OA\Schema(type: 'string', example: 'bonjour')),
+    ],
+    responses: [
+        new OA\Response(response: 200, description: 'Liste paginée des conversations'),
+    ]
+)]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 class ApplicationUserConversationListController
 {

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationListController.php
@@ -17,6 +17,20 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
+#[OA\Get(
+    path: '/v1/chat/private/conversations',
+    operationId: 'chat_conversation_private_list',
+    summary: 'Lister les conversations de l\'utilisateur connecté',
+    tags: ['Chat Conversation'],
+    parameters: [
+        new OA\Parameter(name: 'page', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, default: 1)),
+        new OA\Parameter(name: 'limit', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20)),
+        new OA\Parameter(name: 'message', in: 'query', required: false, schema: new OA\Schema(type: 'string', example: 'bonjour')),
+    ],
+    responses: [
+        new OA\Response(response: 200, description: 'Liste paginée des conversations'),
+    ]
+)]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 class UserConversationListController
 {


### PR DESCRIPTION
### Motivation
- Rendre testables dans `/api/doc` les endpoints de listing des conversations en ajoutant les annotations OpenAPI/Swagger sur les contrôleurs concernés.

### Description
- Ajout d'attributs `#[OA\Get(...)]` détaillant les routes, paramètres et réponse `200` pour les endpoints `
`/v1/chat/private/conversations`, `/v1/chat/private/chats/{chatId}/conversations` et `/v1/chat/chats/{chatId}/conversations`.
- Documentation des paramètres de requête `page`, `limit`, `message` et du path param `chatId` lorsque pertinent, via les propriétés `OA\Parameter` et `OA\Schema`.
- Fichiers mis à jour : `src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationListController.php`, `src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php`, et `src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php`.

### Testing
- Exécution de la vérification syntaxique PHP sur les fichiers modifiés avec `php -l` et validation sans erreur.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af70205afc832684d41c730c481168)