### PR TITLE
Refactor CRM module: richer entities, enums, fixtures and API improvements

### DIFF
--- a/migrations/Version20260311160000.php
+++ b/migrations/Version20260311160000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260311160000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Enhance CRM schema with enums and additional fields for company/project/sprint/task/task_request';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_company ADD industry VARCHAR(120) DEFAULT NULL, ADD website VARCHAR(255) DEFAULT NULL, ADD contact_email VARCHAR(255) DEFAULT NULL, ADD phone VARCHAR(60) DEFAULT NULL');
+
+        $this->addSql("ALTER TABLE crm_project ADD code VARCHAR(80) DEFAULT NULL, ADD description LONGTEXT DEFAULT NULL, ADD status VARCHAR(25) DEFAULT 'planned' NOT NULL, ADD started_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', ADD due_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)'");
+
+        $this->addSql("ALTER TABLE crm_sprint ADD goal LONGTEXT DEFAULT NULL, ADD start_date DATE DEFAULT NULL COMMENT '(DC2Type:date_immutable)', ADD end_date DATE DEFAULT NULL COMMENT '(DC2Type:date_immutable)', ADD status VARCHAR(25) DEFAULT 'planned' NOT NULL");
+
+        $this->addSql("ALTER TABLE crm_task ADD description LONGTEXT DEFAULT NULL, ADD status VARCHAR(25) DEFAULT 'todo' NOT NULL, ADD priority VARCHAR(25) DEFAULT 'medium' NOT NULL, ADD due_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', ADD estimated_hours DOUBLE PRECISION DEFAULT NULL");
+
+        $this->addSql("ALTER TABLE crm_task_request ADD description LONGTEXT DEFAULT NULL, ADD requested_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', ADD resolved_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)'");
+        $this->addSql("UPDATE crm_task_request SET requested_at = created_at WHERE requested_at IS NULL");
+        $this->addSql("ALTER TABLE crm_task_request CHANGE requested_at requested_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_company DROP industry, DROP website, DROP contact_email, DROP phone');
+        $this->addSql('ALTER TABLE crm_project DROP code, DROP description, DROP status, DROP started_at, DROP due_at');
+        $this->addSql('ALTER TABLE crm_sprint DROP goal, DROP start_date, DROP end_date, DROP status');
+        $this->addSql('ALTER TABLE crm_task DROP description, DROP status, DROP priority, DROP due_at, DROP estimated_hours');
+        $this->addSql('ALTER TABLE crm_task_request DROP description, DROP requested_at, DROP resolved_at');
+    }
+}

--- a/src/Crm/Application/Service/CompanyApplicationListService.php
+++ b/src/Crm/Application/Service/CompanyApplicationListService.php
@@ -49,6 +49,10 @@ readonly class CompanyApplicationListService
             $items = array_map(static fn (Company $company): array => [
                 'id' => $company->getId(),
                 'name' => $company->getName(),
+                'industry' => $company->getIndustry(),
+                'website' => $company->getWebsite(),
+                'contactEmail' => $company->getContactEmail(),
+                'phone' => $company->getPhone(),
             ], $qb->getQuery()->getResult());
 
             $countQb = $this->companyRepository->createQueryBuilder('company')

--- a/src/Crm/Application/Service/TaskListService.php
+++ b/src/Crm/Application/Service/TaskListService.php
@@ -35,6 +35,8 @@ readonly class TaskListService
         $filters = [
             'q' => trim((string)$request->query->get('q', '')),
             'title' => trim((string)$request->query->get('title', '')),
+            'status' => trim((string)$request->query->get('status', '')),
+            'priority' => trim((string)$request->query->get('priority', '')),
         ];
         $cacheKey = $this->cacheKeyConventionService->buildCrmTaskListKey($page, $limit, $filters);
 
@@ -64,6 +66,12 @@ readonly class TaskListService
             if ($filters['title'] !== '') {
                 $qb->andWhere('LOWER(task.title) LIKE LOWER(:title)')->setParameter('title', '%' . $filters['title'] . '%');
             }
+            if ($filters['status'] !== '') {
+                $qb->andWhere('task.status = :status')->setParameter('status', $filters['status']);
+            }
+            if ($filters['priority'] !== '') {
+                $qb->andWhere('task.priority = :priority')->setParameter('priority', $filters['priority']);
+            }
             if ($esIds !== null) {
                 $qb->andWhere('task.id IN (:ids)')->setParameter('ids', $esIds);
             }
