### PR TITLE
feat(chat): utiliser un enum pour les réactions de message

### DIFF
--- a/src/Chat/Application/Service/ConversationListService.php
+++ b/src/Chat/Application/Service/ConversationListService.php
@@ -265,7 +265,7 @@ final readonly class ConversationListService
                                 static fn (ChatMessageReaction $reaction): array => [
                                     'id' => $reaction->getId(),
                                     'userId' => $reaction->getUser(),
-                                    'reaction' => $reaction->getReaction(),
+                                    'reaction' => $reaction->getReaction()->value,
                                 ],
                                 $message->getReactions()->toArray()
                             ),

--- a/src/Chat/Domain/Entity/ChatMessageReaction.php
+++ b/src/Chat/Domain/Entity/ChatMessageReaction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Chat\Domain\Entity;
 
+use App\Chat\Domain\Enum\ChatReactionType;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
@@ -37,8 +38,8 @@ class ChatMessageReaction implements EntityInterface
     #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private User $user;
 
-    #[ORM\Column(name: 'reaction', type: Types::STRING, length: 32)]
-    private string $reaction = '';
+    #[ORM\Column(name: 'reaction', type: Types::STRING, enumType: ChatReactionType::class, length: 32)]
+    private ChatReactionType $reaction = ChatReactionType::LIKE;
 
     public function __construct()
     {
@@ -75,12 +76,12 @@ class ChatMessageReaction implements EntityInterface
         return $this;
     }
 
-    public function getReaction(): string
+    public function getReaction(): ChatReactionType
     {
         return $this->reaction;
     }
 
-    public function setReaction(string $reaction): self
+    public function setReaction(ChatReactionType $reaction): self
     {
         $this->reaction = $reaction;
 

--- a/src/Chat/Domain/Enum/ChatReactionType.php
+++ b/src/Chat/Domain/Enum/ChatReactionType.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Domain\Enum;
+
+enum ChatReactionType: string
+{
+    case LIKE = 'like';
+    case LOVE = 'love';
+    case LAUGH = 'laugh';
+    case WOW = 'wow';
+    case SAD = 'sad';
+    case ANGRY = 'angry';
+
+    public const VALUES = [
+        self::LIKE->value,
+        self::LOVE->value,
+        self::LAUGH->value,
+        self::WOW->value,
+        self::SAD->value,
+        self::ANGRY->value,
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public static function values(): array
+    {
+        return array_map(static fn (self $reaction): string => $reaction->value, self::cases());
+    }
+}

--- a/src/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationController.php
@@ -7,6 +7,7 @@ namespace App\Chat\Transport\Controller\Api\V1\Reaction;
 use App\Chat\Domain\Entity\ChatMessage;
 use App\Chat\Domain\Entity\ChatMessageReaction;
 use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Domain\Enum\ChatReactionType;
 use App\Chat\Infrastructure\Repository\ChatMessageReactionRepository;
 use App\Chat\Infrastructure\Repository\ChatMessageRepository;
 use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
@@ -23,12 +24,12 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Message Reaction')]
-#[OA\Post(path: '/v1/chat/private/messages/{messageId}/reactions', operationId: 'chat_reaction_create', summary: 'Créer une réaction', tags: ['Chat Message Reaction'], parameters: [new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['reaction'], properties: [new OA\Property(property: 'reaction', type: 'string', example: 'like')], example: [
+#[OA\Post(path: '/v1/chat/private/messages/{messageId}/reactions', operationId: 'chat_reaction_create', summary: 'Créer une réaction', tags: ['Chat Message Reaction'], parameters: [new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['reaction'], properties: [new OA\Property(property: 'reaction', type: 'string', enum: ChatReactionType::VALUES, example: 'like')], example: [
     'reaction' => 'like',
 ])), responses: [new OA\Response(response: 201, description: 'Réaction créée', content: new OA\JsonContent(example: [
     'id' => '8f210e56-6550-4b61-b7f3-8994f5f6dc41',
 ])), new OA\Response(response: 400, description: 'Payload invalide'), new OA\Response(response: 404, description: 'Message introuvable')])]
