### PR TITLE
Refactor Shop mutation endpoints to explicit Messenger commands

### DIFF
--- a/src/Shop/Application/Message/CreateProductCommand.php
+++ b/src/Shop/Application/Message/CreateProductCommand.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class CreateProductCommand implements MessageHighInterface
+{
+    /**
+     * @param array<int, string> $tagIds
+     */
+    public function __construct(
+        public string $operationId,
+        public string $name,
+        public float $price,
+        public ?string $shopId = null,
+        public ?string $categoryId = null,
+        public array $tagIds = [],
+        public ?string $applicationSlug = null,
+    ) {
+    }
+}

--- a/src/Shop/Application/Message/DeleteProductCommand.php
+++ b/src/Shop/Application/Message/DeleteProductCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class DeleteProductCommand implements MessageHighInterface
+{
+    public function __construct(
+        public string $operationId,
+        public string $productId,
+    ) {
+    }
+}

--- a/src/Shop/Application/MessageHandler/CreateProductCommandHandler.php
+++ b/src/Shop/Application/MessageHandler/CreateProductCommandHandler.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\MessageHandler;
+
+use App\General\Application\Message\EntityCreated;
+use App\Shop\Application\Message\CreateProductCommand;
+use App\Shop\Domain\Entity\Category;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Domain\Entity\Tag;
+use App\Shop\Infrastructure\Repository\CategoryRepository;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Shop\Infrastructure\Repository\TagRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+final readonly class CreateProductCommandHandler
+{
+    public function __construct(
+        private ProductRepository $productRepository,
+        private ShopRepository $shopRepository,
+        private CategoryRepository $categoryRepository,
+        private TagRepository $tagRepository,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function __invoke(CreateProductCommand $command): void
+    {
+        $entityManager = $this->productRepository->getEntityManager();
+
+        $product = $entityManager->getConnection()->transactional(function () use ($command): Product {
+            $product = (new Product())
+                ->setName($command->name)
+                ->setPrice($command->price);
+
+            if ($command->shopId !== null) {
+                $shop = $this->shopRepository->find($command->shopId);
+                if ($shop === null) {
+                    throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Shop not found.');
+                }
+
+                $product->setShop($shop);
+            }
+
+            if ($command->categoryId !== null) {
+                $category = $this->categoryRepository->find($command->categoryId);
+                if (!$category instanceof Category) {
+                    throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Category not found.');
+                }
+
+                if ($command->shopId !== null && $category->getShop()?->getId() !== $command->shopId) {
+                    throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Category does not belong to this shop.');
+                }
+
+                $product->setCategory($category);
+            }
+
+            foreach ($command->tagIds as $tagId) {
+                $tag = $this->tagRepository->find($tagId);
+                if ($tag instanceof Tag) {
+                    $product->addTag($tag);
+                }
+            }
+
+            $this->productRepository->save($product);
+
+            return $product;
+        });
+
+        $this->messageBus->dispatch(new EntityCreated('shop_product', $product->getId(), context: [
+            'operationId' => $command->operationId,
+            'applicationSlug' => $command->applicationSlug,
+        ]));
+    }
+}

--- a/src/Shop/Application/MessageHandler/DeleteProductCommandHandler.php
+++ b/src/Shop/Application/MessageHandler/DeleteProductCommandHandler.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\MessageHandler;
+
+use App\General\Application\Message\EntityDeleted;
+use App\Shop\Application\Message\DeleteProductCommand;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+final readonly class DeleteProductCommandHandler
+{
+    public function __construct(
+        private ProductRepository $productRepository,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function __invoke(DeleteProductCommand $command): void
+    {
+        $entityManager = $this->productRepository->getEntityManager();
+
+        $entityManager->getConnection()->transactional(function () use ($command): void {
+            $product = $this->productRepository->find($command->productId);
+            if (!$product instanceof Product) {
+                return;
+            }
+
+            $this->productRepository->remove($product);
+        });
+
+        $this->messageBus->dispatch(new EntityDeleted('shop_product', $command->productId, context: [
+            'operationId' => $command->operationId,
+        ]));
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/ShopController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ShopController.php
@@ -6,12 +6,14 @@ namespace App\Shop\Transport\Controller\Api\V1;
 
 use App\General\Application\Message\EntityCreated;
 use App\General\Application\Message\EntityDeleted;
+use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PlatformKey;
+use App\Shop\Application\Message\CreateProductCommand;
+use App\Shop\Application\Message\DeleteProductCommand;
 use App\Shop\Application\Service\ProductApplicationListService;
 use App\Shop\Application\Service\ProductListService;
 use App\Shop\Domain\Entity\Category;
-use App\Shop\Domain\Entity\Product;
 use App\Shop\Domain\Entity\Shop;
 use App\Shop\Domain\Entity\Tag;
 use App\Shop\Infrastructure\Repository\CategoryRepository;
@@ -45,6 +47,7 @@ final readonly class ShopController
         private ProductApplicationListService $productApplicationListService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
+        private MessageServiceInterface $messageService,
         private Security $security,
     ) {
     }
@@ -68,43 +71,34 @@ final readonly class ShopController
     {
         $payload = (array)json_decode((string)$request->getContent(), true);
 
-        $product = new Product();
-        $product->setName((string)($payload['name'] ?? ''))->setPrice((float)($payload['price'] ?? 0));
-
-        if (is_string($payload['shopId'] ?? null)) {
-            $product->setShop($this->shopRepository->find($payload['shopId']));
-        }
-        if (is_string($payload['categoryId'] ?? null)) {
-            $product->setCategory($this->categoryRepository->find($payload['categoryId']));
-        }
-        foreach ((array)($payload['tagIds'] ?? []) as $tagId) {
-            if (is_string($tagId) && ($tag = $this->tagRepository->find($tagId)) instanceof Tag) {
-                $product->addTag($tag);
-            }
-        }
-
-        $this->entityManager->persist($product);
-        $this->entityManager->flush();
-        $this->messageBus->dispatch(new EntityCreated('shop_product', $product->getId()));
+        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        $this->messageService->sendMessage(new CreateProductCommand(
+            operationId: $operationId,
+            name: (string)($payload['name'] ?? ''),
+            price: (float)($payload['price'] ?? 0),
+            shopId: is_string($payload['shopId'] ?? null) ? $payload['shopId'] : null,
+            categoryId: is_string($payload['categoryId'] ?? null) ? $payload['categoryId'] : null,
+            tagIds: array_values(array_filter((array)($payload['tagIds'] ?? []), is_string(...))),
+        ));
 
         return new JsonResponse([
-            'id' => $product->getId(),
-        ], JsonResponse::HTTP_CREATED);
+            'operationId' => $operationId,
+        ], JsonResponse::HTTP_ACCEPTED);
     }
 
     #[Route('/v1/shop/products/{id}', methods: [Request::METHOD_DELETE])]
     public function deleteProduct(string $id): JsonResponse
     {
-        $product = $this->productRepository->find($id);
-        if (!$product instanceof Product) {
-            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
-        }
+        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        $this->messageService->sendMessage(new DeleteProductCommand(
+            operationId: $operationId,
+            productId: $id,
+        ));
 
-        $this->entityManager->remove($product);
-        $this->entityManager->flush();
-        $this->messageBus->dispatch(new EntityDeleted('shop_product', $id));
-
-        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+        return new JsonResponse([
+            'operationId' => $operationId,
+            'id' => $id,
+        ], JsonResponse::HTTP_ACCEPTED);
     }
 
     #[Route('/v1/shop/categories', methods: [Request::METHOD_GET])]
@@ -253,35 +247,22 @@ final readonly class ShopController
         $shop = $this->resolveOrCreateShopByApplicationSlug($applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
 
-        $product = (new Product())
-            ->setShop($shop)
-            ->setName((string)($payload['name'] ?? ''))
-            ->setPrice((float)($payload['price'] ?? 0));
-
-        if (is_string($payload['categoryId'] ?? null)) {
-            $category = $this->categoryRepository->find($payload['categoryId']);
-            if ($category instanceof Category && $category->getShop()?->getId() === $shop->getId()) {
-                $product->setCategory($category);
-            }
-        }
-
-        foreach ((array)($payload['tagIds'] ?? []) as $tagId) {
-            if (is_string($tagId) && ($tag = $this->tagRepository->find($tagId)) instanceof Tag) {
-                $product->addTag($tag);
-            }
-        }
-
-        $this->entityManager->persist($product);
-        $this->entityManager->flush();
-        $this->messageBus->dispatch(new EntityCreated('shop_product', $product->getId(), context: [
-            'applicationSlug' => $applicationSlug,
-        ]));
+        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        $this->messageService->sendMessage(new CreateProductCommand(
+            operationId: $operationId,
+            name: (string)($payload['name'] ?? ''),
+            price: (float)($payload['price'] ?? 0),
+            shopId: $shop->getId(),
+            categoryId: is_string($payload['categoryId'] ?? null) ? $payload['categoryId'] : null,
+            tagIds: array_values(array_filter((array)($payload['tagIds'] ?? []), is_string(...))),
+            applicationSlug: $applicationSlug,
+        ));
 
         return new JsonResponse([
-            'id' => $product->getId(),
+            'operationId' => $operationId,
             'shopId' => $shop->getId(),
             'applicationSlug' => $applicationSlug,
-        ], JsonResponse::HTTP_CREATED);
+        ], JsonResponse::HTTP_ACCEPTED);
     }
 
     private function resolveOrCreateShopByApplicationSlug(string $applicationSlug): Shop

