### PR TITLE
Fix duplicate trim import in RequestHandler

### DIFF
--- a/src/General/Transport/Rest/RequestHandler.php
+++ b/src/General/Transport/Rest/RequestHandler.php
@@ -28,7 +28,6 @@ use function trim;
 use function mb_strtoupper;
 use function mb_substr;
 use function str_starts_with;
-use function trim;
 
 /**
  * @package App\General


### PR DESCRIPTION
### Motivation
- Duplicate `use function trim;` caused a PHP compile-time fatal error (`Cannot use function trim as trim because the name is already in use`) during `composer install`/auto-scripts.

### Description
- Remove the duplicate `use function trim;` import from `src/General/Transport/Rest/RequestHandler.php` to eliminate the naming collision.

### Testing
- Ran `php -l src/General/Transport/Rest/RequestHandler.php`, which returned "No syntax errors detected" (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0a52ffa208326a8c267478625a1a0)