### PR TITLE
Fix search term normalization for REST RequestHandler

### DIFF
--- a/src/General/Transport/Rest/RequestHandler.php
+++ b/src/General/Transport/Rest/RequestHandler.php
@@ -15,9 +15,9 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use function abs;
 use function array_filter;
 use function array_key_exists;
+use function array_map;
 use function array_unique;
 use function array_values;
-use function array_walk;
 use function explode;
 use function in_array;
 use function is_array;
@@ -25,6 +25,7 @@ use function is_string;
 use function mb_strtoupper;
 use function mb_substr;
 use function str_starts_with;
+use function trim;
 
 /**
  * @package App\General
@@ -250,8 +251,39 @@ final class RequestHandler
      */
     private static function normalizeSearchTerms(array $searchTerms): array
     {
-        // Normalize user input, note that this support array and string formats on value
-        array_walk($searchTerms, static fn (array $terms): array => array_unique(array_values(array_filter($terms))));
+        foreach (['and', 'or'] as $operand) {
+            if (!array_key_exists($operand, $searchTerms)) {
+                continue;
+            }
+
+            $terms = $searchTerms[$operand];
+
+            if (is_string($terms)) {
+                $terms = array_filter(array_map(trim(...), explode(' ', $terms)));
+            } elseif (is_array($terms)) {
+                $terms = array_map(
+                    static function (mixed $term): string {
+                        if (!is_string($term)) {
+                            throw new HttpException(
+                                HttpFoundationResponse::HTTP_BAD_REQUEST,
+                                'Given search parameter is not valid, each search term must be a string value.',
+                            );
+                        }
+
+                        return trim($term);
+                    },
+                    $terms,
+                );
+                $terms = array_filter($terms);
+            } else {
+                throw new HttpException(
+                    HttpFoundationResponse::HTTP_BAD_REQUEST,
+                    "Given search parameter is not valid, '{$operand}' value must be a string or an array of strings.",
+                );
+            }
+
+            $searchTerms[$operand] = array_unique(array_values($terms));
+        }
 
         return $searchTerms;
     }

--- a/tests/Unit/General/Transport/Rest/RequestHandlerTest.php
+++ b/tests/Unit/General/Transport/Rest/RequestHandlerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\General\Transport\Rest;
+
+use App\General\Transport\Rest\RequestHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * @package App\Tests\Unit\General\Transport\Rest
+ */
+class RequestHandlerTest extends TestCase
+{
+    public function testGetSearchTermsNormalizesOrArrayTerms(): void
+    {
+        $request = new Request(query: ['search' => '{"or":["foo","","foo"]}']);
+
+        self::assertSame(['or' => ['foo']], RequestHandler::getSearchTerms($request));
+    }
+
+    public function testGetSearchTermsNormalizesOrStringTerms(): void
+    {
+        $request = new Request(query: ['search' => '{"or":"foo bar"}']);
+
+        self::assertSame(['or' => ['foo', 'bar']], RequestHandler::getSearchTerms($request));
+    }
+
+    public function testGetSearchTermsThrowsWithInvalidOrType(): void
+    {
+        $request = new Request(query: ['search' => '{"or":123}']);
+
+        try {
+            RequestHandler::getSearchTerms($request);
+            self::fail('Expected HttpException to be thrown for invalid search operand type.');
+        } catch (HttpException $exception) {
+            self::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+            self::assertSame(
+                "Given search parameter is not valid, 'or' value must be a string or an array of strings.",
+                $exception->getMessage(),
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- `normalizeSearchTerms()` previously used an `array_walk` callback that did not effectively mutate and normalize the provided `and`/`or` operands, causing unstable search term structures sent to repositories.
- The intent is to reliably accept both string and array formats for search operands, filter/trim empty terms, deduplicate values and provide defensive validation with consistent HTTP 400 errors for invalid input.

### Description

- Replaced the ineffective `array_walk` with explicit operand handling over `['and','or']` in `src/General/Transport/Rest/RequestHandler.php` and reassign the normalized values to the input array.
- Added handling for string values (split on spaces, `trim`, remove empties) and array values (validate each element is a string, `trim`, remove empties, `array_values`, `array_unique`).
- Added defensive validation that throws `HttpException(400)` when an operand value is neither a string nor array, or when an array contains non-string elements, preserving alignment with `determineSearchTerms()` / `checkSearchTerms()`.
- Added unit tests in `tests/Unit/General/Transport/Rest/RequestHandlerTest.php` covering normalization of `{"or":["foo","","foo"]}` to `['or' => ['foo']]`, normalization of `{"or":"foo bar"}` to `['or' => ['foo','bar']]`, and that an invalid operand type (e.g. `{"or":123}`) yields a `HttpException(400)`.

### Testing

- Ran syntax checks with `php -l` on `src/General/Transport/Rest/RequestHandler.php` and the new test file, both succeeded with no syntax errors.
- Attempted to run `vendor/bin/phpunit` for the new tests but the PHPUnit binary is not available in this environment (project dependencies not installed), so the unit tests were not executed here.
- The new unit tests were added to the repository and are expected to pass when executed in an environment with project dependencies installed and `vendor/bin/phpunit` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b013ffe8088326bff236a80f189bb1)