### PR TITLE
feat(cache): unify cache key builders and migrate reader services

### DIFF
--- a/src/Blog/Application/Service/BlogReadService.php
+++ b/src/Blog/Application/Service/BlogReadService.php
@@ -7,23 +7,36 @@ namespace App\Blog\Application\Service;
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\User\Domain\Entity\User;
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
 final readonly class BlogReadService
 {
-    public function __construct(private BlogRepository $blogRepository, private CacheInterface $cache, private ElasticsearchServiceInterface $elasticsearchService) {}
+    public function __construct(
+        private BlogRepository $blogRepository,
+        private CacheInterface $cache,
+        private ElasticsearchServiceInterface $elasticsearchService,
+        private CacheKeyConventionService $cacheKeyConventionService,
+    ) {}
 
     /** @throws InvalidArgumentException */
     public function getGeneralBlogWithTree(?User $currentUser = null): array
     {
-        $userId = $currentUser?->getId() ?? 'anonymous';
+        $cacheKey = $this->buildBlogCacheKey('general', $currentUser);
 
-        return $this->cache->get('blog_general_tree_' . $userId, function (ItemInterface $item) use ($currentUser): array {
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($currentUser): array {
             $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->tagPublicBlog());
+                if ($currentUser !== null) {
+                    $item->tag($this->cacheKeyConventionService->tagPrivateBlog($currentUser->getId()));
+                }
+            }
             $blog = $this->blogRepository->findGeneralBlog();
 
             return $blog instanceof Blog ? $this->normalizeBlog($blog, $currentUser) : [];
@@ -33,10 +46,16 @@ final readonly class BlogReadService
     /** @throws InvalidArgumentException */
     public function getByApplicationSlug(string $applicationSlug, ?User $currentUser = null): array
     {
-        $userId = $currentUser?->getId() ?? 'anonymous';
+        $cacheKey = $this->buildBlogCacheKey('app/' . $applicationSlug, $currentUser);
 
-        return $this->cache->get('blog_app_' . $applicationSlug . '_' . $userId, function (ItemInterface $item) use ($applicationSlug, $currentUser): array {
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $currentUser): array {
             $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->tagPublicBlog());
+                if ($currentUser !== null) {
+                    $item->tag($this->cacheKeyConventionService->tagPrivateBlog($currentUser->getId()));
+                }
+            }
             $blog = $this->blogRepository->findOneByApplicationSlug($applicationSlug);
 
             return $blog instanceof Blog ? $this->normalizeBlog($blog, $currentUser) : [];
@@ -62,6 +81,15 @@ final readonly class BlogReadService
                 'comments' => $this->normalizeComments($p->getComments()->toArray(), null, $currentUser),
             ], $blog->getPosts()->toArray()),
         ];
+    }
+
+    private function buildBlogCacheKey(string $scope, ?User $currentUser): string
+    {
+        if ($currentUser === null) {
+            return $this->cacheKeyConventionService->buildPublicBlogKey($scope);
+        }
+
+        return $this->cacheKeyConventionService->buildPrivateBlogKey($currentUser->getUsername(), $scope);
     }
 
     /** @param array<int, BlogComment> $comments */

--- a/src/Calendar/Application/Service/EventListService.php
+++ b/src/Calendar/Application/Service/EventListService.php
@@ -6,11 +6,13 @@ namespace App\Calendar\Application\Service;
 
 use App\Calendar\Domain\Entity\Event;
 use App\Calendar\Domain\Repository\Interfaces\EventRepositoryInterface;
+use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\User\Domain\Entity\User;
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Throwable;
 
 use function array_filter;
@@ -22,6 +24,7 @@ final readonly class EventListService
         private EventRepositoryInterface $eventRepository,
         private CacheInterface $cache,
         private ElasticsearchServiceInterface $elasticsearchService,
+        private CacheKeyConventionService $cacheKeyConventionService,
     ) {
     }
 
@@ -79,18 +82,25 @@ final readonly class EventListService
             'location' => trim((string)($filters['location'] ?? '')),
         ];
 
