### PR TITLE
Add reusable blog notifications for comments and reactions

### DIFF
--- a/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Application\MessageHandler;
 
 use App\Blog\Application\Message\CreateBlogCommentCommand;
+use App\Blog\Application\Service\BlogNotificationService;
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Infrastructure\Repository\BlogCommentRepository;
@@ -24,6 +25,7 @@ final readonly class CreateBlogCommentCommandHandler
         private BlogCommentRepository $commentRepository,
         private BlogPostRepository $postRepository,
         private UserRepository $userRepository,
+        private BlogNotificationService $blogNotificationService,
     ) {}
 
     public function __invoke(CreateBlogCommentCommand $command): void
@@ -58,5 +60,6 @@ final readonly class CreateBlogCommentCommandHandler
         }
 
         $this->commentRepository->save($comment);
+        $this->blogNotificationService->notifyCommentCreated($comment);
     }
 }

--- a/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Application\MessageHandler;
 
 use App\Blog\Application\Message\CreateBlogReactionCommand;
+use App\Blog\Application\Service\BlogNotificationService;
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Domain\Entity\BlogReaction;
 use App\Blog\Infrastructure\Repository\BlogCommentRepository;
@@ -22,6 +23,7 @@ final readonly class CreateBlogReactionCommandHandler
         private BlogReactionRepository $reactionRepository,
         private BlogCommentRepository $commentRepository,
         private UserRepository $userRepository,
+        private BlogNotificationService $blogNotificationService,
     ) {}
 
     public function __invoke(CreateBlogReactionCommand $command): void
@@ -38,5 +40,7 @@ final readonly class CreateBlogReactionCommandHandler
             ->setAuthor($user)
             ->setType($command->type)
         );
+
+        $this->blogNotificationService->notifyReactionCreated($comment, $user, $command->type);
     }
 }

--- a/src/Blog/Application/Service/BlogNotificationService.php
+++ b/src/Blog/Application/Service/BlogNotificationService.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Blog\Application\Service;
+
+use App\Blog\Domain\Entity\BlogComment;
+use App\Blog\Domain\Entity\BlogPost;
+use App\Notification\Application\Service\NotificationPublisher;
+use App\User\Domain\Entity\User;
+
+use function mb_strimwidth;
+use function trim;
+
+final readonly class BlogNotificationService
+{
+    public const string BLOG_NOTIFICATION_TYPE = 'blog_notification';
+
+    public function __construct(private NotificationPublisher $notificationPublisher) {}
+
+    public function notifyCommentCreated(BlogComment $comment): void
+    {
+        $actor = $comment->getAuthor();
+        $post = $comment->getPost();
+        $targetLabel = $this->formatPostTitle($post);
+
+        if ($comment->getParent() instanceof BlogComment) {
+            $this->notificationPublisher->publish(
+                from: $actor,
+                recipient: $comment->getParent()->getAuthor(),
+                title: $this->buildTitle($actor, 'commented your comment', $targetLabel),
+                type: self::BLOG_NOTIFICATION_TYPE,
+            );
+
+            return;
+        }
+
+        $this->notificationPublisher->publish(
+            from: $actor,
+            recipient: $post->getAuthor(),
+            title: $this->buildTitle($actor, 'commented your post', $targetLabel),
+            type: self::BLOG_NOTIFICATION_TYPE,
+        );
+    }
+
+    public function notifyReactionCreated(BlogComment $comment, User $actor, string $reactionType): void
+    {
+        $actionLabel = $reactionType === 'like' ? 'liked' : ('reacted (' . $reactionType . ') to');
+
+        if ($comment->getParent() instanceof BlogComment) {
+            $this->notificationPublisher->publish(
+                from: $actor,
+                recipient: $comment->getAuthor(),
+                title: $this->buildTitle($actor, $actionLabel . ' your comment', $this->formatCommentPreview($comment)),
+                type: self::BLOG_NOTIFICATION_TYPE,
+            );
+
+            return;
+        }
+
+        $this->notificationPublisher->publish(
+            from: $actor,
+            recipient: $comment->getPost()->getAuthor(),
+            title: $this->buildTitle($actor, $actionLabel . ' your post', $this->formatPostTitle($comment->getPost())),
+            type: self::BLOG_NOTIFICATION_TYPE,
+        );
+    }
+
+    private function buildTitle(User $actor, string $action, string $target): string
+    {
+        return trim($actor->getFirstName() . ' ' . $actor->getLastName()) . ' ' . $action . ' ' . $target;
+    }
+
+    private function formatPostTitle(BlogPost $post): string
+    {
+        $content = trim((string) $post->getContent());
+
+        if ($content === '') {
+            return '"(no title)"';
+        }
+
+        return '"' . mb_strimwidth($content, 0, 60, '...') . '"';
+    }
+
+    private function formatCommentPreview(BlogComment $comment): string
+    {
+        $content = trim((string) $comment->getContent());
+
+        if ($content === '') {
+            return '"(comment)"';
+        }
+
+        return '"' . mb_strimwidth($content, 0, 60, '...') . '"';
+    }
+}

