### PR TITLE
Refactor application fixtures and plugin-driven content seeding

### DIFF
--- a/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
+++ b/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
@@ -11,6 +11,7 @@ use App\Blog\Domain\Entity\BlogReaction;
 use App\Blog\Domain\Entity\BlogTag;
 use App\Blog\Domain\Enum\BlogType;
 use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\Plugin;
 use App\User\Domain\Entity\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
@@ -27,12 +28,16 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
         $johnRoot = $this->getReference('User-john-root', User::class);
         $johnAdmin = $this->getReference('User-john-admin', User::class);
         $johnUser = $this->getReference('User-john-user', User::class);
+        $blogPlugin = $this->getReference('Plugin-Knowledge-Base-Connector', Plugin::class);
 
-        $applications = [
-            $this->getReference('Application-shop-ops-center', Application::class),
-            $this->getReference('Application-crm-sales-hub', Application::class),
-            $this->getReference('Application-school-campus-core', Application::class),
-        ];
+        $applications = $manager->getRepository(Application::class)
+            ->createQueryBuilder('application')
+            ->innerJoin('application.applicationPlugins', 'applicationPlugin')
+            ->andWhere('applicationPlugin.plugin = :plugin')
+            ->setParameter('plugin', $blogPlugin)
+            ->orderBy('application.title', 'ASC')
+            ->getQuery()
+            ->getResult();
 
         $generalBlog = (new Blog())
             ->setTitle('General Blog Root')
