### PR TITLE
Centraliser la validation du tenant et sécuriser la résolution d'EntityManager

### DIFF
--- a/.env
+++ b/.env
@@ -88,6 +88,7 @@ DEFAULT_URI=http://localhost
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
 # DATABASE_URL="postgresql://app:!ChangeMe!@127.0.0.1:5432/app?serverVersion=15&charset=utf8"
 DATABASE_URL=mysql://root:${MYSQL_ROOT_PASSWORD}@mysql:3306/symfony
+APP_ALLOWED_ENTITY_MANAGERS=["default"]
 ###< doctrine/doctrine-bundle ###
 
 ###> redis ###

--- a/.env.test
+++ b/.env.test
@@ -7,6 +7,7 @@ SYMFONY_DEPRECATIONS_HELPER=999999
 
 ###> doctrine/doctrine-bundle ###
 DATABASE_URL=mysql://root:${MYSQL_ROOT_PASSWORD}@mysql:3306/symfony_testing
+APP_ALLOWED_ENTITY_MANAGERS=["default"]
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/mailer ###

--- a/src/General/Infrastructure/Repository/Traits/RepositoryWrappersTrait.php
+++ b/src/General/Infrastructure/Repository/Traits/RepositoryWrappersTrait.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\Mapping\AssociationMapping;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use Doctrine\ORM\QueryBuilder;
 use Ramsey\Uuid\Exception\InvalidUuidStringException;
+use Throwable;
 use UnexpectedValueException;
 
 use function preg_replace;
