### PR TITLE
Skip Elasticsearch when `q` is empty for public users endpoint

### DIFF
--- a/src/User/Application/Service/UserPublicListService.php
+++ b/src/User/Application/Service/UserPublicListService.php
@@ -49,9 +49,11 @@ readonly class UserPublicListService
                 $item->tag($this->cacheKeyConventionService->publicUserListTag());
             }
 
-            $esIds = $this->searchIdsFromElastic($filters['q']);
+            $esIds = $filters['q'] !== ''
+                ? $this->searchIdsFromElastic($filters['q'])
+                : null;
 
-            if ($esIds === []) {
+            if ($filters['q'] !== '' && $esIds === []) {
                 return [];
             }
 


### PR DESCRIPTION
### Motivation
- The public users endpoint could return an empty list when Elasticsearch had no indexed users because the service always queried ES even for an empty `q` (match_all). 
- The change ensures that when no search query is provided the system falls back to loading users from the database instead of returning `[]` immediately.

### Description
- Update `UserPublicListService::getList` to only call `searchIdsFromElastic` when the `q` filter is non-empty by setting `$esIds = null` for empty `q`.
- Only return an empty array early when `q` is provided and Elasticsearch returns an empty id list (`[]`).
- Preserve existing behavior for searched requests so that when `q` is present and ES returns no IDs the response remains empty.

### Testing
- Ran `php -l src/User/Application/Service/UserPublicListService.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0b91c6cec8326872aa42bfa61b66a)