### PR TITLE
Fix shop fixtures duplicate unique keys

### DIFF
--- a/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
+++ b/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
@@ -34,6 +34,11 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
     public function load(ObjectManager $manager): void
     {
         foreach ($this->getApplicationsByPlatform(PlatformKey::SHOP) as $application) {
+            $existingCatalog = $manager->getRepository(Shop::class)->findOneBy(['application' => $application]);
+            if ($existingCatalog instanceof Shop) {
+                continue;
+            }
+
             $catalog = (new Shop())
                 ->setName($application->getTitle() . ' Catalog')
                 ->setDescription('Catalogue principal de l\'application ' . $application->getSlug())
@@ -62,10 +67,10 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
             }
 
             $products = [
-                (new Product())->setShop($catalog)->setCategory($categories['Electronique'])->setName('Casque Bluetooth')->setSku('SKU-BT-HEADSET')->setDescription('Casque sans fil reduction de bruit')->setPrice(89.99)->setCurrencyCode('EUR')->setStock(32)->setStatus(ProductStatus::ACTIVE)->setIsFeatured(true)->addTag($tags['Nouveau'])->addTag($tags['Promo']),
-                (new Product())->setShop($catalog)->setCategory($categories['Maison'])->setName('Lampe LED connectee')->setSku('SKU-SMART-LAMP')->setDescription('Lampe connectee basse consommation')->setPrice(59.90)->setCurrencyCode('EUR')->setStock(54)->setStatus(ProductStatus::ACTIVE)->addTag($tags['Eco']),
-                (new Product())->setShop($catalog)->setCategory($categories['Bureau'])->setName('Chaise ergonomique')->setSku('SKU-ERG-CHAIR')->setDescription('Chaise bureau confort premium')->setPrice(229.00)->setCurrencyCode('EUR')->setStock(8)->setStatus(ProductStatus::DRAFT)->addTag($tags['Promo']),
-                (new Product())->setShop($catalog)->setCategory($categories['Electronique'])->setName('Souris sans fil')->setSku('SKU-WIRELESS-MOUSE')->setDescription('Souris ergonomique rechargeable')->setPrice(34.50)->setCurrencyCode('EUR')->setStock(65)->setStatus(ProductStatus::ACTIVE)->addTag($tags['Nouveau'])->addTag($tags['Eco']),
+                (new Product())->setShop($catalog)->setCategory($categories['Electronique'])->setName('Casque Bluetooth')->setSku($application->getSlug() . '-SKU-BT-HEADSET')->setDescription('Casque sans fil reduction de bruit')->setPrice(89.99)->setCurrencyCode('EUR')->setStock(32)->setStatus(ProductStatus::ACTIVE)->setIsFeatured(true)->addTag($tags['Nouveau'])->addTag($tags['Promo']),
+                (new Product())->setShop($catalog)->setCategory($categories['Maison'])->setName('Lampe LED connectee')->setSku($application->getSlug() . '-SKU-SMART-LAMP')->setDescription('Lampe connectee basse consommation')->setPrice(59.90)->setCurrencyCode('EUR')->setStock(54)->setStatus(ProductStatus::ACTIVE)->addTag($tags['Eco']),
+                (new Product())->setShop($catalog)->setCategory($categories['Bureau'])->setName('Chaise ergonomique')->setSku($application->getSlug() . '-SKU-ERG-CHAIR')->setDescription('Chaise bureau confort premium')->setPrice(229.00)->setCurrencyCode('EUR')->setStock(8)->setStatus(ProductStatus::DRAFT)->addTag($tags['Promo']),
+                (new Product())->setShop($catalog)->setCategory($categories['Electronique'])->setName('Souris sans fil')->setSku($application->getSlug() . '-SKU-WIRELESS-MOUSE')->setDescription('Souris ergonomique rechargeable')->setPrice(34.50)->setCurrencyCode('EUR')->setStock(65)->setStatus(ProductStatus::ACTIVE)->addTag($tags['Nouveau'])->addTag($tags['Eco']),
             ];
 
             foreach ($products as $product) {


### PR DESCRIPTION
### Motivation

- Prevent SQL unique constraint violations when reloading shop fixtures caused by creating multiple `Shop` rows for the same `application` and by SKU collisions across multiple shop applications.

### Description

- Add a check in `src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php` to skip creating a `Shop` when one already exists for the given `application` by using `findOneBy(['application' => $application])` and `continue`ing if found.
- Make seeded product SKUs application-specific by prefixing SKUs with `application->getSlug()`, preventing SKU uniqueness collisions across different shop applications.
- Persist categories, tags and products as before but only for newly created shop catalogs to avoid duplicate related rows.

### Testing

- Ran syntax check with `php -l src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ed151c688326b82f2fab135e0d15)