### PR TITLE
Ajouter notifications e-mail pour applications platform et demandes d'ami

### DIFF
--- a/config/packages/event_listeners.yaml
+++ b/config/packages/event_listeners.yaml
@@ -27,7 +27,9 @@ services:
     App\Platform\Transport\EventListener\PlatformEntityEventListener:
         tags:
             - { name: doctrine.event_listener, event: prePersist }
+            - { name: doctrine.event_listener, event: postPersist }
             - { name: doctrine.event_listener, event: preUpdate }
+            - { name: doctrine.event_listener, event: postUpdate }
 
     App\Configuration\Transport\EventListener\ConfigurationEntityEventListener:
         tags:

--- a/src/Platform/Transport/EventListener/PlatformEntityEventListener.php
+++ b/src/Platform/Transport/EventListener/PlatformEntityEventListener.php
@@ -4,21 +4,35 @@ declare(strict_types=1);
 
 namespace App\Platform\Transport\EventListener;
 
+use App\General\Domain\Service\Interfaces\MailerServiceInterface;
 use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\ApplicationPlugin;
 use App\Platform\Domain\Entity\Platform;
 use App\Platform\Domain\Entity\Plugin;
 use App\Platform\Domain\Enum\PlatformKey;
 use App\Recruit\Domain\Entity\Recruit;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Twig\Environment as Twig;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function trim;
 
 /**
  * @package App\Platform
  */
 class PlatformEntityEventListener
 {
-    public function __construct(private readonly EntityManagerInterface $entityManager)
-    {
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MailerServiceInterface $mailerService,
+        private readonly Twig $twig,
+        #[Autowire('%env(resolve:APP_SENDER_EMAIL)%')]
+        private readonly string $appSenderEmail,
+    ) {
     }
 
     public function prePersist(LifecycleEventArgs $event): void
@@ -29,6 +43,60 @@ class PlatformEntityEventListener
     public function preUpdate(LifecycleEventArgs $event): void
     {
         $this->process($event);
+    }
+
+    public function postPersist(LifecycleEventArgs $event): void
+    {
+        $entity = $event->getObject();
+
+        if (!$entity instanceof Application) {
+            return;
+        }
+
+        $ownerEmail = $entity->getUser()?->getEmail();
+        if ($ownerEmail === null || $ownerEmail === '') {
+            return;
+        }
+
+        $body = $this->twig->render('Emails/application_created.html.twig', [
+            'application' => $entity,
+            'platformName' => $entity->getPlatform()?->getName() ?? 'Unknown platform',
+            'plugins' => $this->extractPluginNames($entity),
+        ]);
+
+        $this->mailerService->sendMail(
+            'Your platform application has been created',
+            $this->appSenderEmail,
+            $ownerEmail,
+            $body,
+        );
+    }
+
+    public function postUpdate(LifecycleEventArgs $event): void
+    {
+        $entity = $event->getObject();
+
+        if (!$entity instanceof Application) {
+            return;
+        }
+
+        $ownerEmail = $entity->getUser()?->getEmail();
+        if ($ownerEmail === null || $ownerEmail === '') {
+            return;
+        }
+
+        $body = $this->twig->render('Emails/application_updated.html.twig', [
+            'application' => $entity,
+            'platformName' => $entity->getPlatform()?->getName() ?? 'Unknown platform',
+            'plugins' => $this->extractPluginNames($entity),
+        ]);
+
+        $this->mailerService->sendMail(
+            'Your platform application was updated successfully',
+            $this->appSenderEmail,
+            $ownerEmail,
+            $body,
+        );
     }
 
     private function process(LifecycleEventArgs $event): void
@@ -63,5 +131,17 @@ class PlatformEntityEventListener
             ->setApplication($application);
 
         $this->entityManager->persist($recruit);
+    }
+
+    /** @return array<int, string> */
+    private function extractPluginNames(Application $application): array
+    {
+        $pluginNames = array_map(static function (ApplicationPlugin $applicationPlugin): string {
+            $plugin = $applicationPlugin->getPlugin();
+
+            return trim($plugin?->getName() ?? $plugin?->getPluginKeyValue() ?? '');
+        }, $application->getApplicationPlugins()->toArray());
+
+        return array_values(array_filter($pluginNames, static fn (string $name): bool => $name !== ''));
     }
 }

--- a/src/User/Application/Service/UserFriendService.php
+++ b/src/User/Application/Service/UserFriendService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\User\Application\Service;
 
+use App\General\Domain\Service\Interfaces\MailerServiceInterface;
 use App\Notification\Application\Service\NotificationPublisher;
 use App\User\Domain\Entity\User;
 use App\User\Domain\Entity\UserFriendRelation;
@@ -13,8 +14,10 @@ use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\ConflictHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
+use Twig\Environment as Twig;
 
 use function trim;
 
@@ -26,6 +29,10 @@ readonly class UserFriendService
         private EntityManagerInterface $entityManager,
         private CacheInterface $cache,
         private NotificationPublisher $notificationPublisher,
+        private MailerServiceInterface $mailerService,
+        private Twig $twig,
+        #[Autowire('%env(resolve:APP_SENDER_EMAIL)%')]
+        private string $appSenderEmail,
     ) {
     }
 
