### PR TITLE
Extract user-fetch logic and short-circuit empty public user search

### DIFF
--- a/src/User/Application/Service/UserPublicListService.php
+++ b/src/User/Application/Service/UserPublicListService.php
@@ -40,6 +40,15 @@ readonly class UserPublicListService
             'q' => trim((string)$request->query->get('q', '')),
         ];
 
+        if ($filters['q'] === '') {
+            $users = $this->findUsers(null, null);
+
+            return [
+                'users' => $users,
+                'filters' => [],
+            ];
+        }
+
         $cacheKey = $this->cacheKeyConventionService->buildPublicUserListKey($filters);
 
         /** @var array<int, array<string, string|null>> $users */
@@ -55,31 +64,7 @@ readonly class UserPublicListService
                 return [];
             }
 
-            $qb = $this->userRepository->createQueryBuilder('user')
-                ->select('user')
-                ->orderBy('user.createdAt', 'DESC');
-
-            if ($esIds !== null) {
-                $qb->andWhere('user.id IN (:ids)')
-                    ->setParameter('ids', $esIds);
-            }
-
-            if ($filters['q'] !== '' && $esIds === null) {
-                $qb
-                    ->andWhere('LOWER(user.email) LIKE LOWER(:q) OR LOWER(user.firstName) LIKE LOWER(:q) OR LOWER(user.lastName) LIKE LOWER(:q)')
-                    ->setParameter('q', '%' . $filters['q'] . '%');
-            }
-
-            /** @var array<int, User> $entities */
-            $entities = $qb->getQuery()->getResult();
-
-            return array_map(static fn (User $user): array => [
-                'id' => $user->getId(),
-                'email' => $user->getEmail(),
-                'firstName' => $user->getFirstName(),
-                'lastName' => $user->getLastName(),
-                'photo' => $user->getPhoto(),
-            ], $entities);
+            return $this->findUsers($esIds, $filters['q']);
         });
 
         return [
@@ -89,8 +74,39 @@ readonly class UserPublicListService
     }
 
     /**
-     * @return array<int, string>|null
+     * @param array<int, string>|null $esIds
+     *
+     * @return array<int, array<string, string|null>>
      */
+    private function findUsers(?array $esIds, ?string $query): array
+    {
+        $qb = $this->userRepository->createQueryBuilder('user')
+            ->select('user')
+            ->orderBy('user.createdAt', 'DESC');
+
+        if ($esIds !== null) {
+            $qb->andWhere('user.id IN (:ids)')
+                ->setParameter('ids', $esIds);
+        }
+
+        if ($query !== null && $esIds === null) {
+            $qb
+                ->andWhere('LOWER(user.email) LIKE LOWER(:q) OR LOWER(user.firstName) LIKE LOWER(:q) OR LOWER(user.lastName) LIKE LOWER(:q)')
+                ->setParameter('q', '%' . $query . '%');
+        }
+
+        /** @var array<int, User> $entities */
+        $entities = $qb->getQuery()->getResult();
+
+        return array_map(static fn (User $user): array => [
+            'id' => $user->getId(),
+            'email' => $user->getEmail(),
+            'firstName' => $user->getFirstName(),
+            'lastName' => $user->getLastName(),
+            'photo' => $user->getPhoto(),
+        ], $entities);
+    }
+
     private function searchIdsFromElastic(string $query): ?array
     {
         try {


### PR DESCRIPTION
### Motivation

- Avoid running cache/Elasticsearch logic for an empty public user search and return users directly for empty queries to reduce unnecessary work.
- Improve code readability and reuse by extracting the user retrieval logic into a single method.

### Description

- Add an early return in `getList` to handle an empty `q` by calling a new `findUsers` helper and returning empty `filters`.
- Extract the previous query-builder logic into a new private method `findUsers(?array $esIds, ?string $query): array` that builds the Doctrine query and maps `User` entities to arrays.
- Update the cache closure in `getList` to call `findUsers($esIds, $filters['q'])` instead of inlining the query-builder logic, and adjust type annotations accordingly.

### Testing

- Ran the test suite with `phpunit` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0b91c6cec8326872aa42bfa61b66a)