-#[OA\Patch(path: '/v1/chat/private/reactions/{reactionId}', operationId: 'chat_reaction_patch', summary: 'Modifier une réaction', tags: ['Chat Message Reaction'], parameters: [new OA\Parameter(name: 'reactionId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(properties: [new OA\Property(property: 'reaction', type: 'string', example: 'love')], example: [
+#[OA\Patch(path: '/v1/chat/private/reactions/{reactionId}', operationId: 'chat_reaction_patch', summary: 'Modifier une réaction', tags: ['Chat Message Reaction'], parameters: [new OA\Parameter(name: 'reactionId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(properties: [new OA\Property(property: 'reaction', type: 'string', enum: ChatReactionType::VALUES, example: 'love')], example: [
     'reaction' => 'love',
 ])), responses: [new OA\Response(response: 200, description: 'Réaction modifiée', content: new OA\JsonContent(example: [
     'id' => '8f210e56-6550-4b61-b7f3-8994f5f6dc41',
@@ -50,10 +51,7 @@ class UserReactionMutationController
         $message = $this->findParticipantMessage($messageId, $loggedInUser);
         $payload = $request->toArray();
 
-        $reactionType = $payload['reaction'] ?? null;
-        if (!is_string($reactionType) || $reactionType === '') {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "reaction" is required.');
-        }
+        $reactionType = $this->parseReactionType($payload['reaction'] ?? null);
 
         $reaction = (new ChatMessageReaction())
             ->setMessage($message)
@@ -74,8 +72,8 @@ class UserReactionMutationController
         $reaction = $this->findOwnReaction($reactionId, $loggedInUser);
         $payload = $request->toArray();
 
-        if (isset($payload['reaction']) && is_string($payload['reaction']) && $payload['reaction'] !== '') {
-            $reaction->setReaction($payload['reaction']);
+        if (array_key_exists('reaction', $payload)) {
+            $reaction->setReaction($this->parseReactionType($payload['reaction']));
             $this->reactionRepository->save($reaction);
             $this->cacheInvalidationService->invalidateConversationCaches($reaction->getMessage()->getConversation()->getChat()->getId(), $loggedInUser->getId());
         }
@@ -94,6 +92,24 @@ class UserReactionMutationController
         $this->cacheInvalidationService->invalidateConversationCaches($chatId, $loggedInUser->getId());
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+
+
+    private function parseReactionType(mixed $reaction): ChatReactionType
+    {
+        if (!is_string($reaction) || $reaction === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "reaction" must be a non-empty string.');
+        }
+
+        $reactionType = ChatReactionType::tryFrom($reaction);
+        if (!$reactionType instanceof ChatReactionType) {
+            throw new HttpException(
+                JsonResponse::HTTP_BAD_REQUEST,
+                sprintf('Invalid reaction "%s". Allowed values: %s.', $reaction, implode(', ', ChatReactionType::VALUES)),
+            );
+        }
+
+        return $reactionType;
     }
 
     private function findParticipantMessage(string $messageId, User $loggedInUser): ChatMessage

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -13,6 +13,7 @@ use App\Chat\Domain\Entity\ChatMessage;
 use App\Chat\Domain\Entity\ChatMessageReaction;
 use App\Chat\Domain\Entity\Conversation;
 use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Domain\Enum\ChatReactionType;
 use App\Platform\Domain\Entity\Application as PlatformApplication;
 use App\Platform\Domain\Entity\Plugin;
 use App\Recruit\Domain\Entity\Application as RecruitApplication;
@@ -90,24 +91,24 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
                 'partner' => $johnAdmin,
                 'firstMessage' => 'Hello John Admin, on peut échanger en privé sur les prochaines étapes ?',
                 'replyMessage' => 'Oui, je te confirme le plan et je garde cette conversation en direct.',
-                'rootReaction' => '🤝',
-                'partnerReaction' => '✅',
+                'rootReaction' => 'love',
+                'partnerReaction' => 'love',
             ],
             [
                 'application' => $this->getReference('Application-shop-orders-watch', PlatformApplication::class),
                 'partner' => $johnUser,
                 'firstMessage' => 'Salut John User, je te partage ici les points sensibles côté commandes.',
                 'replyMessage' => 'Parfait, je m’en occupe et je te fais un retour rapidement.',
-                'rootReaction' => '👍',
-                'partnerReaction' => '👀',
+                'rootReaction' => 'like',
+                'partnerReaction' => 'wow',
             ],
             [
                 'application' => $this->getReference('Application-school-course-flow', PlatformApplication::class),
                 'partner' => $johnApi,
                 'firstMessage' => 'Hello John API, on valide ensemble la synchro de ce soir en privé ?',
                 'replyMessage' => 'Oui, je lance la synchro et je confirme dès que c’est terminé.',
-                'rootReaction' => '🚀',
-                'partnerReaction' => '👌',
+                'rootReaction' => 'love',
+                'partnerReaction' => 'like',
             ],
         ];
 
@@ -296,8 +297,8 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             []
         );
 
-        $this->ensureReaction($manager, $replyMessage, $john, '👍');
-        $this->ensureReaction($manager, $introMessage, $johnAdmin, '✅');
+        $this->ensureReaction($manager, $replyMessage, $john, 'like');
+        $this->ensureReaction($manager, $introMessage, $johnAdmin, 'love');
     }
 
     private function createJohnRootConversationScenario(ObjectManager $manager, Chat $chat, Calendar $calendar): void
@@ -373,10 +374,10 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             []
         );
 
