### PR TITLE
fix(school): prevent duplicate School rows when loading fixtures

### DIFF
--- a/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
+++ b/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
@@ -37,10 +37,15 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
     public function load(ObjectManager $manager): void
     {
         foreach ($this->getApplicationsByPlatform(PlatformKey::SCHOOL) as $application) {
-            $school = (new School())
-                ->setName($application->getTitle() . ' Academy')
-                ->setApplication($application);
-            $manager->persist($school);
+            $school = $manager->getRepository(School::class)->findOneBy(['application' => $application]);
+
+            if (!$school instanceof School) {
+                $school = (new School())
+                    ->setApplication($application);
+                $manager->persist($school);
+            }
+
+            $school->setName($application->getTitle() . ' Academy');
 
             $classA = (new SchoolClass())->setSchool($school)->setName('Classe A - Sciences');
             $classB = (new SchoolClass())->setSchool($school)->setName('Classe B - Langues');


### PR DESCRIPTION
### Motivation
- Loading school fixtures could attempt to insert a `School` for an `Application` that already exists, triggering a unique constraint violation on `school.application`.
- The change prevents fixture runs from failing when other code (for example event listeners or previous fixtures) already created the `School` row for the same application.

### Description
- Changed `LoadSchoolData::load` to lookup an existing `School` with `findOneBy(['application' => $application])` before creating a new entity.
- Only construct and `persist` a new `School` when no existing entity is found, and always call `setName` so the name is updated for both existing and new schools.
- The change is implemented in `src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php` and preserves the rest of the fixture data flow.

### Testing
- Ran `php -l src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php` and it returned `No syntax errors detected`.
- Attempted to run `php bin/console doctrine:fixtures:load -n` but it could not complete in this environment because dependencies are missing and the console exits with `Dependencies are missing. Try running "composer install"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ee8e15608326af7627e6e10656fe)