### PR TITLE
Masquer les événements privés/annulés dans la liste publique d'événements par application

### DIFF
--- a/src/Calendar/Infrastructure/Repository/EventRepository.php
+++ b/src/Calendar/Infrastructure/Repository/EventRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Calendar\Infrastructure\Repository;
 
 use App\Calendar\Domain\Entity\Event as Entity;
+use App\Calendar\Domain\Enum\EventVisibility;
 use App\Calendar\Domain\Repository\Interfaces\EventRepositoryInterface;
 use App\General\Infrastructure\Repository\BaseRepository;
 use App\User\Domain\Entity\User;
@@ -64,7 +65,10 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
         return $this->applyListFilters($this->createBaseQueryBuilder(), $filters, $esIds)
             ->innerJoin('calendar.application', 'application')
             ->andWhere('application.slug = :applicationSlug')
+            ->andWhere('event.visibility = :visibilityPublic')
+            ->andWhere('event.isCancelled = false')
             ->setParameter('applicationSlug', $applicationSlug)
+            ->setParameter('visibilityPublic', EventVisibility::PUBLIC->value)
             ->orderBy('event.startAt', 'ASC')
             ->setFirstResult($offset)
             ->setMaxResults($limit)
@@ -77,7 +81,10 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
         return (int)$this->applyListFilters($this->createCountQueryBuilder(), $filters, $esIds)
             ->innerJoin('calendar.application', 'application')
             ->andWhere('application.slug = :applicationSlug')
+            ->andWhere('event.visibility = :visibilityPublic')
+            ->andWhere('event.isCancelled = false')
             ->setParameter('applicationSlug', $applicationSlug)
+            ->setParameter('visibilityPublic', EventVisibility::PUBLIC->value)
             ->getQuery()
             ->getSingleScalarResult();
     }

--- a/tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php
+++ b/tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Calendar\Transport\Controller\Api\V1\Event;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ApplicationEventListControllerTest extends WebTestCase
+{
+    #[TestDox('GET /api/v1/calendar/applications/{applicationSlug}/events does not expose private events.')]
+    public function testPublicApplicationEventListDoesNotExposePrivateEvents(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/applications/crm-support-desk/events');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+
+        self::assertIsArray($responseData);
+        self::assertArrayHasKey('items', $responseData);
+        self::assertArrayHasKey('pagination', $responseData);
+        self::assertCount(0, $responseData['items']);
+        self::assertSame(0, $responseData['pagination']['totalItems']);
+    }
+
+    #[TestDox('GET /api/v1/calendar/private/applications/{applicationSlug}/events keeps owner/user access logic.')]
+    public function testPrivateApplicationEventListStillReturnsOwnerEvents(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/private/applications/crm-support-desk/events');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+
+        self::assertIsArray($responseData);
+        self::assertArrayHasKey('items', $responseData);
+        self::assertNotEmpty($responseData['items']);
+    }
+}


### PR DESCRIPTION
### Motivation
- Le endpoint public d'application doit n'exposer que les événements publics et ne pas révéler d'événements privés.
- Il est souhaitable d'exclure également les événements annulés de la liste publique pour éviter toute fuite d'information non désirée.

### Description
- Ajout de l'import de l'enum `EventVisibility` et application du filtre `event.visibility = :visibilityPublic` dans `EventRepository::findByApplicationSlug()` et `EventRepository::countByApplicationSlug()`.
- Ajout du filtre `event.isCancelled = false` dans les mêmes requêtes publiques pour exclure les événements annulés.
- Les méthodes `findByApplicationSlugAndUser()` et `countByApplicationSlugAndUser()` n'ont pas été modifiées afin de préserver la logique d'accès propriétaire/utilisateur côté privé.
- Ajout d'un test d'intégration `tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php` qui vérifie que l'endpoint public n'expose pas d'événements privés et que l'endpoint privé continue de retourner les événements accessibles au propriétaire.

### Testing
- `php -l src/Calendar/Infrastructure/Repository/EventRepository.php` a été exécuté et a renvoyé `No syntax errors detected`.
- `php -l tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php` a été exécuté et a renvoyé `No syntax errors detected`.
- Le test PHPUnit ajouté (`tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php`) n'a pas été exécuté ici car `./vendor/bin/phpunit` n'est pas présent dans l'environnement d'exécution (exécution locale/CI requise pour lancer la suite).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e8d053e88326a6ba3c9135dcfda5)