### PR TITLE
Add detailed OpenAPI annotations for chat conversation and message endpoints

### DIFF
--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
@@ -13,6 +13,21 @@ use Symfony\Component\Routing\Attribute\Route;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
+#[OA\Get(
+    path: '/v1/chat/chats/{chatId}/conversations',
+    operationId: 'chat_conversation_public_chat_list',
+    summary: "Lister les conversations d'un chat",
+    tags: ['Chat Conversation'],
+    parameters: [
+        new OA\Parameter(name: 'chatId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
+        new OA\Parameter(name: 'page', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, default: 1)),
+        new OA\Parameter(name: 'limit', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20)),
+        new OA\Parameter(name: 'message', in: 'query', required: false, schema: new OA\Schema(type: 'string', example: 'bonjour')),
+    ],
+    responses: [
+        new OA\Response(response: 200, description: 'Liste paginée des conversations'),
+    ]
+)]
 class ApplicationConversationListController
 {
     public function __construct(private readonly ConversationListService $conversationListService)

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
@@ -16,6 +16,21 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
+#[OA\Get(
+    path: '/v1/chat/private/chats/{chatId}/conversations',
+    operationId: 'chat_conversation_private_chat_list',
+    summary: "Lister les conversations privées d'un chat pour l'utilisateur connecté",
+    tags: ['Chat Conversation'],
+    parameters: [
+        new OA\Parameter(name: 'chatId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
+        new OA\Parameter(name: 'page', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, default: 1)),
+        new OA\Parameter(name: 'limit', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20)),
+        new OA\Parameter(name: 'message', in: 'query', required: false, schema: new OA\Schema(type: 'string', example: 'bonjour')),
+    ],
+    responses: [
+        new OA\Response(response: 200, description: 'Liste paginée des conversations'),
+    ]
+)]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 class ApplicationUserConversationListController
 {

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationListController.php
@@ -17,6 +17,20 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
+#[OA\Get(
+    path: '/v1/chat/private/conversations',
+    operationId: 'chat_conversation_private_list',
+    summary: 'Lister les conversations de l\'utilisateur connecté',
+    tags: ['Chat Conversation'],
+    parameters: [
+        new OA\Parameter(name: 'page', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, default: 1)),
+        new OA\Parameter(name: 'limit', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20)),
+        new OA\Parameter(name: 'message', in: 'query', required: false, schema: new OA\Schema(type: 'string', example: 'bonjour')),
+    ],
+    responses: [
+        new OA\Response(response: 200, description: 'Liste paginée des conversations'),
+    ]
+)]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 class UserConversationListController
 {

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationMutationController.php
@@ -22,8 +22,78 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
-#[OA\Post(path: '/v1/chat/private/chats/{chatId}/conversations', operationId: 'chat_conversation_create', summary: 'Créer une conversation', tags: ['Chat Conversation'], parameters: [new OA\Parameter(name: 'chatId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['userId'], properties: [new OA\Property(property: 'userId', type: 'string', format: 'uuid', example: '7c9e6679-7425-40de-944b-e07fc1f90ae7')])), responses: [new OA\Response(response: 201, description: 'Conversation créée'), new OA\Response(response: 400, description: 'userId invalide')])]
-#[OA\Patch(path: '/v1/chat/private/conversations/{conversationId}', operationId: 'chat_conversation_patch', summary: 'Ajouter un participant', tags: ['Chat Conversation'], parameters: [new OA\Parameter(name: 'conversationId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['userId'], properties: [new OA\Property(property: 'userId', type: 'string', format: 'uuid', example: '7c9e6679-7425-40de-944b-e07fc1f90ae7')])), responses: [new OA\Response(response: 200, description: 'Participant ajouté'), new OA\Response(response: 404, description: 'Conversation introuvable')])]
+#[OA\Post(
+    path: '/v1/chat/private/chats/{chatId}/conversations',
+    operationId: 'chat_conversation_create',
+    summary: 'Créer une conversation',
+    tags: ['Chat Conversation'],
+    parameters: [
+        new OA\Parameter(name: 'chatId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
+    ],
+    requestBody: new OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['userId'],
+            properties: [
+                new OA\Property(property: 'userId', type: 'string', format: 'uuid', example: '7c9e6679-7425-40de-944b-e07fc1f90ae7'),
+            ],
+            example: ['userId' => '7c9e6679-7425-40de-944b-e07fc1f90ae7']
+        )
+    ),
+    responses: [
+        new OA\Response(
+            response: 201,
+            description: 'Conversation créée',
+            content: new OA\JsonContent(properties: [new OA\Property(property: 'id', type: 'string', format: 'uuid')], example: ['id' => '2a4d0a6c-9465-4d36-8f08-b6302ea62b44'])
+        ),
+        new OA\Response(
+            response: 400,
+            description: 'Payload invalide',
+            content: new OA\JsonContent(properties: [new OA\Property(property: 'message', type: 'string')], example: ['message' => 'Field "userId" is required.'])
+        ),
+        new OA\Response(
+            response: 404,
+            description: 'Chat introuvable',
+            content: new OA\JsonContent(properties: [new OA\Property(property: 'message', type: 'string')], example: ['message' => 'Chat not found.'])
+        ),
+    ]
+)]
+#[OA\Patch(
+    path: '/v1/chat/private/conversations/{conversationId}',
+    operationId: 'chat_conversation_patch',
+    summary: 'Ajouter un participant (update)',
+    tags: ['Chat Conversation'],
+    parameters: [
+        new OA\Parameter(name: 'conversationId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
+    ],
+    requestBody: new OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['userId'],
+            properties: [
+                new OA\Property(property: 'userId', type: 'string', format: 'uuid', example: '7c9e6679-7425-40de-944b-e07fc1f90ae7'),
+            ],
+            example: ['userId' => '7c9e6679-7425-40de-944b-e07fc1f90ae7']
+        )
+    ),
+    responses: [
+        new OA\Response(
+            response: 200,
+            description: 'Participant ajouté',
+            content: new OA\JsonContent(properties: [new OA\Property(property: 'id', type: 'string', format: 'uuid')], example: ['id' => '2a4d0a6c-9465-4d36-8f08-b6302ea62b44'])
+        ),
+        new OA\Response(
+            response: 400,
+            description: 'Payload invalide',
+            content: new OA\JsonContent(properties: [new OA\Property(property: 'message', type: 'string')], example: ['message' => 'Unknown userId.'])
+        ),
+        new OA\Response(
+            response: 404,
+            description: 'Conversation introuvable',
+            content: new OA\JsonContent(properties: [new OA\Property(property: 'message', type: 'string')], example: ['message' => 'Conversation not found.'])
+        ),
+    ]
+)]
 #[OA\Delete(path: '/v1/chat/private/conversations/{conversationId}', operationId: 'chat_conversation_delete', summary: 'Supprimer une conversation', tags: ['Chat Conversation'], parameters: [new OA\Parameter(name: 'conversationId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], responses: [new OA\Response(response: 204, description: 'Supprimée')])]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 class UserConversationMutationController

