### PR TITLE
Add tag-based cache invalidation for blogs, conversations and events

### DIFF
--- a/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
@@ -10,6 +10,7 @@ use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Infrastructure\Repository\BlogCommentRepository;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -26,6 +27,7 @@ final readonly class CreateBlogCommentCommandHandler
         private BlogPostRepository $postRepository,
         private UserRepository $userRepository,
         private BlogNotificationService $blogNotificationService,
+        private CacheInvalidationService $cacheInvalidationService,
     ) {}
 
     public function __invoke(CreateBlogCommentCommand $command): void
@@ -61,5 +63,6 @@ final readonly class CreateBlogCommentCommandHandler
 
         $this->commentRepository->save($comment);
         $this->blogNotificationService->notifyCommentCreated($comment);
+        $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
     }
 }

--- a/src/Blog/Application/MessageHandler/CreateBlogPostCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogPostCommandHandler.php
@@ -9,6 +9,7 @@ use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
 use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -24,6 +25,7 @@ final readonly class CreateBlogPostCommandHandler
         private BlogPostRepository $postRepository,
         private BlogRepository $blogRepository,
         private UserRepository $userRepository,
+        private CacheInvalidationService $cacheInvalidationService,
     ) {}
 
     public function __invoke(CreateBlogPostCommand $command): void
@@ -49,5 +51,7 @@ final readonly class CreateBlogPostCommandHandler
             ->setContent($command->content)
             ->setFilePath($command->filePath)
         );
+
+        $this->cacheInvalidationService->invalidateBlogCaches($blog->getApplication()?->getSlug(), $command->actorUserId);
     }
 }

--- a/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
@@ -10,6 +10,7 @@ use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Domain\Entity\BlogReaction;
 use App\Blog\Infrastructure\Repository\BlogCommentRepository;
 use App\Blog\Infrastructure\Repository\BlogReactionRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -24,6 +25,7 @@ final readonly class CreateBlogReactionCommandHandler
         private BlogCommentRepository $commentRepository,
         private UserRepository $userRepository,
         private BlogNotificationService $blogNotificationService,
+        private CacheInvalidationService $cacheInvalidationService,
     ) {}
 
     public function __invoke(CreateBlogReactionCommand $command): void
@@ -42,5 +44,6 @@ final readonly class CreateBlogReactionCommandHandler
         );
 
         $this->blogNotificationService->notifyReactionCreated($comment, $user, $command->type);
+        $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
     }
 }

--- a/src/Blog/Application/MessageHandler/CreateGeneralBlogCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateGeneralBlogCommandHandler.php
@@ -8,6 +8,7 @@ use App\Blog\Application\Message\CreateGeneralBlogCommand;
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Enum\BlogType;
 use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -17,7 +18,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final readonly class CreateGeneralBlogCommandHandler
 {
-    public function __construct(private BlogRepository $blogRepository, private UserRepository $userRepository) {}
+    public function __construct(private BlogRepository $blogRepository, private UserRepository $userRepository, private CacheInvalidationService $cacheInvalidationService) {}
 
     public function __invoke(CreateGeneralBlogCommand $command): void
     {
@@ -31,5 +32,6 @@ final readonly class CreateGeneralBlogCommandHandler
         }
 
         $this->blogRepository->save((new Blog())->setTitle($command->title)->setOwner($user)->setType(BlogType::GENERAL));
+        $this->cacheInvalidationService->invalidateBlogCaches(null, $command->actorUserId);
     }
 }

--- a/src/Blog/Application/MessageHandler/DeleteBlogCommentCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/DeleteBlogCommentCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Blog\Application\MessageHandler;
 use App\Blog\Application\Message\DeleteBlogCommentCommand;
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Infrastructure\Repository\BlogCommentRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -14,7 +15,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final readonly class DeleteBlogCommentCommandHandler
 {
-    public function __construct(private BlogCommentRepository $commentRepository) {}
+    public function __construct(private BlogCommentRepository $commentRepository, private CacheInvalidationService $cacheInvalidationService) {}
 
     public function __invoke(DeleteBlogCommentCommand $command): void
     {
@@ -28,6 +29,8 @@ final readonly class DeleteBlogCommentCommandHandler
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only comment owner can delete.');
         }
 
+        $applicationSlug = $comment->getPost()->getBlog()->getApplication()?->getSlug();
         $this->commentRepository->remove($comment);
+        $this->cacheInvalidationService->invalidateBlogCaches($applicationSlug, $command->actorUserId);
     }
 }

