### PR TITLE
Scope API routes by applicationSlug and enforce application owner access

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/CrmController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CrmController.php
@@ -21,8 +21,10 @@ use App\General\Application\Message\EntityCreated;
 use App\General\Application\Message\EntityDeleted;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PlatformKey;
+use App\User\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -47,6 +49,7 @@ final readonly class CrmController
         private TaskListService $taskListService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
+        private Security $security,
     ) {
     }
 
@@ -397,20 +400,33 @@ final readonly class CrmController
     {
         $crm = $this->crmRepository->findOneByApplicationSlug($applicationSlug);
         if ($crm instanceof Crm) {
+            $this->assertApplicationAccess($crm->getApplication(), PlatformKey::CRM);
+
             return $crm;
         }
 
         $application = $this->entityManager->getRepository(Application::class)->findOneBy([
             'slug' => $applicationSlug,
         ]);
-        if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== PlatformKey::CRM) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicationSlug" for CRM platform.');
+        if (!$application instanceof Application) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Unknown "applicationSlug".');
         }
 
-        $crm = (new Crm())->setApplication($application);
-        $this->entityManager->persist($crm);
-        $this->entityManager->flush();
+        $this->assertApplicationAccess($application, PlatformKey::CRM);
 
-        return $crm;
+        throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'CRM root entity not found for this application.');
+
+    }
+
+    private function assertApplicationAccess(?Application $application, PlatformKey $platformKey): void
+    {
+        if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== $platformKey) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid "applicationSlug" for the requested platform.');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || $application->getUser()?->getId() !== $user->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot access this application scope.');
+        }
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/PrivateJobListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/PrivateJobListController.php
@@ -24,6 +24,7 @@ class PrivateJobListController
     ) {
     }
 
+    #[Route(path: '/v1/recruit/applications/{applicationSlug}/private/jobs', methods: [Request::METHOD_GET])]
     #[Route(path: '/v1/recruit/private/{applicationSlug}/jobs', methods: [Request::METHOD_GET])]
     #[OA\Get(
         summary: 'Liste privée des offres jobs, paginée et filtrable.',

--- a/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailController.php
@@ -20,6 +20,7 @@ class PublicJobDetailController
     ) {
     }
 
+    #[Route(path: '/v1/recruit/applications/{applicationSlug}/public/jobs/{jobSlug}', methods: [Request::METHOD_GET])]
     #[Route(path: '/v1/recruit/public/{applicationSlug}/jobs/{jobSlug}', methods: [Request::METHOD_GET])]
     #[OA\Get(
         summary: 'Détail public d\'un job avec jobs similaires indexés.',

--- a/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobListController.php
@@ -20,6 +20,7 @@ class PublicJobListController
     ) {
     }
 
+    #[Route(path: '/v1/recruit/applications/{applicationSlug}/public/jobs', methods: [Request::METHOD_GET])]
     #[Route(path: '/v1/recruit/public/{applicationSlug}/jobs', methods: [Request::METHOD_GET])]
     #[OA\Get(
         summary: 'Liste publique des offres jobs, paginée et filtrable.',

--- a/src/School/Transport/Controller/Api/V1/SchoolController.php
+++ b/src/School/Transport/Controller/Api/V1/SchoolController.php
@@ -21,8 +21,10 @@ use App\School\Infrastructure\Repository\SchoolClassRepository;
 use App\School\Infrastructure\Repository\SchoolRepository;
 use App\School\Infrastructure\Repository\StudentRepository;
 use App\School\Infrastructure\Repository\TeacherRepository;
+use App\User\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -47,6 +49,7 @@ final readonly class SchoolController
         private ExamListService $examListService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
+        private Security $security,
     ) {
     }
 
@@ -397,23 +400,32 @@ final readonly class SchoolController
     {
         $school = $this->schoolRepository->findOneByApplicationSlug($applicationSlug);
         if ($school instanceof School) {
+            $this->assertApplicationAccess($school->getApplication(), PlatformKey::SCHOOL);
+
             return $school;
         }
 
         $application = $this->entityManager->getRepository(Application::class)->findOneBy([
             'slug' => $applicationSlug,
         ]);
-        if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== PlatformKey::SCHOOL) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicationSlug" for School platform.');
+        if (!$application instanceof Application) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Unknown "applicationSlug".');
         }
 
-        $school = (new School())
-            ->setApplication($application)
-            ->setName($application->getTitle() . ' Academy');
+        $this->assertApplicationAccess($application, PlatformKey::SCHOOL);
 
-        $this->entityManager->persist($school);
-        $this->entityManager->flush();
+        throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'School root entity not found for this application.');
+    }
 
-        return $school;
+    private function assertApplicationAccess(?Application $application, PlatformKey $platformKey): void
+    {
+        if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== $platformKey) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid "applicationSlug" for the requested platform.');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || $application->getUser()?->getId() !== $user->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot access this application scope.');
+        }
     }
 }

--- a/src/Shop/Transport/Controller/Api/V1/ShopController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ShopController.php
@@ -17,8 +17,10 @@ use App\Shop\Infrastructure\Repository\CategoryRepository;
 use App\Shop\Infrastructure\Repository\ProductRepository;
 use App\Shop\Infrastructure\Repository\ShopRepository;
 use App\Shop\Infrastructure\Repository\TagRepository;
+use App\User\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -41,6 +43,7 @@ final readonly class ShopController
         private ProductListService $productListService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
+        private Security $security,
     ) {
     }
 
