### PR TITLE
Bind IN/NOT IN filters via Doctrine parameters in RepositoryHelper

### DIFF
--- a/src/General/Infrastructure/Rest/RepositoryHelper.php
+++ b/src/General/Infrastructure/Rest/RepositoryHelper.php
@@ -7,7 +7,6 @@ namespace App\General\Infrastructure\Rest;
 use App\General\Domain\Rest\UuidHelper;
 use Closure;
 use Doctrine\ORM\Query\Expr\Composite;
-use Doctrine\ORM\Query\Expr\Literal;
 use Doctrine\ORM\QueryBuilder;
 use InvalidArgumentException;
 use Ramsey\Uuid\Exception\InvalidUuidStringException;
@@ -19,7 +18,6 @@ use function array_map;
 use function array_walk;
 use function call_user_func_array;
 use function is_array;
-use function is_numeric;
 use function str_contains;
 use function strcmp;
 use function strtolower;
@@ -317,7 +315,7 @@ class RepositoryHelper
      * @param array<int, string> $parameters
      * @param array<int, mixed> $value
      *
-     * @return array<int, array<int, Literal>|string>
+     * @return array<int, string>
      */
     private static function getParameters(
         QueryBuilder $queryBuilder,
@@ -341,12 +339,8 @@ class RepositoryHelper
                 syslog(LOG_INFO, $exception->getMessage());
             }
 
-            $parameters[] = array_map(
-                static fn (string $value): Literal => $queryBuilder->expr()->literal(
-                    is_numeric($value) ? (int)$value : $value
-                ),
-                $value
-            );
+            $parameters[] = '?' . self::$parameterCount;
+            $queryBuilder->setParameter(self::$parameterCount, $value);
         }
 
         return $parameters;
@@ -371,7 +365,7 @@ class RepositoryHelper
     /**
      * @param array<int, string> $parameters
      *
-     * @return array<int, array<int, Literal>|string>
+     * @return array<int, string>
      */
     private static function getComparisonParameters(
         QueryBuilder $queryBuilder,

--- a/tests/Unit/General/Infrastructure/Rest/RepositoryHelperTest.php
+++ b/tests/Unit/General/Infrastructure/Rest/RepositoryHelperTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\General\Infrastructure\Rest;
+
+use App\General\Domain\Rest\UuidHelper;
+use App\General\Infrastructure\Rest\RepositoryHelper;
+use Doctrine\ORM\Query\Expr;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class RepositoryHelperTest extends TestCase
+{
+    public function testInOperatorUsesBoundArrayParameter(): void
+    {
+        RepositoryHelper::resetParameterCount();
+
+        $expr = new Expr();
+        $queryBuilder = $this->createQueryBuilderMock($expr, $capturedParameters);
+
+        $uuid = '550e8400-e29b-41d4-a716-446655440000';
+
+        $expression = RepositoryHelper::getExpression(
+            $queryBuilder,
+            $expr->andX(),
+            [
+                ['entity.id', 'in', [$uuid]],
+            ]
+        );
+
+        self::assertStringContainsString('entity.id IN(?1)', (string)$expression);
+        self::assertStringNotContainsString($uuid, (string)$expression);
+
+        self::assertCount(1, $capturedParameters);
+        self::assertSame(1, $capturedParameters[0]['key']);
+        self::assertSame([UuidHelper::getBytes($uuid)], $capturedParameters[0]['value']);
+        self::assertNull($capturedParameters[0]['type']);
+    }
+
+    public function testBetweenKeepsParameterCounterConsistency(): void
+    {
+        RepositoryHelper::resetParameterCount();
+
+        $expr = new Expr();
+        $queryBuilder = $this->createQueryBuilderMock($expr, $capturedParameters);
+
+        $expression = RepositoryHelper::getExpression(
+            $queryBuilder,
+            $expr->andX(),
+            [
+                ['entity.createdAt', 'between', ['2024-01-01', '2024-12-31']],
+                ['entity.status', 'eq', 'active'],
+            ]
+        );
+
+        self::assertStringContainsString('entity.createdAt BETWEEN ?1 AND ?2', (string)$expression);
+        self::assertStringContainsString('entity.status = ?3', (string)$expression);
+
+        self::assertSame(1, $capturedParameters[0]['key']);
+        self::assertSame(2, $capturedParameters[1]['key']);
+        self::assertSame(3, $capturedParameters[2]['key']);
+    }
+
+    /**
+     * @param array<int, array{key: int, value: mixed, type: mixed}> $capturedParameters
+     */
+    private function createQueryBuilderMock(Expr $expr, array &$capturedParameters): QueryBuilder
+    {
+        $capturedParameters = [];
+
+        $queryBuilder = $this->getMockBuilder(QueryBuilder::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['expr', 'setParameter'])
+            ->getMock();
+
+        $queryBuilder->method('expr')->willReturn($expr);
+        $queryBuilder->method('setParameter')->willReturnCallback(
+            function (int $key, mixed $value, mixed $type = null) use (&$capturedParameters, $queryBuilder): QueryBuilder {
+                $capturedParameters[] = [
+                    'key' => $key,
+                    'value' => $value,
+                    'type' => $type,
+                ];
+
+                return $queryBuilder;
+            }
+        );
+
+        return $queryBuilder;
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent injection of literal values into DQL for `IN`/`NOT IN` expressions and use bound parameters instead for safety and consistency.
- Preserve existing UUID handling and `between` semantics while making parameter binding predictable and testable.

### Description
- Changed `getParameters()` in `src/General/Infrastructure/Rest/RepositoryHelper.php` to use a single placeholder (`?N`) for `IN/NOT IN` and call `$queryBuilder->setParameter(N, $valueArray)` instead of injecting `Literal[]` values into the expression.
- Kept UUID byte conversion via `UuidHelper::getBytes()` before binding array parameters and preserved `between` handling with consistent increments of `self::$parameterCount`.
- Updated phpdoc return types for `getParameters()` and `getComparisonParameters()` to `array<int, string>` to reflect bound placeholder strings.
- Added `tests/Unit/General/Infrastructure/Rest/RepositoryHelperTest.php` with assertions that `IN` uses a bound placeholder (no raw literal in expression), that UUID list values are converted to bytes for the bound parameter, and that `between` leaves parameter numbering consistent.

### Testing
- Ran syntax checks with `php -l src/General/Infrastructure/Rest/RepositoryHelper.php` which passed.
- Ran syntax checks with `php -l tests/Unit/General/Infrastructure/Rest/RepositoryHelperTest.php` which passed.
- Attempted to run `./vendor/bin/phpunit` for the new unit test but the PHPUnit binary is not available in this environment, so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b014093fec832698cf52ba9ff8f296)