### PR TITLE
Add comprehensive chat controller and handler tests and stabilize chat fixtures

### DIFF
--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -18,15 +18,30 @@ use App\Platform\Domain\Entity\Application as PlatformApplication;
 use App\Platform\Domain\Entity\Plugin;
 use App\Recruit\Domain\Entity\Application as RecruitApplication;
 use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\General\Domain\Rest\UuidHelper;
+use App\Tests\Utils\PhpUnitUtil;
 use App\User\Domain\Entity\User;
 use DateTimeImmutable;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Override;
+use Throwable;
 
 final class LoadRecruitChatCalendarScenarioData extends Fixture implements OrderedFixtureInterface
 {
+    /**
+     * @var array<non-empty-string, non-empty-string>
+     */
+    public static array $uuids = [
+        'chat-crm-pipeline-pro' => '91000000-0000-1000-8000-000000000001',
+        'conversation-direct-john-root-john-admin' => '91000000-0000-1000-8000-000000000002',
+        'conversation-john-root-scenario' => '91000000-0000-1000-8000-000000000003',
+        'message-john-root-scenario-from-john-root' => '91000000-0000-1000-8000-000000000004',
+        'message-john-root-scenario-from-owner' => '91000000-0000-1000-8000-000000000005',
+        'reaction-john-root-scenario-owner-on-root-message' => '91000000-0000-1000-8000-000000000006',
+    ];
+
     /**
      * @var array<string, Chat>
      */
@@ -72,6 +87,11 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
     public function getOrder(): int
     {
         return 10;
+    }
+
+    public static function getUuidByKey(string $key): string
+    {
+        return self::$uuids[$key];
     }
 
     private function createJohnRootPrivateDirectMessageScenarios(ObjectManager $manager): void
@@ -147,6 +167,9 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         }
     }
 
+    /**
+     * @throws Throwable
+     */
     private function createDedicatedDirectConversationFixture(ObjectManager $manager): void
     {
         /** @var User $johnRoot */
@@ -160,6 +183,8 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
 
         $conversation = (new Conversation())
             ->setChat($chat);
+
+        PhpUnitUtil::setProperty('id', UuidHelper::fromString(self::$uuids['conversation-direct-john-root-john-admin']), $conversation);
 
         $manager->persist($conversation);
 
@@ -187,6 +212,9 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         return array_values(array_filter($results, static fn (mixed $item): bool => $item instanceof PlatformApplication));
     }
 
+    /**
+     * @throws Throwable
+     */
     private function ensureChat(ObjectManager $manager, PlatformApplication $application): Chat
     {
         $application->ensureGeneratedSlug();
@@ -209,6 +237,10 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $chat = (new Chat())
             ->setApplication($application)
             ->setApplicationSlug($slug);
+
+        if ($slug === 'crm-pipeline-pro') {
+            PhpUnitUtil::setProperty('id', UuidHelper::fromString(self::$uuids['chat-crm-pipeline-pro']), $chat);
+        }
 
         $manager->persist($chat);
 
@@ -301,6 +333,9 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $this->ensureReaction($manager, $introMessage, $johnAdmin, 'love');
     }
 
+    /**
+     * @throws Throwable
+     */
     private function createJohnRootConversationScenario(ObjectManager $manager, Chat $chat, Calendar $calendar): void
     {
         /** @var RecruitApplication $johnRootRecruitApplication */
@@ -320,6 +355,9 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         }
 
         $conversation = $this->ensureConversation($manager, $chat);
+        if ($chat->getApplicationSlug() === 'crm-pipeline-pro') {
+            PhpUnitUtil::setProperty('id', UuidHelper::fromString(self::$uuids['conversation-john-root-scenario']), $conversation);
+        }
         $this->ensureParticipant($manager, $conversation, $johnRoot);
 
         if ($johnRoot->getId() !== $otherOwner->getId()) {
@@ -350,6 +388,9 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             []
         );
 
