### PR TITLE
feat(calendar): add attendee/reminder enums and mutation payload validation

### DIFF
--- a/src/Calendar/Application/Service/EventMutationInputFactory.php
+++ b/src/Calendar/Application/Service/EventMutationInputFactory.php
@@ -16,6 +16,11 @@ use Ramsey\Uuid\Uuid;
 
 final class EventMutationInputFactory
 {
+    public function __construct(
+        private readonly EventMutationPayloadValidator $payloadValidator,
+    ) {
+    }
+
     /**
      * @param array<string, mixed> $payload
      */
@@ -98,12 +103,12 @@ final class EventMutationInputFactory
             textColor: isset($payload['textColor']) && is_string($payload['textColor']) ? $payload['textColor'] : null,
             organizerName: isset($payload['organizerName']) && is_string($payload['organizerName']) ? $payload['organizerName'] : null,
             organizerEmail: isset($payload['organizerEmail']) && is_string($payload['organizerEmail']) ? $payload['organizerEmail'] : null,
-            attendees: isset($payload['attendees']) && is_array($payload['attendees']) ? $payload['attendees'] : null,
+            attendees: $this->payloadValidator->validateAttendees($payload['attendees'] ?? null),
             rrule: isset($payload['rrule']) && is_string($payload['rrule']) ? $payload['rrule'] : null,
             recurrenceExceptions: isset($payload['recurrenceExceptions']) && is_array($payload['recurrenceExceptions']) ? $payload['recurrenceExceptions'] : null,
             recurrenceEndAt: isset($payload['recurrenceEndAt']) && is_string($payload['recurrenceEndAt']) ? $this->parseDate($payload['recurrenceEndAt'], 'recurrenceEndAt') : null,
             recurrenceCount: isset($payload['recurrenceCount']) && is_int($payload['recurrenceCount']) ? $payload['recurrenceCount'] : null,
-            reminders: isset($payload['reminders']) && is_array($payload['reminders']) ? $payload['reminders'] : null,
+            reminders: $this->payloadValidator->validateReminders($payload['reminders'] ?? null),
             metadata: isset($payload['metadata']) && is_array($payload['metadata']) ? $payload['metadata'] : null,
             applicationSlug: $applicationSlug,
         );
@@ -143,12 +148,12 @@ final class EventMutationInputFactory
             textColor: isset($payload['textColor']) && is_string($payload['textColor']) ? $payload['textColor'] : null,
             organizerName: isset($payload['organizerName']) && is_string($payload['organizerName']) ? $payload['organizerName'] : null,
             organizerEmail: isset($payload['organizerEmail']) && is_string($payload['organizerEmail']) ? $payload['organizerEmail'] : null,
-            attendees: isset($payload['attendees']) && is_array($payload['attendees']) ? $payload['attendees'] : null,
+            attendees: $this->payloadValidator->validateAttendees($payload['attendees'] ?? null),
             rrule: isset($payload['rrule']) && is_string($payload['rrule']) ? $payload['rrule'] : null,
             recurrenceExceptions: isset($payload['recurrenceExceptions']) && is_array($payload['recurrenceExceptions']) ? $payload['recurrenceExceptions'] : null,
             recurrenceEndAt: isset($payload['recurrenceEndAt']) && is_string($payload['recurrenceEndAt']) ? $this->parseDate($payload['recurrenceEndAt'], 'recurrenceEndAt') : null,
             recurrenceCount: isset($payload['recurrenceCount']) && is_int($payload['recurrenceCount']) ? $payload['recurrenceCount'] : null,
-            reminders: isset($payload['reminders']) && is_array($payload['reminders']) ? $payload['reminders'] : null,
+            reminders: $this->payloadValidator->validateReminders($payload['reminders'] ?? null),
             metadata: isset($payload['metadata']) && is_array($payload['metadata']) ? $payload['metadata'] : null,
             applicationSlug: $applicationSlug,
         );

