### PR TITLE
Refactor chat access checks and reaction parsing into application services

### DIFF
--- a/src/Chat/Application/Service/ChatAccessResolverService.php
+++ b/src/Chat/Application/Service/ChatAccessResolverService.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Application\Service;
+
+use App\Chat\Domain\Entity\ChatMessage;
+use App\Chat\Domain\Entity\ChatMessageReaction;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Infrastructure\Repository\ChatMessageReactionRepository;
+use App\Chat\Infrastructure\Repository\ChatMessageRepository;
+use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
+use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\User\Domain\Entity\User;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ChatAccessResolverService
+{
+    public function __construct(
+        private readonly ConversationRepository $conversationRepository,
+        private readonly ConversationParticipantRepository $participantRepository,
+        private readonly ChatMessageRepository $messageRepository,
+        private readonly ChatMessageReactionRepository $reactionRepository,
+    ) {
+    }
+
+    public function resolveParticipantConversation(string $conversationId, User $loggedInUser): Conversation
+    {
+        $conversation = $this->conversationRepository->find($conversationId);
+        if (!$conversation instanceof Conversation) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+        }
+
+        $participant = $this->participantRepository->findOneByConversationAndUser($conversation, $loggedInUser);
+        if (!$participant instanceof ConversationParticipant) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+        }
+
+        return $conversation;
+    }
+
+    public function resolveAccessibleMessage(string $messageId, User $loggedInUser): ChatMessage
+    {
+        $message = $this->messageRepository->find($messageId);
+        if (!$message instanceof ChatMessage) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Message not found.');
+        }
+
+        $participant = $this->participantRepository->findOneByConversationAndUser($message->getConversation(), $loggedInUser);
+        if (!$participant instanceof ConversationParticipant) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Message not found.');
+        }
+
+        return $message;
+    }
+
+    public function resolveOwnReaction(string $reactionId, User $loggedInUser): ChatMessageReaction
+    {
+        $reaction = $this->reactionRepository->find($reactionId);
+        if (!$reaction instanceof ChatMessageReaction || $reaction->getUser()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Reaction not found.');
+        }
+
+        return $reaction;
+    }
+}
+

--- a/src/Chat/Application/Service/ReactionTypeParser.php
+++ b/src/Chat/Application/Service/ReactionTypeParser.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Application\Service;
+
+use App\Chat\Domain\Enum\ChatReactionType;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ReactionTypeParser
+{
+    public function parse(mixed $reaction): ChatReactionType
+    {
+        if (!is_string($reaction) || $reaction === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "reaction" must be a non-empty string.');
+        }
+
+        $reactionType = ChatReactionType::tryFrom($reaction);
+        if (!$reactionType instanceof ChatReactionType) {
+            throw new HttpException(
+                JsonResponse::HTTP_BAD_REQUEST,
+                sprintf('Invalid reaction "%s". Allowed values: %s.', $reaction, implode(', ', ChatReactionType::VALUES)),
+            );
+        }
+
+        return $reactionType;
+    }
+}

--- a/src/Chat/Transport/Controller/Api/V1/Message/ListConversationMessagesController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/ListConversationMessagesController.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Chat\Transport\Controller\Api\V1\Message;
 
