### PR TITLE
Add registration and social auth endpoints with JWT response

### DIFF
--- a/src/User/Transport/Controller/Api/V1/Auth/RegisterController.php
+++ b/src/User/Transport/Controller/Api/V1/Auth/RegisterController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Transport\Controller\Api\V1\Auth;
+
+use App\General\Domain\Service\Interfaces\MailerServiceInterface;
+use App\General\Domain\Utils\JSON;
+use App\Role\Application\Security\Interfaces\RolesServiceInterface;
+use App\User\Application\Security\SecurityUser;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Repository\Interfaces\UserRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Throwable;
+
+use function explode;
+use function sprintf;
+use function trim;
+
+#[AsController]
+class RegisterController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly JWTTokenManagerInterface $jwtTokenManager,
+        private readonly MailerServiceInterface $mailerService,
+        private readonly UserRepositoryInterface $userRepository,
+        private readonly RolesServiceInterface $rolesService,
+        #[Autowire('%env(resolve:APP_SENDER_EMAIL)%')]
+        private readonly string $appSenderEmail,
+    ) {
+    }
+
+    /**
+     * @throws JsonException
+     * @throws Throwable
+     */
+    #[Route(path: '/v1/auth/register', methods: [Request::METHOD_POST])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = JSON::decode($request->getContent(), true);
+
+        $email = trim((string)($payload['email'] ?? ''));
+        $password = (string)($payload['password'] ?? '');
+        $repeatPassword = (string)($payload['repeatPassword'] ?? '');
+
+        if ($email === '' || $password === '' || $repeatPassword === '') {
+            throw new BadRequestHttpException('email, password and repeatPassword are required');
+        }
+
+        if ($password !== $repeatPassword) {
+            throw new BadRequestHttpException('password and repeatPassword must match');
+        }
+
+        if (!$this->userRepository->isEmailAvailable($email)) {
+            throw new BadRequestHttpException('Email is already used');
+        }
+
+        $user = new User();
+        $user
+            ->setEmail($email)
+            ->setUsername($this->createAvailableUsername($email))
+            ->setFirstName('User')
+            ->setLastName('User')
+            ->setPlainPassword($password);
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        $this->mailerService->sendMail(
+            'Welcome to Bro World',
+            $this->appSenderEmail,
+            $email,
+            '<p>Your account was successfully created.</p>',
+        );
+
+        $securityUser = new SecurityUser($user, $this->rolesService->getInheritedRoles($user->getRoles()));
+
+        return new JsonResponse([
+            'token' => $this->jwtTokenManager->create($securityUser),
+        ], Response::HTTP_CREATED);
+    }
+
+    private function createAvailableUsername(string $email): string
+    {
+        $localPart = trim(explode('@', $email)[0] ?? '');
+        $username = $localPart !== '' ? $localPart : 'user';
+        $baseUsername = $username;
+        $index = 1;
+
+        while (!$this->userRepository->isUsernameAvailable($username)) {
+            $username = sprintf('%s%d', $baseUsername, $index);
+            ++$index;
+        }
+
+        return $username;
+    }
+}

