### PR TITLE
Add richer School fixtures and API tests for scoped School routes

### DIFF
--- a/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
+++ b/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
@@ -36,55 +36,121 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
     #[Override]
     public function load(ObjectManager $manager): void
     {
-        foreach ($this->getApplicationsByPlatform(PlatformKey::SCHOOL) as $application) {
+        $examTypes = ExamType::cases();
+        $examStatuses = ExamStatus::cases();
+        $terms = Term::cases();
+
+        foreach ($this->getApplicationsByPlatform(PlatformKey::SCHOOL) as $applicationIndex => $application) {
+            $appKey = $application->getKey();
+
             $school = (new School())
                 ->setName($application->getTitle() . ' Academy')
                 ->setApplication($application);
             $manager->persist($school);
+            $this->addReference('School-' . $appKey, $school);
 
-            $classA = (new SchoolClass())->setSchool($school)->setName('Classe A - Sciences');
-            $classB = (new SchoolClass())->setSchool($school)->setName('Classe B - Langues');
-            $manager->persist($classA);
-            $manager->persist($classB);
-
-            $teacherMath = (new Teacher())->setName('Mme Martin');
-            $teacherFrench = (new Teacher())->setName('M. Dubois');
-            $teacherMath->getClasses()->add($classA);
-            $teacherFrench->getClasses()->add($classA);
-            $teacherFrench->getClasses()->add($classB);
-            $manager->persist($teacherMath);
-            $manager->persist($teacherFrench);
-
-            $students = [
-                (new Student())->setSchoolClass($classA)->setName('Alice Bernard'),
-                (new Student())->setSchoolClass($classA)->setName('Lucas Petit'),
-                (new Student())->setSchoolClass($classB)->setName('Emma Laurent'),
+            $classes = [];
+            $classesByLabel = [
+                'small' => 'Classe A - Sciences',
+                'medium' => 'Classe B - Langues',
+                'large' => 'Classe C - Technologies',
             ];
 
-            foreach ($students as $student) {
-                $manager->persist($student);
+            foreach ($classesByLabel as $label => $name) {
+                $class = (new SchoolClass())
+                    ->setSchool($school)
+                    ->setName($name);
+                $manager->persist($class);
+
+                $classes[$label] = $class;
+                $this->addReference('SchoolClass-' . $appKey . '-' . $label, $class);
             }
 
-            $examMath = (new Exam())
-                ->setSchoolClass($classA)
-                ->setTeacher($teacherMath)
-                ->setTitle('Examen Mathematiques - Trimestre 1')
-                ->setType(ExamType::MIDTERM)
-                ->setStatus(ExamStatus::PUBLISHED)
-                ->setTerm(Term::TERM_1);
-            $examFrench = (new Exam())
-                ->setSchoolClass($classB)
-                ->setTeacher($teacherFrench)
-                ->setTitle('Examen Francais - Trimestre 1')
-                ->setType(ExamType::QUIZ)
-                ->setStatus(ExamStatus::DRAFT)
-                ->setTerm(Term::TERM_1);
-            $manager->persist($examMath);
-            $manager->persist($examFrench);
+            $teacherMath = (new Teacher())->setName('Mme Martin - ' . $applicationIndex);
+            $teacherFrench = (new Teacher())->setName('M. Dubois - ' . $applicationIndex);
+            $teacherHead = (new Teacher())->setName('Dr. Principal - ' . $applicationIndex);
 
-            $manager->persist((new Grade())->setStudent($students[0])->setExam($examMath)->setScore(16.5));
-            $manager->persist((new Grade())->setStudent($students[1])->setExam($examMath)->setScore(14.0));
-            $manager->persist((new Grade())->setStudent($students[2])->setExam($examFrench)->setScore(17.0));
+            $teacherMath->getClasses()->add($classes['small']);
+            $teacherMath->getClasses()->add($classes['large']);
+            $teacherFrench->getClasses()->add($classes['small']);
+            $teacherFrench->getClasses()->add($classes['medium']);
+            $teacherHead->getClasses()->add($classes['small']);
+            $teacherHead->getClasses()->add($classes['medium']);
+            $teacherHead->getClasses()->add($classes['large']);
+
+            $manager->persist($teacherMath);
+            $manager->persist($teacherFrench);
+            $manager->persist($teacherHead);
+
+            $this->addReference('Teacher-' . $appKey . '-math', $teacherMath);
+            $this->addReference('Teacher-' . $appKey . '-french', $teacherFrench);
+            $this->addReference('Teacher-' . $appKey . '-head', $teacherHead);
+
+            $students = [];
+            $studentCounter = 1;
+            foreach ([
+                'small' => 3,
+                'medium' => 8,
+                'large' => 15,
+            ] as $classLabel => $count) {
+                for ($i = 1; $i <= $count; ++$i) {
+                    $student = (new Student())
+                        ->setSchoolClass($classes[$classLabel])
+                        ->setName('Student ' . $applicationIndex . '-' . $classLabel . '-' . $i);
+                    $manager->persist($student);
+
+                    $students[$classLabel][] = $student;
+                    $this->addReference('Student-' . $appKey . '-' . $studentCounter, $student);
+                    ++$studentCounter;
+                }
+            }
+
+            $exams = [];
+            $examCounter = 1;
+            foreach ($classes as $classLabel => $class) {
+                for ($i = 0; $i < 4; ++$i) {
+                    $exam = (new Exam())
+                        ->setSchoolClass($class)
+                        ->setTeacher($i % 2 === 0 ? $teacherMath : $teacherHead)
+                        ->setTitle('Examen ' . $classLabel . ' #' . ($i + 1) . ' - ' . $applicationIndex)
+                        ->setType($examTypes[($applicationIndex + $i) % count($examTypes)])
+                        ->setStatus($examStatuses[($applicationIndex + $i) % count($examStatuses)])
+                        ->setTerm($terms[($applicationIndex + $i) % count($terms)]);
+                    $manager->persist($exam);
+
+                    $exams[$classLabel][] = $exam;
+                    $this->addReference('Exam-' . $appKey . '-' . $examCounter, $exam);
+                    ++$examCounter;
+                }
+            }
+
+            $gradeCounter = 1;
+            foreach ($exams as $classLabel => $classExams) {
+                foreach ($classExams as $examIndex => $exam) {
+                    foreach ($students[$classLabel] as $studentIndex => $student) {
+                        $score = 20.0;
+                        if ($studentIndex === 0 && $examIndex === 0) {
+                            $score = 0.0;
+                        } elseif ($studentIndex === 1 && $examIndex === 1) {
+                            $score = -1.0;
+                        } elseif ($studentIndex === 2 && $examIndex === 2) {
+                            $score = 25.0;
+                        } elseif ($studentIndex === 3 && $examIndex === 3) {
+                            $score = 9.999;
+                        } else {
+                            $score = (float)(($studentIndex + $examIndex + $applicationIndex) % 21);
+                        }
+
+                        $grade = (new Grade())
+                            ->setStudent($student)
+                            ->setExam($exam)
+                            ->setScore($score);
+                        $manager->persist($grade);
+                        $this->addReference('Grade-' . $appKey . '-' . $gradeCounter, $grade);
+                        ++$gradeCounter;
+                    }
+                }
+            }
         }
 
         $manager->flush();

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\School\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SchoolApplicationScopedRoutesTest extends WebTestCase
+{
+    #[TestDox('School scoped application routes enforce owner/foreign-owner access control across list, detail and mutation endpoints.')]
+    public function testScopedRoutesAccessControlForOwnerAndForeignOwner(): void
+    {
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+        $forbiddenClient = $this->getTestClient('john-user', 'password-user');
+
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes');
+        self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes');
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/students');
+        self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/students');
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/teachers');
+        self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/teachers');
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams');
+        self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams');
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/grades');
+        self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/grades');
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes');
+        $responseData = JSON::decode((string)$ownerClient->getResponse()->getContent(), true);
+        $classId = $responseData['items'][0]['id'];
+
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes/' . $classId);
+        self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes/' . $classId);
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $ownerClient->request('PATCH', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes/' . $classId, [], [], [], JSON::encode(['name' => 'Classe Scoped Updated']));
+        self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient->request('PATCH', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes/' . $classId, [], [], [], JSON::encode(['name' => 'Classe Should Fail']));
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $ownerClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes', [], [], [], JSON::encode(['name' => 'Classe Scoped Create']));
+        self::assertSame(Response::HTTP_CREATED, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes', [], [], [], JSON::encode(['name' => 'Classe Forbidden']));
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\School\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SchoolCrudValidationPaginationTest extends WebTestCase
+{
+    #[TestDox('School API supports CRUD with validation errors, pagination and filters on class/exam scoped listings.')]
+    public function testSchoolCrudValidationPaginationAndFilters(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes', [], [], [], JSON::encode(['name' => '']));
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes', [], [], [], JSON::encode(['name' => 'Classe API Test']));
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+        $createdClass = JSON::decode((string)$client->getResponse()->getContent(), true);
+        $createdClassId = $createdClass['id'];
+
+        $client->request('PATCH', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes/' . $createdClassId, [], [], [], JSON::encode(['name' => 'Classe API Test Updated']));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes?page=1&limit=5&q=Classe');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $listPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        self::assertArrayHasKey('items', $listPayload);
+        self::assertArrayHasKey('pagination', $listPayload);
+        self::assertArrayHasKey('meta', $listPayload);
+        self::assertSame(1, $listPayload['pagination']['page']);
+        self::assertSame(5, $listPayload['pagination']['limit']);
+        self::assertSame('Classe', $listPayload['meta']['filters']['q']);
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/teachers');
+        $teachersPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+        $teacherId = $teachersPayload['items'][0]['id'];
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/exams', [], [], [], JSON::encode([
+            'title' => '',
+            'classId' => $createdClassId,
+            'teacherId' => $teacherId,
+            'type' => 'invalid',
+            'status' => 'invalid',
+            'term' => 'invalid',
+        ]));
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/exams', [], [], [], JSON::encode([
+            'title' => 'Exam CRUD API Test',
+            'classId' => $createdClassId,
+            'teacherId' => $teacherId,
+            'type' => 'midterm',
+            'status' => 'draft',
+            'term' => 'term_2',
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+        $createdExam = JSON::decode((string)$client->getResponse()->getContent(), true);
+        $createdExamId = $createdExam['id'];
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams/' . $createdExamId);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request('PATCH', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams/' . $createdExamId, [], [], [], JSON::encode(['status' => 'published', 'term' => 'term_3']));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request('DELETE', self::API_URL_PREFIX . '/v1/school/exams/' . $createdExamId);
+        self::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+
+        $client->request('DELETE', self::API_URL_PREFIX . '/v1/school/classes/' . $createdClassId);
+        self::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolListingCacheRegressionTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolListingCacheRegressionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\School\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SchoolListingCacheRegressionTest extends WebTestCase
+{
+    #[TestDox('Exam list remains stable across repeated calls with pagination/filters on larger fixture datasets (cache regression).')]
+    public function testExamListCacheAndPaginationRegression(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $endpoint = self::API_URL_PREFIX . '/v1/school/exams?page=1&limit=10&title=Examen&q=Examen';
+
+        $client->request('GET', $endpoint);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $firstPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        $client->request('GET', $endpoint);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $secondPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        self::assertSame($firstPayload['pagination'], $secondPayload['pagination']);
+        self::assertSame($firstPayload['meta']['filters'], $secondPayload['meta']['filters']);
+        self::assertCount(10, $firstPayload['items']);
+        self::assertGreaterThanOrEqual(30, $firstPayload['pagination']['totalItems']);
+    }
+
+    #[TestDox('Class list by application remains stable across repeated calls with pagination/filters on larger fixture datasets (cache regression).')]
+    public function testClassApplicationListCacheAndPaginationRegression(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $endpoint = self::API_URL_PREFIX . '/v1/school/applications/school-course-flow/classes?page=1&limit=2&q=Classe';
+
+        $client->request('GET', $endpoint);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $firstPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        $client->request('GET', $endpoint);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $secondPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        self::assertSame($firstPayload['pagination'], $secondPayload['pagination']);
+        self::assertSame($firstPayload['meta']['filters'], $secondPayload['meta']['filters']);
+        self::assertSame(2, $firstPayload['pagination']['limit']);
+        self::assertGreaterThanOrEqual(3, $firstPayload['pagination']['totalItems']);
+        self::assertCount(2, $firstPayload['items']);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide larger, more realistic seeded datasets for School applications to exercise list/pagination, filters and cache logic. 
- Ensure scoped School routes and resource access control are covered by automated tests including owner vs foreign-owner scenarios. 

### Description
- Extend `src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php` to create multiple schools (per application), three class sizes per school, teachers assigned to multiple classes, multiple exams per class with varying `type`/`status`/`term`, and grades including edge cases (0, negative, >20, decimal precision). 
- Add explicit fixture references with `addReference` for `School`, `SchoolClass`, `Teacher`, `Student`, `Exam`, and `Grade` to enable deterministic reuse in tests. 
- Add new integration tests under `tests/Application/School/Transport/Controller/Api/V1/`: `SchoolApplicationScopedRoutesTest.php` (owner vs foreign-owner access control), `SchoolCrudValidationPaginationTest.php` (CRUD, validation, pagination, filters), and `SchoolListingCacheRegressionTest.php` (cache/listing non-regression for `ExamListService` and `ClassApplicationListService`). 

### Testing
- Static syntax checks passed with `php -l` for `LoadSchoolData.php` and all added test files. 
- Attempted to run `phpunit` but `vendor/bin/phpunit` was not available because `composer install` failed due to missing PHP extensions (`ext-amqp`, `ext-sodium`). 
- Attempted `composer install --ignore-platform-req=ext-amqp --ignore-platform-req=ext-sodium` but it failed due to network/GitHub access errors when fetching packages, so automated PHPUnit runs could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ed27af748326aafa6bd7e9837439)