-use App\Chat\Domain\Entity\Conversation;
-use App\Chat\Domain\Entity\ConversationParticipant;
-use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
-use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\Chat\Application\Service\ChatAccessResolverService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -37,15 +33,14 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class ListConversationMessagesController
 {
     public function __construct(
-        private readonly ConversationRepository $conversationRepository,
-        private readonly ConversationParticipantRepository $participantRepository,
+        private readonly ChatAccessResolverService $chatAccessResolverService,
     ) {
     }
 
     #[Route(path: '/v1/chat/private/conversations/{conversationId}', methods: [Request::METHOD_GET])]
     public function __invoke(string $conversationId, User $loggedInUser): JsonResponse
     {
-        $conversation = $this->findParticipantConversation($conversationId, $loggedInUser);
+        $conversation = $this->chatAccessResolverService->resolveParticipantConversation($conversationId, $loggedInUser);
 
         $items = [];
         foreach ($conversation->getMessages()->toArray() as $message) {
@@ -73,20 +68,5 @@ class ListConversationMessagesController
             'conversationId' => $conversation->getId(),
             'items' => $items,
         ]);
-    }
-
-    private function findParticipantConversation(string $conversationId, User $loggedInUser): Conversation
-    {
-        $conversation = $this->conversationRepository->find($conversationId);
-        if (!$conversation instanceof Conversation) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
-        }
-
-        $participant = $this->participantRepository->findOneByConversationAndUser($conversation, $loggedInUser);
-        if (!$participant instanceof ConversationParticipant) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
-        }
-
-        return $conversation;
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Reaction/CreateReactionController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Reaction/CreateReactionController.php
@@ -4,20 +4,17 @@ declare(strict_types=1);
 
 namespace App\Chat\Transport\Controller\Api\V1\Reaction;
 
-use App\Chat\Domain\Entity\ChatMessage;
+use App\Chat\Application\Service\ChatAccessResolverService;
+use App\Chat\Application\Service\ReactionTypeParser;
 use App\Chat\Domain\Entity\ChatMessageReaction;
-use App\Chat\Domain\Entity\ConversationParticipant;
 use App\Chat\Domain\Enum\ChatReactionType;
 use App\Chat\Infrastructure\Repository\ChatMessageReactionRepository;
-use App\Chat\Infrastructure\Repository\ChatMessageRepository;
-use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
 use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -33,9 +30,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class CreateReactionController
 {
     public function __construct(
-        private readonly ChatMessageRepository $messageRepository,
         private readonly ChatMessageReactionRepository $reactionRepository,
-        private readonly ConversationParticipantRepository $participantRepository,
+        private readonly ChatAccessResolverService $chatAccessResolverService,
+        private readonly ReactionTypeParser $reactionTypeParser,
         private readonly CacheInvalidationService $cacheInvalidationService,
     ) {
     }
@@ -43,10 +40,10 @@ class CreateReactionController
     #[Route(path: '/v1/chat/private/messages/{messageId}/reactions', methods: [Request::METHOD_POST])]
     public function __invoke(string $messageId, Request $request, User $loggedInUser): JsonResponse
     {
-        $message = $this->findParticipantMessage($messageId, $loggedInUser);
+        $message = $this->chatAccessResolverService->resolveAccessibleMessage($messageId, $loggedInUser);
         $payload = $request->toArray();
 
-        $reactionType = $this->parseReactionType($payload['reaction'] ?? null);
+        $reactionType = $this->reactionTypeParser->parse($payload['reaction'] ?? null);
 
         $reaction = (new ChatMessageReaction())
             ->setMessage($message)
@@ -59,37 +56,5 @@ class CreateReactionController
         return new JsonResponse([
             'id' => $reaction->getId(),
         ], JsonResponse::HTTP_CREATED);
-    }
-
-    private function parseReactionType(mixed $reaction): ChatReactionType
-    {
-        if (!is_string($reaction) || $reaction === '') {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "reaction" must be a non-empty string.');
-        }
-
-        $reactionType = ChatReactionType::tryFrom($reaction);
-        if (!$reactionType instanceof ChatReactionType) {
-            throw new HttpException(
-                JsonResponse::HTTP_BAD_REQUEST,
-                sprintf('Invalid reaction "%s". Allowed values: %s.', $reaction, implode(', ', ChatReactionType::VALUES)),
-            );
-        }
-
-        return $reactionType;
-    }
-
-    private function findParticipantMessage(string $messageId, User $loggedInUser): ChatMessage
-    {
-        $message = $this->messageRepository->find($messageId);
-        if (!$message instanceof ChatMessage) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Message not found.');
-        }
-
-        $participant = $this->participantRepository->findOneByConversationAndUser($message->getConversation(), $loggedInUser);
-        if (!$participant instanceof ConversationParticipant) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Message not found.');
-        }
-
-        return $message;
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Reaction/DeleteReactionController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Reaction/DeleteReactionController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Chat\Transport\Controller\Api\V1\Reaction;
 