--- a/src/Blog/Application/MessageHandler/DeleteBlogPostCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/DeleteBlogPostCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Blog\Application\MessageHandler;
 use App\Blog\Application\Message\DeleteBlogPostCommand;
 use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -14,7 +15,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final readonly class DeleteBlogPostCommandHandler
 {
-    public function __construct(private BlogPostRepository $postRepository) {}
+    public function __construct(private BlogPostRepository $postRepository, private CacheInvalidationService $cacheInvalidationService) {}
 
     public function __invoke(DeleteBlogPostCommand $command): void
     {
@@ -28,6 +29,8 @@ final readonly class DeleteBlogPostCommandHandler
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only post owner can delete.');
         }
 
+        $applicationSlug = $post->getBlog()->getApplication()?->getSlug();
         $this->postRepository->remove($post);
+        $this->cacheInvalidationService->invalidateBlogCaches($applicationSlug, $command->actorUserId);
     }
 }

--- a/src/Blog/Application/MessageHandler/DeleteBlogReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/DeleteBlogReactionCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Blog\Application\MessageHandler;
 use App\Blog\Application\Message\DeleteBlogReactionCommand;
 use App\Blog\Domain\Entity\BlogReaction;
 use App\Blog\Infrastructure\Repository\BlogReactionRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -14,7 +15,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final readonly class DeleteBlogReactionCommandHandler
 {
-    public function __construct(private BlogReactionRepository $reactionRepository) {}
+    public function __construct(private BlogReactionRepository $reactionRepository, private CacheInvalidationService $cacheInvalidationService) {}
 
     public function __invoke(DeleteBlogReactionCommand $command): void
     {
@@ -28,6 +29,8 @@ final readonly class DeleteBlogReactionCommandHandler
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only reaction owner can delete.');
         }
 
+        $applicationSlug = $reaction->getComment()->getPost()->getBlog()->getApplication()?->getSlug();
         $this->reactionRepository->remove($reaction);
+        $this->cacheInvalidationService->invalidateBlogCaches($applicationSlug, $command->actorUserId);
     }
 }

--- a/src/Blog/Application/MessageHandler/PatchBlogCommentCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/PatchBlogCommentCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Blog\Application\MessageHandler;
 use App\Blog\Application\Message\PatchBlogCommentCommand;
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Infrastructure\Repository\BlogCommentRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -14,7 +15,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final readonly class PatchBlogCommentCommandHandler
 {
-    public function __construct(private BlogCommentRepository $commentRepository) {}
+    public function __construct(private BlogCommentRepository $commentRepository, private CacheInvalidationService $cacheInvalidationService) {}
 
     public function __invoke(PatchBlogCommentCommand $command): void
     {
@@ -33,5 +34,6 @@ final readonly class PatchBlogCommentCommandHandler
             ->setFilePath($command->filePath);
 
         $this->commentRepository->save($comment);
+        $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
     }
 }

--- a/src/Blog/Application/MessageHandler/PatchBlogPostCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/PatchBlogPostCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Blog\Application\MessageHandler;
 use App\Blog\Application\Message\PatchBlogPostCommand;
 use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -14,7 +15,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final readonly class PatchBlogPostCommandHandler
 {
-    public function __construct(private BlogPostRepository $postRepository) {}
+    public function __construct(private BlogPostRepository $postRepository, private CacheInvalidationService $cacheInvalidationService) {}
 
     public function __invoke(PatchBlogPostCommand $command): void
     {
@@ -33,5 +34,6 @@ final readonly class PatchBlogPostCommandHandler
             ->setFilePath($command->filePath);
 
         $this->postRepository->save($post);
+        $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
     }
 }

--- a/src/Blog/Application/MessageHandler/PatchBlogReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/PatchBlogReactionCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Blog\Application\MessageHandler;
 use App\Blog\Application\Message\PatchBlogReactionCommand;
 use App\Blog\Domain\Entity\BlogReaction;
 use App\Blog\Infrastructure\Repository\BlogReactionRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -14,7 +15,7 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 final readonly class PatchBlogReactionCommandHandler
 {
-    public function __construct(private BlogReactionRepository $reactionRepository) {}
+    public function __construct(private BlogReactionRepository $reactionRepository, private CacheInvalidationService $cacheInvalidationService) {}
 
     public function __invoke(PatchBlogReactionCommand $command): void
     {
@@ -30,5 +31,6 @@ final readonly class PatchBlogReactionCommandHandler
 
         $reaction->setType($command->type);
         $this->reactionRepository->save($reaction);
+        $this->cacheInvalidationService->invalidateBlogCaches($reaction->getComment()->getPost()->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
     }
 }

--- a/src/Blog/Application/Service/BlogReadService.php
+++ b/src/Blog/Application/Service/BlogReadService.php
@@ -33,6 +33,7 @@ final readonly class BlogReadService
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->tagPublicBlog());
+                $item->tag($this->cacheKeyConventionService->tagPublicBlogByApplication(null));
                 if ($currentUser !== null) {
                     $item->tag($this->cacheKeyConventionService->tagPrivateBlog($currentUser->getId()));
                 }
