### PR TITLE
Fix Security autowiring in BlogMutationController

### DIFF
--- a/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogMutationController.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 use function sprintf;


### PR DESCRIPTION
### Motivation
- The container failed to autowire `App\Blog\Transport\Controller\Api\V1\BlogMutationController` because the constructor expected `Symfony\Component\Security\Core\Security` which is not the service type provided by this app's DI container.

### Description
- Replace the `Security` import in `src/Blog/Transport/Controller/Api/V1/BlogMutationController.php` from `Symfony\Component\Security\Core\Security` to `Symfony\Bundle\SecurityBundle\Security` so the controller constructor matches the available service.

### Testing
- Ran `composer prepare`, which could not complete in this environment because dependencies are missing (`Dependencies are missing. Try running "composer install"`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ea5bffc88326bf6b7bbd0b0e56d5)