-use App\Chat\Domain\Entity\ChatMessageReaction;
+use App\Chat\Application\Service\ChatAccessResolverService;
 use App\Chat\Infrastructure\Repository\ChatMessageReactionRepository;
 use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
@@ -12,7 +12,6 @@ use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -25,6 +24,7 @@ class DeleteReactionController
 {
     public function __construct(
         private readonly ChatMessageReactionRepository $reactionRepository,
+        private readonly ChatAccessResolverService $chatAccessResolverService,
         private readonly CacheInvalidationService $cacheInvalidationService,
     ) {
     }
@@ -32,21 +32,11 @@ class DeleteReactionController
     #[Route(path: '/v1/chat/private/reactions/{reactionId}', methods: [Request::METHOD_DELETE])]
     public function __invoke(string $reactionId, User $loggedInUser): JsonResponse
     {
-        $reaction = $this->findOwnReaction($reactionId, $loggedInUser);
+        $reaction = $this->chatAccessResolverService->resolveOwnReaction($reactionId, $loggedInUser);
         $chatId = $reaction->getMessage()->getConversation()->getChat()->getId();
         $this->reactionRepository->remove($reaction);
         $this->cacheInvalidationService->invalidateConversationCaches($chatId, $loggedInUser->getId());
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
-    }
-
-    private function findOwnReaction(string $reactionId, User $loggedInUser): ChatMessageReaction
-    {
-        $reaction = $this->reactionRepository->find($reactionId);
-        if (!$reaction instanceof ChatMessageReaction || $reaction->getUser()->getId() !== $loggedInUser->getId()) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Reaction not found.');
-        }
-
-        return $reaction;
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Reaction/PatchReactionController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Reaction/PatchReactionController.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace App\Chat\Transport\Controller\Api\V1\Reaction;
 
-use App\Chat\Domain\Entity\ChatMessageReaction;
+use App\Chat\Application\Service\ChatAccessResolverService;
+use App\Chat\Application\Service\ReactionTypeParser;
 use App\Chat\Domain\Enum\ChatReactionType;
 use App\Chat\Infrastructure\Repository\ChatMessageReactionRepository;
 use App\General\Application\Service\CacheInvalidationService;
@@ -13,7 +14,6 @@ use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -30,6 +30,8 @@ class PatchReactionController
 {
     public function __construct(
         private readonly ChatMessageReactionRepository $reactionRepository,
+        private readonly ChatAccessResolverService $chatAccessResolverService,
+        private readonly ReactionTypeParser $reactionTypeParser,
         private readonly CacheInvalidationService $cacheInvalidationService,
     ) {
     }
@@ -37,11 +39,11 @@ class PatchReactionController
     #[Route(path: '/v1/chat/private/reactions/{reactionId}', methods: [Request::METHOD_PATCH])]
     public function __invoke(string $reactionId, Request $request, User $loggedInUser): JsonResponse
     {
-        $reaction = $this->findOwnReaction($reactionId, $loggedInUser);
+        $reaction = $this->chatAccessResolverService->resolveOwnReaction($reactionId, $loggedInUser);
         $payload = $request->toArray();
 
         if (array_key_exists('reaction', $payload)) {
-            $reaction->setReaction($this->parseReactionType($payload['reaction']));
+            $reaction->setReaction($this->reactionTypeParser->parse($payload['reaction']));
             $this->reactionRepository->save($reaction);
             $this->cacheInvalidationService->invalidateConversationCaches($reaction->getMessage()->getConversation()->getChat()->getId(), $loggedInUser->getId());
         }
@@ -49,32 +51,5 @@ class PatchReactionController
         return new JsonResponse([
             'id' => $reaction->getId(),
         ]);
-    }
-
-    private function parseReactionType(mixed $reaction): ChatReactionType
-    {
-        if (!is_string($reaction) || $reaction === '') {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "reaction" must be a non-empty string.');
-        }
-
-        $reactionType = ChatReactionType::tryFrom($reaction);
-        if (!$reactionType instanceof ChatReactionType) {
-            throw new HttpException(
-                JsonResponse::HTTP_BAD_REQUEST,
-                sprintf('Invalid reaction "%s". Allowed values: %s.', $reaction, implode(', ', ChatReactionType::VALUES)),
-            );
-        }
-
-        return $reactionType;
-    }
-
-    private function findOwnReaction(string $reactionId, User $loggedInUser): ChatMessageReaction
-    {
-        $reaction = $this->reactionRepository->find($reactionId);
-        if (!$reaction instanceof ChatMessageReaction || $reaction->getUser()->getId() !== $loggedInUser->getId()) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Reaction not found.');
-        }
-
-        return $reaction;
     }
 }

