### PR TITLE
Refactor: externalise la création/trouvaille de conversation directe vers un handler applicatif

### DIFF
--- a/src/Chat/Application/MessageHandler/FindOrCreateConversationWithUserCommandHandler.php
+++ b/src/Chat/Application/MessageHandler/FindOrCreateConversationWithUserCommandHandler.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Application\MessageHandler;
+
+use App\Chat\Application\Message\FindOrCreateConversationWithUserCommand;
+use App\Chat\Domain\Entity\Chat;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Infrastructure\Repository\ChatRepository;
+use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
+use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\General\Application\Service\CacheInvalidationService;
+use App\General\Application\Service\MercurePublisher;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class FindOrCreateConversationWithUserCommandHandler
+{
+    public function __construct(
+        private UserRepository $userRepository,
+        private ConversationRepository $conversationRepository,
+        private ConversationParticipantRepository $participantRepository,
+        private ChatRepository $chatRepository,
+        private CacheInvalidationService $cacheInvalidationService,
+        private MercurePublisher $mercurePublisher,
+    ) {
+    }
+
+    public function __invoke(FindOrCreateConversationWithUserCommand $command): void
+    {
+        $result = $this->conversationRepository->getEntityManager()->getConnection()->transactional(function () use ($command): array {
+            $actor = $this->userRepository->find($command->actorUserId);
+            if (!$actor instanceof User) {
+                throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'User not found.');
+            }
+
+            $targetUser = $this->userRepository->find($command->targetUserId);
+            if (!$targetUser instanceof User) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown userId.');
+            }
+
+            $existingConversation = $this->conversationRepository->findDirectConversationBetweenUsers($actor, $targetUser);
+            if ($existingConversation instanceof Conversation) {
+                return [
+                    'chatId' => $existingConversation->getChat()->getId(),
+                    'conversationId' => $existingConversation->getId(),
+                    'actorUserId' => $actor->getId(),
+                    'targetUserId' => $targetUser->getId(),
+                    'created' => false,
+                ];
+            }
+
+            $chat = $this->chatRepository->findChatForDirectConversation($actor, $targetUser);
+            if (!$chat instanceof Chat) {
+                throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'No chat available for these users in a shared application scope.');
+            }
+
+            $conversation = (new Conversation())->setChat($chat);
+            $this->conversationRepository->save($conversation, false);
+            $this->participantRepository->save((new ConversationParticipant())->setConversation($conversation)->setUser($actor), false);
+            if ($targetUser->getId() !== $actor->getId()) {
+                $this->participantRepository->save((new ConversationParticipant())->setConversation($conversation)->setUser($targetUser), false);
+            }
+
+            $this->conversationRepository->getEntityManager()->flush();
+
+            return [
+                'chatId' => $chat->getId(),
+                'conversationId' => $conversation->getId(),
+                'actorUserId' => $actor->getId(),
+                'targetUserId' => $targetUser->getId(),
+                'created' => true,
+            ];
+        });
+
+        $this->cacheInvalidationService->invalidateConversationCaches($result['chatId'], $result['actorUserId']);
+        $this->cacheInvalidationService->invalidateConversationCaches($result['chatId'], $result['targetUserId']);
+
+        $payload = [
+            'operationId' => $command->operationId,
+            'conversationId' => $result['conversationId'],
+            'chatId' => $result['chatId'],
+            'actorUserId' => $result['actorUserId'],
+            'targetUserId' => $result['targetUserId'],
+            'created' => $result['created'],
+        ];
+
+        $this->mercurePublisher->publish('/users/' . $result['actorUserId'] . '/conversations', $payload);
+        if ($result['targetUserId'] !== $result['actorUserId']) {
+            $this->mercurePublisher->publish('/users/' . $result['targetUserId'] . '/conversations', $payload);
+        }
+    }
+}

--- a/src/Chat/Domain/Repository/Interfaces/ChatRepositoryInterface.php
+++ b/src/Chat/Domain/Repository/Interfaces/ChatRepositoryInterface.php
@@ -6,8 +6,11 @@ namespace App\Chat\Domain\Repository\Interfaces;
 
 use App\Chat\Domain\Entity\Chat;
 use App\Platform\Domain\Entity\Application;
+use App\User\Domain\Entity\User;
 
 interface ChatRepositoryInterface
 {
     public function findOneByApplication(Application $application): ?Chat;
+
+    public function findChatForDirectConversation(User $actor, User $targetUser): ?Chat;
 }

--- a/src/Chat/Infrastructure/Repository/ChatRepository.php
+++ b/src/Chat/Infrastructure/Repository/ChatRepository.php
@@ -8,8 +8,10 @@ use App\Chat\Domain\Entity\Chat as Entity;
 use App\Chat\Domain\Repository\Interfaces\ChatRepositoryInterface;
 use App\General\Infrastructure\Repository\BaseRepository;
 use App\Platform\Domain\Entity\Application;
