### PR TITLE
Fix duplicate OpenAPI Post annotation for application photo upload

### DIFF
--- a/src/User/Transport/Controller/Api/V1/Profile/ApplicationUploadPhotoController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ApplicationUploadPhotoController.php
@@ -36,10 +36,13 @@ class ApplicationUploadPhotoController
         path: '/v1/profile/applications/{application}/photo',
         methods: [Request::METHOD_POST],
     )]
-    #[OA\Post(summary: 'Upload application photo', tags: ['Profile'], parameters: [new OA\Parameter(name: 'application', in: 'path', required: true, schema: new OA\Schema(type: 'string'))])]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
     #[OA\Post(
         summary: "Upload la photo d'une candidature.",
+        tags: ['Profile'],
+        parameters: [
+            new OA\Parameter(name: 'application', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
         requestBody: new OA\RequestBody(
             required: true,
             content: new OA\MediaType(


### PR DESCRIPTION
### Motivation
- Prevent swagger-php / Nelmio from emitting `Multiple definitions for @OA\Post()->summary` for the application photo upload endpoint by consolidating OpenAPI metadata into a single attribute.

### Description
- Removed the duplicate `#[OA\Post(...)]` attribute and moved `tags` and the `application` path `OA\Parameter` into the remaining `#[OA\Post(...)]` on `ApplicationUploadPhotoController::__invoke`.

### Testing
- Ran `php -l src/User/Transport/Controller/Api/V1/Profile/ApplicationUploadPhotoController.php` which reported no syntax errors. 
- Attempted `php bin/console nelmio:apidoc:dump --format=json` but it failed in this environment due to missing Composer dependencies (`Try running "composer install"`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af8f69a03c83269ee7f6fb8e10ccec)