### PR TITLE
Add deep-link descriptions to blog and friend notifications

### DIFF
--- a/src/Blog/Application/Service/BlogNotificationService.php
+++ b/src/Blog/Application/Service/BlogNotificationService.php
@@ -30,6 +30,7 @@ final readonly class BlogNotificationService
                 recipient: $comment->getParent()->getAuthor(),
                 title: $this->buildTitle($actor, 'commented your comment', $targetLabel),
                 type: self::BLOG_NOTIFICATION_TYPE,
+                description: $this->buildPostLinkDescription($post),
             );
 
             return;
@@ -40,6 +41,7 @@ final readonly class BlogNotificationService
             recipient: $post->getAuthor(),
             title: $this->buildTitle($actor, 'commented your post', $targetLabel),
             type: self::BLOG_NOTIFICATION_TYPE,
+            description: $this->buildPostLinkDescription($post),
         );
     }
 
@@ -53,6 +55,7 @@ final readonly class BlogNotificationService
                 recipient: $comment->getAuthor(),
                 title: $this->buildTitle($actor, $actionLabel . ' your comment', $this->formatCommentPreview($comment)),
                 type: self::BLOG_NOTIFICATION_TYPE,
+                description: $this->buildPostLinkDescription($comment->getPost()),
             );
 
             return;
@@ -63,7 +66,13 @@ final readonly class BlogNotificationService
             recipient: $comment->getPost()->getAuthor(),
             title: $this->buildTitle($actor, $actionLabel . ' your post', $this->formatPostTitle($comment->getPost())),
             type: self::BLOG_NOTIFICATION_TYPE,
+            description: $this->buildPostLinkDescription($comment->getPost()),
         );
+    }
+
+    private function buildPostLinkDescription(BlogPost $post): string
+    {
+        return '/blog/post/' . $post->getId();
     }
 
     private function buildTitle(User $actor, string $action, string $target): string

--- a/src/User/Application/Service/UserFriendService.php
+++ b/src/User/Application/Service/UserFriendService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\User\Application\Service;
 
+use App\Notification\Application\Service\NotificationPublisher;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Entity\UserFriendRelation;
 use App\User\Domain\Enum\FriendStatus;
@@ -15,11 +16,16 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 
+use function trim;
+
 readonly class UserFriendService
 {
+    private const string FRIEND_NOTIFICATION_TYPE = 'friend_notification';
+
     public function __construct(
         private EntityManagerInterface $entityManager,
         private CacheInterface $cache,
+        private NotificationPublisher $notificationPublisher,
     ) {
     }
 
@@ -53,6 +59,14 @@ readonly class UserFriendService
         $this->invalidateUserCaches($loggedInUser);
         $this->invalidateUserCaches($targetUser);
 
+        $this->notificationPublisher->publish(
+            from: $loggedInUser,
+            recipient: $targetUser,
+            title: trim($loggedInUser->getFirstName() . ' ' . $loggedInUser->getLastName()) . ' sent you a friend request',
+            type: self::FRIEND_NOTIFICATION_TYPE,
+            description: $this->buildUserProfileLink($loggedInUser),
+        );
+
         return ['status' => 'request_sent'];
     }
 
@@ -68,6 +82,14 @@ readonly class UserFriendService
         $this->entityManager->flush();
         $this->invalidateUserCaches($loggedInUser);
         $this->invalidateUserCaches($requester);
+
+        $this->notificationPublisher->publish(
+            from: $loggedInUser,
+            recipient: $requester,
+            title: trim($loggedInUser->getFirstName() . ' ' . $loggedInUser->getLastName()) . ' accepted your friend request',
+            type: self::FRIEND_NOTIFICATION_TYPE,
+            description: $this->buildUserProfileLink($loggedInUser),
+        );
 
         return ['status' => 'accepted'];
     }
@@ -282,6 +304,11 @@ readonly class UserFriendService
         });
 
         return $payload;
+    }
+
+    private function buildUserProfileLink(User $user): string
+    {
+        return '/user/' . $user->getUsername() . '/profile';
     }
 
     private function invalidateUserCaches(User $user): void


### PR DESCRIPTION
### Motivation
- Make notifications navigable by adding deep links in the notification `description` so clients can open the related blog post or user profile directly. 
- Ensure comment/reaction notifications and friend request/acceptance events include a URL to the relevant resource for better UX.

### Description
- `BlogNotificationService` now sets `description` for all blog-related notifications and adds a helper `buildPostLinkDescription()` that returns `'/blog/post/' . $post->getId()` used for comments, replies and reactions. 
- `UserFriendService` now injects `NotificationPublisher`, defines `FRIEND_NOTIFICATION_TYPE`, and publishes notifications on `sendRequest` and `acceptRequest` with `description` built by a new `buildUserProfileLink()` that returns `'/user/' . $user->getUsername() . '/profile'`. 
- Added required `use` imports and small trimming helper usage when composing notification titles.

### Testing
- Ran PHP syntax checks with `php -l` on the modified files and they reported no syntax errors for `src/Blog/Application/Service/BlogNotificationService.php` and `src/User/Application/Service/UserFriendService.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afef8ffde48326ae26f45d0c050919)