+use App\User\Domain\Entity\User;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 
 /**
  * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
@@ -36,5 +38,51 @@ class ChatRepository extends BaseRepository implements ChatRepositoryInterface
         ]);
 
         return $chat instanceof Entity ? $chat : null;
+    }
+
+    public function findChatForDirectConversation(User $actor, User $targetUser): ?Entity
+    {
+        $sharedConversationChat = $this->createQueryBuilder('chat')
+            ->innerJoin('chat.conversations', 'conversation')
+            ->innerJoin('conversation.participants', 'participant')
+            ->innerJoin('participant.user', 'participantUser')
+            ->where('participantUser.id IN (:users)')
+            ->setParameter('users', [$actor->getId(), $targetUser->getId()], UuidBinaryOrderedTimeType::NAME)
+            ->groupBy('chat.id')
+            ->having('COUNT(DISTINCT participantUser.id) = 2')
+            ->orderBy('MAX(conversation.createdAt)', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if ($sharedConversationChat instanceof Entity) {
+            return $sharedConversationChat;
+        }
+
+        $actorOwnedChat = $this->createQueryBuilder('chat')
+            ->innerJoin('chat.application', 'application')
+            ->innerJoin('application.user', 'applicationOwner')
+            ->where('applicationOwner.id = :actorId')
+            ->setParameter('actorId', $actor->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->orderBy('chat.createdAt', 'ASC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if ($actorOwnedChat instanceof Entity) {
+            return $actorOwnedChat;
+        }
+
+        $targetOwnedChat = $this->createQueryBuilder('chat')
+            ->innerJoin('chat.application', 'application')
+            ->innerJoin('application.user', 'applicationOwner')
+            ->where('applicationOwner.id = :targetId')
+            ->setParameter('targetId', $targetUser->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->orderBy('chat.createdAt', 'ASC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $targetOwnedChat instanceof Entity ? $targetOwnedChat : null;
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationMutationController.php
@@ -6,18 +6,10 @@ namespace App\Chat\Transport\Controller\Api\V1\Conversation;
 
 use App\Chat\Application\Message\CreateConversationCommand;
 use App\Chat\Application\Message\DeleteConversationCommand;
+use App\Chat\Application\Message\FindOrCreateConversationWithUserCommand;
 use App\Chat\Application\Message\PatchConversationCommand;
-use App\Chat\Domain\Entity\Chat;
-use App\Chat\Domain\Entity\Conversation;
-use App\Chat\Domain\Entity\ConversationParticipant;
-use App\Chat\Infrastructure\Repository\ChatRepository;
-use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
-use App\Chat\Infrastructure\Repository\ConversationRepository;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
-use App\User\Infrastructure\Repository\UserRepository;
-use Doctrine\ORM\Exception\ORMException;
-use Doctrine\ORM\OptimisticLockException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -37,10 +29,6 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class UserConversationMutationController
 {
     public function __construct(
-        private readonly ChatRepository $chatRepository,
-        private readonly UserRepository $userRepository,
-        private readonly ConversationRepository $conversationRepository,
-        private readonly ConversationParticipantRepository $participantRepository,
         private readonly MessageServiceInterface $messageService,
     ) {
     }
@@ -106,78 +94,19 @@ class UserConversationMutationController
         ], JsonResponse::HTTP_ACCEPTED);
     }
 
-    /**
-     * @throws OptimisticLockException
-     * @throws ORMException
-     */
     #[Route(path: '/v1/chat/private/conversation/{user}/user', methods: [Request::METHOD_POST])]
     public function findOrCreateWithUser(User $user, User $loggedInUser): JsonResponse
     {
-        $conversation = $this->conversationRepository->findDirectConversationBetweenUsers($loggedInUser, $user);
-        if ($conversation instanceof Conversation) {
-            return new JsonResponse($this->normalizeConversation($conversation, $loggedInUser), JsonResponse::HTTP_OK);
-        }
+        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        $this->messageService->sendMessage(new FindOrCreateConversationWithUserCommand(
+            operationId: $operationId,
+            actorUserId: $loggedInUser->getId(),
+            targetUserId: $user->getId(),
+        ));
 
-        $chat = $this->chatRepository->findBy([], [
-            'createdAt' => 'ASC',
-        ], 1)[0] ?? null;
-        if (!$chat instanceof Chat) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'No chat available to create a conversation.');
-        }
-
-        $conversation = new Conversation()->setChat($chat);
-        $this->conversationRepository->save($conversation, false);
-        $this->participantRepository->save(new ConversationParticipant()->setConversation($conversation)->setUser($loggedInUser), false);
-        $this->participantRepository->save(new ConversationParticipant()->setConversation($conversation)->setUser($user), false);
-        $this->conversationRepository->getEntityManager()->flush();
-
-        return new JsonResponse($this->normalizeConversation($conversation, $loggedInUser), JsonResponse::HTTP_CREATED);
-    }
-
-    private function normalizeConversation(Conversation $conversation, User $loggedInUser): array
-    {
-        $loggedInUserId = $loggedInUser->getId();
-
-        $messages = array_map(static function (\App\Chat\Domain\Entity\ChatMessage $message) use ($loggedInUserId): array {
-            $sender = $message->getSender();
-            $senderId = $sender->getId();
-
-            return [
-                'id' => $message->getId(),
-                'content' => $message->getContent(),
-                'read' => $message->isRead(),
-                'readAt' => $message->getReadAt()?->format(DATE_ATOM),
-                'attachments' => $message->getAttachments(),
-                'createdAt' => $message->getCreatedAt()?->format(DATE_ATOM),
-                'sender' => [
-                    'id' => $senderId,
-                    'firstName' => $sender->getFirstName(),
-                    'lastName' => $sender->getLastName(),
-                    'photo' => $sender->getPhoto(),
-                    'owner' => $senderId === $loggedInUserId,
-                ],
-            ];
-        }, $conversation->getMessages()->toArray());
-
-        return [
-            'id' => $conversation->getId(),
-            'chatId' => $conversation->getChat()->getId(),
-            'participants' => array_map(static function (ConversationParticipant $participant) use ($loggedInUserId): array {
-                $participantUser = $participant->getUser();
-
-                return [
-                    'id' => $participant->getId(),
-                    'user' => [
-                        'id' => $participantUser->getId(),
-                        'firstName' => $participantUser->getFirstName(),
-                        'lastName' => $participantUser->getLastName(),
-                        'photo' => $participantUser->getPhoto(),
-                        'owner' => $participantUser->getId() === $loggedInUserId,
-                    ],
-                ];
-            }, $conversation->getParticipants()->toArray()),
-            'messages' => $messages,
-            'createdAt' => $conversation->getCreatedAt()?->format(DATE_ATOM),
-        ];
+        return new JsonResponse([
+            'operationId' => $operationId,
+            'targetUserId' => $user->getId(),
+        ], JsonResponse::HTTP_ACCEPTED);
     }
 }