@@ -298,23 +301,32 @@ final readonly class ShopController
     {
         $shop = $this->shopRepository->findOneByApplicationSlug($applicationSlug);
         if ($shop instanceof Shop) {
+            $this->assertApplicationAccess($shop->getApplication(), PlatformKey::SHOP);
+
             return $shop;
         }
 
         $application = $this->entityManager->getRepository(Application::class)->findOneBy([
             'slug' => $applicationSlug,
         ]);
-        if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== PlatformKey::SHOP) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicationSlug" for Shop platform.');
+        if (!$application instanceof Application) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Unknown "applicationSlug".');
         }
 
-        $shop = (new Shop())
-            ->setApplication($application)
-            ->setName($application->getTitle() . ' Catalog');
+        $this->assertApplicationAccess($application, PlatformKey::SHOP);
 
-        $this->entityManager->persist($shop);
-        $this->entityManager->flush();
+        throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Shop root entity not found for this application.');
+    }
 
-        return $shop;
+    private function assertApplicationAccess(?Application $application, PlatformKey $platformKey): void
+    {
+        if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== $platformKey) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid "applicationSlug" for the requested platform.');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || $application->getUser()?->getId() !== $user->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot access this application scope.');
+        }
     }
 }

--- a/tests/Application/Scoped/ScopedApplicationRoutesTest.php
+++ b/tests/Application/Scoped/ScopedApplicationRoutesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Scoped;
+
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ScopedApplicationRoutesTest extends WebTestCase
+{
+    #[TestDox('CRM scoped routes return 200 for owner, 403 for foreign owner, and 404 for invalid slug.')]
+    public function testCrmScopedRoutesAccessControl(): void
+    {
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/crm/applications/crm-sales-hub/companies');
+        self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient = $this->getTestClient('john-user', 'password-user');
+        $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/crm/applications/crm-sales-hub/companies');
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $invalidClient = $this->getTestClient('john-root', 'password-root');
+        $invalidClient->request('GET', self::API_URL_PREFIX . '/v1/crm/applications/not-found-slug/companies');
+        self::assertContains($invalidClient->getResponse()->getStatusCode(), [Response::HTTP_BAD_REQUEST, Response::HTTP_NOT_FOUND]);
+    }
+
+    #[TestDox('Shop scoped routes return 200 for owner, 403 for foreign owner, and 400 for wrong platform slug.')]
+    public function testShopScopedRoutesAccessControl(): void
+    {
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/products');
+        self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient = $this->getTestClient('john-user', 'password-user');
+        $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/products');
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $invalidClient = $this->getTestClient('john-root', 'password-root');
+        $invalidClient->request('GET', self::API_URL_PREFIX . '/v1/shop/applications/crm-sales-hub/products');
+        self::assertSame(Response::HTTP_BAD_REQUEST, $invalidClient->getResponse()->getStatusCode());
+    }
+
+    #[TestDox('School scoped routes return 200 for owner, 403 for foreign owner, and 404 for invalid slug.')]
+    public function testSchoolScopedRoutesAccessControl(): void
+    {
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes');
+        self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient = $this->getTestClient('john-user', 'password-user');
+        $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes');
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $invalidClient = $this->getTestClient('john-root', 'password-root');
+        $invalidClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/not-found-slug/classes');
+        self::assertSame(Response::HTTP_NOT_FOUND, $invalidClient->getResponse()->getStatusCode());
+    }
+}


### PR DESCRIPTION
### Motivation
- Unifier le pattern d'accès pour les routes d'application afin d'utiliser `/v1/{module}/applications/{applicationSlug}/...` et éviter des endpoints globaux non scopés.
- Éviter la création implicite d'entités racines depuis un `applicationSlug` invalide afin de forcer un comportement explicite (erreur 404) au lieu d'une migration silencieuse.
- Garantir la cohérence plateforme et restreindre l'accès aux ressources d'application au propriétaire de l'application pour éviter des fuites ou modifications non autorisées.

### Description
- Les contrôleurs transporteurs `CrmController`, `ShopController` et `SchoolController` ont été modifiés pour résoudre systématiquement l'entité racine via `applicationSlug` et vérifier le `platformKey` avant tout accès. 
- Ajout de la dépendance `Security` et du type `User` dans ces contrôleurs et introduction de la méthode `assertApplicationAccess` qui lève `400/403/404` selon les cas (mauvaise plateforme, accès interdit, racine absente).
- Comportement changé : on ne crée plus automatiquement la racine lorsqu'elle manque pour un `applicationSlug`, on retourne désormais un `404` explicite.
- Les routes Recruit publiques/privées ont reçu des alias conformes à `/v1/recruit/applications/{applicationSlug}/...` (anciens chemins conservés en alias pour compatibilité), et un test d'intégration `tests/Application/Scoped/ScopedApplicationRoutesTest.php` a été ajouté couvrant `200/403/400/404` selon les scenarios demandés.

### Testing
- J'ai exécuté la vérification de syntaxe PHP avec `php -l` sur les fichiers modifiés et le nouveau test, et toutes les vérifications de syntaxe sont passées avec succès. 
- Un nouveau test d'accès a été ajouté `tests/Application/Scoped/ScopedApplicationRoutesTest.php` qui couvre les cas attendus (owner OK, foreign user -> `403`, invalid slug -> `400/404`).
- L'exécution des tests PHPUnit n'a pas pu être réalisée ici car le binaire `./vendor/bin/phpunit` (et `bin/phpunit`) n'est pas présent dans l'environnement d'exécution, donc les assertions automatisées n'ont pas été lancées dans ce CI local.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0dc5b01188326bb095a505faefe3c)