### PR TITLE
Renforcer validation: parent d'un commentaire doit appartenir au même post

### DIFF
--- a/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
@@ -59,6 +59,14 @@ final readonly class CreateBlogCommentCommandHandler
             if (!$parent instanceof BlogComment) {
                 throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Parent comment not found.');
             }
+
+            if ($parent->getPost()->getId() !== $post->getId()) {
+                throw new HttpException(
+                    JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+                    'Parent comment must belong to the same post.',
+                );
+            }
+
             $comment->setParent($parent);
         }
 

--- a/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
+++ b/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
@@ -103,6 +103,15 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
                     ->setAuthor($authors[($blogIndex + $postIndex + 2) % count($authors)])
                     ->setContent('Sub child comment #' . $postIndex)
                     ->setParent($child);
+
+                if ($child->getParent()?->getPost()->getId() !== $child->getPost()->getId()) {
+                    throw new \LogicException('Fixture integrity error: child comment parent must belong to the same post.');
+                }
+
+                if ($subChild->getParent()?->getPost()->getId() !== $subChild->getPost()->getId()) {
+                    throw new \LogicException('Fixture integrity error: sub-child comment parent must belong to the same post.');
+                }
+
                 $manager->persist($parent);
                 $manager->persist($child);
                 $manager->persist($subChild);

--- a/tests/Unit/Blog/Application/MessageHandler/CreateBlogCommentCommandHandlerTest.php
+++ b/tests/Unit/Blog/Application/MessageHandler/CreateBlogCommentCommandHandlerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Blog\Application\MessageHandler;
+
+use App\Blog\Application\Message\CreateBlogCommentCommand;
+use App\Blog\Application\MessageHandler\CreateBlogCommentCommandHandler;
+use App\Blog\Application\Service\BlogNotificationService;
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Entity\BlogComment;
+use App\Blog\Domain\Entity\BlogPost;
+use App\Blog\Domain\Enum\BlogStatus;
+use App\Blog\Infrastructure\Repository\BlogCommentRepository;
+use App\Blog\Infrastructure\Repository\BlogPostRepository;
+use App\General\Application\Service\CacheInvalidationService;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class CreateBlogCommentCommandHandlerTest extends TestCase
+{
+    public function testInvokeRejectsParentFromAnotherPost(): void
+    {
+        $commentRepository = $this->createMock(BlogCommentRepository::class);
+        $postRepository = $this->createMock(BlogPostRepository::class);
+        $userRepository = $this->createMock(UserRepository::class);
+        $notificationService = $this->createMock(BlogNotificationService::class);
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+
+        $targetPost = $this->createPost('post-target');
+        $parentPost = $this->createPost('post-parent');
+
+        $user = $this->createMock(User::class);
+
+        $parent = $this->createMock(BlogComment::class);
+        $parent->method('getPost')->willReturn($parentPost);
+
+        $postRepository->method('find')->with('post-target')->willReturn($targetPost);
+        $userRepository->method('find')->with('actor')->willReturn($user);
+        $commentRepository->method('find')->with('parent-comment')->willReturn($parent);
+        $commentRepository->expects(self::never())->method('save');
+        $notificationService->expects(self::never())->method('notifyCommentCreated');
+        $cacheInvalidationService->expects(self::never())->method('invalidateBlogCaches');
+
+        $handler = new CreateBlogCommentCommandHandler(
+            $commentRepository,
+            $postRepository,
+            $userRepository,
+            $notificationService,
+            $cacheInvalidationService,
+        );
+
+        try {
+            $handler(new CreateBlogCommentCommand('op', 'actor', 'post-target', 'content', null, 'parent-comment'));
+            self::fail('Expected HttpException was not thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, $exception->getStatusCode());
+            self::assertSame('Parent comment must belong to the same post.', $exception->getMessage());
+        }
+    }
+
+    private function createPost(string $id): BlogPost
+    {
+        $owner = $this->createMock(User::class);
+        $owner->method('getId')->willReturn('owner-id');
+
+        $blog = $this->createMock(Blog::class);
+        $blog->method('getCommentStatus')->willReturn(BlogStatus::OPEN);
+        $blog->method('getOwner')->willReturn($owner);
+
+        $post = $this->createMock(BlogPost::class);
+        $post->method('getId')->willReturn($id);
+        $post->method('getBlog')->willReturn($blog);
+
+        return $post;
+    }
+}


### PR DESCRIPTION
### Motivation
- Éviter les liaisons parent/enfant cross-post qui laissent la base dans un état incohérent et provoquent des notifications/cache incorrects.

### Description
- Ajout d’une validation dans `CreateBlogCommentCommandHandler` qui compare `parent->getPost()->getId()` avec `post->getId()` et lève une `HttpException` `JsonResponse::HTTP_UNPROCESSABLE_ENTITY` avec le message `Parent comment must belong to the same post.` si différent.
- Ajout d’un test unitaire `tests/Unit/Blog/Application/MessageHandler/CreateBlogCommentCommandHandlerTest.php` vérifiant que la création d’un commentaire avec un parent d’un autre post échoue sans appeler `save`, `notifyCommentCreated` ni l’invalidation de cache.
- Ajout de gardes d’intégrité dans les fixtures `src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php` pour détecter et échouer tôt si une chaîne parent/enfant traverse deux posts différents.

### Testing
- `php -l src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php` a réussi sans erreurs de syntaxe.
- `php -l tests/Unit/Blog/Application/MessageHandler/CreateBlogCommentCommandHandlerTest.php` a réussi sans erreurs de syntaxe.
- `php -l src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php` a réussi sans erreurs de syntaxe.
- Exécution de `phpunit` ciblé impossible dans cet environnement car `vendor/bin/phpunit` est absent, donc le test unitaire a été ajouté mais n’a pas pu être exécuté ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ed1bf8708326925740863cd721b2)