### PR TITLE
Modular idempotent plugin provisioning with minimal business seeds

### DIFF
--- a/src/Platform/Application/Service/ApplicationPluginProvisioningService.php
+++ b/src/Platform/Application/Service/ApplicationPluginProvisioningService.php
@@ -4,29 +4,22 @@ declare(strict_types=1);
 
 namespace App\Platform\Application\Service;
 
-use App\Blog\Domain\Entity\Blog;
-use App\Blog\Domain\Enum\BlogType;
-use App\Blog\Infrastructure\Repository\BlogRepository;
-use App\Calendar\Domain\Entity\Calendar;
-use App\Calendar\Infrastructure\Repository\CalendarRepository;
-use App\Chat\Domain\Entity\Chat;
-use App\Chat\Infrastructure\Repository\ChatRepository;
+use App\Platform\Application\Service\PluginProvisioning\BlogPluginProvisioner;
+use App\Platform\Application\Service\PluginProvisioning\CalendarPluginProvisioner;
+use App\Platform\Application\Service\PluginProvisioning\ChatPluginProvisioner;
+use App\Platform\Application\Service\PluginProvisioning\QuizPluginProvisioner;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PluginKey;
-use App\Quiz\Domain\Entity\Quiz;
-use App\Quiz\Infrastructure\Repository\QuizRepository;
-use Doctrine\ORM\EntityManagerInterface;
 
 use function in_array;
 
 final class ApplicationPluginProvisioningService
 {
     public function __construct(
-        private readonly CalendarRepository $calendarRepository,
-        private readonly ChatRepository $chatRepository,
-        private readonly BlogRepository $blogRepository,
-        private readonly QuizRepository $quizRepository,
-        private readonly EntityManagerInterface $entityManager,
+        private readonly CalendarPluginProvisioner $calendarPluginProvisioner,
+        private readonly ChatPluginProvisioner $chatPluginProvisioner,
+        private readonly BlogPluginProvisioner $blogPluginProvisioner,
+        private readonly QuizPluginProvisioner $quizPluginProvisioner,
     ) {
     }
 
@@ -36,75 +29,18 @@ final class ApplicationPluginProvisioningService
     public function provision(Application $application, array $pluginKeys): void
     {
         if (in_array(PluginKey::CALENDAR, $pluginKeys, true)) {
-            $this->provisionCalendar($application);
+            $this->calendarPluginProvisioner->provision($application);
         }
 
         if (in_array(PluginKey::CHAT, $pluginKeys, true)) {
-            $this->provisionChat($application);
+            $this->chatPluginProvisioner->provision($application);
         }
         if (in_array(PluginKey::BLOG, $pluginKeys, true)) {
-            $this->provisionBlog($application);
+            $this->blogPluginProvisioner->provision($application);
         }
 
         if (in_array(PluginKey::QUIZ, $pluginKeys, true)) {
-            $this->provisionQuiz($application);
+            $this->quizPluginProvisioner->provision($application);
         }
-    }
-
-    private function provisionCalendar(Application $application): void
-    {
-        if ($this->calendarRepository->findOneByApplication($application) instanceof Calendar) {
-            return;
-        }
-
-        $calendar = (new Calendar())
-            ->setTitle('Default calendar')
-            ->setUser($application->getUser())
-            ->setApplication($application);
-
-        $this->entityManager->persist($calendar);
-    }
-
-    private function provisionChat(Application $application): void
-    {
-        if ($this->chatRepository->findOneByApplication($application) instanceof Chat) {
-            return;
-        }
-
-        $application->ensureGeneratedSlug();
-
-        $chat = (new Chat())
-            ->setApplication($application)
-            ->setApplicationSlug($application->getSlug());
-
-        $this->entityManager->persist($chat);
-    }
-
-    private function provisionBlog(Application $application): void
-    {
-        if ($this->blogRepository->findOneByApplication($application) instanceof Blog) {
-            return;
-        }
-
-        $blog = (new Blog())
-            ->setTitle($application->getTitle() . ' Blog')
-            ->setOwner($application->getUser())
-            ->setType(BlogType::APPLICATION)
-            ->setApplication($application);
-
-        $this->entityManager->persist($blog);
-    }
-
-    private function provisionQuiz(Application $application): void
-    {
-        if ($this->quizRepository->findOneByApplication($application) instanceof Quiz) {
-            return;
-        }
-
-        $quiz = (new Quiz())
-            ->setApplication($application)
-            ->setOwner($application->getUser());
-
-        $this->entityManager->persist($quiz);
     }
 }

