### PR TITLE
docs(openapi): enrich request bodies with explicit JSON schemas

### DIFF
--- a/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
@@ -40,7 +40,7 @@ final readonly class BlogMutationController
     ) {}
 
     #[Route('/v1/blogs/general', methods: [Request::METHOD_POST])]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['title' => 'General Blog']))]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object', properties: [new OA\Property(property: 'title', type: 'string', example: 'General Blog')], example: ['title' => 'General Blog']))]
     #[OA\Response(response: 202, description: 'General blog creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createGeneral(Request $request): JsonResponse
     {
@@ -57,7 +57,7 @@ final readonly class BlogMutationController
 
     #[Route('/v1/blogs/{blogId}/posts', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'blogId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e77')]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Nouveau post produit', 'filePath' => 'https://api.example.com/uploads/blog/post.png']))]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object', properties: [new OA\Property(property: 'content', type: 'string', nullable: true, example: 'Nouveau post produit'), new OA\Property(property: 'filePath', type: 'string', nullable: true, example: 'https://api.example.com/uploads/blog/post.png')], example: ['content' => 'Nouveau post produit', 'filePath' => 'https://api.example.com/uploads/blog/post.png']))]
     #[OA\Response(response: 202, description: 'Post creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createPost(string $blogId, Request $request, User $loggedInUser): JsonResponse
     {
@@ -77,7 +77,7 @@ final readonly class BlogMutationController
 
     #[Route('/v1/blog/posts/{postId}', methods: [Request::METHOD_PATCH])]
     #[OA\Parameter(name: 'postId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e78')]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Mise a jour du post', 'filePath' => 'https://api.example.com/uploads/blog/new-file.png']))]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object', properties: [new OA\Property(property: 'content', type: 'string', nullable: true, example: 'Mise a jour du post'), new OA\Property(property: 'filePath', type: 'string', nullable: true, example: 'https://api.example.com/uploads/blog/new-file.png')], example: ['content' => 'Mise a jour du post', 'filePath' => 'https://api.example.com/uploads/blog/new-file.png']))]
     #[OA\Response(response: 204, description: 'Post updated.')]
     public function patchPost(string $postId, Request $request, User $loggedInUser): JsonResponse
     {
@@ -101,7 +101,7 @@ final readonly class BlogMutationController
 
     #[Route('/v1/blog/posts/{postId}/comments', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'postId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e79')]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Je valide ce point', 'parentCommentId' => null]))]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object', properties: [new OA\Property(property: 'content', type: 'string', nullable: true, example: 'Je valide ce point'), new OA\Property(property: 'filePath', type: 'string', nullable: true, example: 'https://api.example.com/uploads/blog/comment.png'), new OA\Property(property: 'parentCommentId', type: 'string', format: 'uuid', nullable: true, example: null)], example: ['content' => 'Je valide ce point', 'parentCommentId' => null]))]
     #[OA\Response(response: 202, description: 'Comment creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createComment(string $postId, Request $request, User $loggedInUser): JsonResponse
     {
@@ -122,7 +122,7 @@ final readonly class BlogMutationController
 
     #[Route('/v1/blog/comments/{commentId}', methods: [Request::METHOD_PATCH])]
     #[OA\Parameter(name: 'commentId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e90')]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['content' => 'Commentaire corrige']))]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object', properties: [new OA\Property(property: 'content', type: 'string', nullable: true, example: 'Commentaire corrige'), new OA\Property(property: 'filePath', type: 'string', nullable: true, example: 'https://api.example.com/uploads/blog/new-file.png')], example: ['content' => 'Commentaire corrige']))]
     #[OA\Response(response: 204, description: 'Comment updated.')]
     public function patchComment(string $commentId, Request $request, User $loggedInUser): JsonResponse
     {
@@ -146,7 +146,7 @@ final readonly class BlogMutationController
 
     #[Route('/v1/blog/comments/{commentId}/reactions', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'commentId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e90')]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['type' => 'heart']))]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object', required: ['type'], properties: [new OA\Property(property: 'type', type: 'string', example: 'heart')], example: ['type' => 'heart']))]
     #[OA\Response(response: 202, description: 'Reaction creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createReaction(string $commentId, Request $request, User $loggedInUser): JsonResponse
     {
@@ -158,7 +158,7 @@ final readonly class BlogMutationController
 
     #[Route('/v1/blog/reactions/{reactionId}', methods: [Request::METHOD_PATCH])]
     #[OA\Parameter(name: 'reactionId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: '0195f4b9-4f2b-7c9a-8e6d-6f9b7d4a6e91')]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['type' => 'laugh']))]
+    #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object', required: ['type'], properties: [new OA\Property(property: 'type', type: 'string', example: 'laugh')], example: ['type' => 'laugh']))]
     #[OA\Response(response: 204, description: 'Reaction updated.')]
     public function patchReaction(string $reactionId, Request $request, User $loggedInUser): JsonResponse
     {

--- a/src/Crm/Transport/Controller/Api/V1/CrmController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CrmController.php
@@ -260,7 +260,17 @@ final readonly class CrmController
 
     #[Route('/v1/crm/applications/{applicationSlug}/companies', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['name' => 'Acme Europe']))]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            type: 'object',
+            required: ['name'],
+            properties: [
+                new OA\Property(property: 'name', type: 'string', minLength: 1, example: 'Acme Europe'),
+            ],
+            example: ['name' => 'Acme Europe'],
+        )
+    )]
     #[OA\Response(response: 201, description: 'Company created under CRM application.', content: new OA\JsonContent(example: ['id' => 'uuid', 'crmId' => 'uuid', 'applicationSlug' => 'crm-sales-hub']))]
     public function createCompanyByApplication(string $applicationSlug, Request $request): JsonResponse
     {

--- a/src/Quiz/Transport/Controller/Api/V1/QuizController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/QuizController.php
@@ -34,7 +34,40 @@ final readonly class QuizController
 
     #[Route('/v1/quiz/application/{applicationSlug}/questions', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'shop-ops-center')]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['title' => 'What is Symfony Messenger?', 'level' => 'medium', 'category' => 'backend', 'answers' => [['label' => 'Message bus component', 'correct' => true], ['label' => 'Template engine', 'correct' => false]], 'configuration' => ['shuffleAnswers' => true, 'timeLimitSec' => 40]]))]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            type: 'object',
+            required: ['title', 'level', 'category', 'answers'],
+            properties: [
+                new OA\Property(property: 'title', type: 'string', minLength: 1, example: 'What is Symfony Messenger?'),
+                new OA\Property(property: 'level', type: 'string', example: 'medium'),
+                new OA\Property(property: 'category', type: 'string', example: 'backend'),
+                new OA\Property(
+                    property: 'answers',
+                    type: 'array',
+                    items: new OA\Items(
+                        type: 'object',
+                        required: ['label', 'correct'],
+                        properties: [
+                            new OA\Property(property: 'label', type: 'string', example: 'Message bus component'),
+                            new OA\Property(property: 'correct', type: 'boolean', example: true),
+                        ],
+                    ),
+                ),
+                new OA\Property(
+                    property: 'configuration',
+                    type: 'object',
+                    nullable: true,
+                    properties: [
+                        new OA\Property(property: 'shuffleAnswers', type: 'boolean', example: true),
+                        new OA\Property(property: 'timeLimitSec', type: 'integer', example: 40),
+                    ],
+                ),
+            ],
+            example: ['title' => 'What is Symfony Messenger?', 'level' => 'medium', 'category' => 'backend', 'answers' => [['label' => 'Message bus component', 'correct' => true], ['label' => 'Template engine', 'correct' => false]], 'configuration' => ['shuffleAnswers' => true, 'timeLimitSec' => 40]],
+        )
+    )]
     #[OA\Response(response: 202, description: 'Question creation requested.', content: new OA\JsonContent(example: ['status' => 'accepted']))]
     public function createQuestion(string $applicationSlug, Request $request): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/SchoolController.php
+++ b/src/School/Transport/Controller/Api/V1/SchoolController.php
@@ -260,7 +260,17 @@ final readonly class SchoolController
 
     #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'school-campus-core')]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['name' => 'Classe C - Informatique']))]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            type: 'object',
+            required: ['name'],
+            properties: [
+                new OA\Property(property: 'name', type: 'string', minLength: 1, example: 'Classe C - Informatique'),
+            ],
+            example: ['name' => 'Classe C - Informatique'],
+        )
+    )]
     #[OA\Response(response: 201, description: 'Class created under school application.', content: new OA\JsonContent(example: ['id' => 'uuid', 'schoolId' => 'uuid', 'applicationSlug' => 'school-campus-core']))]
     public function createClassByApplication(string $applicationSlug, Request $request): JsonResponse
     {

--- a/src/Shop/Transport/Controller/Api/V1/ShopController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ShopController.php
@@ -184,7 +184,20 @@ final readonly class ShopController
 
     #[Route('/v1/shop/applications/{applicationSlug}/products', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'shop-ops-center')]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(example: ['name' => 'Clavier mecanique', 'price' => 129.9, 'categoryId' => null, 'tagIds' => []]))]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            type: 'object',
+            required: ['name', 'price'],
+            properties: [
+                new OA\Property(property: 'name', type: 'string', minLength: 1, example: 'Clavier mecanique'),
+                new OA\Property(property: 'price', type: 'number', format: 'float', example: 129.9),
+                new OA\Property(property: 'categoryId', type: 'string', format: 'uuid', nullable: true, example: null),
+                new OA\Property(property: 'tagIds', type: 'array', items: new OA\Items(type: 'string', format: 'uuid'), example: []),
+            ],
+            example: ['name' => 'Clavier mecanique', 'price' => 129.9, 'categoryId' => null, 'tagIds' => []],
+        )
+    )]
     #[OA\Response(response: 201, description: 'Product created for the application shop.', content: new OA\JsonContent(example: ['id' => 'uuid', 'shopId' => 'uuid', 'applicationSlug' => 'shop-ops-center']))]
     public function createProductByApplication(string $applicationSlug, Request $request): JsonResponse
     {

--- a/src/User/Transport/Controller/Api/V1/User/UserMeController.php
+++ b/src/User/Transport/Controller/Api/V1/User/UserMeController.php
@@ -47,7 +47,51 @@ class UserMeController
     }
 
     #[Route(path: '/v1/users/me/profile', methods: [Request::METHOD_PATCH])]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            type: 'object',