+        PhpUnitUtil::setProperty('id', UuidHelper::fromString(self::$uuids['message-john-root-scenario-from-john-root']), $johnRootMessage);
+        PhpUnitUtil::setProperty('id', UuidHelper::fromString(self::$uuids['message-john-root-scenario-from-owner']), $ownerReplyMessage);
+
         $johnUserMessage = $this->ensureMessage(
             $manager,
             $conversation,
@@ -377,7 +418,13 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $this->ensureReaction($manager, $ownerReplyMessage, $johnRoot, 'love');
         $this->ensureReaction($manager, $ownerReplyMessage, $johnAdmin, 'like');
         $this->ensureReaction($manager, $johnUserMessage, $johnAdmin, 'wow');
-        $this->ensureReaction($manager, $johnRootMessage, $otherOwner, 'laugh');
+        $this->ensureReaction(
+            $manager,
+            $johnRootMessage,
+            $otherOwner,
+            'laugh',
+            self::$uuids['reaction-john-root-scenario-owner-on-root-message']
+        );
 
         $event = $this->ensureJohnRootScenarioEvent($manager, $calendar, $johnRoot);
 
@@ -497,6 +544,8 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $conversation = (new Conversation())
             ->setChat($chat);
 
+        PhpUnitUtil::setProperty('id', UuidHelper::fromString(self::$uuids['conversation-direct-john-root-john-admin']), $conversation);
+
         $manager->persist($conversation);
         $conversationByChat[$chatKey] = $conversation;
 
@@ -567,7 +616,10 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         return $message;
     }
 
