### PR TITLE
feat: integrate Mercure for realtime notifications and conversation messages

### DIFF
--- a/.env
+++ b/.env
@@ -61,6 +61,11 @@ KIBANA_PORT=5601
 REDIS_PORT=6379
 ###< Redis docker configuration ###
 
+###> Mercure docker configuration. Can be overridden in: .env.local, .env.staging, .env.prod. ###
+MERCURE_PORT=3100
+MERCURE_JWT_SECRET=!ChangeThisMercureToken!
+###< Mercure docker configuration ###
+
 ###> symfony/framework-bundle ###
 APP_ENV=dev
 APP_DEBUG=1
@@ -105,6 +110,11 @@ MESSENGER_FAILED_RETRY_WAITING_TIME=10000
 # How many days we should have failed messages inside messenger_messages table
 MESSENGER_MESSAGES_HISTORY_DAYS=7
 ###< symfony/messenger ###
+
+###> Mercure app configuration ###
+MERCURE_PUBLISH_URL=http://mercure/.well-known/mercure
+MERCURE_PUBLIC_URL=http://localhost:${MERCURE_PORT}/.well-known/mercure
+###< Mercure app configuration ###
 
 ###> Elasticsearch app configuration ###
 ELASTICSEARCH_HOST=http://elasticsearch:9200

--- a/.env.prod
+++ b/.env.prod
@@ -33,6 +33,12 @@ APP_ERROR_RECEIVER_EMAIL=admin@localhost
 MESSENGER_TRANSPORT_DSN=amqp://${RABBITMQ_USER}:${RABBITMQ_PASS}@rabbitmq:5672/%2f/messages
 ###< symfony/messenger ###
 
+###> Mercure app configuration ###
+MERCURE_JWT_SECRET=!ChangeThisMercureTokenInProd!
+MERCURE_PUBLISH_URL=http://mercure/.well-known/mercure
+MERCURE_PUBLIC_URL=https://mercure.example.com/.well-known/mercure
+###< Mercure app configuration ###
+
 ###> Elasticsearch configuration ###
 ELASTICSEARCH_HOST=http://elasticsearch:9200
 ELASTICSEARCH_NUMBER_OF_SHARDS=1

--- a/.env.staging
+++ b/.env.staging
@@ -33,6 +33,12 @@ APP_ERROR_RECEIVER_EMAIL=admin@localhost
 MESSENGER_TRANSPORT_DSN=amqp://${RABBITMQ_USER}:${RABBITMQ_PASS}@rabbitmq:5672/%2f/messages
 ###< symfony/messenger ###
 
+###> Mercure app configuration ###
+MERCURE_JWT_SECRET=!ChangeThisMercureTokenInStaging!
+MERCURE_PUBLISH_URL=http://mercure/.well-known/mercure
+MERCURE_PUBLIC_URL=https://mercure-staging.example.com/.well-known/mercure
+###< Mercure app configuration ###
+
 ###> Elasticsearch configuration ###
 ELASTICSEARCH_HOST=http://elasticsearch:9200
 ###< Elasticsearch configuration ###

--- a/.env.test
+++ b/.env.test
@@ -16,6 +16,12 @@ APP_EMAIL_NOTIFICATION_ABOUT_ERROR=1
 APP_ERROR_RECEIVER_EMAIL=admin@localhost
 ###< symfony/mailer ###
 
+###> Mercure app configuration ###
+MERCURE_JWT_SECRET=testMercureSecret
+MERCURE_PUBLISH_URL=http://mercure/.well-known/mercure
+MERCURE_PUBLIC_URL=http://localhost:3100/.well-known/mercure
+###< Mercure app configuration ###
+
 ###> symfony/lock ###
 LOCK_DSN=flock
 ###< symfony/lock ###

--- a/compose-prod.yaml
+++ b/compose-prod.yaml
@@ -35,6 +35,7 @@ services:
             - rabbitmq
             - elasticsearch
             - redis