--- a/tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php
+++ b/tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Shop\Transport\Controller\Api\V1;
+
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Tests\TestCase\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ShopMutationControllerTest extends WebTestCase
+{
+    public function testCreateProductDispatchesCommandAndPersistsEntity(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/products',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'name' => 'Messenger Product',
+                'price' => 12.34,
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(202);
+
+        /** @var array{operationId: string} $payload */
+        $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('operationId', $payload);
+        self::assertNotSame('', $payload['operationId']);
+
+        /** @var ProductRepository $productRepository */
+        $productRepository = static::getContainer()->get(ProductRepository::class);
+        $products = $productRepository->findBy(['name' => 'Messenger Product']);
+
+        self::assertNotEmpty($products);
+    }
+
+    public function testDeleteProductDispatchesCommandAndRemovesEntity(): void
+    {
+        /** @var ProductRepository $productRepository */
+        $productRepository = static::getContainer()->get(ProductRepository::class);
+        $product = $productRepository->findBy(['name' => 'Messenger Product'])[0] ?? null;
+        self::assertNotNull($product);
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request(
+            Request::METHOD_DELETE,
+            self::API_URL_PREFIX . '/v1/shop/products/' . $product->getId(),
+            [],
+            [],
+            $this->getJsonHeaders(),
+        );
+
+        self::assertResponseStatusCodeSame(202);
+
+        /** @var array{operationId: string, id: string} $payload */
+        $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame($product->getId(), $payload['id']);
+        self::assertArrayHasKey('operationId', $payload);
+
+        self::assertNull($productRepository->find($product->getId()));
+    }
+}


