### PR TITLE
Fix blog user resolution in V1 controllers and add API coverage

### DIFF
--- a/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 use function sprintf;
@@ -39,6 +40,7 @@ final readonly class BlogMutationController
     public function __construct(
         private MessageBusInterface $messageBus,
         private MediaUploaderService $mediaUploaderService,
+        private Security $security,
     ) {
     }
 
@@ -52,7 +54,7 @@ final readonly class BlogMutationController
     ]))]
     public function createGeneral(Request $request): JsonResponse
     {
-        $user = $request->getUser();
+        $user = $this->security->getUser();
         if (!$user instanceof User || !in_array('ROLE_ROOT', $user->getRoles(), true)) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only root can create General blog.');
         }

--- a/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
@@ -14,13 +14,15 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 final readonly class BlogReadController
 {
     public function __construct(
-        private BlogReadService $blogReadService
+        private BlogReadService $blogReadService,
+        private Security $security,
     ) {
     }
 
@@ -113,11 +115,11 @@ final readonly class BlogReadController
             ]],
         ]),
     )]
-    public function byApplication(string $applicationSlug, Request $request): JsonResponse
+    public function byApplication(string $applicationSlug): JsonResponse
     {
-        $user = $this->getCurrentUserFromRequest($request);
+        $user = $this->security->getUser();
 
-        return new JsonResponse($this->blogReadService->getByApplicationSlug($applicationSlug, $user));
+        return new JsonResponse($this->blogReadService->getByApplicationSlug($applicationSlug, $user instanceof User ? $user : null));
     }
 
     #[Route('/v1/blogs/reactions/types', methods: [Request::METHOD_GET])]
@@ -133,10 +135,4 @@ final readonly class BlogReadController
         ]);
     }
 
-    private function getCurrentUserFromRequest(Request $request): ?User
-    {
-        $user = $request->getUser();
-
-        return $user instanceof User ? $user : null;
-    }
 }

--- a/tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php
+++ b/tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Blog\Transport\Controller\Api\V1;
+
+use App\Tests\TestCase\WebTestCase;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\HttpFoundation\Request;
+
+final class BlogControllerTest extends WebTestCase
+{
+    public function testCreateGeneralBlogAllowsRootUser(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/blogs/general',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'title' => 'General Blog From Root',
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        self::assertResponseStatusCodeSame(202);
+    }
+
+    public function testCreateGeneralBlogRejectsNonRootUser(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/blogs/general',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'title' => 'Should Fail',
+            ], JSON_THROW_ON_ERROR),
+        );
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    public function testApplicationReadReflectsIsAuthorWithAndWithoutAuth(): void
+    {
+        $anonymousClient = $this->getTestClient();
+        $authenticatedClient = $this->getTestClient('john-user', 'password-user');
+
+        $anonymousClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blogs/application/shop-ops-center');
+        self::assertResponseStatusCodeSame(200);
+        /** @var array<string, mixed> $anonymousPayload */
+        $anonymousPayload = json_decode((string)$anonymousClient->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $authenticatedClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blogs/application/shop-ops-center');
+        self::assertResponseStatusCodeSame(200);
+        /** @var array<string, mixed> $authenticatedPayload */
+        $authenticatedPayload = json_decode((string)$authenticatedClient->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $johnUser = $userRepository->findOneBy(['username' => 'john-user']);
+        self::assertNotNull($johnUser);
+
+        self::assertAuthorFlagsForAnonymousPayload($anonymousPayload);
+        self::assertAuthorFlagsForAuthenticatedPayload($authenticatedPayload, $johnUser->getId());
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function assertAuthorFlagsForAnonymousPayload(array $payload): void
+    {
+        self::assertAuthorFlags($payload, null);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function assertAuthorFlagsForAuthenticatedPayload(array $payload, string $userId): void
+    {
+        self::assertAuthorFlags($payload, $userId);
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private static function assertAuthorFlags(array $node, ?string $userId): void
+    {
+        if (isset($node['authorId'])) {
+            self::assertArrayHasKey('isAuthor', $node);
+            self::assertSame($userId !== null && $node['authorId'] === $userId, $node['isAuthor']);
+        }
+
+        foreach (['posts', 'comments', 'reactions', 'children'] as $listKey) {
+            if (!isset($node[$listKey]) || !is_array($node[$listKey])) {
+                continue;
+            }
+
+            foreach ($node[$listKey] as $child) {
+                if (!is_array($child)) {
+                    continue;
+                }
+
+                self::assertAuthorFlags($child, $userId);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure controllers use a business-entity-compatible source for the currently authenticated user instead of `Request::getUser()`. 
- Keep authorization semantics unchanged (preserve `ROLE_ROOT` guard for general blog creation) while harmonizing user resolution with other endpoints that receive `User $loggedInUser` via value resolvers. 
- Add functional coverage for the blog endpoints to assert authorization and `isAuthor` behavior.

### Description

- Injected `Symfony\Component\Security\Core\Security` into `BlogMutationController` and replaced `Request::getUser()` with `Security::getUser()` in `createGeneral()`, preserving the `ROLE_ROOT` check. (file: `src/Blog/Transport/Controller/Api/V1/BlogMutationController.php`)
- Injected `Security` into `BlogReadController`, removed the request-based helper, and updated `byApplication()` to read the optional `User` from `Security::getUser()` and pass a real `?App\User\Domain\Entity\User` to the read service. (file: `src/Blog/Transport/Controller/Api/V1/BlogReadController.php`)
- Added functional API tests exercising the scenarios: root can create general blog, non-root is forbidden, and the application read endpoint returns correct `isAuthor` values both anonymous and authenticated. (file: `tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php`)

### Testing

- Ran PHP syntax checks with `php -l` against the modified controllers and the new test file and they succeeded (`php -l src/Blog/Transport/Controller/Api/V1/BlogMutationController.php`, `php -l src/Blog/Transport/Controller/Api/V1/BlogReadController.php`, `php -l tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php`).
- Attempted to run PHPUnit for the new test file, but the local PHPUnit binary is not available in this environment (`./vendor/bin/phpunit` missing), so full functional test run could not be executed here.
- Verified no syntax errors and added the new test to the test tree so CI can run the functional tests in an environment with PHPUnit available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e807e6208326b5fb08c23298f01b)