### PR TITLE
feat(school): add generic GET/PATCH resources, class-teacher assignment and scoped routes

### DIFF
--- a/src/School/Application/Serializer/SchoolViewMapper.php
+++ b/src/School/Application/Serializer/SchoolViewMapper.php
@@ -42,14 +42,20 @@ final readonly class SchoolViewMapper
     {
         $items = [];
         foreach ($students as $student) {
-            $items[] = [
-                'id' => $student->getId(),
-                'name' => $student->getName(),
-                'classId' => $student->getSchoolClass()?->getId(),
-            ];
+            $items[] = $this->mapStudent($student);
         }
 
         return $items;
+    }
+
+    /** @return array<string,mixed> */
+    public function mapStudent(Student $student): array
+    {
+        return [
+            'id' => $student->getId(),
+            'name' => $student->getName(),
+            'classId' => $student->getSchoolClass()?->getId(),
+        ];
     }
 
     /** @param array<int,Teacher> $teachers
@@ -59,13 +65,19 @@ final readonly class SchoolViewMapper
     {
         $items = [];
         foreach ($teachers as $teacher) {
-            $items[] = [
-                'id' => $teacher->getId(),
-                'name' => $teacher->getName(),
-            ];
+            $items[] = $this->mapTeacher($teacher);
         }
 
         return $items;
+    }
+
+    /** @return array<string,mixed> */
+    public function mapTeacher(Teacher $teacher): array
+    {
+        return [
+            'id' => $teacher->getId(),
+            'name' => $teacher->getName(),
+        ];
     }
 
     /** @param array<int,Exam> $exams
@@ -75,21 +87,27 @@ final readonly class SchoolViewMapper
     {
         $items = [];
         foreach ($exams as $exam) {
-            $items[] = [
-                'id' => $exam->getId(),
-                'title' => $exam->getTitle(),
-                'classId' => $exam->getSchoolClass()?->getId(),
-                'className' => $exam->getSchoolClass()?->getName(),
-                'teacherId' => $exam->getTeacher()?->getId(),
-                'teacherName' => $exam->getTeacher()?->getName(),
-                'type' => $exam->getType()->value,
-                'status' => $exam->getStatus()->value,
-                'term' => $exam->getTerm()->value,
-                'updatedAt' => $exam->getUpdatedAt()?->format(DATE_ATOM),
-            ];
+            $items[] = $this->mapExam($exam);
         }
 
         return $items;
+    }
+
+    /** @return array<string,mixed> */
+    public function mapExam(Exam $exam): array
+    {
+        return [
+            'id' => $exam->getId(),
+            'title' => $exam->getTitle(),
+            'classId' => $exam->getSchoolClass()?->getId(),
+            'className' => $exam->getSchoolClass()?->getName(),
+            'teacherId' => $exam->getTeacher()?->getId(),
+            'teacherName' => $exam->getTeacher()?->getName(),
+            'type' => $exam->getType()->value,
+            'status' => $exam->getStatus()->value,
+            'term' => $exam->getTerm()->value,
+            'updatedAt' => $exam->getUpdatedAt()?->format(DATE_ATOM),
+        ];
     }
 
     /** @param array<int,Grade> $grades
@@ -99,14 +117,20 @@ final readonly class SchoolViewMapper
     {
         $items = [];
         foreach ($grades as $grade) {
-            $items[] = [
-                'id' => $grade->getId(),
-                'score' => $grade->getScore(),
-                'studentId' => $grade->getStudent()?->getId(),
-                'examId' => $grade->getExam()?->getId(),
-            ];
+            $items[] = $this->mapGrade($grade);
         }
 
         return $items;
+    }
+
+    /** @return array<string,mixed> */
+    public function mapGrade(Grade $grade): array
+    {
+        return [
+            'id' => $grade->getId(),
+            'score' => $grade->getScore(),
+            'studentId' => $grade->getStudent()?->getId(),
+            'examId' => $grade->getExam()?->getId(),
+        ];
     }
 }

