### PR TITLE
Ajout d'enums pour Exam (type/status/term) + validation, fixtures, migration et docs OpenAPI

### DIFF
--- a/migrations/Version20260311200000.php
+++ b/migrations/Version20260311200000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260311200000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add enum-like columns for school_exam type/status/term';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE school_exam ADD type VARCHAR(32) NOT NULL DEFAULT 'QUIZ', ADD status VARCHAR(32) NOT NULL DEFAULT 'DRAFT', ADD term VARCHAR(32) NOT NULL DEFAULT 'TERM_1'");
+        $this->addSql("UPDATE school_exam SET type = 'QUIZ' WHERE type = '' OR type IS NULL");
+        $this->addSql("UPDATE school_exam SET status = 'DRAFT' WHERE status = '' OR status IS NULL");
+        $this->addSql("UPDATE school_exam SET term = 'TERM_1' WHERE term = '' OR term IS NULL");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE school_exam DROP type, DROP status, DROP term');
+    }
+}

--- a/src/School/Application/Serializer/SchoolViewMapper.php
+++ b/src/School/Application/Serializer/SchoolViewMapper.php
@@ -82,6 +82,9 @@ final readonly class SchoolViewMapper
                 'className' => $exam->getSchoolClass()?->getName(),
                 'teacherId' => $exam->getTeacher()?->getId(),
                 'teacherName' => $exam->getTeacher()?->getName(),
+                'type' => $exam->getType()->value,
+                'status' => $exam->getStatus()->value,
+                'term' => $exam->getTerm()->value,
                 'updatedAt' => $exam->getUpdatedAt()?->format(DATE_ATOM),
             ];
         }

--- a/src/School/Application/Service/CreateExamService.php
+++ b/src/School/Application/Service/CreateExamService.php
@@ -6,6 +6,9 @@ namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityCreated;
 use App\School\Domain\Entity\Exam;
+use App\School\Domain\Enum\ExamStatus;
+use App\School\Domain\Enum\ExamType;
+use App\School\Domain\Enum\Term;
 use App\School\Infrastructure\Repository\SchoolClassRepository;
 use App\School\Infrastructure\Repository\TeacherRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -21,9 +24,20 @@ final readonly class CreateExamService
     ) {
     }
 
-    public function create(string $title, ?string $classId, ?string $teacherId): Exam
-    {
-        $exam = (new Exam())->setTitle($title);
+    public function create(
+        string $title,
+        ?string $classId,
+        ?string $teacherId,
+        ExamType $type,
+        ExamStatus $status,
+        Term $term,
+    ): Exam {
+        $exam = (new Exam())
+            ->setTitle($title)
+            ->setType($type)
+            ->setStatus($status)
+            ->setTerm($term);
+
         if (is_string($classId)) {
             $exam->setSchoolClass($this->classRepository->find($classId));
         }

--- a/src/School/Domain/Entity/Exam.php
+++ b/src/School/Domain/Entity/Exam.php
@@ -7,6 +7,9 @@ namespace App\School\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\School\Domain\Enum\ExamStatus;
+use App\School\Domain\Enum\ExamType;
+use App\School\Domain\Enum\Term;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -39,6 +42,15 @@ class Exam implements EntityInterface
 
     #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
     private string $title = '';
+
+    #[ORM\Column(name: 'type', type: Types::STRING, length: 32, enumType: ExamType::class)]
+    private ExamType $type = ExamType::QUIZ;
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 32, enumType: ExamStatus::class)]
+    private ExamStatus $status = ExamStatus::DRAFT;
+
+    #[ORM\Column(name: 'term', type: Types::STRING, length: 32, enumType: Term::class)]
+    private Term $term = Term::TERM_1;
 
     /** @var Collection<int, Grade>|ArrayCollection<int, Grade> */
     #[ORM\OneToMany(targetEntity: Grade::class, mappedBy: 'exam')]
