### PR TITLE
Fix BlogReadController Security service import for autowiring

### DIFF
--- a/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
+++ b/src/Blog/Transport/Controller/Api/V1/BlogReadController.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]


### PR DESCRIPTION
### Motivation
- The container failed to autowire `App\Blog\Transport\Controller\Api\V1\BlogReadController` because the constructor type `Symfony\Component\Security\Core\Security` was not available in this environment, so the import was adjusted to the bundle-level `Symfony\Bundle\SecurityBundle\Security` to match other controllers and restore DI compatibility.

### Description
- Replaced the `use` statement in `src/Blog/Transport/Controller/Api/V1/BlogReadController.php` from `Symfony\Component\Security\Core\Security` to `Symfony\Bundle\SecurityBundle\Security`, leaving constructor usage unchanged.

### Testing
- Ran the project prepare step with `composer prepare`, which could not complete in this environment because dependencies are not installed and returned `Dependencies are missing. Try running "composer install"`, so full container compilation could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0eb7a9b208326bdaac1a06cb5bd2d)