### PR TITLE
feat: cache-first reads for public pages and platform list

### DIFF
--- a/src/General/Application/Service/CacheInvalidationService.php
+++ b/src/General/Application/Service/CacheInvalidationService.php
@@ -113,6 +113,24 @@ class CacheInvalidationService
         $this->cache->invalidateTags($tags);
     }
 
+    public function invalidatePublicPageCaches(): void
+    {
+        if (!$this->cache instanceof TagAwareCacheInterface) {
+            return;
+        }
+
+        $this->cache->invalidateTags([$this->cacheKeyConventionService->tagPublicPage()]);
+    }
+
+    public function invalidatePublicPlatformListCaches(): void
+    {
+        if (!$this->cache instanceof TagAwareCacheInterface) {
+            return;
+        }
+
+        $this->cache->invalidateTags([$this->cacheKeyConventionService->tagPublicPlatformsList()]);
+    }
+
     public function invalidateConversationCaches(?string $chatId, ?string $userId): void
     {
         if (!$this->cache instanceof TagAwareCacheInterface) {

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -9,7 +9,7 @@ use function md5;
 
 class CacheKeyConventionService
 {
-    public function buildPublicPageKey(int $page, string $lang): string
+    public function buildPublicPageKey(string $page, string $lang): string
     {
         return 'public/page/' . $page . '/' . $lang;
     }
@@ -21,7 +21,7 @@ class CacheKeyConventionService
 
     public function buildPublicPlatformsListKey(): string
     {
-        return 'public/platforms/list';
+        return 'public/platform/list';
     }
 
     /**
@@ -142,7 +142,7 @@ class CacheKeyConventionService
 
     public function tagPublicPage(): string
     {
-        return 'cache:public:page';
+        return 'cache:page:public';
     }
 
     public function tagPublicBlog(): string
@@ -157,7 +157,7 @@ class CacheKeyConventionService
 
     public function tagPublicPlatformsList(): string
     {
-        return 'cache:public:platforms:list';
+        return 'cache:platform:public:list';
     }
 
     public function tagPublicApplicationsList(): string

--- a/src/Page/Application/Resource/AboutResource.php
+++ b/src/Page/Application/Resource/AboutResource.php
@@ -6,6 +6,7 @@ namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
 use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\Service\CacheInvalidationService;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\Page\Application\DTO\About\About as AboutDto;
 use App\Page\Domain\Entity\About;
@@ -16,7 +17,11 @@ use RuntimeException;
 
 class AboutResource extends RestResource
 {
-    public function __construct(Repository $repository, private readonly PageLanguageRepositoryInterface $pageLanguageRepository)
+    public function __construct(
+        Repository $repository,
+        private readonly PageLanguageRepositoryInterface $pageLanguageRepository,
+        private readonly CacheInvalidationService $cacheInvalidationService,
+    )
     {
         parent::__construct($repository);
     }
@@ -24,6 +29,10 @@ class AboutResource extends RestResource
     public function beforeCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
     public function beforeUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
     public function beforePatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function afterCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterPatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterDelete(string &$id, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
 
     private function applyLanguage(RestDtoInterface $dto, EntityInterface $entity): void
     {

--- a/src/Page/Application/Resource/ContactResource.php
+++ b/src/Page/Application/Resource/ContactResource.php
@@ -6,6 +6,7 @@ namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
 use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\Service\CacheInvalidationService;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\Page\Application\DTO\Contact\Contact as ContactDto;
 use App\Page\Domain\Entity\Contact;
@@ -16,7 +17,11 @@ use RuntimeException;
 
 class ContactResource extends RestResource
 {
-    public function __construct(Repository $repository, private readonly PageLanguageRepositoryInterface $pageLanguageRepository)
+    public function __construct(
+        Repository $repository,
+        private readonly PageLanguageRepositoryInterface $pageLanguageRepository,
+        private readonly CacheInvalidationService $cacheInvalidationService,
+    )
     {
         parent::__construct($repository);
     }
@@ -24,6 +29,10 @@ class ContactResource extends RestResource
     public function beforeCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
     public function beforeUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
     public function beforePatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function afterCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterPatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterDelete(string &$id, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
 
     private function applyLanguage(RestDtoInterface $dto, EntityInterface $entity): void
     {

--- a/src/Page/Application/Resource/FaqResource.php
+++ b/src/Page/Application/Resource/FaqResource.php
@@ -6,6 +6,7 @@ namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
 use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\Service\CacheInvalidationService;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\Page\Application\DTO\Faq\Faq as FaqDto;
 use App\Page\Domain\Entity\Faq;
@@ -16,7 +17,11 @@ use RuntimeException;
 
 class FaqResource extends RestResource
 {
-    public function __construct(Repository $repository, private readonly PageLanguageRepositoryInterface $pageLanguageRepository)
+    public function __construct(
+        Repository $repository,
+        private readonly PageLanguageRepositoryInterface $pageLanguageRepository,
+        private readonly CacheInvalidationService $cacheInvalidationService,
+    )
     {
         parent::__construct($repository);
     }
@@ -24,6 +29,10 @@ class FaqResource extends RestResource
     public function beforeCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
     public function beforeUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
     public function beforePatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function afterCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterPatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterDelete(string &$id, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
 
     private function applyLanguage(RestDtoInterface $dto, EntityInterface $entity): void
     {

--- a/src/Page/Application/Resource/HomeResource.php
+++ b/src/Page/Application/Resource/HomeResource.php
@@ -6,6 +6,7 @@ namespace App\Page\Application\Resource;
 
 use App\General\Application\Rest\RestResource;
 use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\Service\CacheInvalidationService;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\Page\Application\DTO\Home\Home as HomeDto;
 use App\Page\Domain\Entity\Home;
@@ -16,7 +17,11 @@ use RuntimeException;
 
 class HomeResource extends RestResource
 {
-    public function __construct(Repository $repository, private readonly PageLanguageRepositoryInterface $pageLanguageRepository)
+    public function __construct(
+        Repository $repository,
+        private readonly PageLanguageRepositoryInterface $pageLanguageRepository,
+        private readonly CacheInvalidationService $cacheInvalidationService,
+    )
     {
         parent::__construct($repository);
     }
@@ -24,6 +29,10 @@ class HomeResource extends RestResource
     public function beforeCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
     public function beforeUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
     public function beforePatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->applyLanguage($dto, $entity); }
+    public function afterCreate(RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterUpdate(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterPatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
+    public function afterDelete(string &$id, EntityInterface $entity): void { $this->cacheInvalidationService->invalidatePublicPageCaches(); }
 
     private function applyLanguage(RestDtoInterface $dto, EntityInterface $entity): void
     {

--- a/src/Page/Application/Service/PublicPageReadService.php
+++ b/src/Page/Application/Service/PublicPageReadService.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\Service;
+
+use App\General\Application\Service\CacheKeyConventionService;
+use App\Page\Domain\Entity\About;
+use App\Page\Domain\Entity\Contact;
+use App\Page\Domain\Entity\Faq;
+use App\Page\Domain\Entity\Home;
+use App\Page\Domain\Entity\PageLanguage;
+use App\Page\Infrastructure\Repository\AboutRepository;
+use App\Page\Infrastructure\Repository\ContactRepository;
+use App\Page\Infrastructure\Repository\FaqRepository;
+use App\Page\Infrastructure\Repository\HomeRepository;
+use App\Page\Infrastructure\Repository\PageLanguageRepository;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+final readonly class PublicPageReadService
+{
+    private const int TTL = 600;
+
+    public function __construct(
+        private PageLanguageRepository $pageLanguageRepository,
+        private HomeRepository $homeRepository,
+        private AboutRepository $aboutRepository,
+        private ContactRepository $contactRepository,
+        private FaqRepository $faqRepository,
+        private CacheInterface $cache,
+        private CacheKeyConventionService $cacheKeyConventionService,
+    ) {
+    }
+
+    /** @return array<string, mixed>|null */
+    public function getHome(string $languageCode): ?array
+    {
+        return $this->getPageContent('home', $languageCode);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function getAbout(string $languageCode): ?array
+    {
+        return $this->getPageContent('about', $languageCode);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function getContact(string $languageCode): ?array
+    {
+        return $this->getPageContent('contact', $languageCode);
+    }
+
+    /** @return array<string, mixed>|null */
+    public function getFaq(string $languageCode): ?array
+    {
+        return $this->getPageContent('faq', $languageCode);
+    }
+
+    public function resolveLanguage(string $languageCode): ?PageLanguage
+    {
+        /** @var PageLanguage|null $language */
+        $language = $this->pageLanguageRepository->findOneBy(['code' => $languageCode]);
+
+        return $language;
+    }
+
+    /** @return array<string, mixed>|null */
+    private function getPageContent(string $page, string $languageCode): ?array
+    {
+        $cacheKey = $this->cacheKeyConventionService->buildPublicPageKey($page, $languageCode);
+
+        /** @var array<string, mixed>|null $content */
+        $content = $this->cache->get($cacheKey, function (ItemInterface $item) use ($page, $languageCode): ?array {
+            $item->expiresAfter(self::TTL);
+
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->tagPublicPage());
+            }
+
+            $language = $this->resolveLanguage($languageCode);
+            if ($language === null) {
+                return null;
+            }
+
+            return match ($page) {
+                'home' => $this->readHome($language),
+                'about' => $this->readAbout($language),
+                'contact' => $this->readContact($language),
+                'faq' => $this->readFaq($language),
+                default => null,
+            };
+        });
+
+        return $content;
+    }
+
+    /** @return array<string, mixed>|null */
+    private function readHome(PageLanguage $language): ?array
+    {
+        /** @var Home|null $entity */
+        $entity = $this->homeRepository->findOneBy(['language' => $language]);
+
+        return $entity?->getContent();
+    }
+
+    /** @return array<string, mixed>|null */
+    private function readAbout(PageLanguage $language): ?array
+    {
+        /** @var About|null $entity */
+        $entity = $this->aboutRepository->findOneBy(['language' => $language]);
+
+        return $entity?->getContent();
+    }
+
+    /** @return array<string, mixed>|null */
+    private function readContact(PageLanguage $language): ?array
+    {
+        /** @var Contact|null $entity */
+        $entity = $this->contactRepository->findOneBy(['language' => $language]);
+
+        return $entity?->getContent();
+    }
+
+    /** @return array<string, mixed>|null */
+    private function readFaq(PageLanguage $language): ?array
+    {
+        /** @var Faq|null $entity */
+        $entity = $this->faqRepository->findOneBy(['language' => $language]);
+
+        return $entity?->getContent();
+    }
+}

--- a/src/Page/Transport/Controller/Api/V1/Public/PublicPageController.php
+++ b/src/Page/Transport/Controller/Api/V1/Public/PublicPageController.php
@@ -4,16 +4,7 @@ declare(strict_types=1);
 
 namespace App\Page\Transport\Controller\Api\V1\Public;
 
-use App\Page\Domain\Entity\About;
-use App\Page\Domain\Entity\Contact;
-use App\Page\Domain\Entity\Faq;
-use App\Page\Domain\Entity\Home;
-use App\Page\Domain\Entity\PageLanguage;
-use App\Page\Infrastructure\Repository\AboutRepository;
-use App\Page\Infrastructure\Repository\ContactRepository;
-use App\Page\Infrastructure\Repository\FaqRepository;
-use App\Page\Infrastructure\Repository\HomeRepository;
-use App\Page\Infrastructure\Repository\PageLanguageRepository;
+use App\Page\Application\Service\PublicPageReadService;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,11 +17,7 @@ use Symfony\Component\Routing\Attribute\Route;
 final class PublicPageController
 {
     public function __construct(
-        private readonly PageLanguageRepository $pageLanguageRepository,
-        private readonly HomeRepository $homeRepository,
-        private readonly AboutRepository $aboutRepository,
-        private readonly ContactRepository $contactRepository,
-        private readonly FaqRepository $faqRepository,
+        private readonly PublicPageReadService $publicPageReadService,
     ) {
     }
 
@@ -38,66 +25,38 @@ final class PublicPageController
     #[OA\Get(security: [])]
     public function home(string $languageCode): JsonResponse
     {
-        $language = $this->resolveLanguage($languageCode);
-
-        /** @var Home|null $entity */
-        $entity = $this->homeRepository->findOneBy(['language' => $language]);
-
-        return $this->jsonContentOr404($entity?->getContent());
+        return $this->jsonContentOr404($this->publicPageReadService->getHome($languageCode), $languageCode);
     }
 
     #[Route(path: '/v1/page/public/about/{languageCode}', methods: [Request::METHOD_GET])]
     #[OA\Get(security: [])]
     public function about(string $languageCode): JsonResponse
     {
-        $language = $this->resolveLanguage($languageCode);
-
-        /** @var About|null $entity */
-        $entity = $this->aboutRepository->findOneBy(['language' => $language]);
-
-        return $this->jsonContentOr404($entity?->getContent());
+        return $this->jsonContentOr404($this->publicPageReadService->getAbout($languageCode), $languageCode);
     }
 
     #[Route(path: '/v1/page/public/contact/{languageCode}', methods: [Request::METHOD_GET])]
     #[OA\Get(security: [])]
     public function contact(string $languageCode): JsonResponse
     {
-        $language = $this->resolveLanguage($languageCode);
-
-        /** @var Contact|null $entity */
-        $entity = $this->contactRepository->findOneBy(['language' => $language]);
-
-        return $this->jsonContentOr404($entity?->getContent());
+        return $this->jsonContentOr404($this->publicPageReadService->getContact($languageCode), $languageCode);
     }
 
     #[Route(path: '/v1/page/public/faq/{languageCode}', methods: [Request::METHOD_GET])]
     #[OA\Get(security: [])]
     public function faq(string $languageCode): JsonResponse
     {
-        $language = $this->resolveLanguage($languageCode);
-
-        /** @var Faq|null $entity */
-        $entity = $this->faqRepository->findOneBy(['language' => $language]);
-
-        return $this->jsonContentOr404($entity?->getContent());
-    }
-
-    private function resolveLanguage(string $languageCode): PageLanguage
-    {
-        /** @var PageLanguage|null $language */
-        $language = $this->pageLanguageRepository->findOneBy(['code' => $languageCode]);
-
-        if ($language === null) {
-            throw new NotFoundHttpException('Language not found.');
-        }
-
-        return $language;
+        return $this->jsonContentOr404($this->publicPageReadService->getFaq($languageCode), $languageCode);
     }
 
     /** @param array<string, mixed>|null $content */
-    private function jsonContentOr404(?array $content): JsonResponse
+    private function jsonContentOr404(?array $content, string $languageCode): JsonResponse
     {
         if ($content === null) {
+            if ($this->publicPageReadService->resolveLanguage($languageCode) === null) {
+                throw new NotFoundHttpException('Language not found.');
+            }
+
             throw new NotFoundHttpException('Page content not found.');
         }
 

--- a/src/Platform/Application/Resource/PlatformResource.php
+++ b/src/Platform/Application/Resource/PlatformResource.php
@@ -6,6 +6,7 @@ namespace App\Platform\Application\Resource;
 
 use App\General\Application\DTO\Interfaces\RestDtoInterface;
 use App\General\Application\Rest\RestResource;
+use App\General\Application\Service\CacheInvalidationService;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\Platform\Domain\Entity\Platform as Entity;
 use App\Platform\Domain\Repository\Interfaces\PlatformRepositoryInterface as Repository;
@@ -36,8 +37,29 @@ class PlatformResource extends RestResource
      */
     public function __construct(
         Repository $repository,
+        private readonly CacheInvalidationService $cacheInvalidationService,
     ) {
         parent::__construct($repository);
+    }
+
+    public function afterCreate(RestDtoInterface $restDto, EntityInterface $entity): void
+    {
+        $this->cacheInvalidationService->invalidatePublicPlatformListCaches();
+    }
+
+    public function afterUpdate(string &$id, RestDtoInterface $restDto, EntityInterface $entity): void
+    {
+        $this->cacheInvalidationService->invalidatePublicPlatformListCaches();
+    }
+
+    public function afterPatch(string &$id, RestDtoInterface $dto, EntityInterface $entity): void
+    {
+        $this->cacheInvalidationService->invalidatePublicPlatformListCaches();
+    }
+
+    public function afterDelete(string &$id, EntityInterface $entity): void
+    {
+        $this->cacheInvalidationService->invalidatePublicPlatformListCaches();
     }
 
     /**

--- a/src/Platform/Application/Service/PublicPlatformListReadService.php
+++ b/src/Platform/Application/Service/PublicPlatformListReadService.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Service;
+
+use App\General\Application\Service\CacheKeyConventionService;
+use App\Platform\Application\Resource\PlatformResource;
+use App\Platform\Domain\Entity\Platform;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+final readonly class PublicPlatformListReadService
+{
+    private const int TTL = 600;
+
+    public function __construct(
+        private PlatformResource $platformResource,
+        private CacheInterface $cache,
+        private CacheKeyConventionService $cacheKeyConventionService,
+    ) {
+    }
+
+    /** @return array<int, Platform> */
+    public function getPublicEnabled(): array
+    {
+        $cacheKey = $this->cacheKeyConventionService->buildPublicPlatformsListKey();
+
+        /** @var array<int, Platform> $items */
+        $items = $this->cache->get($cacheKey, function (ItemInterface $item): array {
+            $item->expiresAfter(self::TTL);
+
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->tagPublicPlatformsList());
+            }
+
+            return $this->platformResource->findPublicEnabled();
+        });
+
+        return $items;
+    }
+}

--- a/src/Platform/Transport/Controller/Api/V1/Platform/PublicPlatformListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Platform/PublicPlatformListController.php
@@ -6,6 +6,7 @@ namespace App\Platform\Transport\Controller\Api\V1\Platform;
 
 use App\General\Transport\Rest\ResponseHandler;
 use App\Platform\Application\Resource\PlatformResource;
+use App\Platform\Application\Service\PublicPlatformListReadService;
 use App\Platform\Domain\Entity\Platform;
 use Nelmio\ApiDocBundle\Attribute\Model;
 use OpenApi\Attributes as OA;
@@ -24,6 +25,7 @@ use Throwable;
 class PublicPlatformListController
 {
     public function __construct(
+        private readonly PublicPlatformListReadService $publicPlatformListReadService,
         private readonly PlatformResource $platformResource,
         private readonly ResponseHandler $responseHandler,
     ) {
@@ -58,7 +60,7 @@ class PublicPlatformListController
     {
         return $this->responseHandler->createResponse(
             request: $request,
-            data: $this->platformResource->findPublicEnabled(),
+            data: $this->publicPlatformListReadService->getPublicEnabled(),
             restResource: $this->platformResource,
             context: [
                 'groups' => ['Platform.id', 'Platform.name', 'Platform.description', 'Platform.platformKey', 'Platform.photo'],


### PR DESCRIPTION
### Motivation

- Improve public endpoint performance by introducing cache-first reads for page content and platform list with stable public keys and a short TTL.
- Use stable keys (`public/page/{slug}/{lang}`, `public/platform/list`) and tags to allow targeted invalidation from admin mutations.
- No external skills were used to implement these changes.

### Description

- Added `PublicPageReadService` to provide cache-first reads for `home`, `about`, `contact`, and `faq` using keys built by `CacheKeyConventionService` and TTL set to 600s, tagging entries with `cache:page:public`.
- Added `PublicPlatformListReadService` to provide cache-first reads for the public platforms list using key `public/platform/list`, TTL 600s, and tag `cache:platform:public:list`.
- Updated `PublicPageController` and `PublicPlatformListController` to use the new read services instead of querying repositories/resources directly.
- Normalized cache key/tag names in `CacheKeyConventionService`, added `invalidatePublicPageCaches()` and `invalidatePublicPlatformListCaches()` to `CacheInvalidationService`, and wired invalidation calls in `afterCreate/afterUpdate/afterPatch/afterDelete` hooks of Page and Platform resources.

### Testing

- Ran syntax checks with `php -l` on all modified and new PHP files, which passed successfully.
- Attempted `php bin/console lint:container` which failed in this environment due to missing dependencies (`composer install` required), so container-level validation could not complete.
- Confirmed code compiles locally via explicit `php -l` checks for each changed/new file: success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afb9bc977083268af1c1a79dac21b5)