@@ -75,12 +83,22 @@ readonly class TaskListService
                 'projectName' => $task->getProject()?->getName(),
                 'sprintId' => $task->getSprint()?->getId(),
                 'sprintName' => $task->getSprint()?->getName(),
+                'status' => $task->getStatus()->value,
+                'priority' => $task->getPriority()->value,
+                'dueAt' => $task->getDueAt()?->format(DATE_ATOM),
+                'estimatedHours' => $task->getEstimatedHours(),
                 'updatedAt' => $task->getUpdatedAt()?->format(DATE_ATOM),
             ], $qb->getQuery()->getResult());
 
             $countQb = $this->taskRepository->createQueryBuilder('task')->select('COUNT(task.id)');
             if ($filters['title'] !== '') {
                 $countQb->andWhere('LOWER(task.title) LIKE LOWER(:title)')->setParameter('title', '%' . $filters['title'] . '%');
+            }
+            if ($filters['status'] !== '') {
+                $countQb->andWhere('task.status = :status')->setParameter('status', $filters['status']);
+            }
+            if ($filters['priority'] !== '') {
+                $countQb->andWhere('task.priority = :priority')->setParameter('priority', $filters['priority']);
             }
             if ($esIds !== null) {
                 $countQb->andWhere('task.id IN (:ids)')->setParameter('ids', $esIds);

--- a/src/Crm/Domain/Entity/Company.php
+++ b/src/Crm/Domain/Entity/Company.php
@@ -34,6 +34,18 @@ class Company implements EntityInterface
     #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
     private string $name = '';
 
+    #[ORM\Column(name: 'industry', type: Types::STRING, length: 120, nullable: true)]
+    private ?string $industry = null;
+
+    #[ORM\Column(name: 'website', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $website = null;
+
+    #[ORM\Column(name: 'contact_email', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $contactEmail = null;
+
+    #[ORM\Column(name: 'phone', type: Types::STRING, length: 60, nullable: true)]
+    private ?string $phone = null;
+
     /** @var Collection<int, Project>|ArrayCollection<int, Project> */
     #[ORM\OneToMany(targetEntity: Project::class, mappedBy: 'company')]
     private Collection|ArrayCollection $projects;
@@ -49,23 +61,75 @@ class Company implements EntityInterface
     {
         return $this->id->toString();
     }
+
     public function getCrm(): ?Crm
     {
         return $this->crm;
     }
+
     public function setCrm(?Crm $crm): self
     {
         $this->crm = $crm;
 
         return $this;
     }
+
     public function getName(): string
     {
         return $this->name;
     }
+
     public function setName(string $name): self
     {
         $this->name = $name;
+
+        return $this;
+    }
+
+    public function getIndustry(): ?string
+    {
+        return $this->industry;
+    }
+
+    public function setIndustry(?string $industry): self
+    {
+        $this->industry = $industry;
+
+        return $this;
+    }
+
+    public function getWebsite(): ?string
+    {
+        return $this->website;
+    }
+
+    public function setWebsite(?string $website): self
+    {
+        $this->website = $website;
+
+        return $this;
+    }
+
+    public function getContactEmail(): ?string
+    {
+        return $this->contactEmail;
+    }
+
+    public function setContactEmail(?string $contactEmail): self
+    {
+        $this->contactEmail = $contactEmail;
+
+        return $this;
+    }
+
+    public function getPhone(): ?string
+    {
+        return $this->phone;
+    }
+
+    public function setPhone(?string $phone): self
+    {
+        $this->phone = $phone;
 
         return $this;
     }

--- a/src/Crm/Domain/Entity/Project.php
+++ b/src/Crm/Domain/Entity/Project.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Crm\Domain\Entity;
 
+use App\Crm\Domain\Enum\ProjectStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -34,6 +36,21 @@ class Project implements EntityInterface
     #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
     private string $name = '';
 
+    #[ORM\Column(name: 'code', type: Types::STRING, length: 80, nullable: true)]
+    private ?string $code = null;
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 25, enumType: ProjectStatus::class, options: ['default' => ProjectStatus::PLANNED->value])]
+    private ProjectStatus $status = ProjectStatus::PLANNED;
+
+    #[ORM\Column(name: 'started_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $startedAt = null;
+
+    #[ORM\Column(name: 'due_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $dueAt = null;
+
     /** @var Collection<int, Task>|ArrayCollection<int, Task> */
     #[ORM\OneToMany(targetEntity: Task::class, mappedBy: 'project')]
     private Collection|ArrayCollection $tasks;
