### PR TITLE
Fix duplicate conversation identity collision in recruit fixtures

### DIFF
--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -545,8 +545,6 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $conversation = (new Conversation())
             ->setChat($chat);
 
-        PhpUnitUtil::setProperty('id', UuidHelper::fromString(self::$uuids['conversation-direct-john-root-john-admin']), $conversation);
-
         $manager->persist($conversation);
         $conversationByChat[$chatKey] = $conversation;
 


### PR DESCRIPTION
### Motivation

- The fixtures loader raised a `EntityIdentityCollisionException` because multiple `Conversation` instances created via `ensureConversation()` were assigned the same hardcoded UUID in the same Doctrine Unit of Work. 
- The aim is to stop reusing a single fixed ID for conversations created for different chats to avoid identity collisions while preserving the intentionally reserved ID used by a dedicated fixture.

### Description

- Removed the hardcoded UUID assignment from `ensureConversation()` in `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` so new conversations get a proper generated ID. 
- Preserved the explicit UUID assignment in `createDedicatedDirectConversationFixture()` where that ID is intentionally reserved for a specific direct-conversation fixture. 
- Kept the existing caching logic (`$conversationByChat`) and `persist` calls intact to avoid behavioral regressions when ensuring conversations by chat.

### Testing

- Ran syntax check with `php -l src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php`, which succeeded. 
- Attempted `php bin/console doctrine:fixtures:load -n`, but the run failed due to missing project dependencies (environment requires `composer install`), so full runtime fixtures validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f0cfb80083269db6a81a43c50980)