-        $this->ensureReaction($manager, $ownerReplyMessage, $johnRoot, '✅');
-        $this->ensureReaction($manager, $ownerReplyMessage, $johnAdmin, '👍');
-        $this->ensureReaction($manager, $johnUserMessage, $johnAdmin, '👀');
-        $this->ensureReaction($manager, $johnRootMessage, $otherOwner, '👏');
+        $this->ensureReaction($manager, $ownerReplyMessage, $johnRoot, 'love');
+        $this->ensureReaction($manager, $ownerReplyMessage, $johnAdmin, 'like');
+        $this->ensureReaction($manager, $johnUserMessage, $johnAdmin, 'wow');
+        $this->ensureReaction($manager, $johnRootMessage, $otherOwner, 'laugh');
 
         $event = $this->ensureJohnRootScenarioEvent($manager, $calendar, $johnRoot);
 
@@ -566,12 +567,12 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         return $message;
     }
 
-    private function ensureReaction(ObjectManager $manager, ChatMessage $message, User $user, string $emoji): void
+    private function ensureReaction(ObjectManager $manager, ChatMessage $message, User $user, string $reaction): void
     {
         $existing = $manager->getRepository(ChatMessageReaction::class)->findOneBy([
             'message' => $message,
             'user' => $user,
-            'reaction' => $emoji,
+            'reaction' => $reaction,
         ]);
 
         if ($existing instanceof ChatMessageReaction) {
@@ -581,7 +582,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $reaction = (new ChatMessageReaction())
             ->setMessage($message)
             ->setUser($user)
-            ->setReaction($emoji);
+            ->setReaction(ChatReactionType::from($reaction));
 
         $manager->persist($reaction);
     }


### PR DESCRIPTION
### Motivation

- Rendre les réactions de message typées et restreintes aux valeurs autorisées pour éviter les valeurs libres/emoji inconsistantes en base.
- Exposer la liste des valeurs autorisées dans la doc OpenAPI pour faciliter la validation côté client.
- Adapter le code et les fixtures pour être compatibles avec le nouveau typage enum.

### Description

- Ajout de l'enum string `ChatReactionType` avec les valeurs autorisées `like`, `love`, `laugh`, `wow`, `sad`, `angry` et une constante réutilisable `VALUES` pour documentation/validation. (`src/Chat/Domain/Enum/ChatReactionType.php`)
- Migration du champ `reaction` de `ChatMessageReaction` pour utiliser l'enum côté Doctrine (`enumType: ChatReactionType::class`) et adaptation des signatures `getReaction()` / `setReaction()` pour `ChatReactionType`. (`src/Chat/Domain/Entity/ChatMessageReaction.php`)
- Validation/conversion du payload `reaction` dans `UserReactionMutationController` via une méthode `parseReactionType`, avec erreurs `400` claires si absent ou invalide, et inclusion de la liste d'enum autorisée dans les annotations OpenAPI pour POST/PATCH. (`src/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationController.php`)
- Sérialisation des réactions dans la liste de conversations renvoyant la valeur string de l'enum (`->value`). (`src/Chat/Application/Service/ConversationListService.php`)
- Alignement des fixtures Recruit pour utiliser les valeurs autorisées (remplacement d'emoji par les clés `like`, `love`, etc.) et appel de l'enum (`ChatReactionType::from(...)`) dans le code de fixture. (`src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php`)

### Testing

- Exécution de vérifications de syntaxe PHP avec `php -l` sur les fichiers modifiés: `src/Chat/Domain/Enum/ChatReactionType.php`, `src/Chat/Domain/Entity/ChatMessageReaction.php`, `src/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationController.php`, `src/Chat/Application/Service/ConversationListService.php`, et `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php`, toutes réussies. 
- Vérification additionnelle de `php -l` sur le contrôleur et les fixtures après modifications, également réussie.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e8d607c48326a98c177c62f18c03)