@@ -82,6 +94,36 @@ class Exam implements EntityInterface
     public function setTitle(string $title): self
     {
         $this->title = $title;
+
+        return $this;
+    }
+    public function getType(): ExamType
+    {
+        return $this->type;
+    }
+    public function setType(ExamType $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+    public function getStatus(): ExamStatus
+    {
+        return $this->status;
+    }
+    public function setStatus(ExamStatus $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+    public function getTerm(): Term
+    {
+        return $this->term;
+    }
+    public function setTerm(Term $term): self
+    {
+        $this->term = $term;
 
         return $this;
     }

--- a/src/School/Domain/Enum/ExamStatus.php
+++ b/src/School/Domain/Enum/ExamStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Domain\Enum;
+
+enum ExamStatus: string
+{
+    case DRAFT = 'DRAFT';
+    case PUBLISHED = 'PUBLISHED';
+    case CLOSED = 'CLOSED';
+
+    /** @return list<string> */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/src/School/Domain/Enum/ExamType.php
+++ b/src/School/Domain/Enum/ExamType.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Domain\Enum;
+
+enum ExamType: string
+{
+    case QUIZ = 'QUIZ';
+    case MIDTERM = 'MIDTERM';
+    case FINAL = 'FINAL';
+    case ORAL = 'ORAL';
+
+    /** @return list<string> */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/src/School/Domain/Enum/Term.php
+++ b/src/School/Domain/Enum/Term.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Domain\Enum;
+
+enum Term: string
+{
+    case TERM_1 = 'TERM_1';
+    case TERM_2 = 'TERM_2';
+    case TERM_3 = 'TERM_3';
+
+    /** @return list<string> */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
+++ b/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
@@ -12,6 +12,9 @@ use App\School\Domain\Entity\School;
 use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Student;
 use App\School\Domain\Entity\Teacher;
+use App\School\Domain\Enum\ExamStatus;
+use App\School\Domain\Enum\ExamType;
+use App\School\Domain\Enum\Term;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -65,11 +68,17 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
             $examMath = (new Exam())
                 ->setSchoolClass($classA)
                 ->setTeacher($teacherMath)
-                ->setTitle('Examen Mathematiques - Trimestre 1');
+                ->setTitle('Examen Mathematiques - Trimestre 1')
+                ->setType(ExamType::MIDTERM)
+                ->setStatus(ExamStatus::PUBLISHED)
+                ->setTerm(Term::TERM_1);
             $examFrench = (new Exam())
                 ->setSchoolClass($classB)
                 ->setTeacher($teacherFrench)
-                ->setTitle('Examen Francais - Trimestre 1');
+                ->setTitle('Examen Francais - Trimestre 1')
+                ->setType(ExamType::QUIZ)
+                ->setStatus(ExamStatus::DRAFT)
+                ->setTerm(Term::TERM_1);
             $manager->persist($examMath);
             $manager->persist($examFrench);
 

--- a/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\School\Transport\Controller\Api\V1\Exam;
 
 use App\School\Application\Service\CreateExamService;
+use App\School\Domain\Enum\ExamStatus;
+use App\School\Domain\Enum\ExamType;
+use App\School\Domain\Enum\Term;
 use App\School\Transport\Controller\Api\V1\Input\CreateExamInput;
 use App\School\Transport\Controller\Api\V1\Input\SchoolInputValidator;
 use OpenApi\Attributes as OA;
@@ -26,6 +29,26 @@ final readonly class CreateExamController
     ) {
     }
 
+    #[OA\Post(
+        path: '/v1/school/exams',
+        summary: 'Créer un examen',
+        tags: ['School'],
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+            required: ['title', 'classId', 'teacherId', 'type', 'status', 'term'],
+            properties: [
+                new OA\Property(property: 'title', type: 'string', example: 'Examen Mathematiques - Trimestre 1'),
+                new OA\Property(property: 'classId', type: 'string', format: 'uuid'),
+                new OA\Property(property: 'teacherId', type: 'string', format: 'uuid'),
+                new OA\Property(property: 'type', type: 'string', enum: ['QUIZ', 'MIDTERM', 'FINAL', 'ORAL'], example: 'QUIZ'),
+                new OA\Property(property: 'status', type: 'string', enum: ['DRAFT', 'PUBLISHED', 'CLOSED'], example: 'DRAFT'),
+                new OA\Property(property: 'term', type: 'string', enum: ['TERM_1', 'TERM_2', 'TERM_3'], example: 'TERM_1'),
+            ],
+        )),
+        responses: [
+            new OA\Response(response: 201, description: 'Examen créé'),
+            new OA\Response(response: 422, description: 'Validation failed'),
+        ],
+    )]
     #[Route('/v1/school/exams', methods: [Request::METHOD_POST])]
     public function __invoke(Request $request): JsonResponse
     {
@@ -35,13 +58,23 @@ final readonly class CreateExamController
         $input->title = (string)($payload['title'] ?? '');
         $input->classId = is_string($payload['classId'] ?? null) ? $payload['classId'] : '';
         $input->teacherId = is_string($payload['teacherId'] ?? null) ? $payload['teacherId'] : '';
+        $input->type = is_string($payload['type'] ?? null) ? $payload['type'] : '';
+        $input->status = is_string($payload['status'] ?? null) ? $payload['status'] : '';
+        $input->term = is_string($payload['term'] ?? null) ? $payload['term'] : '';
 
         $validationResponse = $this->inputValidator->validate($input);
         if ($validationResponse instanceof JsonResponse) {
             return $validationResponse;
         }
 
-        $exam = $this->createExamService->create($input->title, $input->classId, $input->teacherId);
+        $exam = $this->createExamService->create(
+            $input->title,
+            $input->classId,
+            $input->teacherId,
+            ExamType::from($input->type),
+            ExamStatus::from($input->status),
+            Term::from($input->term),
+        );
 
         return new JsonResponse(['id' => $exam->getId()], JsonResponse::HTTP_CREATED);
     }

