### PR TITLE
Fix duplicate Chat creation in recruit fixtures

### DIFF
--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -27,6 +27,11 @@ use Override;
 
 final class LoadRecruitChatCalendarScenarioData extends Fixture implements OrderedFixtureInterface
 {
+    /**
+     * @var array<string, Chat>
+     */
+    private array $ensuredChats = [];
+
     #[Override]
     public function load(ObjectManager $manager): void
     {
@@ -187,21 +192,30 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
 
     private function ensureChat(ObjectManager $manager, PlatformApplication $application): Chat
     {
+        $application->ensureGeneratedSlug();
+        $slug = $application->getSlug();
+
+        if (isset($this->ensuredChats[$slug])) {
+            return $this->ensuredChats[$slug];
+        }
+
         $existing = $manager->getRepository(Chat::class)->findOneBy([
             'application' => $application,
         ]);
 
         if ($existing instanceof Chat) {
+            $this->ensuredChats[$slug] = $existing;
+
             return $existing;
         }
 
-        $application->ensureGeneratedSlug();
-
         $chat = (new Chat())
             ->setApplication($application)
-            ->setApplicationSlug($application->getSlug());
+            ->setApplicationSlug($slug);
 
         $manager->persist($chat);
+
+        $this->ensuredChats[$slug] = $chat;
 
         return $chat;
     }


### PR DESCRIPTION
### Motivation
- Loading recruit fixtures raised a unique constraint violation on `chat.uq_chat_application_slug` because `ensureChat()` could persist multiple `Chat` entities for the same application before the EntityManager was flushed. 
- The repository lookup cannot see newly persisted-but-unflushed entities, so a per-run cache is needed to avoid duplicate inserts.

### Description
- Added a private typed cache property `private array $ensuredChats = []` to `LoadRecruitChatCalendarScenarioData` to store ensured `Chat` objects keyed by application slug. 
- Updated `ensureChat()` to compute the application slug once, return a cached `Chat` when present, populate the cache from a found DB row, and cache newly created chats immediately after `persist()`. 
- Normalized usage of the slug by removing the duplicate `ensureGeneratedSlug()` call and using the local `$slug` variable for `setApplicationSlug()`.

### Testing
- Ran a syntax check with `php -l src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php`, which succeeded. 
- Verified repository state with `git status --short` and commit contents with `git show --stat --oneline HEAD`, both of which succeeded. 
- The change is limited to fixture behavior and is intended to prevent the duplicate-insert error during `doctrine:fixtures:load`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af7d5e41f08326b3cdc7ab65cdfd0e)