@@ -52,6 +53,7 @@ final readonly class BlogReadService
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->tagPublicBlog());
+                $item->tag($this->cacheKeyConventionService->tagPublicBlogByApplication($applicationSlug));
                 if ($currentUser !== null) {
                     $item->tag($this->cacheKeyConventionService->tagPrivateBlog($currentUser->getId()));
                 }

--- a/src/Calendar/Application/MessageHandler/CancelEventCommandHandler.php
+++ b/src/Calendar/Application/MessageHandler/CancelEventCommandHandler.php
@@ -8,6 +8,7 @@ use App\Calendar\Application\Message\CancelEventCommand;
 use App\Calendar\Domain\Entity\Event;
 use App\Calendar\Domain\Enum\EventStatus;
 use App\Calendar\Infrastructure\Repository\EventRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Infrastructure\Repository\ApplicationRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -20,6 +21,7 @@ final readonly class CancelEventCommandHandler
     public function __construct(
         private EventRepository $eventRepository,
         private ApplicationRepository $applicationRepository,
+        private CacheInvalidationService $cacheInvalidationService,
     ) {
     }
 
@@ -46,5 +48,7 @@ final readonly class CancelEventCommandHandler
             $event->setIsCancelled(true)->setStatus(EventStatus::CANCELLED);
             $this->eventRepository->save($event);
         });
+
+        $this->cacheInvalidationService->invalidateEventCaches($command->applicationSlug, $command->actorUserId);
     }
 }

--- a/src/Calendar/Application/MessageHandler/CreateEventCommandHandler.php
+++ b/src/Calendar/Application/MessageHandler/CreateEventCommandHandler.php
@@ -8,6 +8,7 @@ use App\Calendar\Application\Message\CreateEventCommand;
 use App\Calendar\Domain\Entity\Event;
 use App\Calendar\Infrastructure\Repository\CalendarRepository;
 use App\Calendar\Infrastructure\Repository\EventRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Infrastructure\Repository\ApplicationRepository;
 use App\User\Domain\Entity\User;
@@ -24,6 +25,7 @@ final readonly class CreateEventCommandHandler
         private UserRepository $userRepository,
         private ApplicationRepository $applicationRepository,
         private CalendarRepository $calendarRepository,
+        private CacheInvalidationService $cacheInvalidationService,
     ) {
     }
 
@@ -61,5 +63,7 @@ final readonly class CreateEventCommandHandler
 
             $this->eventRepository->save($event);
         });
+
+        $this->cacheInvalidationService->invalidateEventCaches($command->applicationSlug, $command->actorUserId);
     }
 }

--- a/src/Calendar/Application/MessageHandler/DeleteEventCommandHandler.php
+++ b/src/Calendar/Application/MessageHandler/DeleteEventCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Calendar\Application\MessageHandler;
 use App\Calendar\Application\Message\DeleteEventCommand;
 use App\Calendar\Domain\Entity\Event;
 use App\Calendar\Infrastructure\Repository\EventRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Infrastructure\Repository\ApplicationRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -19,6 +20,7 @@ final readonly class DeleteEventCommandHandler
     public function __construct(
         private EventRepository $eventRepository,
         private ApplicationRepository $applicationRepository,
+        private CacheInvalidationService $cacheInvalidationService,
     ) {
     }
 
@@ -44,5 +46,7 @@ final readonly class DeleteEventCommandHandler
 
             $this->eventRepository->remove($event);
         });
+
+        $this->cacheInvalidationService->invalidateEventCaches($command->applicationSlug, $command->actorUserId);
     }
 }

--- a/src/Calendar/Application/MessageHandler/PatchEventCommandHandler.php
+++ b/src/Calendar/Application/MessageHandler/PatchEventCommandHandler.php
@@ -6,6 +6,7 @@ namespace App\Calendar\Application\MessageHandler;
 
 use App\Calendar\Application\Message\PatchEventCommand;
 use App\Calendar\Domain\Entity\Event;
