### PR TITLE
Reuse existing School in fixtures to avoid duplicate application insert

### DIFF
--- a/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
+++ b/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
@@ -44,10 +44,17 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
         foreach ($this->getApplicationsByPlatform(PlatformKey::SCHOOL) as $applicationIndex => $application) {
             $appKey = $applicationKeys[$applicationIndex] ?? $application->getSlug();
 
-            $school = (new School())
-                ->setName($application->getTitle() . ' Academy')
-                ->setApplication($application);
-            $manager->persist($school);
+            $school = $manager->getRepository(School::class)->findOneBy([
+                'application' => $application,
+            ]);
+
+            if (!$school instanceof School) {
+                $school = (new School())
+                    ->setApplication($application);
+                $manager->persist($school);
+            }
+
+            $school->setName($application->getTitle() . ' Academy');
             $this->addReference('School-' . $appKey, $school);
 
             $classes = [];


### PR DESCRIPTION
### Motivation
- The `school.application_id` column is unique and fixtures could try to insert a second `School` for an `Application`, causing a duplicate key error during `doctrine:fixtures:load`.
- A platform listener may pre-create `School` rows for applications, so the fixture must safely reuse those existing rows instead of always creating new ones.

### Description
- Updated `src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php` to look up an existing `School` via `$manager->getRepository(School::class)->findOneBy(['application' => $application])` before creating a new instance.
- The fixture now only calls `$manager->persist($school)` when a new `School` is created, and always updates the name via `setName(...)` and registers the `School-<appKey>` reference whether reused or newly created.
- This keeps class/teacher/student/exam/grade creation logic unchanged and avoids inserting duplicates on the unique `application` constraint.

### Testing
- Ran `php -l src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php` and it reported no syntax errors (success).
- Attempted `php bin/console doctrine:fixtures:load --dry-run --group=school --no-interaction` but it could not run in this environment because project dependencies are not installed (`composer install` required), so the fixtures dry-run was blocked (not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f1e75b008326b3ba96a2052085fc)