@@ -54,23 +71,87 @@ class Project implements EntityInterface
     {
         return $this->id->toString();
     }
+
     public function getCompany(): ?Company
     {
         return $this->company;
     }
+
     public function setCompany(?Company $company): self
     {
         $this->company = $company;
 
         return $this;
     }
+
     public function getName(): string
     {
         return $this->name;
     }
+
     public function setName(string $name): self
     {
         $this->name = $name;
+
+        return $this;
+    }
+
+    public function getCode(): ?string
+    {
+        return $this->code;
+    }
+
+    public function setCode(?string $code): self
+    {
+        $this->code = $code;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getStatus(): ProjectStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(ProjectStatus $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getStartedAt(): ?DateTimeImmutable
+    {
+        return $this->startedAt;
+    }
+
+    public function setStartedAt(?DateTimeImmutable $startedAt): self
+    {
+        $this->startedAt = $startedAt;
+
+        return $this;
+    }
+
+    public function getDueAt(): ?DateTimeImmutable
+    {
+        return $this->dueAt;
+    }
+
+    public function setDueAt(?DateTimeImmutable $dueAt): self
+    {
+        $this->dueAt = $dueAt;
 
         return $this;
     }
@@ -82,6 +163,7 @@ class Project implements EntityInterface
     {
         return $this->tasks;
     }
+
     /**
      * @return Collection<int, Sprint>|ArrayCollection<int, Sprint>
      */

--- a/src/Crm/Domain/Entity/Sprint.php
+++ b/src/Crm/Domain/Entity/Sprint.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Crm\Domain\Entity;
 
+use App\Crm\Domain\Enum\SprintStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -34,6 +36,18 @@ class Sprint implements EntityInterface
     #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
     private string $name = '';
 
+    #[ORM\Column(name: 'goal', type: Types::TEXT, nullable: true)]
+    private ?string $goal = null;
+
+    #[ORM\Column(name: 'start_date', type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $startDate = null;
+
+    #[ORM\Column(name: 'end_date', type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $endDate = null;
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 25, enumType: SprintStatus::class, options: ['default' => SprintStatus::PLANNED->value])]
+    private SprintStatus $status = SprintStatus::PLANNED;
+
     /** @var Collection<int, Task>|ArrayCollection<int, Task> */
     #[ORM\OneToMany(targetEntity: Task::class, mappedBy: 'sprint')]
     private Collection|ArrayCollection $tasks;
@@ -49,23 +63,75 @@ class Sprint implements EntityInterface
     {
         return $this->id->toString();
     }
+
     public function getProject(): ?Project
     {
         return $this->project;
     }
+
     public function setProject(?Project $project): self
     {
         $this->project = $project;
 
         return $this;
     }
+
     public function getName(): string
     {
         return $this->name;
     }
+
     public function setName(string $name): self
     {
         $this->name = $name;
+
+        return $this;
+    }
+
+    public function getGoal(): ?string
+    {
+        return $this->goal;
+    }
+
+    public function setGoal(?string $goal): self
+    {
+        $this->goal = $goal;
+
+        return $this;
+    }
+
+    public function getStartDate(): ?DateTimeImmutable
+    {
+        return $this->startDate;
+    }
+
+    public function setStartDate(?DateTimeImmutable $startDate): self
+    {
+        $this->startDate = $startDate;
+
+        return $this;
+    }
+
+    public function getEndDate(): ?DateTimeImmutable
+    {
+        return $this->endDate;
+    }
+
+    public function setEndDate(?DateTimeImmutable $endDate): self
+    {
+        $this->endDate = $endDate;
+
+        return $this;
+    }
+
+    public function getStatus(): SprintStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(SprintStatus $status): self
+    {
+        $this->status = $status;
 
         return $this;
     }

--- a/src/Crm/Domain/Entity/Task.php
+++ b/src/Crm/Domain/Entity/Task.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Crm\Domain\Entity;
 
+use App\Crm\Domain\Enum\TaskPriority;
+use App\Crm\Domain\Enum\TaskStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -38,6 +41,21 @@ class Task implements EntityInterface
     #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
     private string $title = '';
 