+use App\General\Application\Service\CacheInvalidationService;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Infrastructure\Repository\ApplicationRepository;
 use App\Calendar\Infrastructure\Repository\EventRepository;
@@ -19,6 +20,7 @@ final readonly class PatchEventCommandHandler
     public function __construct(
         private EventRepository $eventRepository,
         private ApplicationRepository $applicationRepository,
+        private CacheInvalidationService $cacheInvalidationService,
     ) {
     }
 
@@ -57,5 +59,7 @@ final readonly class PatchEventCommandHandler
 
             $this->eventRepository->save($event);
         });
+
+        $this->cacheInvalidationService->invalidateEventCaches($command->applicationSlug, $command->actorUserId);
     }
 }

--- a/src/Calendar/Application/Service/EventListService.php
+++ b/src/Calendar/Application/Service/EventListService.php
@@ -101,6 +101,9 @@ final readonly class EventListService
             if ($user !== null && method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->tagPrivateEvents($user->getId()));
             }
+            if ($applicationSlug !== null && $applicationSlug !== '' && method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->tagPublicEventsByApplication($applicationSlug));
+            }
 
             $esIds = $this->searchIdsFromElastic($filters);
             if ($esIds === []) {

--- a/src/Chat/Application/Service/ConversationListService.php
+++ b/src/Chat/Application/Service/ConversationListService.php
@@ -102,6 +102,9 @@ final readonly class ConversationListService
             if ($user !== null && method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->tagPrivateConversation($user->getId()));
             }
+            if ($chatId !== null && $chatId !== '' && method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->tagPublicConversationByChat($chatId));
+            }
 
             $esIds = $this->searchIdsFromElastic($filters);
             if ($esIds === []) {

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationMutationController.php
@@ -10,6 +10,7 @@ use App\Chat\Domain\Entity\ConversationParticipant;
 use App\Chat\Infrastructure\Repository\ChatRepository;
 use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
 use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
 use OpenApi\Attributes as OA;
@@ -119,6 +120,7 @@ class UserConversationMutationController
         private readonly UserRepository $userRepository,
         private readonly ConversationRepository $conversationRepository,
         private readonly ConversationParticipantRepository $participantRepository,
+        private readonly CacheInvalidationService $cacheInvalidationService,
     ) {
     }
 
@@ -149,6 +151,8 @@ class UserConversationMutationController
             $this->participantRepository->save((new ConversationParticipant())->setConversation($conversation)->setUser($targetUser), false);
         }
         $this->conversationRepository->getEntityManager()->flush();
+        $this->cacheInvalidationService->invalidateConversationCaches($chat->getId(), $loggedInUser->getId());
+        $this->cacheInvalidationService->invalidateConversationCaches($chat->getId(), $targetUser->getId());
 
         return new JsonResponse(['id' => $conversation->getId()], JsonResponse::HTTP_CREATED);
     }
@@ -174,6 +178,8 @@ class UserConversationMutationController
             $this->participantRepository->save(
                 (new ConversationParticipant())->setConversation($conversation)->setUser($targetUser)
             );
+            $this->cacheInvalidationService->invalidateConversationCaches($conversation->getChat()->getId(), $loggedInUser->getId());
+            $this->cacheInvalidationService->invalidateConversationCaches($conversation->getChat()->getId(), $targetUser->getId());
         }
 
         return new JsonResponse(['id' => $conversation->getId()]);
@@ -183,7 +189,9 @@ class UserConversationMutationController
     public function delete(string $conversationId, User $loggedInUser): JsonResponse
     {
         $conversation = $this->findParticipantConversation($conversationId, $loggedInUser);
+        $chatId = $conversation->getChat()->getId();
         $this->conversationRepository->remove($conversation);
+        $this->cacheInvalidationService->invalidateConversationCaches($chatId, $loggedInUser->getId());
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }
@@ -215,6 +223,8 @@ class UserConversationMutationController
         $this->participantRepository->save((new ConversationParticipant())->setConversation($conversation)->setUser($loggedInUser), false);
         $this->participantRepository->save((new ConversationParticipant())->setConversation($conversation)->setUser($targetUser), false);
         $this->conversationRepository->getEntityManager()->flush();
+        $this->cacheInvalidationService->invalidateConversationCaches($chat->getId(), $loggedInUser->getId());
+        $this->cacheInvalidationService->invalidateConversationCaches($chat->getId(), $targetUser->getId());
 
         return new JsonResponse($this->normalizeConversation($conversation, $loggedInUser), JsonResponse::HTTP_CREATED);
     }

