### PR TITLE
fix(crm): avoid duplicate crm fixture insertion

### DIFF
--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -40,8 +40,13 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
     public function load(ObjectManager $manager): void
     {
         foreach ($this->getApplicationsByPlatform(PlatformKey::CRM) as $application) {
-            $crm = (new Crm())->setApplication($application);
-            $manager->persist($crm);
+            /** @var Crm|null $crm */
+            $crm = $manager->getRepository(Crm::class)->findOneBy(['application' => $application]);
+
+            if (!$crm instanceof Crm) {
+                $crm = (new Crm())->setApplication($application);
+                $manager->persist($crm);
+            }
 
             $companies = [
                 (new Company())


### PR DESCRIPTION
### Motivation
- Prevent unique constraint violations during fixture loading caused by creating duplicate `Crm` entities for the same `application` when fixtures are run multiple times.

### Description
- Update `src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php` to query for an existing `Crm` with `$manager->getRepository(Crm::class)->findOneBy(['application' => $application])` and only `persist` a new `Crm` when none is found.

### Testing
- Linted the modified file with `php -l src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e8aa9ed08326a136a99f8f265f1d)