--- a/src/Calendar/Application/Service/EventMutationPayloadValidator.php
+++ b/src/Calendar/Application/Service/EventMutationPayloadValidator.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Application\Service;
+
+use App\Calendar\Domain\Enum\AttendeeResponseStatus;
+use App\Calendar\Domain\Enum\ReminderMethod;
+use App\General\Transport\Http\ValidationErrorFactory;
+
+final class EventMutationPayloadValidator
+{
+    /**
+     * @param mixed $value
+     *
+     * @return array<int, array{name: string, email: string, status: string}>|null
+     */
+    public function validateAttendees(mixed $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw ValidationErrorFactory::badRequest('Field "attendees" must be an array.');
+        }
+
+        $attendees = [];
+
+        foreach ($value as $index => $attendee) {
+            if (!is_array($attendee)) {
+                throw ValidationErrorFactory::badRequest(sprintf('Field "attendees[%s]" must be an object.', (string) $index));
+            }
+
+            $name = $attendee['name'] ?? null;
+            if (!is_string($name) || '' === trim($name)) {
+                throw ValidationErrorFactory::unprocessable(sprintf('Field "attendees[%s].name" is required.', (string) $index));
+            }
+
+            $email = $attendee['email'] ?? null;
+            if (!is_string($email) || false === filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                throw ValidationErrorFactory::unprocessable(sprintf('Field "attendees[%s].email" must be a valid email.', (string) $index));
+            }
+
+            $status = $attendee['status'] ?? null;
+            if (!is_string($status)) {
+                throw ValidationErrorFactory::unprocessable(sprintf('Field "attendees[%s].status" is required.', (string) $index));
+            }
+
+            $parsedStatus = AttendeeResponseStatus::tryFrom($status);
+            if ($parsedStatus === null) {
+                throw ValidationErrorFactory::unprocessable(sprintf('Field "attendees[%s].status" must be one of: accepted, declined, tentative, needs_action.', (string) $index));
+            }
+
+            $attendees[] = [
+                'name' => $name,
+                'email' => $email,
+                'status' => $parsedStatus->value,
+            ];
+        }
+
+        return $attendees;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return array<int, array{method: string, minutesBefore: int}>|null
+     */
+    public function validateReminders(mixed $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw ValidationErrorFactory::badRequest('Field "reminders" must be an array.');
+        }
+
+        $reminders = [];
+
+        foreach ($value as $index => $reminder) {
+            if (!is_array($reminder)) {
+                throw ValidationErrorFactory::badRequest(sprintf('Field "reminders[%s]" must be an object.', (string) $index));
+            }
+
+            $method = $reminder['method'] ?? null;
+            if (!is_string($method)) {
+                throw ValidationErrorFactory::unprocessable(sprintf('Field "reminders[%s].method" is required.', (string) $index));
+            }
+
+            $parsedMethod = ReminderMethod::tryFrom($method);
+            if ($parsedMethod === null) {
+                throw ValidationErrorFactory::unprocessable(sprintf('Field "reminders[%s].method" must be one of: email, popup, sms.', (string) $index));
+            }
+
+            $minutesBefore = $reminder['minutesBefore'] ?? null;
+            if (!is_int($minutesBefore) || $minutesBefore < 0) {
+                throw ValidationErrorFactory::unprocessable(sprintf('Field "reminders[%s].minutesBefore" must be a positive integer or zero.', (string) $index));
+            }
+
+            $reminders[] = [
+                'method' => $parsedMethod->value,
+                'minutesBefore' => $minutesBefore,
+            ];
+        }
+
+        return $reminders;
+    }
+}

--- a/src/Calendar/Domain/Enum/AttendeeResponseStatus.php
+++ b/src/Calendar/Domain/Enum/AttendeeResponseStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Domain\Enum;
+
+enum AttendeeResponseStatus: string
+{
+    case ACCEPTED = 'accepted';
+    case DECLINED = 'declined';
+    case TENTATIVE = 'tentative';
+    case NEEDS_ACTION = 'needs_action';
+}

--- a/src/Calendar/Domain/Enum/ReminderMethod.php
+++ b/src/Calendar/Domain/Enum/ReminderMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Domain\Enum;
+
+enum ReminderMethod: string
+{
+    case EMAIL = 'email';
+    case POPUP = 'popup';
+    case SMS = 'sms';
+}

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -451,6 +451,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
                 [
                     'name' => 'Hiring Manager',
                     'email' => 'hiring.manager@example.com',
+                    'status' => 'accepted',
                 ],
             ])
             ->setReminders([


### PR DESCRIPTION
### Motivation

- Introduire des enums métier pour normaliser les valeurs utilisées par les rappels et les réponses des participants.
- Empêcher la propagation de payloads mal formés pour `attendees` et `reminders` en validant/normalisant côté application avant création des commandes.
- Mettre à jour les fixtures pour générer des payloads conformes au nouveau contrat afin d'éviter des erreurs lors des scénarios de test/développement.

### Description

- Ajout de l'enum `ReminderMethod` dans `src/Calendar/Domain/Enum/ReminderMethod.php` avec les valeurs `email`, `popup`, `sms`.
- Ajout de l'enum `AttendeeResponseStatus` dans `src/Calendar/Domain/Enum/AttendeeResponseStatus.php` avec les valeurs `accepted`, `declined`, `tentative`, `needs_action`.
- Création de `EventMutationPayloadValidator` (`src/Calendar/Application/Service/EventMutationPayloadValidator.php`) fournissant `validateAttendees` et `validateReminders` pour valider et normaliser les structures attendues (contrôle de présence des champs, format d'email, enum-check, `minutesBefore` >= 0).
- Raccordement du validateur dans le flux mutation via l'injection dans `EventMutationInputFactory` et remplacement des usages bruts de `attendees`/`reminders` par `validateAttendees`/`validateReminders` dans les constructions de commandes `create` et `patch`.
- Mise à jour de la fixture `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` pour inclure le champ `status` sur les `attendees` générés.

### Testing

- Vérification de syntaxe PHP avec `php -l` sur les fichiers modifiés a réussi (pas d'erreurs de syntaxe détectées).
- L'exécution du suite de tests automatique (`vendor/bin/phpunit`) n'était pas disponible dans cet environnement, donc aucun test PHPUnit n'a pu être lancé.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ed20701c8326a3d6d8e3baa17d8a)