### PR TITLE
Adjust OpenAPI response annotations for Profile API controllers

### DIFF
--- a/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
@@ -56,7 +56,7 @@ class ApplicationCreateController
         path: '/v1/profile/applications',
         methods: [Request::METHOD_POST],
     )]
-    #[OA\Post(summary: 'POST /v1/profile/applications', tags: ['Profile'], parameters: [], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
+    #[OA\Post(summary: 'POST /v1/profile/applications', tags: ['Profile'], parameters: [], responses: [new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
     #[OA\RequestBody(
         required: true,

--- a/src/User/Transport/Controller/Api/V1/Profile/ApplicationUploadPhotoController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ApplicationUploadPhotoController.php
@@ -36,7 +36,7 @@ class ApplicationUploadPhotoController
         path: '/v1/profile/applications/{application}/photo',
         methods: [Request::METHOD_POST],
     )]
-    #[OA\Post(summary: 'POST /v1/profile/applications/{application}/photo', tags: ['Profile'], parameters: [new OA\Parameter(name: 'application', in: 'path', required: true, schema: new OA\Schema(type: 'string'))], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
+    #[OA\Post(summary: 'POST /v1/profile/applications/{application}/photo', tags: ['Profile'], parameters: [new OA\Parameter(name: 'application', in: 'path', required: true, schema: new OA\Schema(type: 'string'))], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
     #[OA\RequestBody(
         required: true,

--- a/src/User/Transport/Controller/Api/V1/Profile/ConfigurationCreateController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ConfigurationCreateController.php
@@ -38,7 +38,7 @@ class ConfigurationCreateController
         path: '/v1/profile/configuration',
         methods: [Request::METHOD_POST],
     )]
-    #[OA\Post(summary: 'POST /v1/profile/configuration', tags: ['Profile'], parameters: [], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
+    #[OA\Post(summary: 'POST /v1/profile/configuration', tags: ['Profile'], parameters: [], responses: [new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
     #[OA\RequestBody(
         required: true,

--- a/src/User/Transport/Controller/Api/V1/Profile/PlatformUploadPhotoController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/PlatformUploadPhotoController.php
@@ -34,7 +34,7 @@ class PlatformUploadPhotoController
         path: '/v1/profile/platforms/{platform}/photo',
         methods: [Request::METHOD_POST],
     )]
-    #[OA\Post(summary: 'POST /v1/profile/platforms/{platform}/photo', tags: ['Profile'], parameters: [new OA\Parameter(name: 'platform', in: 'path', required: true, schema: new OA\Schema(type: 'string'))], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
+    #[OA\Post(summary: 'POST /v1/profile/platforms/{platform}/photo', tags: ['Profile'], parameters: [new OA\Parameter(name: 'platform', in: 'path', required: true, schema: new OA\Schema(type: 'string'))], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
     #[OA\RequestBody(
         required: true,

--- a/src/User/Transport/Controller/Api/V1/Profile/PluginUploadPhotoController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/PluginUploadPhotoController.php
@@ -34,7 +34,7 @@ class PluginUploadPhotoController
         path: '/v1/profile/plugins/{plugin}/photo',
         methods: [Request::METHOD_POST],
     )]
-    #[OA\Post(summary: 'POST /v1/profile/plugins/{plugin}/photo', tags: ['Profile'], parameters: [new OA\Parameter(name: 'plugin', in: 'path', required: true, schema: new OA\Schema(type: 'string'))], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
+    #[OA\Post(summary: 'POST /v1/profile/plugins/{plugin}/photo', tags: ['Profile'], parameters: [new OA\Parameter(name: 'plugin', in: 'path', required: true, schema: new OA\Schema(type: 'string'))], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
     #[OA\RequestBody(
         required: true,

--- a/src/User/Transport/Controller/Api/V1/Profile/UploadPhotoController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/UploadPhotoController.php
@@ -37,7 +37,7 @@ class UploadPhotoController
         path: '/v1/profile/photo',
         methods: [Request::METHOD_POST],
     )]
-    #[OA\Post(summary: 'POST /v1/profile/photo', tags: ['Profile'], parameters: [], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 400, description: 'Bad request.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
+    #[OA\Post(summary: 'POST /v1/profile/photo', tags: ['Profile'], parameters: [], responses: [new OA\Response(response: 201, description: 'Success.'), new OA\Response(response: 401, description: 'Unauthorized.'), new OA\Response(response: 404, description: 'Not found.'), new OA\Response(response: 422, description: 'Validation error.')])]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
     #[OA\RequestBody(
         required: true,


### PR DESCRIPTION
### Motivation
- Align OpenAPI attributes on profile endpoints with actual/desired responses by removing incorrect or redundant response codes from the `OA\Post` annotations.

### Description
- Removed the `201` success response from the OpenAPI annotation on `ApplicationCreateController` and `ConfigurationCreateController` `OA\Post` attributes.
- Removed the `400` bad-request response from the OpenAPI annotation on the photo upload controllers: `ApplicationUploadPhotoController`, `PluginUploadPhotoController`, `PlatformUploadPhotoController`, and `UploadPhotoController`.
- Changes are limited to OpenAPI `#[OA\Post(...)]` response arrays and do not modify runtime logic or route definitions.

### Testing
- Ran the project test suite with `phpunit` and all tests completed successfully.
- Ran static analysis with `phpstan` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af8447c9b8832686f78cddffa5733d)