### PR TITLE
feat(chat): endpoint pour marquer tous les messages d'une conversation comme lus

### DIFF
--- a/src/Chat/Application/Message/MarkConversationMessagesAsReadCommand.php
+++ b/src/Chat/Application/Message/MarkConversationMessagesAsReadCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class MarkConversationMessagesAsReadCommand implements MessageHighInterface
+{
+    public function __construct(
+        public string $operationId,
+        public string $actorUserId,
+        public string $conversationId,
+    ) {
+    }
+}

--- a/src/Chat/Application/MessageHandler/MarkConversationMessagesAsReadCommandHandler.php
+++ b/src/Chat/Application/MessageHandler/MarkConversationMessagesAsReadCommandHandler.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Application\MessageHandler;
+
+use App\Chat\Application\Message\MarkConversationMessagesAsReadCommand;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Infrastructure\Repository\ChatMessageRepository;
+use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
+use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\General\Application\Service\CacheInvalidationService;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class MarkConversationMessagesAsReadCommandHandler
+{
+    public function __construct(
+        private ConversationRepository $conversationRepository,
+        private ConversationParticipantRepository $participantRepository,
+        private ChatMessageRepository $messageRepository,
+        private CacheInvalidationService $cacheInvalidationService,
+    ) {
+    }
+
+    public function __invoke(MarkConversationMessagesAsReadCommand $command): void
+    {
+        $conversation = $this->findParticipantConversation($command->conversationId, $command->actorUserId);
+
+        $updated = $this->messageRepository->markConversationMessagesAsRead($conversation->getId());
+        if ($updated > 0) {
+            $this->cacheInvalidationService->invalidateConversationCaches($conversation->getChat()->getId(), $command->actorUserId);
+        }
+    }
+
+    private function findParticipantConversation(string $conversationId, string $actorUserId): Conversation
+    {
+        $conversation = $this->conversationRepository->find($conversationId);
+        if (!$conversation instanceof Conversation) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+        }
+
+        $participant = $this->participantRepository->findOneBy([
+            'conversation' => $conversation,
+            'user' => $actorUserId,
+        ]);
+        if (!$participant instanceof ConversationParticipant) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+        }
+
+        return $conversation;
+    }
+}

--- a/src/Chat/Infrastructure/Repository/ChatMessageRepository.php
+++ b/src/Chat/Infrastructure/Repository/ChatMessageRepository.php
@@ -23,4 +23,21 @@ class ChatMessageRepository extends BaseRepository
         protected ManagerRegistry $managerRegistry
     ) {
     }
+
+    public function markConversationMessagesAsRead(string $conversationId): int
+    {
+        return $this->getEntityManager()->createQueryBuilder()
+            ->update(Entity::class, 'm')
+            ->set('m.read', ':read')
+            ->set('m.readAt', ':readAt')
+            ->where('m.conversation = :conversationId')
+            ->andWhere('m.read = :unread')
+            ->setParameter('read', true)
+            ->setParameter('unread', false)
+            ->setParameter('readAt', new \DateTimeImmutable())
+            ->setParameter('conversationId', $conversationId)
+            ->getQuery()
+            ->execute();
+    }
 }
+

--- a/src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/UserMessageMutationController.php
@@ -7,6 +7,7 @@ namespace App\Chat\Transport\Controller\Api\V1\Message;
 use App\Chat\Application\Message\CreateMessageCommand;
 use App\Chat\Application\Message\DeleteMessageCommand;
 use App\Chat\Application\Message\PatchMessageCommand;
+use App\Chat\Application\Message\MarkConversationMessagesAsReadCommand;
 use App\Chat\Domain\Entity\Conversation;
 use App\Chat\Domain\Entity\ConversationParticipant;
 use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
@@ -86,6 +87,19 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
     responses: [
         new OA\Response(response: 202, description: 'Commande acceptée'),
         new OA\Response(response: 404, description: 'Message introuvable'),
+    ]
+)]
+#[OA\Post(
+    path: '/v1/chat/private/conversations/{conversationId}/messages/read',
+    operationId: 'chat_message_mark_conversation_read',
+    summary: 'Marquer tous les messages d\'une conversation comme lus',
+    tags: ['Chat Message'],
+    parameters: [
+        new OA\Parameter(name: 'conversationId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
+    ],
+    responses: [
+        new OA\Response(response: 202, description: 'Commande acceptée'),
+        new OA\Response(response: 404, description: 'Conversation introuvable'),
     ]
 )]
 #[OA\Delete(path: '/v1/chat/private/messages/{messageId}', operationId: 'chat_message_delete', summary: 'Supprimer son message', tags: ['Chat Message'], parameters: [new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], responses: [new OA\Response(response: 202, description: 'Commande acceptée'), new OA\Response(response: 404, description: 'Message introuvable')])]
@@ -189,6 +203,22 @@ class UserMessageMutationController
         return new JsonResponse([
             'operationId' => $operationId,
             'id' => $messageId,
+        ], JsonResponse::HTTP_ACCEPTED);
+    }
+
+    #[Route(path: '/v1/chat/private/conversations/{conversationId}/messages/read', methods: [Request::METHOD_POST])]
+    public function markConversationAsRead(string $conversationId, User $loggedInUser): JsonResponse
+    {
+        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        $this->messageService->sendMessage(new MarkConversationMessagesAsReadCommand(
+            operationId: $operationId,
+            actorUserId: $loggedInUser->getId(),
+            conversationId: $conversationId,
+        ));
+
+        return new JsonResponse([
+            'operationId' => $operationId,
+            'conversationId' => $conversationId,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 


### PR DESCRIPTION
### Motivation
- Permettre de marquer en masse tous les messages d'une conversation comme lus en utilisant la `conversationId` depuis l'API.

### Description
- Ajout de la commande applicative `MarkConversationMessagesAsReadCommand` transportant `operationId`, `actorUserId` et `conversationId`.
- Ajout du handler `MarkConversationMessagesAsReadCommandHandler` qui vérifie l'existence de la conversation et la participation de l'utilisateur, invoque le repository pour mettre à jour les messages et invalide les caches si nécessaire.
- Implémentation de `ChatMessageRepository::markConversationMessagesAsRead(string $conversationId): int` qui effectue un update en masse (`read = true`, `readAt = now()`) sur les messages non lus de la conversation.
- Ajout d'un endpoint API `POST /v1/chat/private/conversations/{conversationId}/messages/read` dans `UserMessageMutationController` qui dispatch la commande et retourne `202 Accepted` avec `operationId` et `conversationId`.
- Mise à jour de la documentation OpenAPI correspondante.

### Testing
- Lint PHP exécuté via `php -l` sur les fichiers modifiés (`MarkConversationMessagesAsReadCommand.php`, `MarkConversationMessagesAsReadCommandHandler.php`, `ChatMessageRepository.php`, `UserMessageMutationController.php`) et aucun erreur de syntaxe détectée (succès).
- Validation de commit avec `git commit` et création de la PR via l'outil interne (succès).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0113ccdf48326a58832f8e0fcd430)