--- a/src/School/Transport/Controller/Api/V1/Input/CreateExamInput.php
+++ b/src/School/Transport/Controller/Api/V1/Input/CreateExamInput.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace App\School\Transport\Controller\Api\V1\Input;
 
+use App\School\Domain\Enum\ExamStatus;
+use App\School\Domain\Enum\ExamType;
+use App\School\Domain\Enum\Term;
 use Symfony\Component\Validator\Constraints as Assert;
 
 final class CreateExamInput
@@ -18,4 +21,16 @@ final class CreateExamInput
     #[Assert\NotBlank]
     #[Assert\Uuid]
     public string $teacherId = '';
+
+    #[Assert\NotBlank]
+    #[Assert\Choice(callback: [ExamType::class, 'values'])]
+    public string $type = '';
+
+    #[Assert\NotBlank]
+    #[Assert\Choice(callback: [ExamStatus::class, 'values'])]
+    public string $status = '';
+
+    #[Assert\NotBlank]
+    #[Assert\Choice(callback: [Term::class, 'values'])]
+    public string $term = '';
 }

--- a/tests/Unit/School/Application/Serializer/SchoolViewMapperTest.php
+++ b/tests/Unit/School/Application/Serializer/SchoolViewMapperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\School\Application\Serializer;
+
+use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Domain\Entity\Exam;
+use App\School\Domain\Entity\SchoolClass;
+use App\School\Domain\Entity\Teacher;
+use App\School\Domain\Enum\ExamStatus;
+use App\School\Domain\Enum\ExamType;
+use App\School\Domain\Enum\Term;
+use PHPUnit\Framework\TestCase;
+
+final class SchoolViewMapperTest extends TestCase
+{
+    public function testMapExamCollectionIncludesEnumValues(): void
+    {
+        $schoolClass = (new SchoolClass())->setName('Classe A - Sciences');
+        $teacher = (new Teacher())->setName('Mme Martin');
+        $exam = (new Exam())
+            ->setTitle('Examen Mathematiques - Trimestre 1')
+            ->setSchoolClass($schoolClass)
+            ->setTeacher($teacher)
+            ->setType(ExamType::FINAL)
+            ->setStatus(ExamStatus::PUBLISHED)
+            ->setTerm(Term::TERM_2);
+
+        $result = (new SchoolViewMapper())->mapExamCollection([$exam]);
+
+        self::assertSame('FINAL', $result[0]['type']);
+        self::assertSame('PUBLISHED', $result[0]['status']);
+        self::assertSame('TERM_2', $result[0]['term']);
+    }
+}

