### PR TITLE
Add root/admin global statistics API endpoint

### DIFF
--- a/src/Tool/Application/Service/StatisticsService.php
+++ b/src/Tool/Application/Service/StatisticsService.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Application\Service;
+
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+
+class StatisticsService
+{
+    public function __construct(
+        private readonly Connection $connection,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getGlobalStatistics(): array
+    {
+        $now = new DateTimeImmutable();
+        $startOfWeek = $now->modify('monday this week')->setTime(0, 0, 0);
+        $startOfMonth = $now->modify('first day of this month')->setTime(0, 0, 0);
+        $startOfYear = $now->setDate((int) $now->format('Y'), 1, 1)->setTime(0, 0, 0);
+        $lastSevenDays = $now->modify('-7 days');
+
+        return [
+            'users' => [
+                'total' => $this->countAll('user'),
+                'thisWeek' => $this->countSince('user', $startOfWeek),
+                'thisMonth' => $this->countSince('user', $startOfMonth),
+                'thisYear' => $this->countSince('user', $startOfYear),
+            ],
+            'applications' => [
+                'total' => $this->countAll('platform_application'),
+                'byPlatform' => $this->getApplicationsByPlatform(),
+            ],
+            'plugins' => [
+                'total' => $this->countAll('platform_plugin'),
+                'usage' => $this->getPluginUsage(),
+            ],
+            'posts' => [
+                'total' => $this->countAll('blog_post'),
+                'last7Days' => $this->countSince('blog_post', $lastSevenDays),
+                'thisMonth' => $this->countSince('blog_post', $startOfMonth),
+                'thisYear' => $this->countSince('blog_post', $startOfYear),
+            ],
+        ];
+    }
+
+    private function countAll(string $table): int
+    {
+        return (int) $this->connection->fetchOne('SELECT COUNT(*) FROM ' . $table);
+    }
+
+    private function countSince(string $table, DateTimeImmutable $since): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ' . $table . ' WHERE created_at >= :since',
+            [
+                'since' => $since,
+            ],
+            [
+                'since' => 'datetime_immutable',
+            ],
+        );
+    }
+
+    /**
+     * @return list<array{name: string, applicationCount: int}>
+     */
+    private function getApplicationsByPlatform(): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT p.name AS name, COUNT(a.id) AS applicationCount
+                FROM platform_platform p
+                LEFT JOIN platform_application a ON a.platform_id = p.id
+                GROUP BY p.id, p.name
+                ORDER BY applicationCount DESC, p.name ASC
+            SQL,
+        );
+
+        return array_map(
+            static fn (array $row): array => [
+                'name' => (string) $row['name'],
+                'applicationCount' => (int) $row['applicationCount'],
+            ],
+            $rows,
+        );
+    }
+
+    /**
+     * @return list<array{name: string, usageCount: int}>
+     */
+    private function getPluginUsage(): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            <<<'SQL'
+                SELECT p.name AS name, COUNT(ap.id) AS usageCount
+                FROM platform_plugin p
+                LEFT JOIN platform_application_plugin ap ON ap.plugin_id = p.id
+                GROUP BY p.id, p.name
+                ORDER BY usageCount DESC, p.name ASC
+            SQL,
+        );
+
+        return array_map(
+            static fn (array $row): array => [
+                'name' => (string) $row['name'],
+                'usageCount' => (int) $row['usageCount'],
+            ],
+            $rows,
+        );
+    }
+}

--- a/src/Tool/Transport/Controller/Api/V1/StatisticsController.php
+++ b/src/Tool/Transport/Controller/Api/V1/StatisticsController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Controller\Api\V1;
+
+use App\Role\Domain\Enum\Role;
+use App\Tool\Application\Service\StatisticsService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * @package App\Tool
+ */
+#[AsController]
+#[OA\Tag(name: 'Tools')]
+class StatisticsController
+{
+    public function __construct(
+        private readonly StatisticsService $statisticsService,
+    ) {
+    }
+
+    #[Route(
+        path: '/v1/statistics',
+        methods: [Request::METHOD_GET],
+    )]
+    #[IsGranted(Role::ADMIN->value)]
+    #[OA\Get(
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Global statistics for users, applications, plugins and blog posts.',
+            ),
+            new OA\Response(
+                response: 403,
+                description: 'Access denied.',
+            ),
+        ],
+    )]
+    public function __invoke(): JsonResponse
+    {
+        return new JsonResponse($this->statisticsService->getGlobalStatistics());
+    }
+}

