### PR TITLE
Provision des entités de plateforme (CRM/Shop/School) lors de la création d'Application

### DIFF
--- a/src/Platform/Transport/EventListener/PlatformEntityEventListener.php
+++ b/src/Platform/Transport/EventListener/PlatformEntityEventListener.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace App\Platform\Transport\EventListener;
 
 use App\General\Domain\Service\Interfaces\MailerServiceInterface;
+use App\Crm\Domain\Entity\Crm;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Entity\ApplicationPlugin;
 use App\Platform\Domain\Entity\Platform;
 use App\Platform\Domain\Entity\Plugin;
 use App\Platform\Domain\Enum\PlatformKey;
 use App\Recruit\Domain\Entity\Recruit;
+use App\School\Domain\Entity\School;
+use App\Shop\Domain\Entity\Shop;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -108,9 +111,72 @@ class PlatformEntityEventListener
 
             if ($entity instanceof Application) {
                 $entity->ensureGeneratedSlug();
+                $this->createCrmWhenNeeded($entity);
+                $this->createShopWhenNeeded($entity);
+                $this->createSchoolWhenNeeded($entity);
                 $this->createRecruitWhenNeeded($entity);
             }
         }
+    }
+
+    private function createCrmWhenNeeded(Application $application): void
+    {
+        if ($application->getPlatform()?->getPlatformKey() !== PlatformKey::CRM) {
+            return;
+        }
+
+        $existingCrm = $this->entityManager->getRepository(Crm::class)->findOneBy([
+            'application' => $application,
+        ]);
+
+        if ($existingCrm instanceof Crm) {
+            return;
+        }
+
+        $crm = (new Crm())
+            ->setApplication($application);
+
+        $this->entityManager->persist($crm);
+    }
+
+    private function createShopWhenNeeded(Application $application): void
+    {
+        if ($application->getPlatform()?->getPlatformKey() !== PlatformKey::SHOP) {
+            return;
+        }
+
+        $existingShop = $this->entityManager->getRepository(Shop::class)->findOneBy([
+            'application' => $application,
+        ]);
+
+        if ($existingShop instanceof Shop) {
+            return;
+        }
+
+        $shop = (new Shop())
+            ->setApplication($application);
+
+        $this->entityManager->persist($shop);
+    }
+
+    private function createSchoolWhenNeeded(Application $application): void
+    {
+        if ($application->getPlatform()?->getPlatformKey() !== PlatformKey::SCHOOL) {
+            return;
+        }
+
+        $existingSchool = $this->entityManager->getRepository(School::class)->findOneBy([
+            'application' => $application,
+        ]);
+
+        if ($existingSchool instanceof School) {
+            return;
+        }
+
+        $school = (new School())
+            ->setApplication($application);
+
+        $this->entityManager->persist($school);
     }
 
     private function createRecruitWhenNeeded(Application $application): void

--- a/tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace App\Tests\Application\User\Transport\Controller\Api\V1\Profile;
 
 use App\Calendar\Infrastructure\Repository\CalendarRepository;
+use App\Crm\Domain\Entity\Crm;
 use App\General\Domain\Utils\JSON;
 use App\Platform\Application\Service\ApplicationPluginProvisioningService;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PluginKey;
+use App\Recruit\Domain\Entity\Recruit;
+use App\School\Domain\Entity\School;
+use App\Shop\Domain\Entity\Shop;
 use App\Tests\TestCase\WebTestCase;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\TestDox;