### PR DESCRIPTION
### Motivation
- Retirer la persistance directe depuis le controller `UserConversationMutationController::findOrCreateWithUser` pour unifier le comportement des mutations asynchrones.
- Centraliser la logique métier de sélection du `Chat` (par périmètre application/owner/shared scope) au lieu d'un `findBy([])` global et fragile.
- Éviter les divergences entre endpoints en regroupant l'invalidation de cache et la publication temps réel (Mercure) dans un seul handler applicatif.

### Description
- Le controller `src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationMutationController.php` n'effectue plus de persistance; il publie maintenant une commande `FindOrCreateConversationWithUserCommand` et retourne un `202` avec `operationId`.
- Ajout du handler `FindOrCreateConversationWithUserCommandHandler` dans `src/Chat/Application/MessageHandler` qui effectue de façon transactionnelle la validation `actor/target`, la recherche d'une conversation existante, la création si nécessaire, l'invalidation de cache via `CacheInvalidationService` et la publication Mercure via `MercurePublisher`.
- Extension du contrat de repository `ChatRepositoryInterface` et implémentation dans `src/Chat/Infrastructure/Repository/ChatRepository.php` avec la méthode `findChatForDirectConversation(User $actor, User $targetUser): ?Chat` appliquant des règles explicites de sélection : 1) préférer un chat où les deux users ont déjà des conversations partagées, 2) fallback sur le plus ancien chat de l'application du `actor`, 3) fallback sur le plus ancien chat de l'application du `target`, 4) 404 si aucun chat trouvé.
- Suppression de la logique de normalisation/persistance directe du controller pour éviter duplication et garantir un seul point de vérité métier.

### Testing
- Vérification de la syntaxe PHP exécutée avec `php -l` sur les fichiers modifiés :
  - `php -l src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationMutationController.php` — OK
  - `php -l src/Chat/Application/MessageHandler/FindOrCreateConversationWithUserCommandHandler.php` — OK
  - `php -l src/Chat/Infrastructure/Repository/ChatRepository.php` — OK
  - `php -l src/Chat/Domain/Repository/Interfaces/ChatRepositoryInterface.php` — OK

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e6d8e8748326b3930c3f60beab7b)