+            properties: [
+                new OA\Property(property: 'title', type: 'string', nullable: true, example: 'Lead Developer'),
+                new OA\Property(property: 'information', type: 'string', nullable: true, example: 'Disponible pour des projets remote en Europe.'),
+                new OA\Property(property: 'gender', type: 'string', nullable: true, enum: ['Female', 'Male'], example: 'Male'),
+                new OA\Property(property: 'birthday', type: 'string', format: 'date', nullable: true, example: '1993-07-14'),
+                new OA\Property(property: 'location', type: 'string', nullable: true, example: 'Paris'),
+                new OA\Property(property: 'phone', type: 'string', nullable: true, example: '+33 6 11 22 33 44'),
+                new OA\Property(property: 'firstName', type: 'string', nullable: true, example: 'Alexandre'),
+                new OA\Property(property: 'lastName', type: 'string', nullable: true, example: 'Martin'),
+                new OA\Property(property: 'email', type: 'string', format: 'email', nullable: true, example: 'alexandre.martin@example.com'),
+                new OA\Property(
+                    property: 'socials',
+                    type: 'array',
+                    nullable: true,
+                    items: new OA\Items(
+                        type: 'object',
+                        required: ['provider', 'providerId'],
+                        properties: [
+                            new OA\Property(property: 'provider', type: 'string', example: 'linkedin'),
+                            new OA\Property(property: 'providerId', type: 'string', example: 'alex-martin'),
+                        ],
+                    ),
+                ),
+            ],
+            example: [
+                'title' => 'Lead Developer',
+                'information' => 'Disponible pour des projets remote en Europe.',
+                'gender' => 'Male',
+                'birthday' => '1993-07-14',
+                'location' => 'Paris',
+                'phone' => '+33 6 11 22 33 44',
+                'firstName' => 'Alexandre',
+                'lastName' => 'Martin',
+                'email' => 'alexandre.martin@example.com',
+                'socials' => [
+                    ['provider' => 'linkedin', 'providerId' => 'alex-martin'],
+                    ['provider' => 'github', 'providerId' => 'alexmartin-dev'],
+                ],
+            ],
+        )
+    )]
     #[OA\Response(response: 200, description: 'Updated profile')]
     public function patchProfile(Request $request, User $loggedInUser): JsonResponse
     {
@@ -58,7 +102,21 @@ class UserMeController
     }
 
     #[Route(path: '/v1/users/me/password', methods: [Request::METHOD_PATCH])]