--- a/src/School/Application/Service/SchoolApplicationScopeResolver.php
+++ b/src/School/Application/Service/SchoolApplicationScopeResolver.php
@@ -36,23 +36,23 @@ final readonly class SchoolApplicationScopeResolver
             'slug' => $applicationSlug,
         ]);
         if (!$application instanceof Application) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Unknown "applicationSlug".');
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Application scope not found.');
         }
 
         $this->assertApplicationAccess($application, PlatformKey::SCHOOL);
 
-        throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'School root entity not found for this application.');
+        throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'School scope not found.');
     }
 
     public function assertApplicationAccess(?Application $application, PlatformKey $platformKey): void
     {
         if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== $platformKey) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid "applicationSlug" for the requested platform.');
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid application scope for school platform.');
         }
 
         $user = $this->security->getUser();
         if (!$user instanceof User || $application->getUser()?->getId() !== $user->getId()) {
-            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot access this application scope.');
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Forbidden application scope access.');
         }
     }
 }

--- a/src/School/Application/Service/SchoolResourceAccessService.php
+++ b/src/School/Application/Service/SchoolResourceAccessService.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use App\School\Domain\Entity\Exam;
+use App\School\Domain\Entity\Grade;
+use App\School\Domain\Entity\School;
+use App\School\Domain\Entity\SchoolClass;
+use App\School\Domain\Entity\Student;
+use App\School\Domain\Entity\Teacher;
+use App\School\Infrastructure\Repository\ExamRepository;
+use App\School\Infrastructure\Repository\GradeRepository;
+use App\School\Infrastructure\Repository\SchoolClassRepository;
+use App\School\Infrastructure\Repository\StudentRepository;
+use App\School\Infrastructure\Repository\TeacherRepository;
+
+final readonly class SchoolResourceAccessService
+{
+    public function __construct(
+        private SchoolClassRepository $classRepository,
+        private StudentRepository $studentRepository,
+        private TeacherRepository $teacherRepository,
+        private ExamRepository $examRepository,
+        private GradeRepository $gradeRepository,
+    ) {
+    }
+
+    public function find(string $resource, string $id): SchoolClass|Student|Teacher|Exam|Grade|null
+    {
+        return match ($resource) {
+            'classes' => $this->classRepository->find($id),
+            'students' => $this->studentRepository->find($id),
+            'teachers' => $this->teacherRepository->find($id),
+            'exams' => $this->examRepository->find($id),
+            'grades' => $this->gradeRepository->find($id),
+            default => null,
+        };
+    }
+
+    public function belongsToSchool(SchoolClass|Student|Teacher|Exam|Grade $entity, School $school): bool
+    {
+        if ($entity instanceof SchoolClass) {
+            return $entity->getSchool()?->getId() === $school->getId();
+        }
+
+        if ($entity instanceof Student) {
+            return $entity->getSchoolClass()?->getSchool()?->getId() === $school->getId();
+        }
+
+        if ($entity instanceof Exam) {
+            return $entity->getSchoolClass()?->getSchool()?->getId() === $school->getId();
+        }
+
+        if ($entity instanceof Grade) {
+            return $entity->getExam()?->getSchoolClass()?->getSchool()?->getId() === $school->getId();
+        }
+
+        foreach ($entity->getClasses() as $class) {
+            if ($class->getSchool()?->getId() === $school->getId()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/Class/ClassTeacherAssignmentController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/ClassTeacherAssignmentController.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1\Class;
+
+use App\School\Domain\Entity\SchoolClass;
+use App\School\Domain\Entity\Teacher;
+use App\School\Infrastructure\Repository\SchoolClassRepository;
+use App\School\Infrastructure\Repository\TeacherRepository;
+use OpenApi\Attributes as OA;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ClassTeacherAssignmentController
+{
+    public function __construct(
+        private SchoolClassRepository $classRepository,
+        private TeacherRepository $teacherRepository,
+    ) {
+    }
+
+    #[Route('/v1/school/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_POST])]
+    public function assign(string $id, string $teacherId): JsonResponse
+    {
+        [$class, $teacher] = $this->resolve($id, $teacherId);
+
+        if (!$teacher->getClasses()->contains($class)) {
+            $teacher->getClasses()->add($class);
+            $this->teacherRepository->save($teacher);
+        }
+
+        return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    #[Route('/v1/school/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_DELETE])]
+    public function unassign(string $id, string $teacherId): JsonResponse
+    {
+        [$class, $teacher] = $this->resolve($id, $teacherId);
+
+        if ($teacher->getClasses()->contains($class)) {
+            $teacher->getClasses()->removeElement($class);
+            $this->teacherRepository->save($teacher);
+        }
+
+        return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
+    }
+
+    /** @return array{0:SchoolClass,1:Teacher} */
+    private function resolve(string $id, string $teacherId): array
+    {
+        if (!Uuid::isValid($id) || !Uuid::isValid($teacherId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid identifier format.');
+        }
+
+        $class = $this->classRepository->find($id);
+        if (!$class instanceof SchoolClass) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Class not found.');
+        }
+
+        $teacher = $this->teacherRepository->find($teacherId);
+        if (!$teacher instanceof Teacher) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Teacher not found.');
+        }
+
+        return [$class, $teacher];
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1;
+
+use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\School\Application\Service\SchoolResourceAccessService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class SchoolApplicationResourceController
+{
+    public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
+        private SchoolResourceAccessService $resourceAccessService,
+        private SchoolResourceController $schoolResourceController,
+    ) {
+    }
+
+    #[Route('/v1/school/applications/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_GET], requirements: ['resource' => 'classes|students|teachers|exams|grades'])]
+    public function getOne(string $applicationSlug, string $resource, string $id): JsonResponse
+    {
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
+        $entity = $this->resourceAccessService->find($resource, $id);
+
+        if ($entity === null || !$this->resourceAccessService->belongsToSchool($entity, $school)) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found in application scope.');
+        }
+
+        return $this->schoolResourceController->getOne($resource, $id);
+    }
+
+    #[Route('/v1/school/applications/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_PATCH], requirements: ['resource' => 'classes|students|teachers|exams|grades'])]
+    public function patchOne(string $applicationSlug, string $resource, string $id, Request $request): JsonResponse
+    {
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
+        $entity = $this->resourceAccessService->find($resource, $id);
+
+        if ($entity === null || !$this->resourceAccessService->belongsToSchool($entity, $school)) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found in application scope.');
+        }
+
+        return $this->schoolResourceController->patchOne($resource, $id, $request);
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php
+++ b/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1;
+
+use App\School\Application\Serializer\SchoolApiResponseSerializer;
+use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\School\Infrastructure\Repository\ExamRepository;
+use App\School\Infrastructure\Repository\GradeRepository;
+use App\School\Infrastructure\Repository\StudentRepository;
+use App\School\Infrastructure\Repository\TeacherRepository;
+use Doctrine\ORM\QueryBuilder;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class SchoolApplicationResourceListController
+{
+    public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
+        private StudentRepository $studentRepository,
+        private TeacherRepository $teacherRepository,
+        private ExamRepository $examRepository,
+        private GradeRepository $gradeRepository,
+        private SchoolViewMapper $viewMapper,
+        private SchoolApiResponseSerializer $responseSerializer,
+    ) {
+    }
+
+    #[Route('/v1/school/applications/{applicationSlug}/{resource}', methods: [Request::METHOD_GET], requirements: ['resource' => 'students|teachers|exams|grades'])]
+    public function __invoke(string $applicationSlug, string $resource): JsonResponse
+    {
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
+
+        $items = match ($resource) {
+            'students' => $this->viewMapper->mapStudentCollection($this->studentsQueryBuilder($school->getId())->getQuery()->getResult()),
+            'teachers' => $this->viewMapper->mapTeacherCollection($this->teachersQueryBuilder($school->getId())->getQuery()->getResult()),
+            'exams' => $this->viewMapper->mapExamCollection($this->examsQueryBuilder($school->getId())->getQuery()->getResult()),
+            'grades' => $this->viewMapper->mapGradeCollection($this->gradesQueryBuilder($school->getId())->getQuery()->getResult()),
+        };
+
+        return new JsonResponse($this->responseSerializer->list($items, null, [
+            'applicationSlug' => $applicationSlug,
+            'schoolId' => $school->getId(),
+        ]));
+    }
+
+    private function studentsQueryBuilder(string $schoolId): QueryBuilder
+    {
+        return $this->studentRepository->createQueryBuilder('student')
+            ->innerJoin('student.schoolClass', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $schoolId)
+            ->orderBy('student.createdAt', 'DESC')
+            ->setMaxResults(200);
+    }
+
+    private function teachersQueryBuilder(string $schoolId): QueryBuilder
+    {
+        return $this->teacherRepository->createQueryBuilder('teacher')
+            ->innerJoin('teacher.classes', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $schoolId)
+            ->orderBy('teacher.createdAt', 'DESC')
+            ->distinct()
+            ->setMaxResults(200);
+    }
+
+    private function examsQueryBuilder(string $schoolId): QueryBuilder
+    {
+        return $this->examRepository->createQueryBuilder('exam')
+            ->innerJoin('exam.schoolClass', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $schoolId)
+            ->orderBy('exam.createdAt', 'DESC')
+            ->setMaxResults(200);
+    }
+
+    private function gradesQueryBuilder(string $schoolId): QueryBuilder
+    {
+        return $this->gradeRepository->createQueryBuilder('grade')
+            ->innerJoin('grade.exam', 'exam')
+            ->innerJoin('exam.schoolClass', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $schoolId)
+            ->orderBy('grade.createdAt', 'DESC')
+            ->setMaxResults(200);
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/SchoolResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/SchoolResourceController.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1;
+
+use App\General\Application\Message\EntityPatched;
+use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Application\Service\SchoolResourceAccessService;
+use App\School\Domain\Entity\Exam;
+use App\School\Domain\Entity\Grade;
+use App\School\Domain\Entity\SchoolClass;
+use App\School\Domain\Entity\Student;
+use App\School\Domain\Entity\Teacher;
+use App\School\Domain\Enum\ExamStatus;
+use App\School\Domain\Enum\ExamType;
+use App\School\Domain\Enum\Term;
+use App\School\Infrastructure\Repository\ExamRepository;
+use App\School\Infrastructure\Repository\GradeRepository;
+use App\School\Infrastructure\Repository\SchoolClassRepository;
+use App\School\Infrastructure\Repository\StudentRepository;
+use App\School\Infrastructure\Repository\TeacherRepository;
+use OpenApi\Attributes as OA;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class SchoolResourceController
+{
+    public function __construct(
+        private SchoolResourceAccessService $resourceAccessService,
+        private SchoolViewMapper $viewMapper,
+        private SchoolClassRepository $classRepository,
+        private StudentRepository $studentRepository,
+        private TeacherRepository $teacherRepository,
+        private ExamRepository $examRepository,
+        private GradeRepository $gradeRepository,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    #[Route('/v1/school/{resource}/{id}', methods: [Request::METHOD_GET], requirements: ['resource' => 'classes|students|teachers|exams|grades'])]
+    public function getOne(string $resource, string $id): JsonResponse
+    {
+        $entity = $this->findOr404($resource, $id);
+
+        return new JsonResponse($this->mapResource($entity));
+    }
+
+    #[Route('/v1/school/{resource}/{id}', methods: [Request::METHOD_PATCH], requirements: ['resource' => 'classes|students|teachers|exams|grades'])]
+    public function patchOne(string $resource, string $id, Request $request): JsonResponse
+    {
+        $entity = $this->findOr404($resource, $id);
+        $payload = $request->toArray();
+
+        match ($resource) {
+            'classes' => $this->patchClass($entity, $payload),
+            'students' => $this->patchStudent($entity, $payload),
+            'teachers' => $this->patchTeacher($entity, $payload),
+            'exams' => $this->patchExam($entity, $payload),
+            'grades' => $this->patchGrade($entity, $payload),
+            default => throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid resource.'),
+        };
+
+        $this->messageBus->dispatch(new EntityPatched('school_' . substr($resource, 0, -1), $id));
+
+        return new JsonResponse($this->mapResource($entity));
+    }
+
+    private function findOr404(string $resource, string $id): SchoolClass|Student|Teacher|Exam|Grade
+    {
+        if (!Uuid::isValid($id)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid identifier format.');
+        }
+
+        $entity = $this->resourceAccessService->find($resource, $id);
+        if ($entity === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found.');
+        }
+
+        return $entity;
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function patchClass(SchoolClass|Student|Teacher|Exam|Grade $entity, array $payload): void
+    {
+        if (!$entity instanceof SchoolClass) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid resource payload.');
+        }
+
+        if (array_key_exists('name', $payload)) {
+            $name = trim((string)$payload['name']);
+            if ($name === '') {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "name" cannot be blank.');
+            }
+            $entity->setName($name);
+        }
+
+        $this->classRepository->save($entity);
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function patchStudent(SchoolClass|Student|Teacher|Exam|Grade $entity, array $payload): void
+    {
+        if (!$entity instanceof Student) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid resource payload.');
+        }
+
+        if (array_key_exists('name', $payload)) {
+            $name = trim((string)$payload['name']);
+            if ($name === '') {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "name" cannot be blank.');
+            }
+            $entity->setName($name);
+        }
+
+        if (array_key_exists('classId', $payload)) {
+            $classId = (string)$payload['classId'];
+            if (!Uuid::isValid($classId)) {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "classId" must be a valid UUID.');
+            }
+            $schoolClass = $this->classRepository->find($classId);
+            if (!$schoolClass instanceof SchoolClass) {
+                throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Class not found.');
+            }
+            $entity->setSchoolClass($schoolClass);
+        }
+
+        $this->studentRepository->save($entity);
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function patchTeacher(SchoolClass|Student|Teacher|Exam|Grade $entity, array $payload): void
+    {
+        if (!$entity instanceof Teacher) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid resource payload.');
+        }
+
+        if (array_key_exists('name', $payload)) {
+            $name = trim((string)$payload['name']);
+            if ($name === '') {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "name" cannot be blank.');
+            }
+            $entity->setName($name);
+        }
+
+        $this->teacherRepository->save($entity);
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function patchExam(SchoolClass|Student|Teacher|Exam|Grade $entity, array $payload): void
+    {
+        if (!$entity instanceof Exam) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid resource payload.');
+        }
+
+        if (array_key_exists('title', $payload)) {
+            $title = trim((string)$payload['title']);
+            if ($title === '') {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "title" cannot be blank.');
+            }
+            $entity->setTitle($title);
+        }
+
+        if (array_key_exists('classId', $payload)) {
+            $classId = (string)$payload['classId'];
+            if (!Uuid::isValid($classId)) {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "classId" must be a valid UUID.');
+            }
+            $class = $this->classRepository->find($classId);
+            if (!$class instanceof SchoolClass) {
+                throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Class not found.');
+            }
+            $entity->setSchoolClass($class);
+        }
+
+        if (array_key_exists('teacherId', $payload)) {
+            $teacherId = (string)$payload['teacherId'];
+            if (!Uuid::isValid($teacherId)) {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "teacherId" must be a valid UUID.');
+            }
+            $teacher = $this->teacherRepository->find($teacherId);
+            if (!$teacher instanceof Teacher) {
+                throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Teacher not found.');
+            }
+            $entity->setTeacher($teacher);
+        }
+
+        if (array_key_exists('type', $payload)) {
+            $type = ExamType::tryFrom((string)$payload['type']);
+            if ($type === null) {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Invalid exam type.');
+            }
+            $entity->setType($type);
+        }
+
+        if (array_key_exists('status', $payload)) {
+            $status = ExamStatus::tryFrom((string)$payload['status']);
+            if ($status === null) {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Invalid exam status.');
+            }
+            $entity->setStatus($status);
+        }
+
+        if (array_key_exists('term', $payload)) {
+            $term = Term::tryFrom((string)$payload['term']);
+            if ($term === null) {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Invalid exam term.');
+            }
+            $entity->setTerm($term);
+        }
+
+        $this->examRepository->save($entity);
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function patchGrade(SchoolClass|Student|Teacher|Exam|Grade $entity, array $payload): void
+    {
+        if (!$entity instanceof Grade) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid resource payload.');
+        }
+
+        if (array_key_exists('score', $payload)) {
+            if (!is_numeric($payload['score'])) {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "score" must be numeric.');
+            }
+            $entity->setScore((float)$payload['score']);
+        }
+
+        $this->gradeRepository->save($entity);
+    }
+
+    /** @return array<string,mixed> */
+    private function mapResource(SchoolClass|Student|Teacher|Exam|Grade $entity): array
+    {
+        return match (true) {
+            $entity instanceof SchoolClass => $this->viewMapper->mapClass($entity),
+            $entity instanceof Student => $this->viewMapper->mapStudent($entity),
+            $entity instanceof Teacher => $this->viewMapper->mapTeacher($entity),
+            $entity instanceof Exam => $this->viewMapper->mapExam($entity),
+            $entity instanceof Grade => $this->viewMapper->mapGrade($entity),
+        };
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose single-entity read/update operations for School domain entities to support partial updates and consistent read endpoints across `SchoolClass`, `Student`, `Teacher`, `Exam`, and `Grade`.
- Provide teacher↔class assignment endpoints to manage many-to-many relationships via the API.
- Extend application-scoped School routes for multi-tenant consistency under `/v1/school/applications/{applicationSlug}/...` and standardize functional error messages for scope resolution.

### Description
- Added `SchoolResourceController` implementing generic `GET /v1/school/{resource}/{id}` and `PATCH /v1/school/{resource}/{id}` for `classes|students|teachers|exams|grades` with partial-update logic, enum/UUID/numeric validation, and `EntityPatched` dispatch. (`src/School/Transport/Controller/Api/V1/SchoolResourceController.php`).
- Introduced `SchoolResourceAccessService` to centralize entity resolution and ownership checks and `SchoolApplicationResourceController` + `SchoolApplicationResourceListController` to expose scoped `GET`/`PATCH` and list endpoints under `applications/{applicationSlug}`. (`src/School/Application/Service/SchoolResourceAccessService.php`, `src/School/Transport/Controller/Api/V1/SchoolApplicationResourceController.php`, `src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php`).
- Implemented class-teacher assignment endpoints `POST|DELETE /v1/school/classes/{id}/teachers/{teacherId}` with validation and id checks. (`src/School/Transport/Controller/Api/V1/Class/ClassTeacherAssignmentController.php`).
- Extended `SchoolViewMapper` with single-entity mappers (`mapStudent`, `mapTeacher`, `mapExam`, `mapGrade`) used by the new controllers for consistent response shapes. (`src/School/Application/Serializer/SchoolViewMapper.php`).
- Harmonized wording of scope-related functional errors in `SchoolApplicationScopeResolver` to consistent messages and HTTP statuses. (`src/School/Application/Service/SchoolApplicationScopeResolver.php`).

### Testing
- Ran PHP syntax checks with `php -l` against all new/modified School files and they all passed. 
- Attempted to run `phpunit` for scoped routes (`./vendor/bin/phpunit tests/Application/Scoped/ScopedApplicationRoutesTest.php`) but the project dependencies are not installed in this environment so PHPUnit could not be executed. 
- Files were committed under commit message `feat(school): add generic get/patch and scoped resource endpoints` and a PR was created.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0eabb89008326b9ea5a0b81ce4701)