### PR DESCRIPTION
### Motivation
- Move product mutation business logic out of controllers into Messenger handlers to keep controllers thin and focused on input validation and dispatch.
- Introduce explicit command messages to make mutation intents explicit (`CreateProductCommand`, `DeleteProductCommand`).
- Centralize transactional database handling and event publishing in handlers so persistence and projection/cache invalidation are colocated.
- Add functional tests to cover the dispatch path and the actual DB effects of mutations.

### Description
- Added command classes `CreateProductCommand` and `DeleteProductCommand` in `src/Shop/Application/Message` to represent mutation intent.
- Implemented `CreateProductCommandHandler` and `DeleteProductCommandHandler` in `src/Shop/Application/MessageHandler` that contain transactional persistence logic and publish `EntityCreated` / `EntityDeleted` events via the message bus.
- Slimmed `ShopController` mutation endpoints (`createProduct`, `createProductByApplication`, `deleteProduct`) to parse input, dispatch the appropriate command via `MessageServiceInterface`, generate an `operationId`, and return `202 Accepted` with operation metadata.
- Added functional tests `tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php` that assert the controller returns `202` and that products are persisted/removed in the database.
- Adjusted DI and imports in `ShopController` to use `MessageServiceInterface` for high-level message dispatching.

### Testing
- Ran `php -l` (syntax check) on all modified and newly added PHP files and they passed without syntax errors.
- Created functional PHPUnit tests for the Shop mutation flow but full test execution could not be run in this environment because project test dependencies (`vendor` / tools) are not installed, so `phpunit` was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e3371dbc8326ac516caf061066ac)