+            - mercure
         networks:
             - symfony
 
@@ -130,6 +131,22 @@ services:
         restart: always
         volumes:
             - ./var/redis:/data:delegated
+        networks:
+            - symfony
+
+    mercure:
+        image: dunglas/mercure:latest
+        container_name: ${COMPOSE_PROJECT_NAME}-mercure
+        restart: always
+        environment:
+            SERVER_NAME: ':80'
+            MERCURE_PUBLISHER_JWT_KEY: ${MERCURE_JWT_SECRET}
+            MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_JWT_SECRET}
+            MERCURE_EXTRA_DIRECTIVES: |
+                cors_origins *
+                anonymous
+        ports:
+            - "${MERCURE_PORT}:80"
         networks:
             - symfony
 

--- a/compose-staging.yaml
+++ b/compose-staging.yaml
@@ -35,6 +35,7 @@ services:
             - rabbitmq
             - elasticsearch
             - redis
+            - mercure
         networks:
             - symfony
 
@@ -130,6 +131,22 @@ services:
         restart: always
         volumes:
             - ./var/redis:/data:delegated
+        networks:
+            - symfony
+
+    mercure:
+        image: dunglas/mercure:latest
+        container_name: ${COMPOSE_PROJECT_NAME}-mercure
+        restart: always
+        environment:
+            SERVER_NAME: ':80'
+            MERCURE_PUBLISHER_JWT_KEY: ${MERCURE_JWT_SECRET}
+            MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_JWT_SECRET}
+            MERCURE_EXTRA_DIRECTIVES: |
+                cors_origins *
+                anonymous
+        ports:
+            - "${MERCURE_PORT}:80"
         networks:
             - symfony
 

--- a/compose-test-ci.yaml
+++ b/compose-test-ci.yaml
@@ -39,6 +39,7 @@ services:
             - rabbitmq
             - elasticsearch
             - redis
+            - mercure
         networks:
             - symfony
 
@@ -134,6 +135,22 @@ services:
         restart: always
         volumes:
             - ./var/redis:/data:delegated
+        networks:
+            - symfony
+
+    mercure:
+        image: dunglas/mercure:latest
+        container_name: ${COMPOSE_PROJECT_NAME}-mercure
+        restart: always
+        environment:
+            SERVER_NAME: ':80'
+            MERCURE_PUBLISHER_JWT_KEY: ${MERCURE_JWT_SECRET}
+            MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_JWT_SECRET}
+            MERCURE_EXTRA_DIRECTIVES: |
+                cors_origins *
+                anonymous
+        ports:
+            - "${MERCURE_PORT}:80"
         networks:
             - symfony
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -39,6 +39,7 @@ services:
             - elasticsearch
             - redis
             - mail
+            - mercure
         networks:
             - symfony
 
@@ -146,6 +147,22 @@ services:
         ports:
             - "8025:8025"
             - "1025:1025"
+        networks:
+            - symfony
+
+    mercure:
+        image: dunglas/mercure:latest
+        container_name: ${COMPOSE_PROJECT_NAME}-mercure
+        restart: always
+        environment:
+            SERVER_NAME: ':80'
+            MERCURE_PUBLISHER_JWT_KEY: ${MERCURE_JWT_SECRET}
+            MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_JWT_SECRET}
+            MERCURE_EXTRA_DIRECTIVES: |
+                cors_origins *
+                anonymous
+        ports:
+            - "${MERCURE_PORT}:80"
         networks:
             - symfony
 

--- a/src/Chat/Application/MessageHandler/CreateMessageCommandHandler.php
+++ b/src/Chat/Application/MessageHandler/CreateMessageCommandHandler.php
@@ -12,6 +12,7 @@ use App\Chat\Infrastructure\Repository\ChatMessageRepository;
 use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
 use App\Chat\Infrastructure\Repository\ConversationRepository;
 use App\General\Application\Service\CacheInvalidationService;
