### PR TITLE
Add presentable Twig welcome email after user registration

### DIFF
--- a/src/User/Transport/Controller/Api/V1/Auth/RegisterController.php
+++ b/src/User/Transport/Controller/Api/V1/Auth/RegisterController.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Throwable;
+use Twig\Environment as Twig;
 
 use function explode;
 use function sprintf;
@@ -35,6 +36,7 @@ class RegisterController
         private readonly EntityManagerInterface $entityManager,
         private readonly JWTTokenManagerInterface $jwtTokenManager,
         private readonly MailerServiceInterface $mailerService,
+        private readonly Twig $twig,
         private readonly UserRepositoryInterface $userRepository,
         private readonly RolesServiceInterface $rolesService,
         #[Autowire('%env(resolve:APP_SENDER_EMAIL)%')]
@@ -104,11 +106,15 @@ class RegisterController
         $this->entityManager->persist($user);
         $this->entityManager->flush();
 
+        $body = $this->twig->render('Emails/welcome.html.twig', [
+            'email' => $email,
+        ]);
+
         $this->mailerService->sendMail(
             'Welcome to Bro World',
             $this->appSenderEmail,
             $email,
-            '<p>Your account was successfully created.</p>',
+            $body,
         );
 
         $securityUser = new SecurityUser($user, $this->rolesService->getInheritedRoles($user->getRoles()));

--- a/templates/Emails/welcome.html.twig
+++ b/templates/Emails/welcome.html.twig
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Welcome to Bro World</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f3f6fb;font-family:Arial,sans-serif;color:#1f2937;">
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color:#f3f6fb;padding:24px 12px;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width:620px;background:#ffffff;border-radius:14px;overflow:hidden;border:1px solid #e5e7eb;">
+                <tr>
+                    <td style="background:linear-gradient(135deg,#4f46e5,#0ea5e9);padding:32px 24px;color:#ffffff;">
+                        <h1 style="margin:0;font-size:28px;line-height:1.3;">Welcome to Bro World 👋</h1>
+                        <p style="margin:12px 0 0;font-size:15px;line-height:1.6;opacity:0.95;">
+                            Your account is ready — we are happy to have you with us.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:28px 24px 20px;">
+                        <p style="margin:0 0 16px;font-size:16px;line-height:1.6;">
+                            Hi <strong>{{ email }}</strong>,
+                        </p>
+                        <p style="margin:0 0 16px;font-size:15px;line-height:1.7;color:#374151;">
+                            Thanks for joining <strong>Bro World</strong>. Your registration was successful, and you can now sign in and start exploring the platform.
+                        </p>
+                        <p style="margin:0 0 24px;font-size:15px;line-height:1.7;color:#374151;">
+                            If you need help, simply reply to this email — our team will be happy to assist you.
+                        </p>
+                        <table role="presentation" cellspacing="0" cellpadding="0">
+                            <tr>
+                                <td style="border-radius:8px;background:#4f46e5;">
+                                    <span style="display:inline-block;padding:12px 18px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">
+                                        Account created successfully
+                                    </span>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:18px 24px 24px;border-top:1px solid #e5e7eb;background:#f9fafb;">
+                        <p style="margin:0;font-size:12px;line-height:1.6;color:#6b7280;">
+                            This is an automatic welcome email from Bro World.
+                        </p>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Improve the first email sent after a successful user registration by replacing a simple inline HTML string with a presentable, reusable Twig template. 
- Personalize the welcome message for the newly registered user and provide a nicer responsive layout to improve onboarding.

### Description
- Inject `Twig\Environment` into `RegisterController` and render `Emails/welcome.html.twig` to produce the email body. 
- Replace the previous inline HTML argument to `MailerServiceInterface::sendMail` with the rendered `$body` from Twig. 
- Add a new template file `templates/Emails/welcome.html.twig` containing a polished, responsive welcome email layout that accepts the `email` variable.
- Keep the existing registration flow and token creation unchanged so the endpoint still returns the JWT token on success.

### Testing
- Ran `php -l src/User/Transport/Controller/Api/V1/Auth/RegisterController.php` which reported no syntax errors. 
- Ran `php -l templates/Emails/welcome.html.twig` which reported no syntax errors. 
- Attempted `./vendor/bin/phpunit tests/Application/User/Transport/Controller/Api/V1/Auth/RegisterControllerTest.php` but the PHPUnit binary is not present in this environment so the test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afefea5cb48326a3c1202fca8e1a27)