--- a/tests/Application/Tool/Transport/Controller/Api/V1/StatisticsControllerTest.php
+++ b/tests/Application/Tool/Transport/Controller/Api/V1/StatisticsControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Tool\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use Generator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @package App\Tests
+ */
+class StatisticsControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/statistics';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /api/v1/statistics` request returns `401` for non-logged user.')]
+    public function testThatGetStatisticsReturns401ForAnonymousUser(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', $this->baseUrl);
+        $response = $client->getResponse();
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[DataProvider('dataProviderAuthorizedUsers')]
+    #[TestDox('Test that `GET /api/v1/statistics` returns `$responseCode` with login: `$login`.')]
+    public function testThatGetStatisticsAccessControlWorks(string $login, string $password, int $responseCode): void
+    {
+        $client = $this->getTestClient($login, $password);
+
+        $client->request('GET', $this->baseUrl);
+        $response = $client->getResponse();
+        self::assertSame($responseCode, $response->getStatusCode(), "Response:\n" . $response);
+
+        if ($responseCode !== Response::HTTP_OK) {
+            return;
+        }
+
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+
+        $data = JSON::decode($content, true);
+        self::assertIsArray($data);
+        self::assertArrayHasKey('users', $data);
+        self::assertArrayHasKey('applications', $data);
+        self::assertArrayHasKey('plugins', $data);
+        self::assertArrayHasKey('posts', $data);
+    }
+
+    /**
+     * @return Generator<array{0: string, 1: string, 2: int}>
+     */
+    public static function dataProviderAuthorizedUsers(): Generator
+    {
+        yield ['john', 'password', Response::HTTP_FORBIDDEN];
+        yield ['john-logged', 'password-logged', Response::HTTP_FORBIDDEN];
+        yield ['john-api', 'password-api', Response::HTTP_FORBIDDEN];
+        yield ['john-user', 'password-user', Response::HTTP_FORBIDDEN];
+        yield ['john-admin', 'password-admin', Response::HTTP_OK];
+        yield ['john-root', 'password-root', Response::HTTP_OK];
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a single endpoint to expose useful global statistics (users, applications, plugins, posts) for administrators and root users.
- Allow operators and dashboards to query aggregated platform metrics without assembling multiple queries on the client side.

### Description
- Add `StatisticsService` (`src/Tool/Application/Service/StatisticsService.php`) which aggregates counts and breakdowns using DBAL queries, including `getGlobalStatistics()`, `getApplicationsByPlatform()` and `getPluginUsage()`.
- Add `StatisticsController` (`src/Tool/Transport/Controller/Api/V1/StatisticsController.php`) exposing `GET /v1/statistics` and protecting the route with `#[IsGranted(Role::ADMIN->value)]` (root is allowed via role hierarchy).
- Return JSON with top-level keys `users`, `applications`, `plugins`, and `posts`, each containing the requested sub-metrics (total, time ranges, by-platform, usage counts).
- Add application test `StatisticsControllerTest` (`tests/Application/Tool/Transport/Controller/Api/V1/StatisticsControllerTest.php`) that verifies anonymous access returns `401`, non-admin users receive `403`, and admin/root receive `200` and the expected keys in the response.

### Testing
- Ran PHP lint on the new files with `php -l` and all checks passed for `StatisticsService`, `StatisticsController`, and the test file.
- Attempted to run the PHPUnit test (`vendor/bin/phpunit tests/Application/Tool/Transport/Controller/Api/V1/StatisticsControllerTest.php`), but the test runner is unavailable in this environment because `vendor/bin/phpunit` is not installed, so full test execution could not be performed.
- Static validation: new files were checked for basic syntax and included code-level DB queries using existing schema tables (`user`, `platform_application`, `platform_platform`, `platform_plugin`, `platform_application_plugin`, `blog_post`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01015e7208326ad5678af32cba608)