@@ -67,6 +74,20 @@ readonly class UserFriendService
             description: $this->buildUserProfileLink($loggedInUser),
         );
 
+        if ($targetUser->getEmail() !== '') {
+            $body = $this->twig->render('Emails/friend_request_received.html.twig', [
+                'requester' => $loggedInUser,
+                'recipient' => $targetUser,
+            ]);
+
+            $this->mailerService->sendMail(
+                'You received a friend request',
+                $this->appSenderEmail,
+                $targetUser->getEmail(),
+                $body,
+            );
+        }
+
         return ['status' => 'request_sent'];
     }
 
@@ -90,6 +111,20 @@ readonly class UserFriendService
             type: self::FRIEND_NOTIFICATION_TYPE,
             description: $this->buildUserProfileLink($loggedInUser),
         );
+
+        if ($requester->getEmail() !== '') {
+            $body = $this->twig->render('Emails/friend_request_accepted.html.twig', [
+                'accepter' => $loggedInUser,
+                'recipient' => $requester,
+            ]);
+
+            $this->mailerService->sendMail(
+                'Your friend request has been accepted',
+                $this->appSenderEmail,
+                $requester->getEmail(),
+                $body,
+            );
+        }
 
         return ['status' => 'accepted'];
     }

--- a/templates/Emails/application_created.html.twig
+++ b/templates/Emails/application_created.html.twig
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <h2>Your application has been created 🎉</h2>
+    <p><strong>Title:</strong> {{ application.title }}</p>
+    <p><strong>Platform:</strong> {{ platformName }}</p>
+    <p><strong>Description:</strong> {{ application.description is not empty ? application.description : 'No description provided.' }}</p>
+    <p><strong>Slug:</strong> {{ application.slug }}</p>
+    <p><strong>Status:</strong> {{ application.status.value }}</p>
+    <p><strong>Plugins:</strong> {{ plugins is not empty ? plugins|join(', ') : 'No plugin selected.' }}</p>
+  </body>
+</html>

--- a/templates/Emails/application_updated.html.twig
+++ b/templates/Emails/application_updated.html.twig
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <h2>Your application update was successful ✅</h2>
+    <p><strong>Title:</strong> {{ application.title }}</p>
+    <p><strong>Platform:</strong> {{ platformName }}</p>
+    <p><strong>Description:</strong> {{ application.description is not empty ? application.description : 'No description provided.' }}</p>
+    <p><strong>Slug:</strong> {{ application.slug }}</p>
+    <p><strong>Status:</strong> {{ application.status.value }}</p>
+    <p><strong>Plugins:</strong> {{ plugins is not empty ? plugins|join(', ') : 'No plugin selected.' }}</p>
+  </body>
+</html>

--- a/templates/Emails/friend_request_accepted.html.twig
+++ b/templates/Emails/friend_request_accepted.html.twig
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <h2>Your friend request was accepted 🎉</h2>
+    <p>{{ accepter.firstName }} {{ accepter.lastName }} accepted your friend request.</p>
+  </body>
+</html>

--- a/templates/Emails/friend_request_received.html.twig
+++ b/templates/Emails/friend_request_received.html.twig
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <h2>You received a friend request 👋</h2>
+    <p>{{ requester.firstName }} {{ requester.lastName }} sent you a friend request.</p>
+    <p>You can accept or reject it from your friends section.</p>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Informer automatiquement les propriétaires d'application lorsque leur `Application` est créée ou mise à jour et leur fournir les propriétés importantes (titre, plateforme, description, slug, statut, plugins). 
- Notifier par e-mail les utilisateurs lors de la réception d'une demande d'ami et lors de l'acceptation d'une demande pour améliorer l'engagement utilisateur.

### Description
- Étendu `PlatformEntityEventListener` pour écouter `postPersist` et `postUpdate`, injecter `MailerServiceInterface`, `Twig` et l'adresse `APP_SENDER_EMAIL`, et envoyer des e-mails aux propriétaires d'applications après création et mise à jour en injectant les propriétés pertinentes et la liste des plugins (nouvelle méthode `extractPluginNames`).
- Mis à jour `config/packages/event_listeners.yaml` pour enregistrer les événements `postPersist` et `postUpdate` pour le listener platform.
- Enrichi `UserFriendService` pour envoyer un e-mail au destinataire lorsqu'une demande d'ami est reçue et au demandeur lorsqu'une demande est acceptée, en réutilisant `NotificationPublisher` et en ajoutant le rendu Twig des templates d'e-mail.
- Ajouté 4 templates Twig d'e-mail : `templates/Emails/application_created.html.twig`, `application_updated.html.twig`, `friend_request_received.html.twig` et `friend_request_accepted.html.twig`.

### Testing
- Exécuté la vérification de syntaxe PHP sur les fichiers modifiés avec `php -l` pour `PlatformEntityEventListener` et `UserFriendService`, et les deux ont passé la vérification.
- Tentative de `php bin/console lint:yaml config/packages/event_listeners.yaml` échouée pour raisons d'environnement (`Dependencies are missing. Try running "composer install"`).
- Les modifications ont été ajoutées et commitées (tests locaux de linting PHP OK, validation complète d'intégration requiert installation des dépendances et exécution des tests fonctionnels).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aff7a4f4c8832698c464a6cadead75)