+    #[ORM\Column(name: 'description', type: Types::TEXT, nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 25, enumType: TaskStatus::class, options: ['default' => TaskStatus::TODO->value])]
+    private TaskStatus $status = TaskStatus::TODO;
+
+    #[ORM\Column(name: 'priority', type: Types::STRING, length: 25, enumType: TaskPriority::class, options: ['default' => TaskPriority::MEDIUM->value])]
+    private TaskPriority $priority = TaskPriority::MEDIUM;
+
+    #[ORM\Column(name: 'due_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $dueAt = null;
+
+    #[ORM\Column(name: 'estimated_hours', type: Types::FLOAT, nullable: true)]
+    private ?float $estimatedHours = null;
+
     /** @var Collection<int, TaskRequest>|ArrayCollection<int, TaskRequest> */
     #[ORM\OneToMany(targetEntity: TaskRequest::class, mappedBy: 'task')]
     private Collection|ArrayCollection $taskRequests;
@@ -53,33 +71,99 @@ class Task implements EntityInterface
     {
         return $this->id->toString();
     }
+
     public function getProject(): ?Project
     {
         return $this->project;
     }
+
     public function setProject(?Project $project): self
     {
         $this->project = $project;
 
         return $this;
     }
+
     public function getSprint(): ?Sprint
     {
         return $this->sprint;
     }
+
     public function setSprint(?Sprint $sprint): self
     {
         $this->sprint = $sprint;
 
         return $this;
     }
+
     public function getTitle(): string
     {
         return $this->title;
     }
+
     public function setTitle(string $title): self
     {
         $this->title = $title;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getStatus(): TaskStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(TaskStatus $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getPriority(): TaskPriority
+    {
+        return $this->priority;
+    }
+
+    public function setPriority(TaskPriority $priority): self
+    {
+        $this->priority = $priority;
+
+        return $this;
+    }
+
+    public function getDueAt(): ?DateTimeImmutable
+    {
+        return $this->dueAt;
+    }
+
+    public function setDueAt(?DateTimeImmutable $dueAt): self
+    {
+        $this->dueAt = $dueAt;
+
+        return $this;
+    }
+
+    public function getEstimatedHours(): ?float
+    {
+        return $this->estimatedHours;
+    }
+
+    public function setEstimatedHours(?float $estimatedHours): self
+    {
+        $this->estimatedHours = $estimatedHours;
 
         return $this;
     }

--- a/src/Crm/Domain/Entity/TaskRequest.php
+++ b/src/Crm/Domain/Entity/TaskRequest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Crm\Domain\Entity;
 
+use App\Crm\Domain\Enum\TaskRequestStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
@@ -32,14 +34,24 @@ class TaskRequest implements EntityInterface
     #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
     private string $title = '';
 
-    #[ORM\Column(name: 'status', type: Types::STRING, length: 50, options: [
-        'default' => 'pending',
+    #[ORM\Column(name: 'description', type: Types::TEXT, nullable: true)]
+    private ?string $description = null;
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 50, enumType: TaskRequestStatus::class, options: [
+        'default' => TaskRequestStatus::PENDING->value,
     ])]
-    private string $status = 'pending';
+    private TaskRequestStatus $status = TaskRequestStatus::PENDING;
+
+    #[ORM\Column(name: 'requested_at', type: Types::DATETIME_IMMUTABLE)]
+    private DateTimeImmutable $requestedAt;
+
+    #[ORM\Column(name: 'resolved_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $resolvedAt = null;
 
     public function __construct()
     {
         $this->id = $this->createUuid();
+        $this->requestedAt = new DateTimeImmutable();
     }
 
     #[Override]
@@ -47,33 +59,75 @@ class TaskRequest implements EntityInterface
     {
         return $this->id->toString();
     }
+
     public function getTask(): ?Task
     {
         return $this->task;
     }
+
     public function setTask(?Task $task): self
     {
         $this->task = $task;
 
         return $this;
     }
+
     public function getTitle(): string
     {
         return $this->title;
     }
+
     public function setTitle(string $title): self
     {
         $this->title = $title;
 
         return $this;
     }
-    public function getStatus(): string
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getStatus(): TaskRequestStatus
     {
         return $this->status;
     }
-    public function setStatus(string $status): self
+
+    public function setStatus(TaskRequestStatus $status): self
     {
         $this->status = $status;
+
+        return $this;
+    }
+
+    public function getRequestedAt(): DateTimeImmutable
+    {
+        return $this->requestedAt;
+    }
+
+    public function setRequestedAt(DateTimeImmutable $requestedAt): self
+    {
+        $this->requestedAt = $requestedAt;
+
+        return $this;
+    }
+
+    public function getResolvedAt(): ?DateTimeImmutable
+    {
+        return $this->resolvedAt;
+    }
+
+    public function setResolvedAt(?DateTimeImmutable $resolvedAt): self
+    {
+        $this->resolvedAt = $resolvedAt;
 
         return $this;
     }