--- a/src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php
@@ -22,8 +22,72 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Message')]
-#[OA\Post(path: '/v1/chat/private/conversations/{conversationId}/messages', operationId: 'chat_message_create', summary: 'Créer un message', tags: ['Chat Message'], parameters: [new OA\Parameter(name: 'conversationId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['content'], properties: [new OA\Property(property: 'content', type: 'string', minLength: 1, example: 'Bonjour, dispo pour un entretien demain ?')])), responses: [new OA\Response(response: 201, description: 'Message créé'), new OA\Response(response: 404, description: 'Conversation introuvable')])]
-#[OA\Patch(path: '/v1/chat/private/messages/{messageId}', operationId: 'chat_message_patch', summary: 'Modifier son message', tags: ['Chat Message'], parameters: [new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(properties: [new OA\Property(property: 'content', type: 'string', minLength: 1, example: 'Bonjour, finalement mercredi 10h ?')])), responses: [new OA\Response(response: 200, description: 'Message mis à jour'), new OA\Response(response: 404, description: 'Message introuvable')])]
+#[OA\Post(
+    path: '/v1/chat/private/conversations/{conversationId}/messages',
+    operationId: 'chat_message_create',
+    summary: 'Créer un message',
+    tags: ['Chat Message'],
+    parameters: [
+        new OA\Parameter(name: 'conversationId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
+    ],
+    requestBody: new OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['content'],
+            properties: [
+                new OA\Property(property: 'content', type: 'string', minLength: 1, example: 'Bonjour, dispo pour un entretien demain ?'),
+            ],
+            example: ['content' => 'Bonjour, dispo pour un entretien demain ?']
+        )
+    ),
+    responses: [
+        new OA\Response(
+            response: 201,
+            description: 'Message créé',
+            content: new OA\JsonContent(properties: [new OA\Property(property: 'id', type: 'string', format: 'uuid')], example: ['id' => '8f210e56-6550-4b61-b7f3-8994f5f6dc41'])
+        ),
+        new OA\Response(
+            response: 400,
+            description: 'Payload invalide',
+            content: new OA\JsonContent(properties: [new OA\Property(property: 'message', type: 'string')], example: ['message' => 'Field "content" is required.'])
+        ),
+        new OA\Response(
+            response: 404,
+            description: 'Conversation introuvable',
+            content: new OA\JsonContent(properties: [new OA\Property(property: 'message', type: 'string')], example: ['message' => 'Conversation not found.'])
+        ),
+    ]
+)]
+#[OA\Patch(
+    path: '/v1/chat/private/messages/{messageId}',
+    operationId: 'chat_message_patch',
+    summary: 'Modifier son message (update)',
+    tags: ['Chat Message'],
+    parameters: [
+        new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
+    ],
+    requestBody: new OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'content', type: 'string', minLength: 1, example: 'Bonjour, finalement mercredi 10h ?'),
+            ],
+            example: ['content' => 'Bonjour, finalement mercredi 10h ?']
+        )
+    ),
+    responses: [
+        new OA\Response(
+            response: 200,
+            description: 'Message mis à jour',
+            content: new OA\JsonContent(properties: [new OA\Property(property: 'id', type: 'string', format: 'uuid')], example: ['id' => '8f210e56-6550-4b61-b7f3-8994f5f6dc41'])
+        ),
+        new OA\Response(
+            response: 404,
+            description: 'Message introuvable',
+            content: new OA\JsonContent(properties: [new OA\Property(property: 'message', type: 'string')], example: ['message' => 'Message not found.'])
+        ),
+    ]
+)]
 #[OA\Delete(path: '/v1/chat/private/messages/{messageId}', operationId: 'chat_message_delete', summary: 'Supprimer son message', tags: ['Chat Message'], parameters: [new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], responses: [new OA\Response(response: 204, description: 'Supprimé'), new OA\Response(response: 404, description: 'Message introuvable')])]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 class UserMessageMutationController


### PR DESCRIPTION
### Motivation
- Provide comprehensive API documentation for chat conversation and message endpoints, including parameters, request bodies, responses and examples.
- Differentiate public and private chat routes in the OpenAPI spec and standardize error response schemas for better client integration.

### Description
- Added `OA\nGet` annotations to list controllers (`ApplicationConversationListController`, `ApplicationUserConversationListController`, `UserConversationListController`) with path parameters, query parameters and 200 response descriptions.
- Expanded `OA
Post` and `OA
Patch` annotations in `UserConversationMutationController` and `UserMessageMutationController` to include detailed `requestBody` schemas, example payloads, response content schemas and error responses for 400/404 statuses.
- Adjusted operationIds and summaries to be more descriptive and included example UUIDs and example response payloads in the OpenAPI attributes.
- No runtime controller logic was modified; the changes are limited to OpenAPI attributes and documentation metadata.

### Testing
- Ran the project's test suite with `phpunit` and all tests passed.
- Executed static analysis (`phpstan`) and formatting checks (`php-cs-fixer`) with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af70205afc832684d41c730c481168)