@@ -75,5 +79,66 @@ class ApplicationCreateControllerTest extends WebTestCase
         self::assertCount(1, $chatRepository->findBy([
             'application' => $application,
         ]));
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that creating applications provisions one entity per platform (crm, shop, school, recruit) and stays idempotent on update.')]
+    public function testThatPostApplicationProvisionsPlatformEntityAndIsIdempotentOnUpdate(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $crmApplication = $this->createApplication('40000000-0000-1000-8000-000000000001', 'CRM app auto provision');
+        $shopApplication = $this->createApplication('40000000-0000-1000-8000-000000000003', 'Shop app auto provision');
+        $schoolApplication = $this->createApplication('40000000-0000-1000-8000-000000000005', 'School app auto provision');
+        $recruitApplication = $this->createApplication('40000000-0000-1000-8000-000000000004', 'Recruit app auto provision');
+
+        self::assertCount(1, $entityManager->getRepository(Crm::class)->findBy(['application' => $crmApplication]));
+        self::assertCount(1, $entityManager->getRepository(Shop::class)->findBy(['application' => $shopApplication]));
+        self::assertCount(1, $entityManager->getRepository(School::class)->findBy(['application' => $schoolApplication]));
+        self::assertCount(1, $entityManager->getRepository(Recruit::class)->findBy(['application' => $recruitApplication]));
+
+        $crmApplication->setDescription('CRM app updated');
+        $shopApplication->setDescription('Shop app updated');
+        $schoolApplication->setDescription('School app updated');
+        $recruitApplication->setDescription('Recruit app updated');
+        $entityManager->flush();
+
+        self::assertCount(1, $entityManager->getRepository(Crm::class)->findBy(['application' => $crmApplication]));
+        self::assertCount(1, $entityManager->getRepository(Shop::class)->findBy(['application' => $shopApplication]));
+        self::assertCount(1, $entityManager->getRepository(School::class)->findBy(['application' => $schoolApplication]));
+        self::assertCount(1, $entityManager->getRepository(Recruit::class)->findBy(['application' => $recruitApplication]));
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function createApplication(string $platformId, string $title): Application
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request('POST', $this->baseUrl, content: JSON::encode([
+            'platformId' => $platformId,
+            'title' => $title,
+            'description' => 'Platform provisioning integration test',
+        ]));
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertArrayHasKey('id', $responseData);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $application = $entityManager->getRepository(Application::class)->find($responseData['id']);
+
+        self::assertInstanceOf(Application::class, $application);
+
+        return $application;
     }
 }


### PR DESCRIPTION
### Motivation

- Automatiser le provisioning des entités métier liées à une `Application` pour les plateformes `crm`, `shop` et `school` de la même façon que pour `recruit`, afin que chaque application ait sa ressource dédiée dès sa création.

### Description

- Ajout des méthodes `createCrmWhenNeeded()`, `createShopWhenNeeded()` et `createSchoolWhenNeeded()` dans `PlatformEntityEventListener` et branchement de ces appels dans `process()` juste après `ensureGeneratedSlug()` pour `Application`.
- Chaque méthode vérifie le `platformKey`, recherche l'entité existante via `findOneBy(['application' => $application])` et ne crée/persiste l'entité (`App\Crm\Domain\Entity\Crm`, `App\Shop\Domain\Entity\Shop`, `App\School\Domain\Entity\School`) que si elle n'existe pas, garantissant ainsi l'idempotence.
- Le comportement existant pour `recruit` est conservé et appelé après les nouveaux provisioners.
- Ajout d'un test d'intégration (`tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php`) qui crée des applications pour les 4 `platformKey` (`crm`, `shop`, `school`, `recruit`) et vérifie qu'une mise à jour ultérieure n'introduit pas de doublons.

### Testing

- Vérification de la syntaxe PHP des fichiers modifiés avec `php -l src/Platform/Transport/EventListener/PlatformEntityEventListener.php` et `php -l tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php`, les deux ont réussi.
- Tentative d'exécution des tests ciblés avec `php -d memory_limit=1G vendor/bin/phpunit tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php` mais le binaire `vendor/bin/phpunit` n'est pas disponible dans cet environnement de build, donc les tests PHPUnit n'ont pas été lancés ici.
- Les nouveaux tests ont été ajoutés et prêts pour exécution dans l'environnement CI ou local où `phpunit` est installé.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0daf93b4c83269db68541edb9c06b)