-    private function ensureReaction(ObjectManager $manager, ChatMessage $message, User $user, string $reaction): void
+    /**
+     * @throws Throwable
+     */
+    private function ensureReaction(ObjectManager $manager, ChatMessage $message, User $user, string $reaction, ?string $forcedUuid = null): void
     {
         $existing = $manager->getRepository(ChatMessageReaction::class)->findOneBy([
             'message' => $message,
@@ -583,6 +635,10 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             ->setMessage($message)
             ->setUser($user)
             ->setReaction(ChatReactionType::from($reaction));
+
+        if ($forcedUuid !== null) {
+            PhpUnitUtil::setProperty('id', UuidHelper::fromString($forcedUuid), $reaction);
+        }
 
         $manager->persist($reaction);
     }

--- a/tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php
+++ b/tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Chat\Transport\Controller\Api\V1\Conversation;
+
+use App\General\Domain\Utils\JSON;
+use App\Recruit\Infrastructure\DataFixtures\ORM\LoadRecruitChatCalendarScenarioData;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Infrastructure\DataFixtures\ORM\LoadUserData;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+final class UserConversationControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/chat/private';
+
+    /** @throws Throwable */
+    #[TestDox('GET conversations requires authentication')]
+    public function testListRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+        $client->request('GET', $this->baseUrl . '/conversations');
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
+    }
+
+    /** @throws Throwable */
+    #[TestDox('GET conversations returns items for authenticated user')]
+    public function testListNominal(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', $this->baseUrl . '/conversations');
+
+        $content = $client->getResponse()->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('items', $payload);
+        self::assertNotEmpty($payload['items']);
+    }
+
+    /** @throws Throwable */
+    #[TestDox('POST conversation create accepts valid payload and rejects invalid payload')]
+    public function testCreateNominalAndValidationError(): void
+    {
+        $chatId = LoadRecruitChatCalendarScenarioData::getUuidByKey('chat-crm-pipeline-pro');
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('POST', $this->baseUrl . '/chats/' . $chatId . '/conversations', [], [], [], JSON::encode([
+            'userId' => LoadUserData::getUuidByKey('john-user'),
+        ]));
+        self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+
+        $client->request('POST', $this->baseUrl . '/chats/' . $chatId . '/conversations', [], [], [], JSON::encode([]));
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+    }
+
+    /** @throws Throwable */
+    #[TestDox('PATCH and DELETE conversation endpoints accept for participant and hide unauthorized conversation')]
+    public function testPatchDeleteAndUnauthorizedFindOrCreate(): void
+    {
+        $conversationId = LoadRecruitChatCalendarScenarioData::getUuidByKey('conversation-john-root-scenario');
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('PATCH', $this->baseUrl . '/conversations/' . $conversationId, [], [], [], JSON::encode([
+            'userId' => LoadUserData::getUuidByKey('alice'),
+        ]));
+        self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+
+        $client->request('DELETE', $this->baseUrl . '/conversations/' . $conversationId);
+        self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+
+        $otherConversationId = LoadRecruitChatCalendarScenarioData::getUuidByKey('conversation-direct-john-root-john-admin');
+        $unauthorizedClient = $this->getTestClient('john-user', 'password-user');
+        $unauthorizedClient->request('GET', $this->baseUrl . '/conversations/' . $otherConversationId);
+        self::assertSame(Response::HTTP_NOT_FOUND, $unauthorizedClient->getResponse()->getStatusCode());
+
+        $client->request('POST', $this->baseUrl . '/conversation/' . LoadUserData::getUuidByKey('john-admin') . '/user');
+        self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Application/Chat/Transport/Controller/Api/V1/Message/UserMessageControllerTest.php
+++ b/tests/Application/Chat/Transport/Controller/Api/V1/Message/UserMessageControllerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Chat\Transport\Controller\Api\V1\Message;
+
+use App\General\Domain\Utils\JSON;
+use App\Recruit\Infrastructure\DataFixtures\ORM\LoadRecruitChatCalendarScenarioData;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+final class UserMessageControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/chat/private';
+
+    /** @throws Throwable */
+    #[TestDox('Message list/create/patch/delete/read endpoints cover nominal + validation + authorization')]
+    public function testMessageEndpoints(): void
+    {
+        $conversationId = LoadRecruitChatCalendarScenarioData::getUuidByKey('conversation-john-root-scenario');
+        $messageId = LoadRecruitChatCalendarScenarioData::getUuidByKey('message-john-root-scenario-from-john-root');
+
+        $anonymous = $this->getTestClient();
+        $anonymous->request('GET', $this->baseUrl . '/conversations/' . $conversationId);
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $anonymous->getResponse()->getStatusCode());
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', $this->baseUrl . '/conversations/' . $conversationId);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $content = $client->getResponse()->getContent();
+        self::assertNotFalse($content);
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('items', $payload);
+
+        $client->request('POST', $this->baseUrl . '/conversations/' . $conversationId . '/messages', [], [], [], JSON::encode([
+            'content' => 'Nouveau message de test fonctionnel',
+        ]));
+        self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+
+        $client->request('POST', $this->baseUrl . '/conversations/' . $conversationId . '/messages', [], [], [], JSON::encode([
+            'content' => '',
+        ]));
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+
+        $client->request('PATCH', $this->baseUrl . '/messages/' . $messageId, [], [], [], JSON::encode([
+            'read' => true,
+            'content' => 'Message édité via test',
+        ]));
+        self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+
+        $client->request('PATCH', $this->baseUrl . '/messages/' . $messageId, [], [], [], JSON::encode([
+            'read' => 'yes',
+        ]));
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+
+        $client->request('POST', $this->baseUrl . '/conversations/' . $conversationId . '/messages/read');
+        self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+
+        $unauthorizedClient = $this->getTestClient('john-user', 'password-user');
+        $directConversationId = LoadRecruitChatCalendarScenarioData::getUuidByKey('conversation-direct-john-root-john-admin');
+        $unauthorizedClient->request('GET', $this->baseUrl . '/conversations/' . $directConversationId);
+        self::assertSame(Response::HTTP_NOT_FOUND, $unauthorizedClient->getResponse()->getStatusCode());
+
+        $client->request('DELETE', $this->baseUrl . '/messages/' . $messageId);
+        self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Application/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationControllerTest.php
+++ b/tests/Application/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationControllerTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Chat\Transport\Controller\Api\V1\Reaction;
+
+use App\General\Domain\Utils\JSON;
+use App\Recruit\Infrastructure\DataFixtures\ORM\LoadRecruitChatCalendarScenarioData;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+final class UserReactionMutationControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/chat/private';
+
+    /** @throws Throwable */
+    #[TestDox('Reaction create/patch/delete nominal + validation + ownership authorization')]
+    public function testReactionEndpoints(): void
+    {
+        $messageId = LoadRecruitChatCalendarScenarioData::getUuidByKey('message-john-root-scenario-from-john-root');
+
+        $anonymous = $this->getTestClient();
+        $anonymous->request('POST', $this->baseUrl . '/messages/' . $messageId . '/reactions', [], [], [], JSON::encode([
+            'reaction' => 'like',
+        ]));
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $anonymous->getResponse()->getStatusCode());
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('POST', $this->baseUrl . '/messages/' . $messageId . '/reactions', [], [], [], JSON::encode([
+            'reaction' => 'like',
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $content = $client->getResponse()->getContent();
+        self::assertNotFalse($content);
+        $payload = JSON::decode($content, true);
+        $reactionId = $payload['id'] ?? null;
+        self::assertIsString($reactionId);
+
+        $client->request('PATCH', $this->baseUrl . '/reactions/' . $reactionId, [], [], [], JSON::encode([
+            'reaction' => 'love',
+        ]));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request('PATCH', $this->baseUrl . '/reactions/' . $reactionId, [], [], [], JSON::encode([
+            'reaction' => 'invalid-value',
+        ]));
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+
+        $otherClient = $this->getTestClient('john-admin', 'password-admin');
+        $otherClient->request('PATCH', $this->baseUrl . '/reactions/' . $reactionId, [], [], [], JSON::encode([
+            'reaction' => 'wow',
+        ]));
+        self::assertSame(Response::HTTP_NOT_FOUND, $otherClient->getResponse()->getStatusCode());
+
+        $client->request('DELETE', $this->baseUrl . '/reactions/' . $reactionId);
+        self::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+    }
+}

--- a/tests/Unit/Chat/Application/MessageHandler/MessageHandlersTest.php
+++ b/tests/Unit/Chat/Application/MessageHandler/MessageHandlersTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Chat\Application\MessageHandler;
+
+use App\Chat\Application\Message\CreateMessageCommand;
+use App\Chat\Application\Message\MarkConversationMessagesAsReadCommand;
+use App\Chat\Application\Message\PatchMessageCommand;
+use App\Chat\Application\MessageHandler\CreateMessageCommandHandler;
+use App\Chat\Application\MessageHandler\MarkConversationMessagesAsReadCommandHandler;
+use App\Chat\Application\MessageHandler\PatchMessageCommandHandler;
+use App\Chat\Domain\Entity\Chat;
+use App\Chat\Domain\Entity\ChatMessage;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Infrastructure\Repository\ChatMessageRepository;
+use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
+use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\General\Application\Service\CacheInvalidationService;
+use App\General\Application\Service\MercurePublisher;
+use App\General\Domain\Rest\UuidHelper;
+use App\Tests\Utils\PhpUnitUtil;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class MessageHandlersTest extends TestCase
+{
+    public function testCreateMessageHandlerRejectsNonParticipant(): void
+    {
+        $conversationRepo = $this->createMock(ConversationRepository::class);
+        $participantRepo = $this->createMock(ConversationParticipantRepository::class);
+        $userRepo = $this->createMock(UserRepository::class);
+        $messageRepo = $this->createMock(ChatMessageRepository::class);
+        $cache = $this->createMock(CacheInvalidationService::class);
+        $mercure = $this->createMock(MercurePublisher::class);
+
+        $actor = $this->makeUser('20000000-0000-1000-8000-000000000006');
+        $conversation = $this->makeConversation('91000000-0000-1000-8000-000000000003');
+
+        $userRepo->method('find')->willReturn($actor);
+        $conversationRepo->method('find')->willReturn($conversation);
+        $participantRepo->method('findOneByConversationAndUser')->willReturn(null);
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('transactional')->willReturnCallback(static fn (callable $func) => $func());
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getConnection')->willReturn($connection);
+        $messageRepo->method('getEntityManager')->willReturn($em);
+
+        $cache->expects(self::never())->method('invalidateConversationCaches');
+
+        $handler = new CreateMessageCommandHandler($conversationRepo, $participantRepo, $userRepo, $messageRepo, $cache, $mercure);
+
+        $this->expectException(HttpException::class);
+        $handler(new CreateMessageCommand('op', $actor->getId(), $conversation->getId(), 'hello'));
+    }
+
+    public function testPatchMessageHandlerUpdatesReadTransitionsAndInvalidatesCache(): void
+    {
+        $messageRepo = $this->createMock(ChatMessageRepository::class);
+        $cache = $this->createMock(CacheInvalidationService::class);
+
+        $sender = $this->makeUser('20000000-0000-1000-8000-000000000006');
+        $conversation = $this->makeConversation('91000000-0000-1000-8000-000000000003');
+        $message = (new ChatMessage())
+            ->setConversation($conversation)
+            ->setSender($sender)
+            ->setContent('draft')
+            ->setRead(false);
+        PhpUnitUtil::setProperty('id', UuidHelper::fromString('91000000-0000-1000-8000-000000000010'), $message);
+
+        $messageRepo->method('find')->willReturn($message);
+        $messageRepo->expects(self::exactly(2))->method('save');
+
+        $connection = $this->createMock(Connection::class);
+        $connection->method('transactional')->willReturnCallback(static fn (callable $func) => $func());
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getConnection')->willReturn($connection);
+        $messageRepo->method('getEntityManager')->willReturn($em);
+
+        $cache->expects(self::exactly(2))->method('invalidateConversationCaches')->with($conversation->getChat()->getId(), $sender->getId());
+
+        $handler = new PatchMessageCommandHandler($messageRepo, $cache);
+
+        $handler(new PatchMessageCommand('op-1', $sender->getId(), $message->getId(), null, true));
+        self::assertTrue($message->isRead());
+        self::assertNotNull($message->getReadAt());
+
+        $handler(new PatchMessageCommand('op-2', $sender->getId(), $message->getId(), null, false));
+        self::assertFalse($message->isRead());
+        self::assertNull($message->getReadAt());
+    }
+
+    public function testMarkConversationMessagesAsReadInvalidatesCacheOnlyWhenMessagesWereUpdated(): void
+    {
+        $conversationRepo = $this->createMock(ConversationRepository::class);
+        $participantRepo = $this->createMock(ConversationParticipantRepository::class);
+        $messageRepo = $this->createMock(ChatMessageRepository::class);
+        $cache = $this->createMock(CacheInvalidationService::class);
+
+        $actor = $this->makeUser('20000000-0000-1000-8000-000000000006');
+        $conversation = $this->makeConversation('91000000-0000-1000-8000-000000000003');
+        $participant = (new ConversationParticipant())->setConversation($conversation)->setUser($actor);
+
+        $conversationRepo->method('find')->willReturn($conversation);
+        $participantRepo->method('findOneBy')->willReturn($participant);
+        $participantRepo->expects(self::exactly(2))->method('save');
+
+        $messageRepo->expects(self::exactly(2))->method('markConversationMessagesAsRead')
+            ->with($conversation->getId(), $actor->getId())
+            ->willReturnOnConsecutiveCalls(0, 2);
+
+        $cache->expects(self::once())->method('invalidateConversationCaches')->with($conversation->getChat()->getId(), $actor->getId());
+
+        $handler = new MarkConversationMessagesAsReadCommandHandler($conversationRepo, $participantRepo, $messageRepo, $cache);
+
+        $handler(new MarkConversationMessagesAsReadCommand('op-1', $actor->getId(), $conversation->getId()));
+        $firstReadAt = $participant->getLastReadMessageAt();
+        self::assertNotNull($firstReadAt);
+
+        $handler(new MarkConversationMessagesAsReadCommand('op-2', $actor->getId(), $conversation->getId()));
+        self::assertNotNull($participant->getLastReadMessageAt());
+    }
+
+    private function makeConversation(string $id): Conversation
+    {
+        $chat = new Chat();
+        PhpUnitUtil::setProperty('id', UuidHelper::fromString('91000000-0000-1000-8000-000000000001'), $chat);
+
+        $conversation = (new Conversation())->setChat($chat);
+        PhpUnitUtil::setProperty('id', UuidHelper::fromString($id), $conversation);
+
+        return $conversation;
+    }
+
+    private function makeUser(string $id): User
+    {
+        $user = (new User())
+            ->setUsername('john-root')
+            ->setFirstName('John')
+            ->setLastName('Root')
+            ->setEmail('john.root@test.com')
+            ->setPlainPassword('password-root');
+        PhpUnitUtil::setProperty('id', UuidHelper::fromString($id), $user);
+
+        return $user;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide deterministic, realistic chat fixtures and add functional + unit test coverage to ensure chat conversation/message/reaction APIs and handlers behave correctly for nominal, authorization and validation scenarios.
- Make handler behaviour (participant checks, cache invalidation, read/readAt transitions) explicitly covered by unit tests to avoid regressions.

### Description
- Added functional API tests for conversations under `tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php` covering list/create/patch/delete/find-or-create with auth and payload validation checks.
- Added functional API tests for messages under `tests/Application/Chat/Transport/Controller/Api/V1/Message/UserMessageControllerTest.php` covering list/create/patch/delete/mark-read with auth and validation cases.
- Added functional API tests for reactions under `tests/Application/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationControllerTest.php` covering create/patch/delete including ownership and invalid payload handling.
- Added focused unit tests for message handlers in `tests/Unit/Chat/Application/MessageHandler/MessageHandlersTest.php` asserting participant permission rejection for `CreateMessage`, cache invalidation behaviour and `read`/`readAt` transitions for `PatchMessage` and `MarkConversationMessagesAsRead` handlers.
- Stabilized recruit chat scenario fixtures in `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` by introducing deterministic UUIDs, a `getUuidByKey` accessor and forcing IDs for specific chats/conversations/messages/reactions to make functional tests deterministic; added optional forced UUID handling for reactions.

### Testing
- Ran PHP syntax checks with `php -l` on the modified fixture and all newly added test files and they reported no syntax errors (all succeeded). 
- Attempted to run the unit test file with PHPUnit but the test runner binary was unavailable in this environment (`./vendor/bin/phpunit` not found), so automated test execution could not be completed here.
- Created and validated the new files compile and are syntactically correct via the lint checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0ed23f5548326aff26c52b905e1ee)