+use App\General\Application\Service\MercurePublisher;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -27,12 +28,14 @@ final readonly class CreateMessageCommandHandler
         private UserRepository $userRepository,
         private ChatMessageRepository $messageRepository,
         private CacheInvalidationService $cacheInvalidationService,
+        private MercurePublisher $mercurePublisher,
     ) {
     }
 
     public function __invoke(CreateMessageCommand $command): void
     {
-        $chatId = $this->messageRepository->getEntityManager()->getConnection()->transactional(function () use ($command): string {
+        /** @var array{chatId: string, message: ChatMessage} $result */
+        $result = $this->messageRepository->getEntityManager()->getConnection()->transactional(function () use ($command): array {
             $actor = $this->userRepository->find($command->actorUserId);
             if (!$actor instanceof User) {
                 throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'User not found.');
@@ -49,10 +52,22 @@ final readonly class CreateMessageCommandHandler
 
             $this->messageRepository->save($message);
 
-            return $conversation->getChat()->getId();
+            return [
+                'chatId' => $conversation->getChat()->getId(),
+                'message' => $message,
+            ];
         });
 
-        $this->cacheInvalidationService->invalidateConversationCaches($chatId, $command->actorUserId);
+        $this->cacheInvalidationService->invalidateConversationCaches($result['chatId'], $command->actorUserId);
+
+        $this->mercurePublisher->publish('/conversations/' . $command->conversationId . '/messages', [
+            'id' => $result['message']->getId(),
+            'conversationId' => $command->conversationId,
+            'senderId' => $result['message']->getSender()->getId(),
+            'content' => $result['message']->getContent(),
+            'attachments' => $result['message']->getAttachments(),
+            'createdAt' => $result['message']->getCreatedAt()?->format(DATE_ATOM),
+        ]);
     }
 
     private function findParticipantConversation(string $conversationId, User $actor): Conversation

--- a/src/General/Application/Service/MercurePublisher.php
+++ b/src/General/Application/Service/MercurePublisher.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\Service;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+use function json_encode;
+
+final readonly class MercurePublisher
+{
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private LoggerInterface $logger,
+        #[Autowire('%env(string:MERCURE_PUBLISH_URL)%')]
+        private string $mercurePublishUrl,
+        #[Autowire('%env(string:MERCURE_JWT_SECRET)%')]
+        private string $mercureJwtSecret,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function publish(string $topic, array $data, bool $private = true): void
+    {
+        $payload = [
+            'topic' => $topic,
+            'data' => (string) json_encode($data, JSON_THROW_ON_ERROR),
+        ];
+
+        if ($private) {
+            $payload['private'] = 'on';
+        }
+
+        try {
+            $this->httpClient->request('POST', $this->mercurePublishUrl, [
+                'auth_bearer' => $this->mercureJwtSecret,
+                'body' => $payload,
+            ])->getStatusCode();
+        } catch (ExceptionInterface $exception) {
+            $this->logger->error('Mercure publish failed.', [
+                'topic' => $topic,
+                'error' => $exception->getMessage(),
+            ]);
+        }
+    }
+}
+

--- a/src/Notification/Application/MessageHandler/CreateNotificationCommandHandler.php
+++ b/src/Notification/Application/MessageHandler/CreateNotificationCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Notification\Application\MessageHandler;
 
 use App\General\Application\Message\EntityCreated;
+use App\General\Application\Service\MercurePublisher;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\Notification\Application\Message\CreateNotificationCommand;
 use App\Notification\Domain\Entity\Notification;
@@ -24,6 +25,7 @@ final readonly class CreateNotificationCommandHandler
         private NotificationRepository $notificationRepository,
         private UserRepository $userRepository,
         private MessageServiceInterface $messageService,
+        private MercurePublisher $mercurePublisher,
     ) {
     }
 
@@ -64,5 +66,15 @@ final readonly class CreateNotificationCommandHandler
                 'recipientId' => $notification->getRecipient()->getId(),
             ],
         ));
