### PR TITLE
Exclure l'acteur lors du marquage en lu et synchroniser `readAt`

### DIFF
--- a/src/Chat/Application/MessageHandler/MarkConversationMessagesAsReadCommandHandler.php
+++ b/src/Chat/Application/MessageHandler/MarkConversationMessagesAsReadCommandHandler.php
@@ -30,7 +30,7 @@ final readonly class MarkConversationMessagesAsReadCommandHandler
     {
         $conversation = $this->findParticipantConversation($command->conversationId, $command->actorUserId);
 
-        $updated = $this->messageRepository->markConversationMessagesAsRead($conversation->getId());
+        $updated = $this->messageRepository->markConversationMessagesAsRead($conversation->getId(), $command->actorUserId);
         if ($updated > 0) {
             $this->cacheInvalidationService->invalidateConversationCaches($conversation->getChat()->getId(), $command->actorUserId);
         }

--- a/src/Chat/Application/MessageHandler/PatchMessageCommandHandler.php
+++ b/src/Chat/Application/MessageHandler/PatchMessageCommandHandler.php
@@ -34,6 +34,7 @@ final readonly class PatchMessageCommandHandler
 
             if ($command->read !== null) {
                 $message->setRead($command->read);
+                $message->setReadAt($command->read ? new \DateTimeImmutable() : null);
                 $updated = true;
             }
 

--- a/src/Chat/Infrastructure/Repository/ChatMessageRepository.php
+++ b/src/Chat/Infrastructure/Repository/ChatMessageRepository.php
@@ -24,20 +24,21 @@ class ChatMessageRepository extends BaseRepository
     ) {
     }
 
-    public function markConversationMessagesAsRead(string $conversationId): int
+    public function markConversationMessagesAsRead(string $conversationId, string $actorUserId): int
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->update(Entity::class, 'm')
             ->set('m.read', ':read')
             ->set('m.readAt', ':readAt')
             ->where('m.conversation = :conversationId')
+            ->andWhere('m.sender != :actorUserId')
             ->andWhere('m.read = :unread')
             ->setParameter('read', true)
             ->setParameter('unread', false)
             ->setParameter('readAt', new \DateTimeImmutable())
             ->setParameter('conversationId', $conversationId)
+            ->setParameter('actorUserId', $actorUserId)
             ->getQuery()
             ->execute();
     }
 }
-


### PR DESCRIPTION
### Motivation
- Empêcher que les messages envoyés par l'utilisateur connecté soient marqués comme lus lors d'un marquage en masse de la conversation.
- Garder la cohérence entre le champ `read` et `readAt` lors d'un patch individuel d'un message.

### Description
- Modifié la signature de `ChatMessageRepository::markConversationMessagesAsRead` pour accepter `string $actorUserId` et ajouté le filtre `->andWhere('m.sender != :actorUserId')` avec le paramètre `actorUserId`.
- Mis à jour `MarkConversationMessagesAsReadCommandHandler` pour transmettre ` $command->actorUserId` à l'appel de repository via `markConversationMessagesAsRead($conversation->getId(), $command->actorUserId)`.
- Ajusté `PatchMessageCommandHandler` pour mettre à jour `readAt` en cohérence avec `read` en faisant `setReadAt($command->read ? new \DateTimeImmutable() : null)` lorsque le champ `read` est patché.

### Testing
- Exécution de la vérification de syntaxe PHP avec `php -l` sur les fichiers modifiés a réussi sans erreurs.
- Aucun test automatisé supplémentaire n'était présent ou requis pour ces modifications de logique et signature, seules les vérifications de syntaxe ont été exécutées et sont passées.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e4db0350832681971310522022c3)