--- a/src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php
@@ -10,6 +10,7 @@ use App\Chat\Domain\Entity\ConversationParticipant;
 use App\Chat\Infrastructure\Repository\ChatMessageRepository;
 use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
 use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -110,6 +111,7 @@ class UserMessageMutationController
         private readonly ConversationRepository $conversationRepository,
         private readonly ConversationParticipantRepository $participantRepository,
         private readonly ChatMessageRepository $messageRepository,
+        private readonly CacheInvalidationService $cacheInvalidationService,
     ) {
     }
 
@@ -165,6 +167,7 @@ class UserMessageMutationController
             ->setRead(false);
 
         $this->messageRepository->save($message);
+        $this->cacheInvalidationService->invalidateConversationCaches($conversation->getChat()->getId(), $loggedInUser->getId());
 
         return new JsonResponse(['id' => $message->getId()], JsonResponse::HTTP_CREATED);
     }
@@ -189,6 +192,7 @@ class UserMessageMutationController
 
         if ($updated) {
             $this->messageRepository->save($message);
+            $this->cacheInvalidationService->invalidateConversationCaches($message->getConversation()->getChat()->getId(), $loggedInUser->getId());
         }
 
         return new JsonResponse(['id' => $message->getId()]);
@@ -198,7 +202,9 @@ class UserMessageMutationController
     public function delete(string $messageId, User $loggedInUser): JsonResponse
     {
         $message = $this->findOwnMessage($messageId, $loggedInUser);
+        $chatId = $message->getConversation()->getChat()->getId();
         $this->messageRepository->remove($message);
+        $this->cacheInvalidationService->invalidateConversationCaches($chatId, $loggedInUser->getId());
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }

--- a/src/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationController.php
@@ -7,6 +7,7 @@ namespace App\Chat\Transport\Controller\Api\V1\Reaction;
 use App\Chat\Domain\Entity\ChatMessage;
 use App\Chat\Domain\Entity\ChatMessageReaction;
 use App\Chat\Domain\Entity\ConversationParticipant;
+use App\General\Application\Service\CacheInvalidationService;
 use App\Chat\Infrastructure\Repository\ChatMessageReactionRepository;
 use App\Chat\Infrastructure\Repository\ChatMessageRepository;
 use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
@@ -31,6 +32,7 @@ class UserReactionMutationController
         private readonly ChatMessageRepository $messageRepository,
         private readonly ChatMessageReactionRepository $reactionRepository,
         private readonly ConversationParticipantRepository $participantRepository,
+        private readonly CacheInvalidationService $cacheInvalidationService,
     ) {
     }
 
@@ -51,6 +53,7 @@ class UserReactionMutationController
             ->setReaction($reactionType);
 
         $this->reactionRepository->save($reaction);
+        $this->cacheInvalidationService->invalidateConversationCaches($message->getConversation()->getChat()->getId(), $loggedInUser->getId());
 
         return new JsonResponse(['id' => $reaction->getId()], JsonResponse::HTTP_CREATED);
     }
@@ -64,6 +67,7 @@ class UserReactionMutationController
         if (isset($payload['reaction']) && is_string($payload['reaction']) && $payload['reaction'] !== '') {
             $reaction->setReaction($payload['reaction']);
             $this->reactionRepository->save($reaction);
+            $this->cacheInvalidationService->invalidateConversationCaches($reaction->getMessage()->getConversation()->getChat()->getId(), $loggedInUser->getId());
         }
 
         return new JsonResponse(['id' => $reaction->getId()]);
@@ -73,7 +77,9 @@ class UserReactionMutationController
     public function delete(string $reactionId, User $loggedInUser): JsonResponse
     {
         $reaction = $this->findOwnReaction($reactionId, $loggedInUser);
+        $chatId = $reaction->getMessage()->getConversation()->getChat()->getId();
         $this->reactionRepository->remove($reaction);
+        $this->cacheInvalidationService->invalidateConversationCaches($chatId, $loggedInUser->getId());
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }

--- a/src/General/Application/Service/CacheInvalidationService.php
+++ b/src/General/Application/Service/CacheInvalidationService.php
@@ -94,4 +94,60 @@ class CacheInvalidationService
             'q' => '',
         ]));
     }
