### PR TITLE
feat(chat): add private conversation messages endpoint

### DIFF
--- a/src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php
@@ -22,6 +22,19 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Message')]
+#[OA\Get(
+    path: '/v1/chat/private/conversations/{conversationId}',
+    operationId: 'chat_message_private_conversation_messages',
+    summary: "Lister tous les messages d'une conversation privée",
+    tags: ['Chat Message'],
+    parameters: [
+        new OA\Parameter(name: 'conversationId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
+    ],
+    responses: [
+        new OA\Response(response: 200, description: 'Liste des messages de la conversation'),
+        new OA\Response(response: 404, description: 'Conversation introuvable'),
+    ]
+)]
 #[OA\Post(
     path: '/v1/chat/private/conversations/{conversationId}/messages',
     operationId: 'chat_message_create',
@@ -98,6 +111,39 @@ class UserMessageMutationController
         private readonly ConversationParticipantRepository $participantRepository,
         private readonly ChatMessageRepository $messageRepository,
     ) {
+    }
+
+    #[Route(path: '/v1/chat/private/conversations/{conversationId}', methods: [Request::METHOD_GET])]
+    public function list(string $conversationId, User $loggedInUser): JsonResponse
+    {
+        $conversation = $this->findParticipantConversation($conversationId, $loggedInUser);
+
+        $items = [];
+        foreach ($conversation->getMessages()->toArray() as $message) {
+            $sender = $message->getSender();
+            $senderId = $sender->getId();
+
+            $items[] = [
+                'id' => $message->getId(),
+                'content' => $message->getContent(),
+                'sender' => [
+                    'id' => $senderId,
+                    'firstName' => $sender->getFirstName(),
+                    'lastName' => $sender->getLastName(),
+                    'photo' => $sender->getPhoto(),
+                    'owner' => $senderId === $loggedInUser->getId(),
+                ],
+                'attachments' => $message->getAttachments(),
+                'read' => $message->isRead(),
+                'readAt' => $message->getReadAt()?->format(DATE_ATOM),
+                'createdAt' => $message->getCreatedAt()?->format(DATE_ATOM),
+            ];
+        }
+
+        return new JsonResponse([
+            'conversationId' => $conversation->getId(),
+            'items' => $items,
+        ]);
     }
 
     #[Route(path: '/v1/chat/private/conversations/{conversationId}/messages', methods: [Request::METHOD_POST])]


### PR DESCRIPTION
### Motivation
- Fournir un endpoint `GET /v1/chat/private/conversations/{conversationId}` qui retourne tous les messages d'une conversation privée.
- Restreindre l'accès aux seuls participants de la conversation et exposer les informations nécessaires côté client (expéditeur, pièces jointes, états de lecture, horodatages).

### Description
- Ajout d'un nouvel endpoint côté contrôleur des messages dans `src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php` exposé via `#[Route(path: '/v1/chat/private/conversations/{conversationId}', methods: [Request::METHOD_GET])]`.
- La méthode `list` valide que l'utilisateur connecté est participant en réutilisant `findParticipantConversation` avant de lire et normaliser les messages.
- La réponse JSON contient `conversationId` et `items` avec pour chaque message les champs `id`, `content`, `sender` (id, firstName, lastName, photo, owner), `attachments`, `read`, `readAt` et `createdAt`.
- Documentation OpenAPI ajoutée via `#[OA"Get(...)]` (paramètre `conversationId`, réponses 200/404) pour générer correctement la spec.

### Testing
- `php -l src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php` a été exécuté et n'a retourné aucune erreur de syntaxe.
- `vendor/bin/phpunit tests/Unit/Chat` a été tenté mais n'a pas pu être exécuté dans cet environnement car `vendor/bin/phpunit` est indisponible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af9e6524fc8326957cd1f494a000e2)