### PR TITLE
feat(user): public GET /api/v1/public/users with cache & Elasticsearch

### DIFF
--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -30,6 +30,14 @@ class CacheKeyConventionService
     /**
      * @param array<string, mixed> $filters
      */
+    public function buildPublicUserListKey(array $filters): string
+    {
+        return 'public_users_list_' . $this->buildHash($filters);
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     */
     public function buildPublicApplicationsListKey(array $filters): string
     {
         return 'public_applications_list_' . $this->buildHash($filters);
@@ -161,6 +169,11 @@ class CacheKeyConventionService
     public function tagPublicPlatformsList(): string
     {
         return 'cache_platform_public_list';
+    }
+
+    public function publicUserListTag(): string
+    {
+        return 'cache_public_users_list';
     }
 
     public function tagPublicApplicationsList(): string

--- a/src/User/Application/Service/UserPublicListService.php
+++ b/src/User/Application/Service/UserPublicListService.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Service;
+
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function trim;
+
+readonly class UserPublicListService
+{
+    private const string ELASTIC_INDEX = 'users';
+
+    public function __construct(
+        private UserRepository $userRepository,
+        private CacheInterface $cache,
+        private ElasticsearchServiceInterface $elasticsearchService,
+        private CacheKeyConventionService $cacheKeyConventionService,
+    ) {
+    }
+
+    /** @return array{users: array<int, array<string, string|null>>, filters: array<string, string>} */
+    public function getList(Request $request): array
+    {
+        $filters = [
+            'q' => trim((string) $request->query->get('q', '')),
+        ];
+
+        $cacheKey = $this->cacheKeyConventionService->buildPublicUserListKey($filters);
+
+        /** @var array<int, array<string, string|null>> $users */
+        $users = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters): array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->publicUserListTag());
+            }
+
+            $esIds = $this->searchIdsFromElastic($filters['q']);
+
+            if ($esIds === []) {
+                return [];
+            }
+
+            $qb = $this->userRepository->createQueryBuilder('user')
+                ->select('user')
+                ->orderBy('user.createdAt', 'DESC');
+
+            if ($esIds !== null) {
+                $qb->andWhere('user.id IN (:ids)')
+                    ->setParameter('ids', $esIds);
+            }
+
+            if ($filters['q'] !== '' && $esIds === null) {
+                $qb
+                    ->andWhere('LOWER(user.email) LIKE LOWER(:q) OR LOWER(user.firstName) LIKE LOWER(:q) OR LOWER(user.lastName) LIKE LOWER(:q)')
+                    ->setParameter('q', '%' . $filters['q'] . '%');
+            }
+
+            /** @var array<int, User> $entities */
+            $entities = $qb->getQuery()->getResult();
+
+            return array_map(static fn (User $user): array => [
+                'id' => $user->getId(),
+                'email' => $user->getEmail(),
+                'firstName' => $user->getFirstName(),
+                'lastName' => $user->getLastName(),
+                'photo' => $user->getPhoto(),
+            ], $entities);
+        });
+
+        return [
+            'users' => $users,
+            'filters' => array_filter($filters, static fn (string $value): bool => $value !== ''),
+        ];
+    }
+
+    /** @return array<int, string>|null */
+    private function searchIdsFromElastic(string $query): ?array
+    {
+        try {
+            $body = [
+                'query' => $query === ''
+                    ? ['match_all' => (object) []]
+                    : [
+                        'multi_match' => [
+                            'query' => $query,
+                            'type' => 'phrase_prefix',
+                            'fields' => ['email^3', 'firstName^2', 'lastName^2', 'username'],
+                        ],
+                    ],
+                '_source' => ['id'],
+            ];
+
+            $response = $this->elasticsearchService->search(self::ELASTIC_INDEX, $body, 0, 1000);
+        } catch (Throwable) {
+            return null;
+        }
+
+        $hits = $response['hits']['hits'] ?? [];
+
+        return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
+    }
+}

--- a/src/User/Transport/Controller/Api/V1/User/PublicUserListController.php
+++ b/src/User/Transport/Controller/Api/V1/User/PublicUserListController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Transport\Controller\Api\V1\User;
+
+use App\User\Application\Service\UserPublicListService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'User Management')]
+class PublicUserListController
+{
+    public function __construct(private readonly UserPublicListService $userPublicListService)
+    {
+    }
+
+    #[Route(path: '/v1/public/users', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'Liste publique des utilisateurs (id, email, prénom, nom, photo).',
+        security: [],
+        parameters: [
+            new OA\Parameter(name: 'q', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
+        ],
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse($this->userPublicListService->getList($request));
+    }
+}


### PR DESCRIPTION
### Motivation

- Exposer un endpoint public qui retourne la liste des utilisateurs (seulement `id`, `email`, `firstName`, `lastName`, `photo`) et supporter la recherche avec Elasticsearch tout en utilisant un cache pour réduire la charge.

### Description

- Ajout du contrôleur `PublicUserListController` avec la route `GET /api/v1/public/users` et documentation OpenAPI (`security: []`).
- Ajout du service `UserPublicListService` qui construit la clé de cache, met en cache la réponse (TTL 120s, tag-aware), interroge l’index Elasticsearch `users` pour résoudre les IDs et retombe sur une requête SQL `LIKE` si Elasticsearch n’est pas disponible.
- Extension de `CacheKeyConventionService` avec `buildPublicUserListKey(array $filters)` et `publicUserListTag()` pour centraliser la génération de clé et la taggage d’invalidation.
- La charge retournée contient uniquement les champs demandés: `id`, `email`, `firstName`, `lastName`, `photo`.

### Testing

- Lint PHP sur les fichiers ajoutés/modifiés (`php -l src/User/Application/Service/UserPublicListService.php`, `php -l src/User/Transport/Controller/Api/V1/User/PublicUserListController.php`, `php -l src/General/Application/Service/CacheKeyConventionService.php`) a réussi.
- La commande `php bin/console debug:router | rg "public/users|recruit/public"` a échoué dans cet environnement car les dépendances ne sont pas installées (`composer install` requis) et la console PHP n’a pas pu s’exécuter.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afeb14141c8326a0ed17e70e57c030)