+
+        $this->mercurePublisher->publish('/users/' . $notification->getRecipient()->getId() . '/notifications', [
+            'id' => $notification->getId(),
+            'title' => $notification->getTitle(),
+            'description' => $notification->getDescription(),
+            'type' => $notification->getType(),
+            'recipientId' => $notification->getRecipient()->getId(),
+            'fromId' => $notification->getFrom()?->getId(),
+            'createdAt' => $notification->getCreatedAt()?->format(DATE_ATOM),
+        ]);
     }
 }

--- a/src/Notification/Application/Service/NotificationPublisher.php
+++ b/src/Notification/Application/Service/NotificationPublisher.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Notification\Application\Service;
 
+use App\General\Application\Service\MercurePublisher;
 use App\Notification\Domain\Entity\Notification;
 use App\Notification\Infrastructure\Repository\NotificationRepository;
 use App\User\Domain\Entity\User;
@@ -11,7 +12,8 @@ use App\User\Domain\Entity\User;
 final readonly class NotificationPublisher
 {
     public function __construct(
-        private NotificationRepository $notificationRepository
+        private NotificationRepository $notificationRepository,
+        private MercurePublisher $mercurePublisher,
     ) {
     }
 
@@ -29,5 +31,15 @@ final readonly class NotificationPublisher
             ->setRecipient($recipient);
 
         $this->notificationRepository->save($notification);
+
+        $this->mercurePublisher->publish('/users/' . $recipient->getId() . '/notifications', [
+            'id' => $notification->getId(),
+            'title' => $notification->getTitle(),
+            'description' => $notification->getDescription(),
+            'type' => $notification->getType(),
+            'recipientId' => $recipient->getId(),
+            'fromId' => $from->getId(),
+            'createdAt' => $notification->getCreatedAt()?->format(DATE_ATOM),
+        ]);
     }
 }


### PR DESCRIPTION
### Motivation
- Permettre la diffusion temps réel des notifications et des messages de conversation via un hub Mercure. 
- Exposer Mercure sur un port configurable en évitant le port `3000`, par défaut `MERCURE_PORT=3100`.

### Description
- Ajout d'un nouveau service applicatif `App\General\Application\Service\MercurePublisher` qui publie vers le hub Mercure en utilisant `HttpClient` et l'authentification JWT via les variables d'environnement `MERCURE_PUBLISH_URL` et `MERCURE_JWT_SECRET`.
- Intégration des publications Mercure dans le flux de notifications via `NotificationPublisher` et `CreateNotificationCommandHandler` vers le topic `/users/{id}/notifications`.
- Intégration de la publication Mercure lors de la création de messages de chat dans `CreateMessageCommandHandler` vers le topic `/conversations/{id}/messages`.
- Ajout d'un service `mercure` dans les fichiers Docker Compose (`compose.yaml`, `compose-prod.yaml`, `compose-staging.yaml`, `compose-test-ci.yaml`) et ajout de variables d'environnement dans `.env`, `.env.prod`, `.env.staging` et `.env.test` (`MERCURE_PORT`, `MERCURE_JWT_SECRET`, `MERCURE_PUBLISH_URL`, `MERCURE_PUBLIC_URL`).

### Testing
- Exécution de `php -l` pour `src/General/Application/Service/MercurePublisher.php`, `src/Notification/Application/Service/NotificationPublisher.php`, `src/Notification/Application/MessageHandler/CreateNotificationCommandHandler.php` et `src/Chat/Application/MessageHandler/CreateMessageCommandHandler.php` : toutes les vérifications de syntaxe ont réussi.
- Tentative de validation des fichiers Compose avec `docker compose ... config` : impossible dans cet environnement car le binaire `docker` n'est pas installé, donc la validation des fichiers Compose n'a pas pu être exécutée.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b010ebc7588326bc80bdeaf61e2148)