### PR TITLE
Fix school fixture app key lookup

### DIFF
--- a/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
+++ b/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
@@ -39,9 +39,10 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
         $examTypes = ExamType::cases();
         $examStatuses = ExamStatus::cases();
         $terms = Term::cases();
+        $applicationKeys = self::APPLICATION_KEYS_BY_PLATFORM[PlatformKey::SCHOOL->value] ?? [];
 
         foreach ($this->getApplicationsByPlatform(PlatformKey::SCHOOL) as $applicationIndex => $application) {
-            $appKey = $application->getKey();
+            $appKey = $applicationKeys[$applicationIndex] ?? $application->getSlug();
 
             $school = (new School())
                 ->setName($application->getTitle() . ' Academy')


### PR DESCRIPTION
### Motivation
- Prevent a runtime error caused by calling the nonexistent `Application::getKey()` from the `LoadSchoolData` fixture by deriving fixture reference keys from known application keys.

### Description
- Add ` $applicationKeys = self::APPLICATION_KEYS_BY_PLATFORM[PlatformKey::SCHOOL->value] ?? [];` and set `$appKey` to the indexed key from that list with a fallback to `Application::getSlug()` instead of calling `getKey()`.

### Testing
- Ran `php -l src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php` which reported no syntax errors; the check passed.
- Attempted `php bin/console doctrine:fixtures:load -n` which failed in this environment due to missing dependencies and recommends running `composer install` (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0efafd4508326994f8d521a985cad)