-        $cacheKey = 'event_list_' . md5((string) json_encode([
+        $cachePayload = [
             'accessContext' => $accessContext,
             'userId' => $user?->getId(),
             'applicationSlug' => $applicationSlug,
             'page' => $page,
             'limit' => $limit,
             'filters' => $filters,
-        ], JSON_THROW_ON_ERROR));
+        ];
+
+        $cacheKey = $user !== null
+            ? $this->cacheKeyConventionService->buildPrivateEventKey($user->getUsername(), $cachePayload)
+            : 'event_list_' . md5((string) json_encode($cachePayload, JSON_THROW_ON_ERROR));
 
         /** @var array<string, mixed> $result */
         $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($accessContext, $user, $applicationSlug, $filters, $page, $limit): array {
             $item->expiresAfter(120);
+            if ($user !== null && method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->tagPrivateEvents($user->getId()));
+            }
 
             $esIds = $this->searchIdsFromElastic($filters);
             if ($esIds === []) {

--- a/src/Chat/Application/Service/ConversationListService.php
+++ b/src/Chat/Application/Service/ConversationListService.php
@@ -9,11 +9,13 @@ use App\Chat\Domain\Entity\ChatMessage;
 use App\Chat\Domain\Entity\ChatMessageReaction;
 use App\Chat\Domain\Entity\ConversationParticipant;
 use App\Chat\Domain\Repository\Interfaces\ConversationRepositoryInterface;
+use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\User\Domain\Entity\User;
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Throwable;
 
 use function array_filter;
@@ -25,6 +27,7 @@ final readonly class ConversationListService
         private ConversationRepositoryInterface $conversationRepository,
         private CacheInterface $cache,
         private ElasticsearchServiceInterface $elasticsearchService,
+        private CacheKeyConventionService $cacheKeyConventionService,
     ) {
     }
 
@@ -80,18 +83,25 @@ final readonly class ConversationListService
             'message' => trim((string)($filters['message'] ?? '')),
         ];
 
