### PR TITLE
refactor(calendar): align event controllers injection convention

### DIFF
--- a/src/Calendar/README.md
+++ b/src/Calendar/README.md
@@ -1,0 +1,10 @@
+# Calendar module guidelines
+
+## Controllers
+
+For controllers in `src/Calendar/Transport/Controller`:
+
+- Do not use `private readonly` constructor property promotion.
+- Use the team convention with `public readonly` promoted dependencies (or inject services without promoted properties when delegating to a dedicated service is more appropriate).
+- Keep controllers thin and orchestration-only.
+- Do not add `private` methods in controllers. Move reusable/complex logic to an application/domain service.

--- a/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListController.php
@@ -17,7 +17,7 @@ use Symfony\Component\Routing\Attribute\Route;
 class ApplicationEventListController
 {
     public function __construct(
-        private readonly EventListService $eventListService
+        public readonly EventListService $eventListService
     ) {
     }
 

--- a/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationUserEventListController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/ApplicationUserEventListController.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class ApplicationUserEventListController
 {
     public function __construct(
-        private readonly EventListService $eventListService
+        public readonly EventListService $eventListService
     ) {
     }
 

--- a/src/Calendar/Transport/Controller/Api/V1/Event/CancelApplicationEventController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/CancelApplicationEventController.php
@@ -22,8 +22,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class CancelApplicationEventController
 {
     public function __construct(
-        private readonly MessageServiceInterface $messageService,
-        private readonly EventMutationInputFactory $eventMutationInputFactory,
+        public readonly MessageServiceInterface $messageService,
+        public readonly EventMutationInputFactory $eventMutationInputFactory,
     ) {
     }
 

--- a/src/Calendar/Transport/Controller/Api/V1/Event/CancelPrivateEventController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/CancelPrivateEventController.php
@@ -22,8 +22,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class CancelPrivateEventController
 {
     public function __construct(
-        private readonly MessageServiceInterface $messageService,
-        private readonly EventMutationInputFactory $eventMutationInputFactory,
+        public readonly MessageServiceInterface $messageService,
+        public readonly EventMutationInputFactory $eventMutationInputFactory,
     ) {
     }
 

--- a/src/Calendar/Transport/Controller/Api/V1/Event/CreateApplicationEventController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/CreateApplicationEventController.php
@@ -22,8 +22,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class CreateApplicationEventController
 {
     public function __construct(
-        private readonly MessageServiceInterface $messageService,
-        private readonly EventMutationInputFactory $eventMutationInputFactory,
+        public readonly MessageServiceInterface $messageService,
+        public readonly EventMutationInputFactory $eventMutationInputFactory,
     ) {
     }
 

--- a/src/Calendar/Transport/Controller/Api/V1/Event/CreatePrivateEventController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/CreatePrivateEventController.php
@@ -22,8 +22,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class CreatePrivateEventController
 {
     public function __construct(
-        private readonly MessageServiceInterface $messageService,
-        private readonly EventMutationInputFactory $eventMutationInputFactory,
+        public readonly MessageServiceInterface $messageService,
+        public readonly EventMutationInputFactory $eventMutationInputFactory,
     ) {
     }
 

--- a/src/Calendar/Transport/Controller/Api/V1/Event/DeleteApplicationEventController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/DeleteApplicationEventController.php
@@ -22,8 +22,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class DeleteApplicationEventController
 {
     public function __construct(
-        private readonly MessageServiceInterface $messageService,
-        private readonly EventMutationInputFactory $eventMutationInputFactory,
+        public readonly MessageServiceInterface $messageService,
+        public readonly EventMutationInputFactory $eventMutationInputFactory,
     ) {
     }
 

--- a/src/Calendar/Transport/Controller/Api/V1/Event/DeletePrivateEventController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/DeletePrivateEventController.php
@@ -22,8 +22,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class DeletePrivateEventController
 {
     public function __construct(
-        private readonly MessageServiceInterface $messageService,
-        private readonly EventMutationInputFactory $eventMutationInputFactory,
+        public readonly MessageServiceInterface $messageService,
+        public readonly EventMutationInputFactory $eventMutationInputFactory,
     ) {
     }
 

--- a/src/Calendar/Transport/Controller/Api/V1/Event/PatchApplicationEventController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/PatchApplicationEventController.php
@@ -22,8 +22,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class PatchApplicationEventController
 {
     public function __construct(
-        private readonly MessageServiceInterface $messageService,
-        private readonly EventMutationInputFactory $eventMutationInputFactory,
+        public readonly MessageServiceInterface $messageService,
+        public readonly EventMutationInputFactory $eventMutationInputFactory,
     ) {
     }
 

--- a/src/Calendar/Transport/Controller/Api/V1/Event/PatchPrivateEventController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/PatchPrivateEventController.php
@@ -22,8 +22,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class PatchPrivateEventController
 {
     public function __construct(
-        private readonly MessageServiceInterface $messageService,
-        private readonly EventMutationInputFactory $eventMutationInputFactory,
+        public readonly MessageServiceInterface $messageService,
+        public readonly EventMutationInputFactory $eventMutationInputFactory,
     ) {
     }
 

--- a/src/Calendar/Transport/Controller/Api/V1/Event/UserEventListController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/UserEventListController.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class UserEventListController
 {
     public function __construct(
-        private readonly EventListService $eventListService
+        public readonly EventListService $eventListService
     ) {
     }
 


### PR DESCRIPTION
### Motivation
- Harmoniser l’injection de dépendances dans les controllers calendar en retirant les promotions `private readonly` et en appliquant la convention d’équipe pour éviter des problèmes d’accès/visibilité et faciliter la relecture.
- S’assurer qu’aucune logique privée n’est laissée dans les controllers afin de garder la couche transport mince et déléguée.
- Skills utilisés : aucun skill externe de la liste `SKILL.md` n’a été nécessaire pour cette opération.

### Description
- Remplacé `private readonly` par `public readonly` pour les propriétés promotées dans tous les fichiers sous `src/Calendar/Transport/Controller/Api/V1/Event/`.
- Vérifié qu’il n’existe pas de `private` methods dans ces controllers.
- Ajouté `src/Calendar/README.md` documentant la règle (pas de `private readonly`, préférence `public readonly` ou injection non-promotée et interdiction des méthodes privées dans controllers).
- Les fichiers modifiés ont été commités sur la branche courante.

### Testing
- Exécution de `rg -n "private readonly|private function" src/Calendar/Transport/Controller/Api/V1/Event/*.php src/Calendar/README.md` a réussi et n’a retourné aucune occurrence non conforme.
- Lint PHP sur tous les controllers via `for f in src/Calendar/Transport/Controller/Api/V1/Event/*.php; do php -l "$f"; done` s’est terminé avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b199deb6b08326b405b81ba8206762)