--- a/src/Platform/Application/Service/PluginProvisioning/BlogPluginProvisioner.php
+++ b/src/Platform/Application/Service/PluginProvisioning/BlogPluginProvisioner.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Service\PluginProvisioning;
+
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Entity\BlogPost;
+use App\Blog\Domain\Entity\BlogTag;
+use App\Blog\Domain\Enum\BlogType;
+use App\Blog\Infrastructure\Repository\BlogPostRepository;
+use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\Blog\Infrastructure\Repository\BlogTagRepository;
+use App\Platform\Domain\Entity\Application;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class BlogPluginProvisioner
+{
+    public function __construct(
+        private BlogRepository $blogRepository,
+        private BlogPostRepository $blogPostRepository,
+        private BlogTagRepository $blogTagRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function provision(Application $application): void
+    {
+        $blog = $this->blogRepository->findOneByApplication($application);
+        if (!$blog instanceof Blog) {
+            $blog = (new Blog())
+                ->setTitle($application->getTitle() . ' Blog')
+                ->setOwner($application->getUser())
+                ->setType(BlogType::APPLICATION)
+                ->setApplication($application);
+
+            $this->entityManager->persist($blog);
+        }
+
+        $tag = $this->blogTagRepository->findOneBy([
+            'blog' => $blog,
+            'label' => 'Getting Started',
+        ]);
+
+        if (!$tag instanceof BlogTag) {
+            $tag = (new BlogTag())
+                ->setBlog($blog)
+                ->setLabel('Getting Started');
+
+            $this->entityManager->persist($tag);
+        }
+
+        $post = $this->blogPostRepository->findOneBy([
+            'blog' => $blog,
+            'content' => 'Welcome to your application blog.',
+        ]);
+
+        if ($post instanceof BlogPost) {
+            return;
+        }
+
+        $post = (new BlogPost())
+            ->setBlog($blog)
+            ->setAuthor($application->getUser())
+            ->setContent('Welcome to your application blog.');
+
+        $this->entityManager->persist($post);
+    }
+}

--- a/src/Platform/Application/Service/PluginProvisioning/CalendarPluginProvisioner.php
+++ b/src/Platform/Application/Service/PluginProvisioning/CalendarPluginProvisioner.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Service\PluginProvisioning;
+
+use App\Calendar\Domain\Entity\Calendar;
+use App\Calendar\Domain\Entity\Event;
+use App\Calendar\Infrastructure\Repository\CalendarRepository;
+use App\Calendar\Infrastructure\Repository\EventRepository;
+use App\Platform\Domain\Entity\Application;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class CalendarPluginProvisioner
+{
+    public function __construct(
+        private CalendarRepository $calendarRepository,
+        private EventRepository $eventRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function provision(Application $application): void
+    {
+        $calendar = $this->calendarRepository->findOneByApplication($application);
+        if (!$calendar instanceof Calendar) {
+            $calendar = (new Calendar())
+                ->setTitle('Default calendar')
+                ->setUser($application->getUser())
+                ->setApplication($application);
+
+            $this->entityManager->persist($calendar);
+        }
+
+        $event = $this->eventRepository->findOneBy([
+            'calendar' => $calendar,
+            'title' => 'Welcome event',
+        ]);
+
+        if ($event instanceof Event) {
+            return;
+        }
+
+        $startAt = new DateTimeImmutable('+1 day 09:00');
+
+        $event = (new Event())
+            ->setCalendar($calendar)
+            ->setUser($application->getUser())
+            ->setTitle('Welcome event')
+            ->setDescription('Initial planning event for your team.')
+            ->setStartAt($startAt)
+            ->setEndAt($startAt->modify('+1 hour'));
+
+        $this->entityManager->persist($event);
+    }
+}

--- a/src/Platform/Application/Service/PluginProvisioning/ChatPluginProvisioner.php
+++ b/src/Platform/Application/Service/PluginProvisioning/ChatPluginProvisioner.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Service\PluginProvisioning;
+
+use App\Chat\Domain\Entity\Chat;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Infrastructure\Repository\ChatRepository;
+use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\Platform\Domain\Entity\Application;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class ChatPluginProvisioner
+{
+    public function __construct(
+        private ChatRepository $chatRepository,
+        private ConversationRepository $conversationRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function provision(Application $application): void
+    {
+        $chat = $this->chatRepository->findOneByApplication($application);
+        if (!$chat instanceof Chat) {
+            $application->ensureGeneratedSlug();
+
+            $chat = (new Chat())
+                ->setApplication($application)
+                ->setApplicationSlug($application->getSlug());
+
+            $this->entityManager->persist($chat);
+        }
+
+        if ($this->conversationRepository->findOneByChat($chat) instanceof Conversation) {
+            return;
+        }
+
+        $conversation = (new Conversation())
+            ->setChat($chat);
+
+        $this->entityManager->persist($conversation);
+    }
+}

--- a/src/Platform/Application/Service/PluginProvisioning/QuizPluginProvisioner.php
+++ b/src/Platform/Application/Service/PluginProvisioning/QuizPluginProvisioner.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Service\PluginProvisioning;
+
+use App\Platform\Domain\Entity\Application;
+use App\Quiz\Domain\Entity\Quiz;
+use App\Quiz\Domain\Entity\QuizQuestion;
+use App\Quiz\Infrastructure\Repository\QuizQuestionRepository;
+use App\Quiz\Infrastructure\Repository\QuizRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class QuizPluginProvisioner
+{
+    public function __construct(
+        private QuizRepository $quizRepository,
+        private QuizQuestionRepository $quizQuestionRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function provision(Application $application): void
+    {
+        $quiz = $this->quizRepository->findOneByApplication($application);
+        if (!$quiz instanceof Quiz) {
+            $quiz = (new Quiz())
+                ->setApplication($application)
+                ->setOwner($application->getUser());
+
+            $this->entityManager->persist($quiz);
+        }
+
+        $question = $this->quizQuestionRepository->findOneBy([
+            'quiz' => $quiz,
+            'title' => 'What is the first step to launch this app?',
+        ]);
+
+        if ($question instanceof QuizQuestion) {
+            return;
+        }
+
+        $question = (new QuizQuestion())
+            ->setQuiz($quiz)
+            ->setTitle('What is the first step to launch this app?')
+            ->setCategory('onboarding')
+            ->setLevel('easy');
+
+        $this->entityManager->persist($question);
+    }
+}

--- a/tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php
@@ -4,12 +4,20 @@ declare(strict_types=1);
 
 namespace App\Tests\Application\User\Transport\Controller\Api\V1\Profile;
 
+use App\Blog\Infrastructure\Repository\BlogPostRepository;
+use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\Blog\Infrastructure\Repository\BlogTagRepository;
 use App\Calendar\Infrastructure\Repository\CalendarRepository;
+use App\Calendar\Infrastructure\Repository\EventRepository;
+use App\Chat\Infrastructure\Repository\ChatRepository;
+use App\Chat\Infrastructure\Repository\ConversationRepository;
 use App\Crm\Domain\Entity\Crm;
 use App\General\Domain\Utils\JSON;
 use App\Platform\Application\Service\ApplicationPluginProvisioningService;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PluginKey;
+use App\Quiz\Infrastructure\Repository\QuizQuestionRepository;
+use App\Quiz\Infrastructure\Repository\QuizRepository;
 use App\Recruit\Domain\Entity\Recruit;
 use App\School\Domain\Entity\School;
 use App\Shop\Domain\Entity\Shop;
@@ -26,13 +34,13 @@ class ApplicationCreateControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that creating an application with calendar and chat plugins provisions default entities.')]
-    public function testThatPostApplicationWithCalendarAndChatPluginsProvisionDefaults(): void
+    #[TestDox('Test that creating an application with calendar/chat/blog/quiz plugins provisions default entities and idempotent seeds.')]
+    public function testThatPostApplicationWithPluginsProvisionDefaultsAndSeedData(): void
     {
         $client = $this->getTestClient('john-user', 'password-user');
         $payload = [
             'platformId' => '40000000-0000-1000-8000-000000000001',
-            'title' => 'App with calendar and chat',
+            'title' => 'App with all plugins',
             'description' => 'Provisioning integration test',
             'plugins' => [
                 [
@@ -40,6 +48,12 @@ class ApplicationCreateControllerTest extends WebTestCase
                 ],
                 [
                     'pluginId' => '50000000-0000-1000-8000-000000000002',
+                ],
+                [
+                    'pluginId' => '50000000-0000-1000-8000-000000000005',
+                ],
+                [
+                    'pluginId' => '50000000-0000-1000-8000-000000000006',
                 ],
             ],
         ];
@@ -55,30 +69,52 @@ class ApplicationCreateControllerTest extends WebTestCase
 
         $container = static::getContainer();
         $entityManager = $container->get(EntityManagerInterface::class);
-        $calendarRepository = $container->get(CalendarRepository::class);
-        $chatRepository = $container->get(\App\Chat\Infrastructure\Repository\ChatRepository::class);
 
         $application = $entityManager->getRepository(Application::class)->find($responseData['id']);
         self::assertInstanceOf(Application::class, $application);
 
+        $calendarRepository = $container->get(CalendarRepository::class);
+        $chatRepository = $container->get(ChatRepository::class);
+        $conversationRepository = $container->get(ConversationRepository::class);
+        $eventRepository = $container->get(EventRepository::class);
+        $blogRepository = $container->get(BlogRepository::class);
+        $blogPostRepository = $container->get(BlogPostRepository::class);
+        $blogTagRepository = $container->get(BlogTagRepository::class);
+        $quizRepository = $container->get(QuizRepository::class);
+        $quizQuestionRepository = $container->get(QuizQuestionRepository::class);
+
         $calendar = $calendarRepository->findOneByApplication($application);
         $chat = $chatRepository->findOneByApplication($application);
+        $blog = $blogRepository->findOneByApplication($application);
+        $quiz = $quizRepository->findOneByApplication($application);
 
         self::assertNotNull($calendar);
         self::assertSame('Default calendar', $calendar->getTitle());
         self::assertNotNull($chat);
         self::assertSame($application->getSlug(), $chat->getApplicationSlug());
+        self::assertNotNull($blog);
+        self::assertNotNull($quiz);
+
+        self::assertCount(1, $conversationRepository->findBy(['chat' => $chat]));
+        self::assertCount(1, $eventRepository->findBy(['calendar' => $calendar, 'title' => 'Welcome event']));
+        self::assertCount(1, $blogTagRepository->findBy(['blog' => $blog, 'label' => 'Getting Started']));
+        self::assertCount(1, $blogPostRepository->findBy(['blog' => $blog, 'content' => 'Welcome to your application blog.']));
+        self::assertCount(1, $quizQuestionRepository->findBy(['quiz' => $quiz, 'title' => 'What is the first step to launch this app?']));
 
         $provisioningService = $container->get(ApplicationPluginProvisioningService::class);
-        $provisioningService->provision($application, [PluginKey::CALENDAR, PluginKey::CHAT]);
+        $provisioningService->provision($application, [PluginKey::CALENDAR, PluginKey::CHAT, PluginKey::BLOG, PluginKey::QUIZ]);
         $entityManager->flush();
 
-        self::assertCount(1, $calendarRepository->findBy([
-            'application' => $application,
-        ]));
-        self::assertCount(1, $chatRepository->findBy([
-            'application' => $application,
-        ]));
+        self::assertCount(1, $calendarRepository->findBy(['application' => $application]));
+        self::assertCount(1, $chatRepository->findBy(['application' => $application]));
+        self::assertCount(1, $blogRepository->findBy(['application' => $application]));
+        self::assertCount(1, $quizRepository->findBy(['application' => $application]));
+
+        self::assertCount(1, $conversationRepository->findBy(['chat' => $chat]));
+        self::assertCount(1, $eventRepository->findBy(['calendar' => $calendar, 'title' => 'Welcome event']));
+        self::assertCount(1, $blogTagRepository->findBy(['blog' => $blog, 'label' => 'Getting Started']));
+        self::assertCount(1, $blogPostRepository->findBy(['blog' => $blog, 'content' => 'Welcome to your application blog.']));
+        self::assertCount(1, $quizQuestionRepository->findBy(['quiz' => $quiz, 'title' => 'What is the first step to launch this app?']));
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Reduce complexity of the central provisioning service and allow per-plugin provisioning responsibilities. 
- Ensure plugin root entities remain idempotent while creating minimal business seeds for a better out-of-the-box experience. 
- Prevent repeated calls from creating duplicate sub-objects and keep provisioning safe on updates. 

### Description
- Replace in-file provisioning with per-plugin provisioner services and inject them into `ApplicationPluginProvisioningService` (`CalendarPluginProvisioner`, `ChatPluginProvisioner`, `BlogPluginProvisioner`, `QuizPluginProvisioner`).
- Each provisioner keeps root entity creation idempotent and adds a minimal domain seed: chat creates a default `Conversation`, calendar creates a `Welcome event`, blog creates a `Getting Started` tag and a welcome `BlogPost`, quiz creates a starter `QuizQuestion`.
- Add guard checks (repository lookups) to avoid re-creating the same sub-objects on subsequent provisioning calls.
- Extend integration test `tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php` to cover `POST /v1/profile/applications` for calendar/chat/blog/quiz plugins, assert seeded objects exist and verify idempotence after re-running provisioning.

### Testing
- Linted all touched PHP files with `php -l` and verified there are no syntax errors for the changed provisioners and the updated test file (success).
- Attempted to run the PHPUnit integration test but the PHPUnit binary was not available in the current environment (`./vendor/bin/phpunit` and `bin/phpunit` not found), so the PHPUnit test run could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0de58b5788326a84e5b3180083f56)