--- a/src/Notification/Application/Service/NotificationPublisher.php
+++ b/src/Notification/Application/Service/NotificationPublisher.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\Service;
+
+use App\Notification\Domain\Entity\Notification;
+use App\Notification\Infrastructure\Repository\NotificationRepository;
+use App\User\Domain\Entity\User;
+
+final readonly class NotificationPublisher
+{
+    public function __construct(private NotificationRepository $notificationRepository) {}
+
+    public function publish(User $from, User $recipient, string $title, string $type, string $description = ''): void
+    {
+        if ($from->getId() === $recipient->getId()) {
+            return;
+        }
+
+        $notification = (new Notification())
+            ->setTitle($title)
+            ->setDescription($description)
+            ->setType($type)
+            ->setFrom($from)
+            ->setRecipient($recipient);
+
+        $this->notificationRepository->save($notification);
+    }
+}

--- a/tests/Unit/Blog/Application/Service/BlogNotificationServiceTest.php
+++ b/tests/Unit/Blog/Application/Service/BlogNotificationServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Blog\Application\Service;
+
+use App\Blog\Application\Service\BlogNotificationService;
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Entity\BlogComment;
+use App\Blog\Domain\Entity\BlogPost;
+use App\Notification\Application\Service\NotificationPublisher;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+final class BlogNotificationServiceTest extends TestCase
+{
+    public function testNotifyCommentCreatedOnPostTargetsPostAuthor(): void
+    {
+        $author = $this->createUser('Adam', 'Author');
+        $commenter = $this->createUser('Rami', 'User');
+
+        $post = (new BlogPost())
+            ->setAuthor($author)
+            ->setBlog(new Blog())
+            ->setContent('My first post title');
+
+        $comment = (new BlogComment())
+            ->setPost($post)
+            ->setAuthor($commenter)
+            ->setContent('nice post');
+
+        $publisher = $this->createMock(NotificationPublisher::class);
+        $publisher->expects(self::once())
+            ->method('publish')
+            ->with(
+                $commenter,
+                $author,
+                'Rami User commented your post "My first post title"',
+                BlogNotificationService::BLOG_NOTIFICATION_TYPE,
+            );
+
+        (new BlogNotificationService($publisher))->notifyCommentCreated($comment);
+    }
+
+    public function testNotifyReactionCreatedOnReplyTargetsCommentAuthor(): void
+    {
+        $postAuthor = $this->createUser('Adam', 'Author');
+        $replyAuthor = $this->createUser('Sara', 'Reply');
+        $reactor = $this->createUser('Rami', 'User');
+
+        $post = (new BlogPost())
+            ->setAuthor($postAuthor)
+            ->setBlog(new Blog())
+            ->setContent('General update');
+
+        $parent = (new BlogComment())
+            ->setPost($post)
+            ->setAuthor($postAuthor)
+            ->setContent('parent');
+
+        $reply = (new BlogComment())
+            ->setPost($post)
+            ->setParent($parent)
+            ->setAuthor($replyAuthor)
+            ->setContent('reply content');
+
+        $publisher = $this->createMock(NotificationPublisher::class);
+        $publisher->expects(self::once())
+            ->method('publish')
+            ->with(
+                $reactor,
+                $replyAuthor,
+                'Rami User liked your comment "reply content"',
+                BlogNotificationService::BLOG_NOTIFICATION_TYPE,
+            );
+
+        (new BlogNotificationService($publisher))->notifyReactionCreated($reply, $reactor, 'like');
+    }
+
+    private function createUser(string $firstName, string $lastName): User
+    {
+        return (new User())
+            ->setFirstName($firstName)
+            ->setLastName($lastName)
+            ->setUsername(strtolower($firstName . '.' . $lastName))
+            ->setEmail(strtolower($firstName . '.' . $lastName . '@example.com'));
+    }
+}