-    #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object', required: ['currentPassword', 'newPassword']))]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            type: 'object',
+            required: ['currentPassword', 'newPassword'],
+            properties: [
+                new OA\Property(property: 'currentPassword', type: 'string', minLength: 1, example: 'CurrentPass!2024'),
+                new OA\Property(property: 'newPassword', type: 'string', minLength: 1, example: 'MyNewStrongPass!2026'),
+            ],
+            example: [
+                'currentPassword' => 'CurrentPass!2024',
+                'newPassword' => 'MyNewStrongPass!2026',
+            ],
+        )
+    )]
     #[OA\Response(response: 200, description: 'Password changed', content: new OA\JsonContent(example: ['status' => 'ok']))]
     public function changePassword(Request $request, User $loggedInUser): JsonResponse
     {


### PR DESCRIPTION
### Motivation
- Improve OpenAPI request body documentation by replacing loosely-typed `OA\JsonContent` examples with explicit `type: 'object'` schemas that list `properties`, `required` fields and realistic `example`s to match the controllers' behavioral expectations.
- Align documentation with business validation present in services (e.g. required fields used by `UserMeService` and other handlers) so generated API specs are accurate for consumers.
- Apply a consistent rule across controllers that still used `OA\JsonContent` without explicit properties to reduce ambiguity in the API surface.

### Description
- Enriched `UserMeController` request bodies for `patchProfile` and `changePassword` with `OA\JsonContent(type: 'object', properties: [...], required: [...], example: ...)` describing each field and realistic examples in `src/User/Transport/Controller/Api/V1/User/UserMeController.php`.
- Replaced example-only `OA\JsonContent` with explicit object schemas in the following controllers: `BlogMutationController`, `CrmController`, `QuizController`, `SchoolController` and `ShopController`, adding `properties`, `required` where applicable, and examples to reflect actual payloads processed by the code.
- Kept DTO `Model` references out of these changes when no dedicated input DTO existed, to avoid introducing mismatched models; the annotations describe the exact payload the controllers expect.
- Changes are limited to OpenAPI attributes/annotations and do not alter runtime controller logic.

### Testing
- Ran PHP syntax checks with `php -l` on all modified controllers (`src/User/...UserMeController.php`, `src/Blog/...BlogMutationController.php`, `src/Crm/...CrmController.php`, `src/Quiz/...QuizController.php`, `src/School/...SchoolController.php`, `src/Shop/...ShopController.php`) and all reported "No syntax errors detected.".
- Committed the changes (`docs(openapi): enrich request bodies with explicit JSON schemas`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af856429fc832699e04b5fcdcd9e0c)