### PR TITLE
Prevent duplicate blog reactions per comment/author

### DIFF
--- a/migrations/Version20260311210000.php
+++ b/migrations/Version20260311210000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260311210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Enforce unique blog reaction per (comment_id, author_id)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE blog_reaction ADD CONSTRAINT uniq_blog_reaction_comment_author UNIQUE (comment_id, author_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE blog_reaction DROP INDEX uniq_blog_reaction_comment_author');
+    }
+}

--- a/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
@@ -38,6 +38,17 @@ final readonly class CreateBlogReactionCommandHandler
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found.');
         }
 
+        $existingReaction = $this->reactionRepository->findOneByCommentAndAuthor($comment, $user);
+
+        if ($existingReaction instanceof BlogReaction) {
+            $existingReaction->setType($command->type);
+            $this->reactionRepository->save($existingReaction);
+
+            $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
+
+            return;
+        }
+
         $this->reactionRepository->save((new BlogReaction())
             ->setComment($comment)
             ->setAuthor($user)

--- a/src/Blog/Infrastructure/Repository/BlogReactionRepository.php
+++ b/src/Blog/Infrastructure/Repository/BlogReactionRepository.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Blog\Infrastructure\Repository;
 
+use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Domain\Entity\BlogReaction;
 use App\General\Infrastructure\Repository\BaseRepository;
+use App\User\Domain\Entity\User;
 use Doctrine\Persistence\ManagerRegistry;
 
 class BlogReactionRepository extends BaseRepository
@@ -16,5 +18,15 @@ class BlogReactionRepository extends BaseRepository
     public function __construct(
         protected ManagerRegistry $managerRegistry
     ) {
+    }
+
+    public function findOneByCommentAndAuthor(BlogComment $comment, User $author): ?BlogReaction
+    {
+        $reaction = $this->findOneBy([
+            'comment' => $comment,
+            'author' => $author,
+        ]);
+
+        return $reaction instanceof BlogReaction ? $reaction : null;
     }
 }

--- a/tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php
+++ b/tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php
@@ -70,6 +70,128 @@ final class BlogControllerTest extends WebTestCase
         self::assertAuthorFlagsForAuthenticatedPayload($authenticatedPayload, $johnUser->getId());
     }
 
