### PR TITLE
Add explicit, unique blog slug provisioning with bootstrap post title

### DIFF
--- a/src/Platform/Application/Service/PluginProvisioning/BlogPluginProvisioner.php
+++ b/src/Platform/Application/Service/PluginProvisioning/BlogPluginProvisioner.php
@@ -14,6 +14,14 @@ use App\Blog\Infrastructure\Repository\BlogTagRepository;
 use App\Platform\Domain\Entity\Application;
 use Doctrine\ORM\EntityManagerInterface;
 
+use function iconv;
+use function is_string;
+use function preg_replace;
+use function strlen;
+use function strtolower;
+use function substr;
+use function trim;
+
 final readonly class BlogPluginProvisioner
 {
     public function __construct(
@@ -28,8 +36,11 @@ final readonly class BlogPluginProvisioner
     {
         $blog = $this->blogRepository->findOneByApplication($application);
         if (!$blog instanceof Blog) {
+            $blogSlug = $this->generateUniqueBlogSlug($application);
+
             $blog = (new Blog())
                 ->setTitle($application->getTitle() . ' Blog')
+                ->setSlug($blogSlug)
                 ->setOwner($application->getUser())
                 ->setType(BlogType::APPLICATION)
                 ->setApplication($application);
@@ -62,8 +73,44 @@ final readonly class BlogPluginProvisioner
         $post = (new BlogPost())
             ->setBlog($blog)
             ->setAuthor($application->getUser())
+            ->setTitle('Welcome to ' . $application->getTitle() . ' Blog')
             ->setContent('Welcome to your application blog.');
 
         $this->entityManager->persist($post);
+    }
+
+    private function generateUniqueBlogSlug(Application $application): string
+    {
+        $baseSlug = $this->buildBaseSlug($application);
+        $slug = $baseSlug;
+        $suffix = 2;
+
+        while ($this->blogRepository->findOneBy(['slug' => $slug]) instanceof Blog) {
+            $suffixToken = '-' . $suffix;
+            $slug = substr($baseSlug, 0, 150 - strlen($suffixToken)) . $suffixToken;
+            ++$suffix;
+        }
+
+        return $slug;
+    }
+
+    private function buildBaseSlug(Application $application): string
+    {
+        $application->ensureGeneratedSlug();
+
+        $candidate = trim($application->getSlug(), '-');
+        if ($candidate === '') {
+            $candidate = 'app-' . substr($application->getId(), 0, 8);
+        }
+
+        $normalizedValue = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $candidate . '-blog');
+        $base = is_string($normalizedValue) ? $normalizedValue : $candidate . '-blog';
+        $slug = trim((string) preg_replace('/[^a-z0-9]+/i', '-', strtolower($base)), '-');
+
+        if ($slug === '') {
+            $slug = 'blog-' . substr($application->getId(), 0, 8);
+        }
+
+        return substr($slug, 0, 150);
     }
 }

--- a/tests/Unit/Platform/Application/Service/PluginProvisioning/BlogPluginProvisionerTest.php
+++ b/tests/Unit/Platform/Application/Service/PluginProvisioning/BlogPluginProvisionerTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Platform\Application\Service\PluginProvisioning;
+
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Entity\BlogPost;
+use App\Blog\Domain\Entity\BlogTag;
+use App\Blog\Infrastructure\Repository\BlogPostRepository;
+use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\Blog\Infrastructure\Repository\BlogTagRepository;
+use App\Platform\Application\Service\PluginProvisioning\BlogPluginProvisioner;
+use App\Platform\Domain\Entity\Application;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+final class BlogPluginProvisionerTest extends TestCase
+{
+    public function testProvisionCreatesBlogWithUniqueSlugAndBootstrapPostTitle(): void
+    {
+        $application = (new Application())
+            ->setTitle('My App')
+            ->setUser(new User());
+
+        $blogRepository = $this->createMock(BlogRepository::class);
+        $blogRepository->method('findOneByApplication')->willReturn(null);
+
+        $existingBlog = (new Blog())->setSlug('my-app-blog');
+        $blogRepository
+            ->method('findOneBy')
+            ->willReturnCallback(static function (array $criteria) use ($existingBlog): ?Blog {
+                if (($criteria['slug'] ?? null) === 'my-app-blog') {
+                    return $existingBlog;
+                }
+
+                return null;
+            });
+
+        $blogPostRepository = $this->createMock(BlogPostRepository::class);
+        $blogPostRepository->method('findOneBy')->willReturn(null);
+
+        $blogTagRepository = $this->createMock(BlogTagRepository::class);
+        $blogTagRepository->method('findOneBy')->willReturn(null);
+
+        $persisted = [];
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects(self::exactly(3))
+            ->method('persist')
+            ->willReturnCallback(static function (object $entity) use (&$persisted): void {
+                $persisted[] = $entity;
+            });
+
+        $provisioner = new BlogPluginProvisioner(
+            blogRepository: $blogRepository,
+            blogPostRepository: $blogPostRepository,
+            blogTagRepository: $blogTagRepository,
+            entityManager: $entityManager,
+        );
+
+        $provisioner->provision($application);
+
+        $blog = self::findPersistedEntity($persisted, Blog::class);
+        self::assertSame('my-app-blog-2', $blog->getSlug());
+
+        $post = self::findPersistedEntity($persisted, BlogPost::class);
+        self::assertSame('Welcome to My App Blog', $post->getTitle());
+
+        $tag = self::findPersistedEntity($persisted, BlogTag::class);
+        self::assertSame('Getting Started', $tag->getLabel());
+    }
+
+    public function testProvisionUsesSafeSlugFallbackWhenApplicationSlugGenerationIsEmpty(): void
+    {
+        $application = (new Application())
+            ->setTitle('***')
+            ->setUser(new User());
+
+        $blogRepository = $this->createMock(BlogRepository::class);
+        $blogRepository->method('findOneByApplication')->willReturn(null);
+        $blogRepository->method('findOneBy')->willReturn(null);
+
+        $blogPostRepository = $this->createMock(BlogPostRepository::class);
+        $blogPostRepository->method('findOneBy')->willReturn(null);
+
+        $blogTagRepository = $this->createMock(BlogTagRepository::class);
+        $blogTagRepository->method('findOneBy')->willReturn(null);
+
+        $persisted = [];
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->method('persist')
+            ->willReturnCallback(static function (object $entity) use (&$persisted): void {
+                $persisted[] = $entity;
+            });
+
+        $provisioner = new BlogPluginProvisioner(
+            blogRepository: $blogRepository,
+            blogPostRepository: $blogPostRepository,
+            blogTagRepository: $blogTagRepository,
+            entityManager: $entityManager,
+        );
+
+        $provisioner->provision($application);
+
+        $blog = self::findPersistedEntity($persisted, Blog::class);
+        self::assertMatchesRegularExpression('/^app-[a-f0-9]{8}-blog$/', $blog->getSlug());
+    }
+
+    /**
+     * @template T of object
+     * @param list<object> $persisted
+     * @param class-string<T> $expectedClass
+     * @return T
+     */
+    private static function findPersistedEntity(array $persisted, string $expectedClass): object
+    {
+        foreach ($persisted as $entity) {
+            if ($entity instanceof $expectedClass) {
+                return $entity;
+            }
+        }
+
+        self::fail('Entity of type ' . $expectedClass . ' was not persisted.');
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure newly provisioned blogs receive a deterministic, explicit `slug` instead of an implicit empty value to satisfy DB uniqueness constraints. 
- Derive a human-friendly default from the application (`<application-slug>-blog`) while providing a safe fallback when the application slug is empty. 
- Avoid slug collisions by resolving duplicates with numeric suffixes and provide a meaningful bootstrap post title instead of leaving it empty.

### Description
- Set an explicit blog slug during provisioning by adding `->setSlug(...)` and implementing `generateUniqueBlogSlug()` to produce a deterministic base and resolve collisions. 
- Add `buildBaseSlug()` to normalize the application slug (calls `ensureGeneratedSlug()`), append `-blog`, transliterate and sanitize the value, and enforce the DB length limit. 
- Handle collisions by probing `BlogRepository::findOneBy(['slug' => $slug])` and appending `-2`, `-3`, ... while trimming the base to respect the 150-char column. 
- Set a coherent bootstrap post title via `->setTitle('Welcome to ' . $application->getTitle() . ' Blog')` and add unit tests at `tests/Unit/Platform/Application/Service/PluginProvisioning/BlogPluginProvisionerTest.php` covering collision handling and safe-fallback slug generation.

### Testing
- Ran PHP syntax checks: `php -l src/Platform/Application/Service/PluginProvisioning/BlogPluginProvisioner.php` and `php -l tests/Unit/Platform/Application/Service/PluginProvisioning/BlogPluginProvisionerTest.php`, both succeeded. 
- Exercised the new provisioning logic via the added PHPUnit test file `tests/Unit/Platform/Application/Service/PluginProvisioning/BlogPluginProvisionerTest.php` (test logic created and verified for syntax). 
- Attempted to run `phpunit` in this environment (`./vendor/bin/phpunit` and `./bin/phpunit`) but the PHPUnit binary was not available, so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e92d361483268133065fec2b4bbb)