--- a/src/Crm/Domain/Enum/ProjectStatus.php
+++ b/src/Crm/Domain/Enum/ProjectStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Domain\Enum;
+
+enum ProjectStatus: string
+{
+    case PLANNED = 'planned';
+    case ACTIVE = 'active';
+    case ON_HOLD = 'on_hold';
+    case COMPLETED = 'completed';
+}
+

--- a/src/Crm/Domain/Enum/SprintStatus.php
+++ b/src/Crm/Domain/Enum/SprintStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Domain\Enum;
+
+enum SprintStatus: string
+{
+    case PLANNED = 'planned';
+    case ACTIVE = 'active';
+    case CLOSED = 'closed';
+}

--- a/src/Crm/Domain/Enum/TaskPriority.php
+++ b/src/Crm/Domain/Enum/TaskPriority.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Domain\Enum;
+
+enum TaskPriority: string
+{
+    case LOW = 'low';
+    case MEDIUM = 'medium';
+    case HIGH = 'high';
+    case CRITICAL = 'critical';
+}

--- a/src/Crm/Domain/Enum/TaskRequestStatus.php
+++ b/src/Crm/Domain/Enum/TaskRequestStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Domain\Enum;
+
+enum TaskRequestStatus: string
+{
+    case PENDING = 'pending';
+    case APPROVED = 'approved';
+    case REJECTED = 'rejected';
+}

--- a/src/Crm/Domain/Enum/TaskStatus.php
+++ b/src/Crm/Domain/Enum/TaskStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Domain\Enum;
+
+enum TaskStatus: string
+{
+    case TODO = 'todo';
+    case IN_PROGRESS = 'in_progress';
+    case BLOCKED = 'blocked';
+    case DONE = 'done';
+}

--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -10,8 +10,14 @@ use App\Crm\Domain\Entity\Project;
 use App\Crm\Domain\Entity\Sprint;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Domain\Enum\ProjectStatus;
+use App\Crm\Domain\Enum\SprintStatus;
+use App\Crm\Domain\Enum\TaskPriority;
+use App\Crm\Domain\Enum\TaskRequestStatus;
+use App\Crm\Domain\Enum\TaskStatus;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PlatformKey;
+use DateTimeImmutable;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -38,8 +44,20 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
             $manager->persist($crm);
 
             $companies = [
-                (new Company())->setCrm($crm)->setName($application->getTitle() . ' - Acme Corp'),
-                (new Company())->setCrm($crm)->setName($application->getTitle() . ' - Globex'),
+                (new Company())
+                    ->setCrm($crm)
+                    ->setName($application->getTitle() . ' - Acme Corp')
+                    ->setIndustry('SaaS')
+                    ->setWebsite('https://acme.example.com')
+                    ->setContactEmail('contact@acme.example.com')
+                    ->setPhone('+33 1 00 00 00 00'),
+                (new Company())
+                    ->setCrm($crm)
+                    ->setName($application->getTitle() . ' - Globex')
+                    ->setIndustry('Consulting')
+                    ->setWebsite('https://globex.example.com')
+                    ->setContactEmail('sales@globex.example.com')
+                    ->setPhone('+33 1 11 11 11 11'),
             ];
 
             foreach ($companies as $companyIndex => $company) {
@@ -47,22 +65,41 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
 
                 $project = (new Project())
                     ->setCompany($company)
-                    ->setName($company->getName() . ' - Projet Transformation');
+                    ->setName($company->getName() . ' - Projet Transformation')
+                    ->setCode('PRJ-' . (string)($companyIndex + 1))
+                    ->setDescription('Optimisation du pipeline CRM et outillage commercial')
+                    ->setStatus(ProjectStatus::ACTIVE)
+                    ->setStartedAt(new DateTimeImmutable('-12 days'))
+                    ->setDueAt(new DateTimeImmutable('+60 days'));
                 $manager->persist($project);
 
                 $sprint = (new Sprint())
                     ->setProject($project)
-                    ->setName('Sprint ' . (string)($companyIndex + 1));
+                    ->setName('Sprint ' . (string)($companyIndex + 1))
+                    ->setGoal('Livrer les automatisations de relance')
+                    ->setStatus(SprintStatus::ACTIVE)
+                    ->setStartDate(new DateTimeImmutable('-7 days'))
+                    ->setEndDate(new DateTimeImmutable('+7 days'));
                 $manager->persist($sprint);
 
                 $taskBacklog = (new Task())
                     ->setProject($project)
                     ->setSprint($sprint)
-                    ->setTitle('Consolider le backlog');
+                    ->setTitle('Consolider le backlog')
+                    ->setDescription('Rassembler toutes les opportunités dans un backlog unique')
+                    ->setStatus(TaskStatus::IN_PROGRESS)
+                    ->setPriority(TaskPriority::HIGH)
+                    ->setDueAt(new DateTimeImmutable('+10 days'))
+                    ->setEstimatedHours(12.5);
                 $taskAutomation = (new Task())
                     ->setProject($project)
                     ->setSprint($sprint)
-                    ->setTitle('Automatiser les relances');
+                    ->setTitle('Automatiser les relances')
+                    ->setDescription('Créer les séquences mails selon la probabilité de closing')
+                    ->setStatus(TaskStatus::TODO)
+                    ->setPriority(TaskPriority::CRITICAL)
+                    ->setDueAt(new DateTimeImmutable('+5 days'))
+                    ->setEstimatedHours(18.0);
 
                 $manager->persist($taskBacklog);
                 $manager->persist($taskAutomation);
@@ -71,14 +108,17 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                     (new TaskRequest())
                         ->setTask($taskBacklog)
                         ->setTitle('Prioriser les leads chauds')
-                        ->setStatus('pending'),
+                        ->setDescription('Ajouter une règle SLA pour les leads > 80%')
+                        ->setStatus(TaskRequestStatus::PENDING),
                 );
 
                 $manager->persist(
                     (new TaskRequest())
                         ->setTask($taskAutomation)
                         ->setTitle('Valider le workflow de notifications')
-                        ->setStatus('approved'),
+                        ->setDescription('Valider la conformité RGPD avant diffusion')
+                        ->setStatus(TaskRequestStatus::APPROVED)
+                        ->setResolvedAt(new DateTimeImmutable('-1 day')),
                 );
             }
         }