+
+    public function invalidateBlogCaches(?string $applicationSlug, ?string $userId): void
+    {
+        if (!$this->cache instanceof TagAwareCacheInterface) {
+            return;
+        }
+
+        $tags = [
+            $this->cacheKeyConventionService->tagPublicBlog(),
+            $this->cacheKeyConventionService->tagPublicBlogByApplication($applicationSlug),
+        ];
+
+        if ($userId !== null && $userId !== '') {
+            $tags[] = $this->cacheKeyConventionService->tagPrivateBlog($userId);
+        }
+
+        $this->cache->invalidateTags($tags);
+    }
+
+    public function invalidateConversationCaches(?string $chatId, ?string $userId): void
+    {
+        if (!$this->cache instanceof TagAwareCacheInterface) {
+            return;
+        }
+
+        $tags = [];
+        if ($chatId !== null && $chatId !== '') {
+            $tags[] = $this->cacheKeyConventionService->tagPublicConversationByChat($chatId);
+        }
+        if ($userId !== null && $userId !== '') {
+            $tags[] = $this->cacheKeyConventionService->tagPrivateConversation($userId);
+        }
+
+        if ($tags !== []) {
+            $this->cache->invalidateTags($tags);
+        }
+    }
+
+    public function invalidateEventCaches(?string $applicationSlug, ?string $userId): void
+    {
+        if (!$this->cache instanceof TagAwareCacheInterface) {
+            return;
+        }
+
+        $tags = [];
+        if ($applicationSlug !== null && $applicationSlug !== '') {
+            $tags[] = $this->cacheKeyConventionService->tagPublicEventsByApplication($applicationSlug);
+        }
+        if ($userId !== null && $userId !== '') {
+            $tags[] = $this->cacheKeyConventionService->tagPrivateEvents($userId);
+        }
+
+        if ($tags !== []) {
+            $this->cache->invalidateTags($tags);
+        }
+    }
 }

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -150,6 +150,11 @@ class CacheKeyConventionService
         return 'cache:public:blog';
     }
 
+    public function tagPublicBlogByApplication(?string $applicationSlug): string
+    {
+        return 'cache:public:blog:' . ($applicationSlug !== null && $applicationSlug !== '' ? $applicationSlug : 'general');
+    }
+
     public function tagPublicPlatformsList(): string
     {
         return 'cache:public:platforms:list';
@@ -170,6 +175,11 @@ class CacheKeyConventionService
         return 'cache:private:' . $userId . ':conversation';
     }
 
+    public function tagPublicConversationByChat(string $chatId): string
+    {
+        return 'cache:public:conversation:' . $chatId;
+    }
+
     public function tagPrivateNotification(string $userId): string
     {
         return 'cache:private:' . $userId . ':notifications';
@@ -178,6 +188,11 @@ class CacheKeyConventionService
     public function tagPrivateEvents(string $userId): string
     {
         return 'cache:private:' . $userId . ':events';
+    }
+
+    public function tagPublicEventsByApplication(string $applicationSlug): string
+    {
+        return 'cache:public:events:' . $applicationSlug;
     }
 
     public function tagPrivateBlog(string $userId): string


### PR DESCRIPTION
### Motivation
- Enable efficient cache invalidation by domain and user using tags instead of deleting individual cache keys to simplify and speed up cache refresh for blog, chat and calendar domains. 

### Description
- Add dedicated invalidation APIs `invalidateBlogCaches(?string $applicationSlug, ?string $userId)`, `invalidateConversationCaches(?string $chatId, ?string $userId)` and `invalidateEventCaches(?string $applicationSlug, ?string $userId)` to `src/General/Application/Service/CacheInvalidationService.php` that use `TagAwareCacheInterface` when available.  
- Introduce new tag conventions in `src/General/Application/Service/CacheKeyConventionService.php` (`tagPublicBlogByApplication`, `tagPublicConversationByChat`, `tagPublicEventsByApplication`) to scope invalidation to domain/application/chat or user.  
- Apply tags in read services so cache items are tagged on save: `src/Blog/Application/Service/BlogReadService.php`, `src/Chat/Application/Service/ConversationListService.php`, and `src/Calendar/Application/Service/EventListService.php`.  
- Call the new invalidation methods after successful persistence in mutation paths: blog message handlers (create/patch/delete post/comment/reaction and create general blog), chat controllers for conversations/messages/reactions, and calendar event handlers (create/patch/delete/cancel).  

### Testing
- Ran a PHP syntax check (`php -l`) over all changed PHP files and there were no syntax errors.  
- Attempted to run the unit test suite (`vendor/bin/phpunit`) but `phpunit` is not available in this environment, so full test suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afb59116c08326b9822819c16de6b7)