-        $cacheKey = 'conversation_list_' . md5((string) json_encode([
+        $cachePayload = [
             'accessContext' => $accessContext,
             'userId' => $user?->getId(),
             'chatId' => $chatId,
             'page' => $page,
             'limit' => $limit,
             'filters' => $filters,
-        ], JSON_THROW_ON_ERROR));
+        ];
+
+        $cacheKey = $user !== null
+            ? $this->cacheKeyConventionService->buildPrivateConversationKey($user->getUsername(), $cachePayload)
+            : 'conversation_list_' . md5((string) json_encode($cachePayload, JSON_THROW_ON_ERROR));
 
         /** @var array<string, mixed> $result */
         $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($accessContext, $user, $chatId, $filters, $page, $limit): array {
             $item->expiresAfter(120);
+            if ($user !== null && method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->tagPrivateConversation($user->getId()));
+            }
 
             $esIds = $this->searchIdsFromElastic($filters);
             if ($esIds === []) {

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -9,6 +9,63 @@ use function md5;
 
 class CacheKeyConventionService
 {
+    public function buildPublicPageKey(int $page, string $lang): string
+    {
+        return 'public/page/' . $page . '/' . $lang;
+    }
+
+    public function buildPublicBlogKey(string $scope): string
+    {
+        return 'public/blog/' . $scope;
+    }
+
+    public function buildPublicPlatformsListKey(): string
+    {
+        return 'public/platforms/list';
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    public function buildPublicApplicationsListKey(array $filters): string
+    {
+        return 'public/applications/list/' . $this->buildHash($filters);
+    }
+
+    public function buildPrivateProfileKey(string $username): string
+    {
+        return 'private/' . $username . '/profile';
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    public function buildPrivateConversationKey(string $username, array $filters): string
+    {
+        return 'private/' . $username . '/conversation/' . $this->buildHash($filters);
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    public function buildPrivateNotificationKey(string $username, array $filters): string
+    {
+        return 'private/' . $username . '/notifications/' . $this->buildHash($filters);
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     */
+    public function buildPrivateEventKey(string $username, array $filters): string
+    {
+        return 'private/' . $username . '/events/' . $this->buildHash($filters);
+    }
+
+    public function buildPrivateBlogKey(string $username, string $scope): string
+    {
+        return 'private/' . $username . '/blog/' . $scope;
+    }
+
     /**
      * @param array<string, mixed> $filters
      */
@@ -75,12 +132,57 @@ class CacheKeyConventionService
 
     public function applicationListTag(): string
     {
-        return 'cache:application:list';
+        return $this->tagPublicApplicationsList();
     }
 
     public function recruitJobListTag(string $applicationSlug): string
     {
         return 'cache:recruit:job:list:' . $applicationSlug;
+    }
+
+    public function tagPublicPage(): string
+    {
+        return 'cache:public:page';
+    }
+
+    public function tagPublicBlog(): string
+    {
+        return 'cache:public:blog';
+    }
+
+    public function tagPublicPlatformsList(): string
+    {
+        return 'cache:public:platforms:list';
+    }
+
+    public function tagPublicApplicationsList(): string
+    {
+        return 'cache:public:applications:list';
+    }
+
+    public function tagPrivateProfile(string $userId): string
+    {
+        return 'cache:private:' . $userId . ':profile';
+    }
+
+    public function tagPrivateConversation(string $userId): string
+    {
+        return 'cache:private:' . $userId . ':conversation';
+    }
+
+    public function tagPrivateNotification(string $userId): string
+    {
+        return 'cache:private:' . $userId . ':notifications';
+    }
+
+    public function tagPrivateEvents(string $userId): string
+    {
+        return 'cache:private:' . $userId . ':events';
+    }
+
+    public function tagPrivateBlog(string $userId): string
+    {
+        return 'cache:private:' . $userId . ':blog';
     }
 
     public function shopProductListTag(): string
@@ -96,5 +198,13 @@ class CacheKeyConventionService
     public function schoolExamListTag(): string
     {
         return 'cache:school:exam:list';
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function buildHash(array $payload): string
+    {
+        return md5((string) json_encode($payload, JSON_THROW_ON_ERROR));
     }
 }

--- a/src/Platform/Application/Service/ApplicationListService.php
+++ b/src/Platform/Application/Service/ApplicationListService.php
@@ -67,13 +67,21 @@ readonly class ApplicationListService
             'platformKey' => trim((string) $request->query->get('platformKey', '')),
         ];
 
-        $cacheKey = $this->cacheKeyConventionService->buildApplicationListKey($loggedInUser?->getId(), $page, $limit, $filters);
+        $cacheKey = $this->cacheKeyConventionService->buildPublicApplicationsListKey([
+            'userId' => $loggedInUser?->getId(),
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ]);
 
         /** @var array<string, mixed> $result */
         $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($loggedInUser, $filters, $page, $limit): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->applicationListTag());
+                if ($loggedInUser !== null) {
+                    $item->tag($this->cacheKeyConventionService->tagPrivateProfile($loggedInUser->getId()));
+                }
             }
 
             $esIds = $this->searchIdsFromElastic($filters);


### PR DESCRIPTION
### Motivation
- Centralize cache key formats and group invalidation to make cache usage consistent across public and private read endpoints.
- Provide explicit, human-readable builders for keys like `public/page/{page}/{lang}`, `public/blog/{scope}`, `public/applications/list/{hash}`, and `private/{username}/...` to avoid ad-hoc concatenations.
- Enable grouped invalidation via tag helpers to simplify cache invalidation for related entries.

### Description
- Added a unified convention service `src/General/Application/Service/CacheKeyConventionService.php` with explicit builders such as `buildPublicPageKey()`, `buildPublicBlogKey()`, `buildPublicPlatformsListKey()`, `buildPublicApplicationsListKey()`, `buildPrivateProfileKey()`, `buildPrivateConversationKey()`, `buildPrivateNotificationKey()`, `buildPrivateEventKey()`, `buildPrivateBlogKey()` and a `buildHash()` helper for filter payload hashing.
- Added tag helper methods in the convention service (examples: `tagPublicBlog()`, `tagPublicApplicationsList()`, `tagPrivateConversation($userId)`, `tagPrivateEvents($userId)`, `tagPrivateBlog($userId)`) and aligned `applicationListTag()` to the new public applications tag.
- Migrated reader/list services to use the new builders instead of local concatenations in the following files: `src/Blog/Application/Service/BlogReadService.php`, `src/Chat/Application/Service/ConversationListService.php`, `src/Calendar/Application/Service/EventListService.php`, and `src/Platform/Application/Service/ApplicationListService.php`.
- Wired tag assignment inside migrated services when the cache supports `TagAwareCacheInterface` to enable grouped invalidation while preserving previous public fallbacks for contexts not yet migrated.

### Testing
- Ran PHP lint checks on modified files: `php -l src/General/Application/Service/CacheKeyConventionService.php`, `php -l src/Blog/Application/Service/BlogReadService.php`, `php -l src/Chat/Application/Service/ConversationListService.php`, `php -l src/Calendar/Application/Service/EventListService.php`, and `php -l src/Platform/Application/Service/ApplicationListService.php`, all succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afb48d88388326a6a4a925c3f9db27)