@@ -43,6 +48,10 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
         /** @var list<Blog> $blogs */
         $blogs = [$generalBlog];
         foreach ($applications as $index => $application) {
+            if (!$application instanceof Application) {
+                continue;
+            }
+
             $blog = (new Blog())
                 ->setTitle(sprintf('Application Blog %d', $index + 1))
                 ->setOwner($johnRoot)

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
@@ -46,7 +46,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'uuid' => '60000000-0000-1000-8000-000000000001',
             'key' => 'crm-sales-hub',
             'title' => 'CRM Sales Hub',
-            'description' => 'Espace commercial pour suivre le pipeline et les opportunites.',
+            'description' => 'Workspace CRM pour piloter les leads et opportunites commerciales.',
             'status' => PlatformStatus::ACTIVE,
             'private' => false,
             'ownerReference' => 'User-john-root',
@@ -54,36 +54,23 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'appConfigurations' => [
                 [
                     'uuid' => '61000000-0000-1000-8000-000000000001',
-                    'key' => 'application.crm.theme',
+                    'key' => 'application.crm.dashboard',
                     'value' => [
-                        'theme' => 'dark',
+                        'pipelineView' => 'kanban',
+                        'timezone' => 'Europe/Paris',
                     ],
                 ],
             ],
-            'plugins' => [
-                [
-                    'uuid' => '62000000-0000-1000-8000-000000000001',
-                    'reference' => 'Plugin-CRM-Assistant',
-                    'configurations' => [
-                        [
-                            'uuid' => '63000000-0000-1000-8000-000000000001',
-                            'key' => 'plugin.crm-assistant.mode',
-                            'value' => [
-                                'assistant' => 'sales',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
+            'plugins' => [],
         ],
         [
             'uuid' => '60000000-0000-1000-8000-000000000002',
             'key' => 'crm-pipeline-pro',
             'title' => 'CRM Pipeline Pro',
-            'description' => 'Vue avancee des etapes de conversion et relances.',
+            'description' => 'Vue avancee des etapes de conversion et relances clients.',
             'status' => PlatformStatus::MAINTENANCE,
             'private' => true,
-            'ownerReference' => 'User-john-admin',
+            'ownerReference' => 'User-john-root',
             'platformReference' => 'Platform-CR-CRM 1',
             'appConfigurations' => [
                 [
@@ -97,12 +84,12 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'plugins' => [
                 [
                     'uuid' => '62000000-0000-1000-8000-000000000002',
-                    'reference' => 'Plugin-Analytics-Booster',
+                    'reference' => 'Plugin-CRM-Assistant',
                     'configurations' => [
                         [
                             'uuid' => '63000000-0000-1000-8000-000000000002',
-                            'key' => 'plugin.analytics.widgets',
-                            'value' => ['pipeline', 'wonDeals'],
+                            'key' => 'plugin.chat.channels',
+                            'value' => ['sales-war-room', 'vip-clients'],
                         ],
                     ],
                 ],
@@ -115,7 +102,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'description' => 'Gestion des demandes clients et suivi de satisfaction.',
             'status' => PlatformStatus::ACTIVE,
             'private' => false,
-            'ownerReference' => 'User-john-user',
+            'ownerReference' => 'User-john-root',
             'platformReference' => 'Platform-CR-CRM 2',
             'appConfigurations' => [
                 [
@@ -129,12 +116,23 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'plugins' => [
                 [
                     'uuid' => '62000000-0000-1000-8000-000000000003',
-                    'reference' => 'Plugin-Knowledge-Base-Connector',
+                    'reference' => 'Plugin-CRM-Assistant',
                     'configurations' => [
                         [
                             'uuid' => '63000000-0000-1000-8000-000000000003',
-                            'key' => 'plugin.kb.categories',
-                            'value' => ['support', 'faq'],
+                            'key' => 'plugin.chat.moderation',
+                            'value' => ['autoArchiveHours' => 72],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000013',
+                    'reference' => 'Plugin-Analytics-Booster',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000013',
+                            'key' => 'plugin.calendar.interviews',
+                            'value' => ['defaultDurationMinutes' => 30],
                         ],
                     ],
                 ],
@@ -165,9 +163,9 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                     'configurations' => [
                         [
                             'uuid' => '63000000-0000-1000-8000-000000000004',
-                            'key' => 'plugin.kb.sync',
+                            'key' => 'plugin.blog.publication',
                             'value' => [
-                                'intervalMinutes' => 30,
+                                'moderation' => 'pre',
                             ],
                         ],
                     ],
@@ -181,7 +179,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'description' => 'Travail sur les fiches produits et categories.',
             'status' => PlatformStatus::DISABLED,
             'private' => true,
-            'ownerReference' => 'User-john-api',
+            'ownerReference' => 'User-john-root',
             'platformReference' => 'Platform-SH-Shop Principal',
             'appConfigurations' => [
                 [
@@ -201,7 +199,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'description' => 'Suivi des commandes et incidents de paiement.',
             'status' => PlatformStatus::MAINTENANCE,
             'private' => false,
-            'ownerReference' => 'User-john-logged',
+            'ownerReference' => 'User-john-root',
             'platformReference' => 'Platform-SH-Shop Principal',
             'appConfigurations' => [
                 [
@@ -215,13 +213,26 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'plugins' => [
                 [
                     'uuid' => '62000000-0000-1000-8000-000000000006',
-                    'reference' => 'Plugin-Analytics-Booster',
+                    'reference' => 'Plugin-Knowledge-Base-Connector',
                     'configurations' => [
                         [
                             'uuid' => '63000000-0000-1000-8000-000000000006',
-                            'key' => 'plugin.analytics.orders',
+                            'key' => 'plugin.blog.orders',
                             'value' => [
                                 'daily' => true,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000014',
+                    'reference' => 'Plugin-Quiz-Master',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000014',
+                            'key' => 'plugin.quiz.learning',
+                            'value' => [
+                                'questionPool' => 'order-quality',
                             ],
                         ],
                     ],
@@ -246,7 +257,21 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                     ],
                 ],
             ],
-            'plugins' => [],
+            'plugins' => [
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000015',
+                    'reference' => 'Plugin-Quiz-Master',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000015',
+                            'key' => 'plugin.quiz.classroom',
+                            'value' => [
+                                'difficultyCurve' => 'adaptive',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ],
         [
             'uuid' => '60000000-0000-1000-8000-000000000008',
@@ -255,7 +280,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'description' => 'Flux des cours et suivi de progression pedagogique.',
             'status' => PlatformStatus::ACTIVE,
             'private' => true,
-            'ownerReference' => 'User-john-admin',
+            'ownerReference' => 'User-john-root',
             'platformReference' => 'Platform-SC-School Principal',
             'appConfigurations' => [
                 [
@@ -269,13 +294,26 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'plugins' => [
                 [
                     'uuid' => '62000000-0000-1000-8000-000000000008',
-                    'reference' => 'Plugin-Private-Beta-Plugin',
+                    'reference' => 'Plugin-Analytics-Booster',
                     'configurations' => [
                         [
                             'uuid' => '63000000-0000-1000-8000-000000000008',
-                            'key' => 'plugin.beta.flags',
+                            'key' => 'plugin.calendar.classes',
                             'value' => [
-                                'classAssistant' => true,
+                                'syncTeachers' => true,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000016',
+                    'reference' => 'Plugin-CRM-Assistant',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000016',
+                            'key' => 'plugin.chat.classrooms',
+                            'value' => [
+                                'channels' => ['classe-a', 'classe-b'],
                             ],
                         ],
                     ],
@@ -289,7 +327,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'description' => 'Saisie des notes et evaluation continue.',
             'status' => PlatformStatus::MAINTENANCE,
             'private' => false,
-            'ownerReference' => 'User-john-user',
+            'ownerReference' => 'User-john-root',
             'platformReference' => 'Platform-SC-School Principal',
             'appConfigurations' => [
                 [
@@ -327,9 +365,48 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                     'configurations' => [
                         [
                             'uuid' => '63000000-0000-1000-8000-000000000010',
-                            'key' => 'plugin.crm-assistant.recruit',
+                            'key' => 'plugin.chat.recruit',
                             'value' => [
                                 'rankingHelp' => true,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000017',
+                    'reference' => 'Plugin-Analytics-Booster',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000017',
+                            'key' => 'plugin.calendar.recruit',
+                            'value' => [
+                                'interviewSlots' => 6,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000018',
+                    'reference' => 'Plugin-Knowledge-Base-Connector',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000018',
+                            'key' => 'plugin.blog.recruit',
+                            'value' => [
+                                'editorialWorkflow' => 'team-review',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000019',
+                    'reference' => 'Plugin-Quiz-Master',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000019',
+                            'key' => 'plugin.quiz.recruit',
+                            'value' => [
+                                'skillsAssessment' => true,
                             ],
                         ],
                     ],
@@ -343,7 +420,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'description' => 'Pipeline de recrutement avec etapes de qualification.',
             'status' => PlatformStatus::ACTIVE,
             'private' => true,
-            'ownerReference' => 'User-john-admin',
+            'ownerReference' => 'User-john-root',
             'platformReference' => 'Platform-RE-Recruit Principal',
             'appConfigurations' => [
                 [
@@ -357,11 +434,11 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'plugins' => [
                 [
                     'uuid' => '62000000-0000-1000-8000-000000000011',
-                    'reference' => 'Plugin-Private-Beta-Plugin',
+                    'reference' => 'Plugin-Analytics-Booster',
                     'configurations' => [
                         [
                             'uuid' => '63000000-0000-1000-8000-000000000011',
-                            'key' => 'plugin.beta.recruit',
+                            'key' => 'plugin.calendar.pipeline',
                             'value' => [
                                 'cvParsingV2' => true,
                             ],
@@ -377,7 +454,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'description' => 'Gestion des entretiens et feedbacks candidats.',
             'status' => PlatformStatus::DISABLED,
             'private' => false,
-            'ownerReference' => 'User-john-user',
+            'ownerReference' => 'User-john-root',
             'platformReference' => 'Platform-RE-Recruit Principal',
             'appConfigurations' => [
                 [
@@ -388,8 +465,53 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                     ],
                 ],
             ],
-            'plugins' => [],
+            'plugins' => [
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000020',
+                    'reference' => 'Plugin-CRM-Assistant',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000020',
+                            'key' => 'plugin.chat.interview',
+                            'value' => [
+                                'privateThreads' => true,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000021',
+                    'reference' => 'Plugin-Knowledge-Base-Connector',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000021',
+                            'key' => 'plugin.blog.interview',
+                            'value' => [
+                                'feedbackTemplates' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ],
+    ];
+
+    /**
+     * @var array<non-empty-string, non-empty-string>
+     */
+    public static array $uuids = [
+        'crm-sales-hub' => '60000000-0000-1000-8000-000000000001',
+        'crm-pipeline-pro' => '60000000-0000-1000-8000-000000000002',
+        'crm-support-desk' => '60000000-0000-1000-8000-000000000003',
+        'shop-ops-center' => '60000000-0000-1000-8000-000000000004',
+        'shop-catalog-lab' => '60000000-0000-1000-8000-000000000005',
+        'shop-orders-watch' => '60000000-0000-1000-8000-000000000006',
+        'school-campus-core' => '60000000-0000-1000-8000-000000000007',
+        'school-course-flow' => '60000000-0000-1000-8000-000000000008',
+        'school-grade-track' => '60000000-0000-1000-8000-000000000009',
+        'recruit-talent-hub' => '60000000-0000-1000-8000-000000000010',
+        'recruit-hiring-pipeline' => '60000000-0000-1000-8000-000000000011',
+        'recruit-interview-desk' => '60000000-0000-1000-8000-000000000012',
     ];
 
     /**
@@ -477,5 +599,10 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
     public function getOrder(): int
     {
         return 7;
+    }
+
+    public static function getUuidByKey(string $key): string
+    {
+        return self::$uuids[$key];
     }
 }

--- a/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
+++ b/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
@@ -7,6 +7,7 @@ namespace App\Quiz\Infrastructure\DataFixtures\ORM;
 use App\Configuration\Domain\Entity\Configuration;
 use App\Configuration\Domain\Enum\ConfigurationScope;
 use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\Plugin;
 use App\Quiz\Domain\Entity\Quiz;
 use App\Quiz\Domain\Entity\QuizAnswer;
 use App\Quiz\Domain\Entity\QuizQuestion;
@@ -26,14 +27,22 @@ final class LoadQuizData extends Fixture implements OrderedFixtureInterface
             $this->getReference('User-john-admin', User::class),
             $this->getReference('User-john-user', User::class),
         ];
+        $quizPlugin = $this->getReference('Plugin-Quiz-Master', Plugin::class);
 
-        $applications = [
-            $this->getReference('Application-shop-ops-center', Application::class),
-            $this->getReference('Application-crm-sales-hub', Application::class),
-            $this->getReference('Application-school-campus-core', Application::class),
-        ];
+        $applications = $manager->getRepository(Application::class)
+            ->createQueryBuilder('application')
+            ->innerJoin('application.applicationPlugins', 'applicationPlugin')
+            ->andWhere('applicationPlugin.plugin = :plugin')
+            ->setParameter('plugin', $quizPlugin)
+            ->orderBy('application.title', 'ASC')
+            ->getQuery()
+            ->getResult();
 
         foreach ($applications as $applicationIndex => $application) {
+            if (!$application instanceof Application) {
+                continue;
+            }
+
             $configuration = (new Configuration())
                 ->setApplication($application)
                 ->setConfigurationKey('quiz.module.configuration')

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -14,7 +14,6 @@ use App\Chat\Domain\Entity\ChatMessageReaction;
 use App\Chat\Domain\Entity\Conversation;
 use App\Chat\Domain\Entity\ConversationParticipant;
 use App\Platform\Domain\Entity\Application as PlatformApplication;
-use App\Platform\Domain\Entity\ApplicationPlugin;
 use App\Platform\Domain\Entity\Plugin;
 use App\Recruit\Domain\Entity\Application as RecruitApplication;
 use App\Recruit\Domain\Enum\ApplicationStatus;
@@ -43,30 +42,23 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         /** @var User $johnRoot */
         $johnRoot = $this->getReference('User-john-root', User::class);
 
-        $recruitApplications = [
-            $this->getReference('Application-recruit-talent-hub', PlatformApplication::class),
-            $this->getReference('Application-recruit-hiring-pipeline', PlatformApplication::class),
-            $this->getReference('Application-recruit-interview-desk', PlatformApplication::class),
-        ];
+        $chatEnabledApplications = $this->getApplicationsByPlugin($manager, $chatPlugin);
+        $calendarEnabledApplications = $this->getApplicationsByPlugin($manager, $calendarPlugin);
 
-        foreach ($recruitApplications as $application) {
-            if (!$application instanceof PlatformApplication) {
-                continue;
-            }
-
-            $this->ensurePluginAttached($manager, $application, $chatPlugin);
-            $this->ensurePluginAttached($manager, $application, $calendarPlugin);
-
+        foreach ($chatEnabledApplications as $application) {
             $chat = $this->ensureChat($manager, $application);
-            $calendar = $this->ensureCalendar($manager, $application);
-
-            $this->ensureApplicationCalendarEvents($manager, $application, $calendar);
-            $this->ensureJohnRootPrivateEvents($manager, $application, $calendar, $johnRoot);
 
             if ($application->getTitle() === 'Recruit Talent Hub') {
+                $calendar = $this->ensureCalendar($manager, $application);
                 $this->createDiscussionConversationScenario($manager, $chat);
                 $this->createJohnRootConversationScenario($manager, $chat, $calendar);
             }
+        }
+
+        foreach ($calendarEnabledApplications as $application) {
+            $calendar = $this->ensureCalendar($manager, $application);
+            $this->ensureApplicationCalendarEvents($manager, $application, $calendar);
+            $this->ensureJohnRootPrivateEvents($manager, $application, $calendar, $johnRoot);
         }
 
         $this->createJohnRootPrivateDirectMessageScenarios($manager);
@@ -176,23 +168,22 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $this->addReference('Recruit-Conversation-direct-john-root-john-admin', $conversation);
     }
 
-    private function ensurePluginAttached(ObjectManager $manager, PlatformApplication $application, Plugin $plugin): void
+
+    /**
+     * @return list<PlatformApplication>
+     */
+    private function getApplicationsByPlugin(ObjectManager $manager, Plugin $plugin): array
     {
-        $existing = $manager->getRepository(ApplicationPlugin::class)->findOneBy([
-            'application' => $application,
-            'plugin' => $plugin,
-        ]);
+        $results = $manager->getRepository(PlatformApplication::class)
+            ->createQueryBuilder('application')
+            ->innerJoin('application.applicationPlugins', 'applicationPlugin')
+            ->andWhere('applicationPlugin.plugin = :plugin')
+            ->setParameter('plugin', $plugin)
+            ->orderBy('application.title', 'ASC')
+            ->getQuery()
+            ->getResult();
 
-        if ($existing instanceof ApplicationPlugin) {
-            return;
-        }
-
-        $applicationPlugin = (new ApplicationPlugin())
-            ->setApplication($application)
-            ->setPlugin($plugin);
-
-        $application->addApplicationPlugin($applicationPlugin);
-        $manager->persist($applicationPlugin);
+        return array_values(array_filter($results, static fn (mixed $item): bool => $item instanceof PlatformApplication));
     }
 
     private function ensureChat(ObjectManager $manager, PlatformApplication $application): Chat


### PR DESCRIPTION
### Motivation
- Provide a single, predictable fixtures matrix of 12 applications (3 per platform) with consistent ownership, plugin plans and coherent app/plugin configurations for integration testing.
- Ensure platform entities and plugin attachments can be provisioned automatically and that plugin-related fixtures (chat/calendar/blog/quiz) are only created for applications that actually have the corresponding plugin attached.
- Add stable fixture UUID lookups so tests can reference applications deterministically.

### Description
- Rebuilt `src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php` to define 12 applications owned by `User-john-root`, assign a plugin plan per app, adapt application and plugin configuration payloads, and add a stable `$uuids` map with `getUuidByKey()` for test ergonomics.
- Updated blog fixtures in `src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php` to discover applications that have `Plugin-Knowledge-Base-Connector` attached and only generate application blogs for those apps.
- Updated quiz fixtures in `src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php` to discover applications that have `Plugin-Quiz-Master` attached and only generate quiz configuration/content for those apps.
- Refactored recruit chat/calendar scenario in `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` to discover applications by plugin using a new `getApplicationsByPlugin()` helper and create chat/calendar fixtures dynamically, removing the prior on-the-fly `ensurePluginAttached` behavior.

### Testing
- Ran `php -l` on the modified files: `src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php`, `src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php`, `src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php` and `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php`, all returning no syntax errors.
- Attempted to run `php bin/console doctrine:fixtures:load --env=test -n`, which failed in this environment due to missing Composer dependencies (environment limitation), so full end-to-end fixture loading could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0dfbeb018832685e7415eb4fb11a1)