--- a/src/User/Transport/Controller/Api/V1/Auth/SocialLoginController.php
+++ b/src/User/Transport/Controller/Api/V1/Auth/SocialLoginController.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Transport\Controller\Api\V1\Auth;
+
+use App\General\Domain\Utils\JSON;
+use App\Role\Application\Security\Interfaces\RolesServiceInterface;
+use App\User\Application\Security\SecurityUser;
+use App\User\Domain\Entity\Social;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Repository\Interfaces\UserRepositoryInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Throwable;
+
+use function array_contains;
+use function bin2hex;
+use function explode;
+use function random_bytes;
+use function sprintf;
+use function trim;
+
+#[AsController]
+class SocialLoginController
+{
+    /** @var array<int, string> */
+    private const array ALLOWED_PROVIDERS = ['github', 'instagram', 'facebook', 'google'];
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly JWTTokenManagerInterface $jwtTokenManager,
+        private readonly UserRepositoryInterface $userRepository,
+        private readonly RolesServiceInterface $rolesService,
+    ) {
+    }
+
+    /**
+     * @throws JsonException
+     * @throws Throwable
+     */
+    #[Route(path: '/v1/auth/social_login', methods: [Request::METHOD_POST])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = JSON::decode($request->getContent(), true);
+
+        $email = trim((string)($payload['email'] ?? ''));
+        $provider = trim((string)($payload['provider'] ?? ''));
+        $providerId = trim((string)($payload['providerId'] ?? ''));
+
+        if ($email === '' || $provider === '' || $providerId === '') {
+            throw new BadRequestHttpException('email, provider and providerId are required');
+        }
+
+        if (!array_contains(self::ALLOWED_PROVIDERS, $provider)) {
+            throw new BadRequestHttpException('provider must be one of: github, instagram, facebook, google');
+        }
+
+        $social = $this->entityManager
+            ->getRepository(Social::class)
+            ->createQueryBuilder('social')
+            ->select('social', 'user')
+            ->innerJoin('social.user', 'user')
+            ->andWhere('social.provider = :provider')
+            ->andWhere('social.providerId = :providerId')
+            ->andWhere('user.email = :email')
+            ->setParameter('provider', $provider)
+            ->setParameter('providerId', $providerId)
+            ->setParameter('email', $email)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if (!($social instanceof Social)) {
+            $user = $this->userRepository->loadUserByIdentifier($email, false);
+
+            if (!($user instanceof User)) {
+                $user = new User();
+                $user
+                    ->setEmail($email)
+                    ->setUsername($this->createAvailableUsername($email))
+                    ->setFirstName('User')
+                    ->setLastName('User')
+                    ->setPlainPassword($this->generateRandomPassword());
+
+                $this->entityManager->persist($user);
+            }
+
+            $social = new Social();
+            $social
+                ->setProvider($provider)
+                ->setProviderId($providerId)
+                ->setUser($user);
+
+            $this->entityManager->persist($social);
+            $this->entityManager->flush();
+        }
+
+        $securityUser = new SecurityUser(
+            $social->getUser(),
+            $this->rolesService->getInheritedRoles($social->getUser()->getRoles()),
+        );
+
+        return new JsonResponse([
+            'token' => $this->jwtTokenManager->create($securityUser),
+        ], Response::HTTP_OK);
+    }
+
+    private function createAvailableUsername(string $email): string
+    {
+        $localPart = trim(explode('@', $email)[0] ?? '');
+        $username = $localPart !== '' ? $localPart : 'user';
+        $baseUsername = $username;
+        $index = 1;
+
+        while (!$this->userRepository->isUsernameAvailable($username)) {
+            $username = sprintf('%s%d', $baseUsername, $index);
+            ++$index;
+        }
+
+        return $username;
+    }
+
+    /** @throws Throwable */
+    private function generateRandomPassword(): string
+    {
+        return bin2hex(random_bytes(16));
+    }
+}

--- a/tests/Application/User/Transport/Controller/Api/V1/Auth/RegisterControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/Auth/RegisterControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\Auth;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class RegisterControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/auth';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `POST /api/v1/auth/register` returns token for valid payload.')]
+    public function testThatRegisterActionReturnsToken(): void
+    {
+        $client = $this->getTestClient();
+
+        $requestData = [
+            'email' => 'new-user-register@test.com',
+            'password' => 'password-register',
+            'repeatPassword' => 'password-register',
+        ];
+
+        $client->request(method: 'POST', uri: $this->baseUrl . '/register', content: JSON::encode($requestData));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('token', $responseData);
+        self::assertIsString($responseData['token']);
+    }
+}

--- a/tests/Application/User/Transport/Controller/Api/V1/Auth/SocialLoginControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/Auth/SocialLoginControllerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\Auth;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class SocialLoginControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/auth';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `POST /api/v1/auth/social_login` creates a social user and returns token.')]
+    public function testThatSocialLoginCreatesUserAndReturnsToken(): void
+    {
+        $client = $this->getTestClient();
+
+        $requestData = [
+            'email' => 'new-social-user@test.com',
+            'provider' => 'github',
+            'providerId' => 'new-social-user-github-id',
+        ];
+
+        $client->request(method: 'POST', uri: $this->baseUrl . '/social_login', content: JSON::encode($requestData));
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertArrayHasKey('token', $responseData);
+        self::assertIsString($responseData['token']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `POST /api/v1/auth/register` endpoint to create a user from `email`, `password`, `repeatPassword`
- send a welcome email after registration and return a JWT token immediately
- add `POST /api/v1/auth/social_login` endpoint accepting `email`, `provider`, `providerId`
- support providers: `github`, `instagram`, `facebook`, `google`
- if social identity exists, return token; otherwise create/link user + social identity and return token

## Tests
- add functional test for register endpoint token response
- add functional test for social login endpoint token response
- validated PHP syntax for new controllers/tests with `php -l`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af7c954d208326b981288dda8c2eb4)