@@ -56,13 +57,24 @@ trait RepositoryWrappersTrait
      */
     public function getEntityManager(?string $entityManagerName = null): EntityManager
     {
-        $manager = $entityManagerName
-            ? $this->managerRegistry->getManager($entityManagerName)
-            : $this->managerRegistry->getManagerForClass($this->getEntityName());
+        try {
+            $manager = $entityManagerName
+                ? $this->managerRegistry->getManager($entityManagerName)
+                : $this->managerRegistry->getManagerForClass($this->getEntityName());
+        } catch (Throwable $exception) {
+            throw new UnexpectedValueException(
+                $entityManagerName !== null
+                    ? 'Entity manager \'' . $entityManagerName . '\' is not available for API request.'
+                    : 'Cannot resolve entity manager for entity \'' . $this->getEntityName() . '\'.',
+                previous: $exception,
+            );
+        }
 
         if (!($manager instanceof EntityManager)) {
             throw new UnexpectedValueException(
-                'Cannot get entity manager for entity \'' . $this->getEntityName() . '\''
+                $entityManagerName !== null
+                    ? 'Entity manager \'' . $entityManagerName . '\' is not available for API request.'
+                    : 'Cannot get entity manager for entity \'' . $this->getEntityName() . '\''
             );
         }
 

--- a/src/General/Transport/Rest/RequestHandler.php
+++ b/src/General/Transport/Rest/RequestHandler.php
@@ -21,7 +21,10 @@ use function array_walk;
 use function explode;
 use function in_array;
 use function is_array;
+use function json_decode;
 use function is_string;
+use function sprintf;
+use function trim;
 use function mb_strtoupper;
 use function mb_substr;
 use function str_starts_with;
@@ -139,9 +142,52 @@ final class RequestHandler
     public static function getTenant(HttpFoundationRequest $request): ?string
     {
         $tenant = $request->query->get('tenant') ?? $request->request->get('tenant');
-        //TODO: Think about validation for tenant.
 
-        return $tenant !== null ? (string)$tenant : null;
+        if ($tenant === null) {
+            return null;
+        }
+
+        $tenant = (string)$tenant;
+        $allowedEntityManagers = self::getAllowedEntityManagers();
+
+        if (!in_array($tenant, $allowedEntityManagers, true)) {
+            throw new HttpException(
+                HttpFoundationResponse::HTTP_BAD_REQUEST,
+                sprintf(
+                    "Given 'tenant' value '%s' is not allowed. Allowed values: %s.",
+                    $tenant,
+                    implode(', ', $allowedEntityManagers),
+                ),
+            );
+        }
+
+        return $tenant;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function getAllowedEntityManagers(): array
+    {
+        $configuredEntityManagers = $_SERVER['APP_ALLOWED_ENTITY_MANAGERS']
+            ?? $_ENV['APP_ALLOWED_ENTITY_MANAGERS']
+            ?? '["default"]';
+
+        /** @var mixed $decoded */
+        $decoded = json_decode($configuredEntityManagers, true);
+
+        if (!is_array($decoded)) {
+            return ['default'];
+        }
+
+        $allowedEntityManagers = array_values(
+            array_filter(
+                $decoded,
+                static fn (mixed $entityManager): bool => is_string($entityManager) && trim($entityManager) !== ''
+            )
+        );
+
+        return $allowedEntityManagers !== [] ? $allowedEntityManagers : ['default'];
     }
 
     /**

--- a/tests/Application/ApiKey/Transport/Controller/Api/V2/ApiKeyListControllerTest.php
+++ b/tests/Application/ApiKey/Transport/Controller/Api/V2/ApiKeyListControllerTest.php
@@ -35,6 +35,40 @@ class ApiKeyListControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
+    #[TestDox('Test that `GET /v2/api_key?tenant=default` for the Root user returns success response.')]
+    public function testThatFindActionWithValidTenantReturnsSuccessResponse(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(method: 'GET', uri: $this->baseUrl . '?tenant=default');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v2/api_key?tenant=unknown` for the Root user returns bad request response.')]
+    public function testThatFindActionWithUnknownTenantReturnsBadRequestResponse(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(method: 'GET', uri: $this->baseUrl . '?tenant=unknown');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_BAD_REQUEST, $response->getStatusCode(), "Response:\n" . $response);
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertArrayHasKey('message', $responseData);
+        self::assertStringContainsString("Given 'tenant' value 'unknown' is not allowed", $responseData['message']);
+    }
+
+    /**
+     * @throws Throwable
+     */
     #[TestDox('Test that `GET /v2/api_key` for the Root user returns success response.')]
     public function testThatFindActionForRootUserReturnsSuccessResponse(): void
     {


### PR DESCRIPTION
### Motivation

- Centraliser la validation du paramètre `tenant` pour éviter des vérifications dispersées dans les méthodes REST et fournir un message d'erreur API clair en cas de valeur non autorisée.
- Rendre la résolution de l'`EntityManager` plus robuste afin d'intercepter les erreurs de résolution et de remonter un message maîtrisé côté API.

### Description

- Ajout d'une validation centralisée dans `RequestHandler::getTenant()` qui vérifie le `tenant` contre une whitelist d'EntityManagers fournie via `APP_ALLOWED_ENTITY_MANAGERS` (fallback `["default"]`) et lève une `HttpException(400)` si la valeur n'est pas autorisée.
- Implémentation de `RequestHandler::getAllowedEntityManagers()` pour lire et parser la liste autorisée depuis `$_SERVER`/`$_ENV` et normaliser la liste retournée.
- Durcissement de `RepositoryWrappersTrait::getEntityManager()` en entourant la résolution du manager par un `try/catch` et en lançant une `UnexpectedValueException` avec un message API-friendly quand le manager n'est pas disponible.
- Ajout de deux tests d'intégration dans `tests/Application/ApiKey/Transport/Controller/Api/V2/ApiKeyListControllerTest.php` couvrant `?tenant=default` (OK) et `?tenant=unknown` (400 + message explicite) et ajout de la variable `APP_ALLOWED_ENTITY_MANAGERS=["default"]` dans `.env` et `.env.test`.

### Testing

- Syntaxe PHP vérifiée avec `php -l` sur `src/General/Transport/Rest/RequestHandler.php`, `src/General/Infrastructure/Repository/Traits/RepositoryWrappersTrait.php` et le nouveau test, et ces fichiers sont sans erreur de syntaxe.
- Tests d'intégration ajoutés (`ApiKeyListControllerTest::testThatFindActionWithValidTenantReturnsSuccessResponse` et `...UnknownTenantReturnsBadRequestResponse`) sont présents mais n'ont pas été exécutés via PHPUnit dans cet environnement car `vendor/bin/phpunit` est absent.
- Les changements ont été commités après validation statique et les fichiers modifiés sont `src/General/Transport/Rest/RequestHandler.php`, `src/General/Infrastructure/Repository/Traits/RepositoryWrappersTrait.php`, `tests/Application/ApiKey/Transport/Controller/Api/V2/ApiKeyListControllerTest.php`, `.env` et `.env.test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b014055c4c83268ffbc369c2d1711f)