### PR TITLE
refactor: centralize calendar event mutation input parsing

### DIFF
--- a/src/Calendar/Application/Service/EventMutationInputFactory.php
+++ b/src/Calendar/Application/Service/EventMutationInputFactory.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Application\Service;
+
+use App\Calendar\Application\Message\CancelEventCommand;
+use App\Calendar\Application\Message\CreateEventCommand;
+use App\Calendar\Application\Message\DeleteEventCommand;
+use App\Calendar\Application\Message\PatchEventCommand;
+use App\Calendar\Domain\Enum\EventStatus;
+use App\General\Transport\Http\ValidationErrorFactory;
+use DateTimeImmutable;
+use Ramsey\Uuid\Uuid;
+
+final class EventMutationInputFactory
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function createPrivateCreateCommand(array $payload, string $actorUserId): CreateEventCommand
+    {
+        return $this->buildCreateCommand($payload, $actorUserId);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function createApplicationCreateCommand(array $payload, string $actorUserId, string $applicationSlug): CreateEventCommand
+    {
+        return $this->buildCreateCommand($payload, $actorUserId, $applicationSlug);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function createPrivatePatchCommand(string $eventId, array $payload, string $actorUserId): PatchEventCommand
+    {
+        return $this->buildPatchCommand($eventId, $payload, $actorUserId);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function createApplicationPatchCommand(string $applicationSlug, string $eventId, array $payload, string $actorUserId): PatchEventCommand
+    {
+        return $this->buildPatchCommand($eventId, $payload, $actorUserId, $applicationSlug);
+    }
+
+    public function createPrivateDeleteCommand(string $eventId, string $actorUserId): DeleteEventCommand
+    {
+        return $this->buildDeleteCommand($eventId, $actorUserId);
+    }
+
+    public function createApplicationDeleteCommand(string $applicationSlug, string $eventId, string $actorUserId): DeleteEventCommand
+    {
+        return $this->buildDeleteCommand($eventId, $actorUserId, $applicationSlug);
+    }
+
+    public function createPrivateCancelCommand(string $eventId, string $actorUserId): CancelEventCommand
+    {
+        return $this->buildCancelCommand($eventId, $actorUserId);
+    }
+
+    public function createApplicationCancelCommand(string $applicationSlug, string $eventId, string $actorUserId): CancelEventCommand
+    {
+        return $this->buildCancelCommand($eventId, $actorUserId, $applicationSlug);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function buildCreateCommand(array $payload, string $actorUserId, ?string $applicationSlug = null): CreateEventCommand
+    {
+        $this->assertApplicationSlug($applicationSlug);
+
+        $startAt = $this->requireDate($payload, 'startAt');
+        $endAt = $this->requireDate($payload, 'endAt');
+        $this->assertDateRange($startAt, $endAt);
+
+        return new CreateEventCommand(
+            operationId: Uuid::uuid4()->toString(),
+            actorUserId: $actorUserId,
+            title: $this->requireString($payload, 'title'),
+            description: (string) ($payload['description'] ?? ''),
+            startAt: $startAt,
+            endAt: $endAt,
+            status: $this->parseStatus((string) ($payload['status'] ?? EventStatus::CONFIRMED->value)),
+            location: isset($payload['location']) && is_string($payload['location']) ? $payload['location'] : null,
+            applicationSlug: $applicationSlug,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function buildPatchCommand(string $eventId, array $payload, string $actorUserId, ?string $applicationSlug = null): PatchEventCommand
+    {
+        $this->assertApplicationSlug($applicationSlug);
+        $this->assertUuid($eventId, 'eventId');
+
+        $startAt = isset($payload['startAt']) && is_string($payload['startAt']) ? $this->parseDate($payload['startAt'], 'startAt') : null;
+        $endAt = isset($payload['endAt']) && is_string($payload['endAt']) ? $this->parseDate($payload['endAt'], 'endAt') : null;
+
+        if ($startAt !== null && $endAt !== null) {
+            $this->assertDateRange($startAt, $endAt);
+        }
+
+        return new PatchEventCommand(
+            operationId: Uuid::uuid4()->toString(),
+            actorUserId: $actorUserId,
+            eventId: $eventId,
+            title: isset($payload['title']) && is_string($payload['title']) ? $payload['title'] : null,
+            description: isset($payload['description']) && is_string($payload['description']) ? $payload['description'] : null,
+            startAt: $startAt,
+            endAt: $endAt,
+            applicationSlug: $applicationSlug,
+        );
+    }
+
+    private function buildDeleteCommand(string $eventId, string $actorUserId, ?string $applicationSlug = null): DeleteEventCommand
+    {
+        $this->assertApplicationSlug($applicationSlug);
+        $this->assertUuid($eventId, 'eventId');
+
+        return new DeleteEventCommand(
+            operationId: Uuid::uuid4()->toString(),
+            actorUserId: $actorUserId,
+            eventId: $eventId,
+            applicationSlug: $applicationSlug,
+        );
+    }
+
+    private function buildCancelCommand(string $eventId, string $actorUserId, ?string $applicationSlug = null): CancelEventCommand
+    {
+        $this->assertApplicationSlug($applicationSlug);
+        $this->assertUuid($eventId, 'eventId');
+
+        return new CancelEventCommand(
+            operationId: Uuid::uuid4()->toString(),
+            actorUserId: $actorUserId,
+            eventId: $eventId,
+            applicationSlug: $applicationSlug,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function requireString(array $payload, string $field): string
+    {
+        $value = $payload[$field] ?? null;
+        if (!is_string($value) || $value === '') {
+            throw ValidationErrorFactory::badRequest('Field "' . $field . '" is required.');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function requireDate(array $payload, string $field): DateTimeImmutable
+    {
+        $value = $payload[$field] ?? null;
+        if (!is_string($value)) {
+            throw ValidationErrorFactory::badRequest('Field "' . $field . '" must be a valid date string.');
+        }
+
+        return $this->parseDate($value, $field);
+    }
+
+    private function parseDate(string $value, string $field): DateTimeImmutable
+    {
+        try {
+            return new DateTimeImmutable($value);
+        } catch (\Throwable) {
+            throw ValidationErrorFactory::badRequest('Field "' . $field . '" must be a valid date string.');
+        }
+    }
+
+    private function parseStatus(string $status): EventStatus
+    {
+        return EventStatus::tryFrom($status) ?? throw ValidationErrorFactory::unprocessable('Invalid event status.');
+    }
+
+    private function assertApplicationSlug(?string $applicationSlug): void
+    {
+        if ($applicationSlug !== null && $applicationSlug === '') {
+            throw ValidationErrorFactory::badRequest('Field "applicationSlug" is required.');
+        }
+    }
+
+    private function assertUuid(string $value, string $field): void
+    {
+        if (!Uuid::isValid($value)) {
+            throw ValidationErrorFactory::badRequest('Field "' . $field . '" must be a valid UUID.');
+        }
+    }
+
+    private function assertDateRange(DateTimeImmutable $startAt, DateTimeImmutable $endAt): void
+    {
+        if ($endAt < $startAt) {
+            throw ValidationErrorFactory::unprocessable('Field "endAt" must be greater than or equal to "startAt".');
+        }
+    }
+}

--- a/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationOwnerEventMutationController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationOwnerEventMutationController.php
@@ -4,15 +4,9 @@ declare(strict_types=1);
 
 namespace App\Calendar\Transport\Controller\Api\V1\Event;
 
-use App\Calendar\Application\Message\CancelEventCommand;
-use App\Calendar\Application\Message\CreateEventCommand;
-use App\Calendar\Application\Message\DeleteEventCommand;
-use App\Calendar\Application\Message\PatchEventCommand;
-use App\Calendar\Domain\Enum\EventStatus;
+use App\Calendar\Application\Service\EventMutationInputFactory;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
-use App\General\Transport\Http\ValidationErrorFactory;
 use App\User\Domain\Entity\User;
-use DateTimeImmutable;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +14,6 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Uid\Uuid;
 
 #[AsController]
 #[OA\Tag(name: 'Calendar Event')]
@@ -31,66 +24,30 @@ use Symfony\Component\Uid\Uuid;
 class ApplicationOwnerEventMutationController
 {
     public function __construct(
-        private readonly MessageServiceInterface $messageService
+        private readonly MessageServiceInterface $messageService,
+        private readonly EventMutationInputFactory $eventMutationInputFactory,
     ) {
     }
 
     #[Route(path: '/v1/calendar/private/applications/{applicationSlug}/events', methods: [Request::METHOD_POST])]
     public function create(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
     {
-        $this->assertApplicationSlug($applicationSlug);
-
-        $payload = $request->toArray();
-        $startAt = $this->requireDate($payload, 'startAt');
-        $endAt = $this->requireDate($payload, 'endAt');
-        $this->assertDateRange($startAt, $endAt);
-
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
-        $this->messageService->sendMessage(new CreateEventCommand(
-            operationId: $operationId,
-            actorUserId: $loggedInUser->getId(),
-            title: $this->requireString($payload, 'title'),
-            description: (string)($payload['description'] ?? ''),
-            startAt: $startAt,
-            endAt: $endAt,
-            status: $this->parseStatus((string)($payload['status'] ?? EventStatus::CONFIRMED->value)),
-            location: isset($payload['location']) && is_string($payload['location']) ? $payload['location'] : null,
-            applicationSlug: $applicationSlug,
-        ));
+        $command = $this->eventMutationInputFactory->createApplicationCreateCommand($request->toArray(), $loggedInUser->getId(), $applicationSlug);
+        $this->messageService->sendMessage($command);
 
         return new JsonResponse([
-            'operationId' => $operationId,
+            'operationId' => $command->operationId,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 
     #[Route(path: '/v1/calendar/private/applications/{applicationSlug}/events/{eventId}', methods: [Request::METHOD_PATCH])]
     public function patch(string $applicationSlug, string $eventId, Request $request, User $loggedInUser): JsonResponse
     {
-        $this->assertApplicationSlug($applicationSlug);
-        $this->assertUuid($eventId, 'eventId');
-
-        $payload = $request->toArray();
-        $startAt = isset($payload['startAt']) && is_string($payload['startAt']) ? $this->parseDate($payload['startAt'], 'startAt') : null;
-        $endAt = isset($payload['endAt']) && is_string($payload['endAt']) ? $this->parseDate($payload['endAt'], 'endAt') : null;
-
-        if ($startAt !== null && $endAt !== null) {
-            $this->assertDateRange($startAt, $endAt);
-        }
-
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
-        $this->messageService->sendMessage(new PatchEventCommand(
-            operationId: $operationId,
-            actorUserId: $loggedInUser->getId(),
-            eventId: $eventId,
-            title: isset($payload['title']) && is_string($payload['title']) ? $payload['title'] : null,
-            description: isset($payload['description']) && is_string($payload['description']) ? $payload['description'] : null,
-            startAt: $startAt,
-            endAt: $endAt,
-            applicationSlug: $applicationSlug,
-        ));
+        $command = $this->eventMutationInputFactory->createApplicationPatchCommand($applicationSlug, $eventId, $request->toArray(), $loggedInUser->getId());
+        $this->messageService->sendMessage($command);
 
         return new JsonResponse([
-            'operationId' => $operationId,
+            'operationId' => $command->operationId,
             'id' => $eventId,
         ], JsonResponse::HTTP_ACCEPTED);
     }
@@ -98,19 +55,11 @@ class ApplicationOwnerEventMutationController
     #[Route(path: '/v1/calendar/private/applications/{applicationSlug}/events/{eventId}', methods: [Request::METHOD_DELETE])]
     public function delete(string $applicationSlug, string $eventId, User $loggedInUser): JsonResponse
     {
-        $this->assertApplicationSlug($applicationSlug);
-        $this->assertUuid($eventId, 'eventId');
-
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
-        $this->messageService->sendMessage(new DeleteEventCommand(
-            operationId: $operationId,
-            actorUserId: $loggedInUser->getId(),
-            eventId: $eventId,
-            applicationSlug: $applicationSlug,
-        ));
+        $command = $this->eventMutationInputFactory->createApplicationDeleteCommand($applicationSlug, $eventId, $loggedInUser->getId());
+        $this->messageService->sendMessage($command);
 
         return new JsonResponse([
-            'operationId' => $operationId,
+            'operationId' => $command->operationId,
             'id' => $eventId,
         ], JsonResponse::HTTP_ACCEPTED);
     }
@@ -118,81 +67,12 @@ class ApplicationOwnerEventMutationController
     #[Route(path: '/v1/calendar/private/applications/{applicationSlug}/events/{eventId}/cancel', methods: [Request::METHOD_POST])]
     public function cancel(string $applicationSlug, string $eventId, User $loggedInUser): JsonResponse
     {
-        $this->assertApplicationSlug($applicationSlug);
-        $this->assertUuid($eventId, 'eventId');
-
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
-        $this->messageService->sendMessage(new CancelEventCommand(
-            operationId: $operationId,
-            actorUserId: $loggedInUser->getId(),
-            eventId: $eventId,
-            applicationSlug: $applicationSlug,
-        ));
+        $command = $this->eventMutationInputFactory->createApplicationCancelCommand($applicationSlug, $eventId, $loggedInUser->getId());
+        $this->messageService->sendMessage($command);
 
         return new JsonResponse([
-            'operationId' => $operationId,
+            'operationId' => $command->operationId,
             'id' => $eventId,
         ], JsonResponse::HTTP_ACCEPTED);
-    }
-
-    /**
-     * @param array<string, mixed> $payload
-     */
-    private function requireString(array $payload, string $field): string
-    {
-        $value = $payload[$field] ?? null;
-        if (!is_string($value) || $value === '') {
-            throw ValidationErrorFactory::badRequest('Field "' . $field . '" is required.');
-        }
-
-        return $value;
-    }
-
-    /**
-     * @param array<string, mixed> $payload
-     */
-    private function requireDate(array $payload, string $field): DateTimeImmutable
-    {
-        $value = $payload[$field] ?? null;
-        if (!is_string($value)) {
-            throw ValidationErrorFactory::badRequest('Field "' . $field . '" must be a valid date string.');
-        }
-
-        return $this->parseDate($value, $field);
-    }
-
-    private function parseDate(string $value, string $field): DateTimeImmutable
-    {
-        try {
-            return new DateTimeImmutable($value);
-        } catch (\Throwable) {
-            throw ValidationErrorFactory::badRequest('Field "' . $field . '" must be a valid date string.');
-        }
-    }
-
-    private function parseStatus(string $status): EventStatus
-    {
-        return EventStatus::tryFrom($status) ?? throw ValidationErrorFactory::unprocessable('Invalid event status.');
-    }
-
-    private function assertApplicationSlug(string $applicationSlug): void
-    {
-        if ($applicationSlug === '') {
-            throw ValidationErrorFactory::badRequest('Field "applicationSlug" is required.');
-        }
-    }
-
-    private function assertUuid(string $value, string $field): void
-    {
-        if (!Uuid::isValid($value)) {
-            throw ValidationErrorFactory::badRequest('Field "' . $field . '" must be a valid UUID.');
-        }
-    }
-
-    private function assertDateRange(DateTimeImmutable $startAt, DateTimeImmutable $endAt): void
-    {
-        if ($endAt < $startAt) {
-            throw ValidationErrorFactory::unprocessable('Field "endAt" must be greater than or equal to "startAt".');
-        }
     }
 }

--- a/src/Calendar/Transport/Controller/Api/V1/Event/UserEventMutationController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/UserEventMutationController.php
@@ -4,15 +4,9 @@ declare(strict_types=1);
 
 namespace App\Calendar\Transport\Controller\Api\V1\Event;
 
-use App\Calendar\Application\Message\CancelEventCommand;
-use App\Calendar\Application\Message\CreateEventCommand;
-use App\Calendar\Application\Message\DeleteEventCommand;
-use App\Calendar\Application\Message\PatchEventCommand;
-use App\Calendar\Domain\Enum\EventStatus;
+use App\Calendar\Application\Service\EventMutationInputFactory;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
-use App\General\Transport\Http\ValidationErrorFactory;
 use App\User\Domain\Entity\User;
-use DateTimeImmutable;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +14,6 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Uid\Uuid;
 
 #[AsController]
 #[OA\Tag(name: 'Calendar Event')]
@@ -31,61 +24,30 @@ use Symfony\Component\Uid\Uuid;
 class UserEventMutationController
 {
     public function __construct(
-        private readonly MessageServiceInterface $messageService
+        private readonly MessageServiceInterface $messageService,
+        private readonly EventMutationInputFactory $eventMutationInputFactory,
     ) {
     }
 
     #[Route(path: '/v1/calendar/private/events', methods: [Request::METHOD_POST])]
     public function create(Request $request, User $loggedInUser): JsonResponse
     {
-        $payload = $request->toArray();
-        $startAt = $this->requireDate($payload, 'startAt');
-        $endAt = $this->requireDate($payload, 'endAt');
-        $this->assertDateRange($startAt, $endAt);
-
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
-        $this->messageService->sendMessage(new CreateEventCommand(
-            operationId: $operationId,
-            actorUserId: $loggedInUser->getId(),
-            title: $this->requireString($payload, 'title'),
-            description: (string)($payload['description'] ?? ''),
-            startAt: $startAt,
-            endAt: $endAt,
-            status: $this->parseStatus((string)($payload['status'] ?? EventStatus::CONFIRMED->value)),
-            location: isset($payload['location']) && is_string($payload['location']) ? $payload['location'] : null,
-        ));
+        $command = $this->eventMutationInputFactory->createPrivateCreateCommand($request->toArray(), $loggedInUser->getId());
+        $this->messageService->sendMessage($command);
 
         return new JsonResponse([
-            'operationId' => $operationId,
+            'operationId' => $command->operationId,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 
     #[Route(path: '/v1/calendar/private/events/{eventId}', methods: [Request::METHOD_PATCH])]
     public function patch(string $eventId, Request $request, User $loggedInUser): JsonResponse
     {
-        $this->assertUuid($eventId, 'eventId');
-        $payload = $request->toArray();
-
-        $startAt = isset($payload['startAt']) && is_string($payload['startAt']) ? $this->parseDate($payload['startAt'], 'startAt') : null;
-        $endAt = isset($payload['endAt']) && is_string($payload['endAt']) ? $this->parseDate($payload['endAt'], 'endAt') : null;
-
-        if ($startAt !== null && $endAt !== null) {
-            $this->assertDateRange($startAt, $endAt);
-        }
-
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
-        $this->messageService->sendMessage(new PatchEventCommand(
-            operationId: $operationId,
-            actorUserId: $loggedInUser->getId(),
-            eventId: $eventId,
-            title: isset($payload['title']) && is_string($payload['title']) ? $payload['title'] : null,
-            description: isset($payload['description']) && is_string($payload['description']) ? $payload['description'] : null,
-            startAt: $startAt,
-            endAt: $endAt,
-        ));
+        $command = $this->eventMutationInputFactory->createPrivatePatchCommand($eventId, $request->toArray(), $loggedInUser->getId());
+        $this->messageService->sendMessage($command);
 
         return new JsonResponse([
-            'operationId' => $operationId,
+            'operationId' => $command->operationId,
             'id' => $eventId,
         ], JsonResponse::HTTP_ACCEPTED);
     }
@@ -93,17 +55,11 @@ class UserEventMutationController
     #[Route(path: '/v1/calendar/private/events/{eventId}', methods: [Request::METHOD_DELETE])]
     public function delete(string $eventId, User $loggedInUser): JsonResponse
     {
-        $this->assertUuid($eventId, 'eventId');
-
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
-        $this->messageService->sendMessage(new DeleteEventCommand(
-            operationId: $operationId,
-            actorUserId: $loggedInUser->getId(),
-            eventId: $eventId,
-        ));
+        $command = $this->eventMutationInputFactory->createPrivateDeleteCommand($eventId, $loggedInUser->getId());
+        $this->messageService->sendMessage($command);
 
         return new JsonResponse([
-            'operationId' => $operationId,
+            'operationId' => $command->operationId,
             'id' => $eventId,
         ], JsonResponse::HTTP_ACCEPTED);
     }
@@ -111,72 +67,12 @@ class UserEventMutationController
     #[Route(path: '/v1/calendar/private/events/{eventId}/cancel', methods: [Request::METHOD_POST])]
     public function cancel(string $eventId, User $loggedInUser): JsonResponse
     {
-        $this->assertUuid($eventId, 'eventId');
-
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
-        $this->messageService->sendMessage(new CancelEventCommand(
-            operationId: $operationId,
-            actorUserId: $loggedInUser->getId(),
-            eventId: $eventId,
-        ));
+        $command = $this->eventMutationInputFactory->createPrivateCancelCommand($eventId, $loggedInUser->getId());
+        $this->messageService->sendMessage($command);
 
         return new JsonResponse([
-            'operationId' => $operationId,
+            'operationId' => $command->operationId,
             'id' => $eventId,
         ], JsonResponse::HTTP_ACCEPTED);
-    }
-
-    /**
-     * @param array<string, mixed> $payload
-     */
-    private function requireString(array $payload, string $field): string
-    {
-        $value = $payload[$field] ?? null;
-        if (!is_string($value) || $value === '') {
-            throw ValidationErrorFactory::badRequest('Field "' . $field . '" is required.');
-        }
-
-        return $value;
-    }
-
-    /**
-     * @param array<string, mixed> $payload
-     */
-    private function requireDate(array $payload, string $field): DateTimeImmutable
-    {
-        $value = $payload[$field] ?? null;
-        if (!is_string($value)) {
-            throw ValidationErrorFactory::badRequest('Field "' . $field . '" must be a valid date string.');
-        }
-
-        return $this->parseDate($value, $field);
-    }
-
-    private function parseDate(string $value, string $field): DateTimeImmutable
-    {
-        try {
-            return new DateTimeImmutable($value);
-        } catch (\Throwable) {
-            throw ValidationErrorFactory::badRequest('Field "' . $field . '" must be a valid date string.');
-        }
-    }
-
-    private function parseStatus(string $status): EventStatus
-    {
-        return EventStatus::tryFrom($status) ?? throw ValidationErrorFactory::unprocessable('Invalid event status.');
-    }
-
-    private function assertUuid(string $value, string $field): void
-    {
-        if (!Uuid::isValid($value)) {
-            throw ValidationErrorFactory::badRequest('Field "' . $field . '" must be a valid UUID.');
-        }
-    }
-
-    private function assertDateRange(DateTimeImmutable $startAt, DateTimeImmutable $endAt): void
-    {
-        if ($endAt < $startAt) {
-            throw ValidationErrorFactory::unprocessable('Field "endAt" must be greater than or equal to "startAt".');
-        }
     }
 }


### PR DESCRIPTION
### Motivation
- Centraliser le parsing/validation des payloads mutations d'événement pour éviter la duplication de logique entre contrôleurs et garantir des règles cohérentes (uuid/date/status/date-range/application slug).

### Description
- Ajout du service applicatif `src/Calendar/Application/Service/EventMutationInputFactory.php` qui parse/valide les payloads et construit les commandes `CreateEventCommand`, `PatchEventCommand`, `DeleteEventCommand` et `CancelEventCommand` en exposant des méthodes dédiées pour contexte privé et contexte application (option `applicationSlug`).
- Refactor de `src/Calendar/Transport/Controller/Api/V1/Event/UserEventMutationController.php` pour déléguer la construction des commandes à la factory et ne conserver que l’orchestration HTTP (lecture de la requête, envoi du message, retour `202`).
- Refactor de `src/Calendar/Transport/Controller/Api/V1/Event/ApplicationOwnerEventMutationController.php` sur le même modèle avec prise en compte du `applicationSlug` via la factory et suppression des méthodes privées dupliquées de parsing/validation.

### Testing
- Exécution de `php -l src/Calendar/Application/Service/EventMutationInputFactory.php` qui a réussi.
- Exécution de `php -l src/Calendar/Transport/Controller/Api/V1/Event/UserEventMutationController.php` qui a réussi.
- Exécution de `php -l src/Calendar/Transport/Controller/Api/V1/Event/ApplicationOwnerEventMutationController.php` qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e4d1cbf8832681275925a76603aa)