+
+    public function testCreateReactionUpsertsForSameAuthorAndComment(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blogs/application/shop-ops-center');
+        self::assertResponseStatusCodeSame(200);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $johnUser = $userRepository->findOneBy(['username' => 'john-user']);
+        self::assertNotNull($johnUser);
+
+        $targetCommentId = self::findFirstCommentId($payload);
+        self::assertNotNull($targetCommentId);
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/blog/comments/' . $targetCommentId . '/reactions',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode(['type' => 'heart'], JSON_THROW_ON_ERROR),
+        );
+        self::assertResponseStatusCodeSame(202);
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/blog/comments/' . $targetCommentId . '/reactions',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode(['type' => 'laugh'], JSON_THROW_ON_ERROR),
+        );
+        self::assertResponseStatusCodeSame(202);
+
+        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blogs/application/shop-ops-center');
+        self::assertResponseStatusCodeSame(200);
+        /** @var array<string, mixed> $updatedPayload */
+        $updatedPayload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $targetComment = self::findCommentById($updatedPayload, $targetCommentId);
+        self::assertIsArray($targetComment);
+        self::assertArrayHasKey('reactions', $targetComment);
+        self::assertIsArray($targetComment['reactions']);
+
+        $johnUserReactionTypes = [];
+        foreach ($targetComment['reactions'] as $reaction) {
+            if (!is_array($reaction)) {
+                continue;
+            }
+
+            if (($reaction['authorId'] ?? null) === $johnUser->getId()) {
+                $johnUserReactionTypes[] = $reaction['type'] ?? null;
+            }
+        }
+
+        self::assertCount(1, $johnUserReactionTypes);
+        self::assertSame('laugh', $johnUserReactionTypes[0]);
+    }
+
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private static function findFirstCommentId(array $node): ?string
+    {
+        if (isset($node['id']) && isset($node['content'])) {
+            return is_string($node['id']) ? $node['id'] : null;
+        }
+
+        foreach (['posts', 'comments', 'children'] as $listKey) {
+            if (!isset($node[$listKey]) || !is_array($node[$listKey])) {
+                continue;
+            }
+
+            foreach ($node[$listKey] as $child) {
+                if (!is_array($child)) {
+                    continue;
+                }
+
+                $id = self::findFirstCommentId($child);
+                if (is_string($id)) {
+                    return $id;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $node
+     */
+    private static function findCommentById(array $node, string $commentId): ?array
+    {
+        if (($node['id'] ?? null) === $commentId && isset($node['content'])) {
+            return $node;
+        }
+
+        foreach (['posts', 'comments', 'children'] as $listKey) {
+            if (!isset($node[$listKey]) || !is_array($node[$listKey])) {
+                continue;
+            }
+
+            foreach ($node[$listKey] as $child) {
+                if (!is_array($child)) {
+                    continue;
+                }
+
+                $found = self::findCommentById($child, $commentId);
+                if (is_array($found)) {
+                    return $found;
+                }
+            }
+        }
+
+        return null;
+    }
+
     /**
      * @param array<string, mixed> $payload
      */

--- a/tests/Unit/Blog/Application/MessageHandler/CreateBlogReactionCommandHandlerTest.php
+++ b/tests/Unit/Blog/Application/MessageHandler/CreateBlogReactionCommandHandlerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Blog\Application\MessageHandler;
+
+use App\Blog\Application\Message\CreateBlogReactionCommand;
+use App\Blog\Application\MessageHandler\CreateBlogReactionCommandHandler;
+use App\Blog\Application\Service\BlogNotificationService;
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Entity\BlogComment;
+use App\Blog\Domain\Entity\BlogPost;
+use App\Blog\Domain\Entity\BlogReaction;
+use App\Blog\Domain\Enum\BlogReactionType;
+use App\Blog\Infrastructure\Repository\BlogCommentRepository;
+use App\Blog\Infrastructure\Repository\BlogReactionRepository;
+use App\General\Application\Service\CacheInvalidationService;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use PHPUnit\Framework\TestCase;
+
+final class CreateBlogReactionCommandHandlerTest extends TestCase
+{
+    public function testInvokeCreatesReactionWhenNoneExists(): void
+    {
+        $reactionRepository = $this->createMock(BlogReactionRepository::class);
+        $commentRepository = $this->createMock(BlogCommentRepository::class);
+        $userRepository = $this->createMock(UserRepository::class);
+        $notificationService = $this->createMock(BlogNotificationService::class);
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+
+        [$comment, $user] = $this->createCommentAndUser();
+
+        $commentRepository->method('find')->willReturn($comment);
+        $userRepository->method('find')->willReturn($user);
+        $reactionRepository->expects(self::once())
+            ->method('findOneByCommentAndAuthor')
+            ->with($comment, $user)
+            ->willReturn(null);
+        $reactionRepository->expects(self::once())
+            ->method('save')
+            ->with(self::isInstanceOf(BlogReaction::class));
+        $notificationService->expects(self::once())
+            ->method('notifyReactionCreated')
+            ->with($comment, $user, BlogReactionType::HEART->value);
+        $cacheInvalidationService->expects(self::once())->method('invalidateBlogCaches');
+
+        $handler = new CreateBlogReactionCommandHandler(
+            $reactionRepository,
+            $commentRepository,
+            $userRepository,
+            $notificationService,
+            $cacheInvalidationService,
+        );
+
+        $handler(new CreateBlogReactionCommand('op', 'actor', 'comment', BlogReactionType::HEART));
+    }
+
+    public function testInvokeUpdatesExistingReactionForSameCommentAndAuthor(): void
+    {
+        $reactionRepository = $this->createMock(BlogReactionRepository::class);
+        $commentRepository = $this->createMock(BlogCommentRepository::class);
+        $userRepository = $this->createMock(UserRepository::class);
+        $notificationService = $this->createMock(BlogNotificationService::class);
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+
+        [$comment, $user] = $this->createCommentAndUser();
+        $existingReaction = (new BlogReaction())
+            ->setComment($comment)
+            ->setAuthor($user)
+            ->setType(BlogReactionType::LIKE);
+
+        $commentRepository->method('find')->willReturn($comment);
+        $userRepository->method('find')->willReturn($user);
+        $reactionRepository->expects(self::once())
+            ->method('findOneByCommentAndAuthor')
+            ->with($comment, $user)
+            ->willReturn($existingReaction);
+        $reactionRepository->expects(self::once())
+            ->method('save')
+            ->with($existingReaction);
+        $notificationService->expects(self::never())->method('notifyReactionCreated');
+        $cacheInvalidationService->expects(self::once())->method('invalidateBlogCaches');
+
+        $handler = new CreateBlogReactionCommandHandler(
+            $reactionRepository,
+            $commentRepository,
+            $userRepository,
+            $notificationService,
+            $cacheInvalidationService,
+        );
+
+        $handler(new CreateBlogReactionCommand('op', 'actor', 'comment', BlogReactionType::LAUGH));
+
+        self::assertSame(BlogReactionType::LAUGH, $existingReaction->getType());
+    }
+
+    /**
+     * @return array{0: BlogComment, 1: User}
+     */
+    private function createCommentAndUser(): array
+    {
+        $blog = $this->createMock(Blog::class);
+        $blog->method('getApplication')->willReturn(null);
+
+        $post = $this->createMock(BlogPost::class);
+        $post->method('getBlog')->willReturn($blog);
+
+        $comment = $this->createMock(BlogComment::class);
+        $comment->method('getPost')->willReturn($post);
+
+        $user = $this->createMock(User::class);
+
+        return [$comment, $user];
+    }
+}


### PR DESCRIPTION
### Motivation
- Empêcher qu’un même auteur crée plusieurs réactions sur un même commentaire en appliquant une logique métier d’upsert et une contrainte de base de données pour garantir l’unicité.

### Description
- Ajout de la méthode `BlogReactionRepository::findOneByCommentAndAuthor(BlogComment $comment, User $author)` pour retrouver la réaction existante pour un couple `(comment, author)`.
- Mise à jour de `CreateBlogReactionCommandHandler` pour effectuer un upsert métier : si une réaction existe on met à jour son `type` et on la sauvegarde, sinon on crée une nouvelle réaction et on déclenche la notification comme avant.
- Ajout d’une migration Doctrine `migrations/Version20260311210000.php` qui ajoute la contrainte unique sur `(comment_id, author_id)` pour la table `blog_reaction`.
- Ajout d’un test unitaire `tests/Unit/Blog/Application/MessageHandler/CreateBlogReactionCommandHandlerTest.php` couvrant création et mise à jour, et extension du test API `tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php` pour vérifier le comportement en deux POST successifs par le même utilisateur sur le même commentaire.

### Testing
- Les fichiers modifiés ont passé les contrôles de syntaxe PHP via `php -l` (vérification effectuée sur les fichiers modifiés). 
- L’exécution de la suite `phpunit` n’a pas pu être lancée dans cet environnement car l’exécutable de test n’était pas présent (`vendor/bin/phpunit` / `bin/phpunit`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ea93d36c8326a58abe291f40d1d2)