--- a/tests/Unit/School/Transport/Controller/Api/V1/Input/CreateExamInputTest.php
+++ b/tests/Unit/School/Transport/Controller/Api/V1/Input/CreateExamInputTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\School\Transport\Controller\Api\V1\Input;
+
+use App\School\Transport\Controller\Api\V1\Input\CreateExamInput;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validation;
+
+final class CreateExamInputTest extends TestCase
+{
+    public function testEnumValidationRejectsUnknownValues(): void
+    {
+        $input = new CreateExamInput();
+        $input->title = 'Exam';
+        $input->classId = '550e8400-e29b-41d4-a716-446655440000';
+        $input->teacherId = '550e8400-e29b-41d4-a716-446655440001';
+        $input->type = 'HOMEWORK';
+        $input->status = 'ARCHIVED';
+        $input->term = 'TERM_4';
+
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+        $violations = $validator->validate($input);
+
+        self::assertGreaterThanOrEqual(3, $violations->count());
+    }
+
+    public function testEnumValidationAcceptsAllowedValues(): void
+    {
+        $input = new CreateExamInput();
+        $input->title = 'Exam';
+        $input->classId = '550e8400-e29b-41d4-a716-446655440000';
+        $input->teacherId = '550e8400-e29b-41d4-a716-446655440001';
+        $input->type = 'QUIZ';
+        $input->status = 'DRAFT';
+        $input->term = 'TERM_1';
+
+        $validator = Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator();
+
+        self::assertCount(0, $validator->validate($input));
+    }
+}


### PR DESCRIPTION
### Motivation
- Normaliser les valeurs métier des examens (type, statut, trimestre) en remplaçant des strings libres par des enums pour éviter les valeurs invalides et faciliter la validation et la documentation.
- Exposer explicitement les valeurs autorisées dans la doc OpenAPI pour les endpoints de création/mise à jour.

### Description
- Ajout des enums `ExamType`, `ExamStatus`, `Term` dans `src/School/Domain/Enum/` avec une méthode `values()` utilisable par les contraintes de validation (`CreateExamInput`).
- Mise à jour de l'entité `Exam` pour inclure les colonnes Doctrine `type`, `status`, `term` en utilisant `enumType` et ajout des getters/setters correspondants.
- Adaptation du flux de création d'examen : `CreateExamInput` (contraintes `Choice`), `CreateExamController` (lecture des champs, conversion en enums et annotation OpenAPI avec `enum: [...]`), et `CreateExamService` (acceptation d'enums typés et persistance).
- Fixtures mises à jour (`LoadSchoolData`) pour initialiser explicitement `type/status/term`, et ajout d'une migration `migrations/Version20260311200000.php` pour créer les colonnes avec valeurs par défaut.
- Sérialisation enrichie pour exposer `type`, `status`, `term` dans la sortie via `SchoolViewMapper` et ajout de tests unitaires pour la sérialisation et la validation DTO (`tests/Unit/School/...`).

### Testing
- Syntax checks via `php -l` sur les fichiers modifiés passés sans erreur (tous les fichiers PHP modifiés vérifiés avec `php -l`).
- Unit tests added (`tests/Unit/School/Application/Serializer/SchoolViewMapperTest.php` and `tests/Unit/School/Transport/Controller/Api/V1/Input/CreateExamInputTest.php`) but not executed here because `vendor/bin/phpunit` is not available in the environment (PHPUnit not installed); `composer test` also could not run for the same reason.
- Migration file created at `migrations/Version20260311200000.php` to add `type/status/term` columns with sensible defaults and a `down` rollback.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0e8dd1dac8326afcde550d4d731f8)