### PR TITLE
Remove redundant 201 OpenAPI response from profile create controllers

### DIFF
--- a/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
@@ -56,7 +56,7 @@ class ApplicationCreateController
         path: '/v1/profile/applications',
         methods: [Request::METHOD_POST],
     )]
-    #[OA\Post(summary: 'POST /v1/profile/applications', tags: ['Profile'], parameters: [], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
+    #[OA\Post(summary: 'POST /v1/profile/applications', tags: ['Profile'], parameters: [], responses: [new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
     #[OA\RequestBody(
         required: true,

--- a/src/User/Transport/Controller/Api/V1/Profile/ConfigurationCreateController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ConfigurationCreateController.php
@@ -38,7 +38,7 @@ class ConfigurationCreateController
         path: '/v1/profile/configuration',
         methods: [Request::METHOD_POST],
     )]
-    #[OA\Post(summary: 'POST /v1/profile/configuration', tags: ['Profile'], parameters: [], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
+    #[OA\Post(summary: 'POST /v1/profile/configuration', tags: ['Profile'], parameters: [], responses: [new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
     #[OA\RequestBody(
         required: true,


### PR DESCRIPTION
### Motivation
- Ensure the OpenAPI annotations for profile creation endpoints do not include a redundant `201` response in the `#[OA\Post]` attributes so the API spec is consistent and not duplicated.

### Description
- Removed `new OA\Response(response: 201, description: 'Success.')` from the `#[OA\Post(...)]` attributes in `src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php` and `src/User/Transport/Controller/Api/V1/Profile/ConfigurationCreateController.php` so `201` is only declared where a dedicated `#[OA\Response(response: 201, ...)]` is present.

### Testing
- Ran the test suite with `phpunit` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af8447c9b8832686f78cddffa5733d)