--- a/src/Crm/Transport/Controller/Api/V1/CrmController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CrmController.php
@@ -12,6 +12,11 @@ use App\Crm\Domain\Entity\Project;
 use App\Crm\Domain\Entity\Sprint;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Domain\Enum\ProjectStatus;
+use App\Crm\Domain\Enum\SprintStatus;
+use App\Crm\Domain\Enum\TaskPriority;
+use App\Crm\Domain\Enum\TaskRequestStatus;
+use App\Crm\Domain\Enum\TaskStatus;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Infrastructure\Repository\CrmRepository;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
@@ -23,6 +28,7 @@ use App\General\Application\Message\EntityDeleted;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PlatformKey;
 use App\User\Domain\Entity\User;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -61,6 +67,10 @@ final readonly class CrmController
         $items = array_map(static fn (Company $company): array => [
             'id' => $company->getId(),
             'name' => $company->getName(),
+            'industry' => $company->getIndustry(),
+            'website' => $company->getWebsite(),
+            'contactEmail' => $company->getContactEmail(),
+            'phone' => $company->getPhone(),
         ], $this->companyRepository->findBy([], [
             'createdAt' => 'DESC',
         ], 200));
@@ -83,7 +93,11 @@ final readonly class CrmController
     {
         $payload = (array)json_decode((string)$request->getContent(), true);
         $company = new Company();
-        $company->setName((string)($payload['name'] ?? ''));
+        $company->setName((string)($payload['name'] ?? ''))
+            ->setIndustry(isset($payload['industry']) ? (string)$payload['industry'] : null)
+            ->setWebsite(isset($payload['website']) ? (string)$payload['website'] : null)
+            ->setContactEmail(isset($payload['contactEmail']) ? (string)$payload['contactEmail'] : null)
+            ->setPhone(isset($payload['phone']) ? (string)$payload['phone'] : null);
         if (is_string($payload['crmId'] ?? null)) {
             $company->setCrm($this->crmRepository->find($payload['crmId']));
         }
@@ -119,6 +133,10 @@ final readonly class CrmController
             'id' => $project->getId(),
             'name' => $project->getName(),
             'companyId' => $project->getCompany()?->getId(),
+            'code' => $project->getCode(),
+            'status' => $project->getStatus()->value,
+            'startedAt' => $project->getStartedAt()?->format(DATE_ATOM),
+            'dueAt' => $project->getDueAt()?->format(DATE_ATOM),
         ], $this->projectRepository->findBy([], [
             'createdAt' => 'DESC',
         ], 200));