--- a/tests/Unit/Notification/Application/Service/NotificationPublisherTest.php
+++ b/tests/Unit/Notification/Application/Service/NotificationPublisherTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Notification\Application\Service;
+
+use App\Notification\Application\Service\NotificationPublisher;
+use App\Notification\Domain\Entity\Notification;
+use App\Notification\Infrastructure\Repository\NotificationRepository;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+
+final class NotificationPublisherTest extends TestCase
+{
+    public function testPublishSkipsSelfNotifications(): void
+    {
+        $user = $this->createUser('Rami', 'User');
+
+        $repository = $this->createMock(NotificationRepository::class);
+        $repository->expects(self::never())->method('save');
+
+        $publisher = new NotificationPublisher($repository);
+        $publisher->publish($user, $user, 'title', 'blog_notification');
+    }
+
+    public function testPublishPersistsNotification(): void
+    {
+        $from = $this->createUser('Rami', 'User');
+        $recipient = $this->createUser('Adam', 'Author');
+
+        $repository = $this->createMock(NotificationRepository::class);
+        $repository->expects(self::once())
+            ->method('save')
+            ->with(self::callback(static function (Notification $notification) use ($from, $recipient): bool {
+                return $notification->getFrom() === $from
+                    && $notification->getRecipient() === $recipient
+                    && $notification->getTitle() === 'Rami commented your post "Post title"'
+                    && $notification->getType() === 'blog_notification'
+                    && $notification->getDescription() === '';
+            }));
+
+        $publisher = new NotificationPublisher($repository);
+        $publisher->publish($from, $recipient, 'Rami commented your post "Post title"', 'blog_notification');
+    }
+
+    private function createUser(string $firstName, string $lastName): User
+    {
+        return (new User())
+            ->setFirstName($firstName)
+            ->setLastName($lastName)
+            ->setUsername(strtolower($firstName . '.' . $lastName))
+            ->setEmail(strtolower($firstName . '.' . $lastName . '@example.com'));
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable, centralized way to create and persist notifications across the app when users comment or react. 
- Standardize blog-related notification messages under the `blog_notification` type and prevent self-notifications. 
- Trigger notifications from blog mutation paths so comments and reactions produce consistent notifications for post authors or comment authors. 

### Description
- Add `NotificationPublisher` (`src/Notification/Application/Service/NotificationPublisher.php`) that persists `Notification` entities and skips notifications when `fromId === recipientId`. 
- Add `BlogNotificationService` (`src/Blog/Application/Service/BlogNotificationService.php`) that formats titles, selects recipients (post author or parent comment author), and emits notifications with type `blog_notification`. 
- Wire notification calls into blog handlers by invoking `notifyCommentCreated(...)` in `CreateBlogCommentCommandHandler` and `notifyReactionCreated(...)` in `CreateBlogReactionCommandHandler`. 
- Add unit tests for the two services under `tests/Unit/Notification/Application/Service/NotificationPublisherTest.php` and `tests/Unit/Blog/Application/Service/BlogNotificationServiceTest.php`. 

### Testing
- Ran syntax checks with `php -l` on all added/modified PHP files and they returned no syntax errors. 
- Attempted to run focused tests with `./vendor/bin/phpunit tests/Unit/Notification/Application/Service/NotificationPublisherTest.php tests/Unit/Blog/Application/Service/BlogNotificationServiceTest.php` but the project PHPUnit binary was not available in this environment so tests were not executed. 
- Unit tests were added to cover persistence behavior and recipient/title selection logic (tests present but not executed due to missing binary).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af7f05d5d88326a8073f7825d5de38)