--- a/tests/Unit/Chat/Application/Service/ChatAccessResolverServiceTest.php
+++ b/tests/Unit/Chat/Application/Service/ChatAccessResolverServiceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Chat\Application\Service;
+
+use App\Chat\Application\Service\ChatAccessResolverService;
+use App\Chat\Domain\Entity\ChatMessage;
+use App\Chat\Domain\Entity\ChatMessageReaction;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Infrastructure\Repository\ChatMessageReactionRepository;
+use App\Chat\Infrastructure\Repository\ChatMessageRepository;
+use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
+use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ChatAccessResolverServiceTest extends TestCase
+{
+    public function testResolveParticipantConversationReturnsConversation(): void
+    {
+        $user = $this->createMock(User::class);
+        $conversation = $this->createMock(Conversation::class);
+        $participant = $this->createMock(ConversationParticipant::class);
+
+        $conversationRepository = $this->createMock(ConversationRepository::class);
+        $participantRepository = $this->createMock(ConversationParticipantRepository::class);
+        $messageRepository = $this->createMock(ChatMessageRepository::class);
+        $reactionRepository = $this->createMock(ChatMessageReactionRepository::class);
+
+        $conversationRepository->method('find')->with('conversation-id')->willReturn($conversation);
+        $participantRepository->method('findOneByConversationAndUser')->with($conversation, $user)->willReturn($participant);
+
+        $service = new ChatAccessResolverService($conversationRepository, $participantRepository, $messageRepository, $reactionRepository);
+
+        self::assertSame($conversation, $service->resolveParticipantConversation('conversation-id', $user));
+    }
+
+    public function testResolveAccessibleMessageThrowsNotFoundWhenUserIsNotConversationParticipant(): void
+    {
+        $user = $this->createMock(User::class);
+        $message = $this->createMock(ChatMessage::class);
+        $conversation = $this->createMock(Conversation::class);
+
+        $conversationRepository = $this->createMock(ConversationRepository::class);
+        $participantRepository = $this->createMock(ConversationParticipantRepository::class);
+        $messageRepository = $this->createMock(ChatMessageRepository::class);
+        $reactionRepository = $this->createMock(ChatMessageReactionRepository::class);
+
+        $message->method('getConversation')->willReturn($conversation);
+        $messageRepository->method('find')->with('message-id')->willReturn($message);
+        $participantRepository->method('findOneByConversationAndUser')->with($conversation, $user)->willReturn(null);
+
+        $service = new ChatAccessResolverService($conversationRepository, $participantRepository, $messageRepository, $reactionRepository);
+
+        try {
+            $service->resolveAccessibleMessage('message-id', $user);
+            self::fail('Expected HttpException was not thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(404, $exception->getStatusCode());
+            self::assertSame('Message not found.', $exception->getMessage());
+        }
+    }
+
+    public function testResolveOwnReactionThrowsNotFoundWhenReactionDoesNotBelongToUser(): void
+    {
+        $user = $this->createMock(User::class);
+        $owner = $this->createMock(User::class);
+        $reaction = $this->createMock(ChatMessageReaction::class);
+
+        $conversationRepository = $this->createMock(ConversationRepository::class);
+        $participantRepository = $this->createMock(ConversationParticipantRepository::class);
+        $messageRepository = $this->createMock(ChatMessageRepository::class);
+        $reactionRepository = $this->createMock(ChatMessageReactionRepository::class);
+
+        $user->method('getId')->willReturn('user-id');
+        $owner->method('getId')->willReturn('owner-id');
+        $reaction->method('getUser')->willReturn($owner);
+        $reactionRepository->method('find')->with('reaction-id')->willReturn($reaction);
+
+        $service = new ChatAccessResolverService($conversationRepository, $participantRepository, $messageRepository, $reactionRepository);
+
+        try {
+            $service->resolveOwnReaction('reaction-id', $user);
+            self::fail('Expected HttpException was not thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(404, $exception->getStatusCode());
+            self::assertSame('Reaction not found.', $exception->getMessage());
+        }
+    }
+}

--- a/tests/Unit/Chat/Application/Service/ReactionTypeParserTest.php
+++ b/tests/Unit/Chat/Application/Service/ReactionTypeParserTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Chat\Application\Service;
+
+use App\Chat\Application\Service\ReactionTypeParser;
+use App\Chat\Domain\Enum\ChatReactionType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ReactionTypeParserTest extends TestCase
+{
+    public function testParseReturnsReactionType(): void
+    {
+        $parser = new ReactionTypeParser();
+
+        self::assertSame(ChatReactionType::LIKE, $parser->parse('like'));
+    }
+
+    public function testParseThrowsBadRequestWhenReactionIsNotNonEmptyString(): void
+    {
+        $parser = new ReactionTypeParser();
+
+        try {
+            $parser->parse('');
+            self::fail('Expected HttpException was not thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(400, $exception->getStatusCode());
+            self::assertSame('Field "reaction" must be a non-empty string.', $exception->getMessage());
+        }
+    }
+
+    public function testParseThrowsBadRequestWhenReactionValueIsInvalid(): void
+    {
+        $parser = new ReactionTypeParser();
+
+        try {
+            $parser->parse('invalid-value');
+            self::fail('Expected HttpException was not thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(400, $exception->getStatusCode());
+            self::assertSame('Invalid reaction "invalid-value". Allowed values: ' . implode(', ', ChatReactionType::VALUES) . '.', $exception->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Centralize controller helper logic for chat access and reaction parsing into reusable application services to simplify controllers and enable direct unit testing.
- Preserve existing HTTP contract by keeping the same `400/404` semantics and error messages.
- Replace private controller helpers with injected services so mono-endpoint controllers remain thin and testable.

### Description
- Added `ChatAccessResolverService` in `src/Chat/Application/Service/ChatAccessResolverService.php` which implements `resolveParticipantConversation`, `resolveAccessibleMessage`, and `resolveOwnReaction` and throws the same `HttpException` messages on access errors.
- Added `ReactionTypeParser` in `src/Chat/Application/Service/ReactionTypeParser.php` which extracts the `parseReactionType` logic and preserves `400` behaviour for invalid payloads.
- Updated controllers to inject and use the services and removed private helper methods from `CreateReactionController`, `PatchReactionController`, `DeleteReactionController`, and `ListConversationMessagesController` (files under `src/Chat/Transport/Controller/Api/V1/...`).
- Added unit tests targeting the new services: `tests/Unit/Chat/Application/Service/ChatAccessResolverServiceTest.php` and `tests/Unit/Chat/Application/Service/ReactionTypeParserTest.php`.

### Testing
- Ran PHP syntax checks with `php -l` against the new and modified files, which reported no syntax errors for all touched files.
- Attempted to run PHPUnit (`./vendor/bin/phpunit tests/Unit/Chat/Application/Service/ReactionTypeParserTest.php tests/Unit/Chat/Application/Service/ChatAccessResolverServiceTest.php`) but the test binary is missing in the environment (`./vendor/bin/phpunit: No such file or directory`).
- Added unit tests that exercise parsing and access resolution logic and assert preservation of `400/404` error messages (tests are included in the PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b199d8fce883269a639f4b40443147)