@@ -141,7 +159,12 @@ final readonly class CrmController
     {
         $payload = (array)json_decode((string)$request->getContent(), true);
         $project = new Project();
-        $project->setName((string)($payload['name'] ?? ''));
+        $project->setName((string)($payload['name'] ?? ''))
+            ->setCode(isset($payload['code']) ? (string)$payload['code'] : null)
+            ->setDescription(isset($payload['description']) ? (string)$payload['description'] : null)
+            ->setStatus(ProjectStatus::tryFrom((string)($payload['status'] ?? '')) ?? ProjectStatus::PLANNED)
+            ->setStartedAt(isset($payload['startedAt']) ? new DateTimeImmutable((string)$payload['startedAt']) : null)
+            ->setDueAt(isset($payload['dueAt']) ? new DateTimeImmutable((string)$payload['dueAt']) : null);
         if (is_string($payload['companyId'] ?? null)) {
             $project->setCompany($this->companyRepository->find($payload['companyId']));
         }
@@ -189,7 +212,12 @@ final readonly class CrmController
     {
         $payload = (array)json_decode((string)$request->getContent(), true);
         $task = new Task();
-        $task->setTitle((string)($payload['title'] ?? ''));
+        $task->setTitle((string)($payload['title'] ?? ''))
+            ->setDescription(isset($payload['description']) ? (string)$payload['description'] : null)
+            ->setStatus(TaskStatus::tryFrom((string)($payload['status'] ?? '')) ?? TaskStatus::TODO)
+            ->setPriority(TaskPriority::tryFrom((string)($payload['priority'] ?? '')) ?? TaskPriority::MEDIUM)
+            ->setDueAt(isset($payload['dueAt']) ? new DateTimeImmutable((string)$payload['dueAt']) : null)
+            ->setEstimatedHours(isset($payload['estimatedHours']) ? (float)$payload['estimatedHours'] : null);
         if (is_string($payload['projectId'] ?? null)) {
             $task->setProject($this->projectRepository->find($payload['projectId']));
         }
@@ -227,7 +255,9 @@ final readonly class CrmController
         $items = array_map(static fn (TaskRequest $taskRequest): array => [
             'id' => $taskRequest->getId(),
             'title' => $taskRequest->getTitle(),
-            'status' => $taskRequest->getStatus(),
+            'status' => $taskRequest->getStatus()->value,
+            'requestedAt' => $taskRequest->getRequestedAt()->format(DATE_ATOM),
+            'resolvedAt' => $taskRequest->getResolvedAt()?->format(DATE_ATOM),
             'taskId' => $taskRequest->getTask()?->getId(),
         ], $this->taskRequestRepository->findBy([], [
             'createdAt' => 'DESC',
@@ -251,7 +281,10 @@ final readonly class CrmController
     {
         $payload = (array)json_decode((string)$request->getContent(), true);
         $taskRequest = new TaskRequest();
-        $taskRequest->setTitle((string)($payload['title'] ?? ''))->setStatus((string)($payload['status'] ?? 'pending'));
+        $taskRequest->setTitle((string)($payload['title'] ?? ''))
+            ->setDescription(isset($payload['description']) ? (string)$payload['description'] : null)
+            ->setStatus(TaskRequestStatus::tryFrom((string)($payload['status'] ?? '')) ?? TaskRequestStatus::PENDING)
+            ->setResolvedAt(isset($payload['resolvedAt']) ? new DateTimeImmutable((string)$payload['resolvedAt']) : null);
         if (is_string($payload['taskId'] ?? null)) {
             $taskRequest->setTask($this->taskRepository->find($payload['taskId']));
         }
@@ -287,6 +320,9 @@ final readonly class CrmController
             'id' => $sprint->getId(),
             'name' => $sprint->getName(),
             'projectId' => $sprint->getProject()?->getId(),
+            'status' => $sprint->getStatus()->value,
+            'startDate' => $sprint->getStartDate()?->format('Y-m-d'),
+            'endDate' => $sprint->getEndDate()?->format('Y-m-d'),
         ], $this->sprintRepository->findBy([], [
             'createdAt' => 'DESC',
         ], 200));
@@ -309,7 +345,11 @@ final readonly class CrmController
     {
         $payload = (array)json_decode((string)$request->getContent(), true);
         $sprint = new Sprint();
-        $sprint->setName((string)($payload['name'] ?? ''));
+        $sprint->setName((string)($payload['name'] ?? ''))
+            ->setGoal(isset($payload['goal']) ? (string)$payload['goal'] : null)
+            ->setStatus(SprintStatus::tryFrom((string)($payload['status'] ?? '')) ?? SprintStatus::PLANNED)
+            ->setStartDate(isset($payload['startDate']) ? new DateTimeImmutable((string)$payload['startDate']) : null)
+            ->setEndDate(isset($payload['endDate']) ? new DateTimeImmutable((string)$payload['endDate']) : null);
         if (is_string($payload['projectId'] ?? null)) {
             $sprint->setProject($this->projectRepository->find($payload['projectId']));
         }
@@ -371,7 +411,11 @@ final readonly class CrmController
 
         $company = (new Company())
             ->setCrm($crm)
-            ->setName((string)($payload['name'] ?? ''));
+            ->setName((string)($payload['name'] ?? ''))
+            ->setIndustry(isset($payload['industry']) ? (string)$payload['industry'] : null)
+            ->setWebsite(isset($payload['website']) ? (string)$payload['website'] : null)
+            ->setContactEmail(isset($payload['contactEmail']) ? (string)$payload['contactEmail'] : null)
+            ->setPhone(isset($payload['phone']) ? (string)$payload['phone'] : null);
 
         $this->entityManager->persist($company);
         $this->entityManager->flush();
@@ -384,6 +428,22 @@ final readonly class CrmController
             'crmId' => $crm->getId(),
             'applicationSlug' => $applicationSlug,
         ], JsonResponse::HTTP_CREATED);
+    }
+
+
+    #[Route('/v1/crm/dashboard', methods: [Request::METHOD_GET])]
+    public function dashboard(): JsonResponse
+    {
+        return new JsonResponse([
+            'companies' => $this->companyRepository->count([]),
+            'projects' => $this->projectRepository->count([]),
+            'tasks' => $this->taskRepository->count([]),
+            'taskRequests' => [
+                TaskRequestStatus::PENDING->value => $this->taskRequestRepository->count(['status' => TaskRequestStatus::PENDING]),
+                TaskRequestStatus::APPROVED->value => $this->taskRequestRepository->count(['status' => TaskRequestStatus::APPROVED]),
+                TaskRequestStatus::REJECTED->value => $this->taskRequestRepository->count(['status' => TaskRequestStatus::REJECTED]),
+            ],
+        ]);
     }
 
     private function resolveOrCreateCrmByApplicationSlug(string $applicationSlug): Crm


### PR DESCRIPTION
## Summary
- Refactored CRM domain entities to support richer business data and cleaner typing.
- Added dedicated enums for project, sprint, task and task-request statuses/priorities.
- Extended CRM API responses and create endpoints with new fields.
- Added a new CRM dashboard endpoint for lightweight aggregate metrics.
- Updated CRM fixtures with realistic, typed seed data.
- Added a migration to evolve CRM schema safely.

## Main changes
### Domain model enhancements
- `Company`: added `industry`, `website`, `contactEmail`, `phone`.
- `Project`: added `code`, `description`, `status`, `startedAt`, `dueAt`.
- `Sprint`: added `goal`, `startDate`, `endDate`, `status`.
- `Task`: added `description`, `status`, `priority`, `dueAt`, `estimatedHours`.
- `TaskRequest`: added `description`, typed `status`, `requestedAt`, `resolvedAt`.

### New enums
- `App\Crm\Domain\Enum\ProjectStatus`
- `App\Crm\Domain\Enum\SprintStatus`
- `App\Crm\Domain\Enum\TaskStatus`
- `App\Crm\Domain\Enum\TaskPriority`
- `App\Crm\Domain\Enum\TaskRequestStatus`

### API improvements (`CrmController`)
- Enriched payload handling for create endpoints (companies/projects/sprints/tasks/task-requests).
- Enriched list responses with new typed metadata fields.
- Added `GET /v1/crm/dashboard` with aggregate counters and task-request status distribution.

### Services
- `TaskListService`: added `status` and `priority` filters and exposed status/priority/due/estimate in result items.
- `CompanyApplicationListService`: now returns newly added company fields.

### Fixtures
- `LoadCrmData`: now seeds realistic values for new CRM fields and enum-backed statuses.

### Database migration
- Added `migrations/Version20260311160000.php` to add all new CRM columns and safely backfill `requested_at`.

## Validation
- Ran PHP lint on all changed CRM files and migration; all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e39ff318832684c5fa18f3691a34)