### PR TITLE
refactor(shop): extraire l’hydratation/slug/résolution application vers des services

### DIFF
--- a/src/Shop/Application/Service/ProductHydratorService.php
+++ b/src/Shop/Application/Service/ProductHydratorService.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Service;
+
+use App\Shop\Domain\Entity\Category;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Domain\Entity\Tag;
+use App\Shop\Domain\Enum\ProductStatus;
+use App\Shop\Infrastructure\Repository\CategoryRepository;
+use App\Shop\Infrastructure\Repository\TagRepository;
+
+final readonly class ProductHydratorService
+{
+    public function __construct(
+        private CategoryRepository $categoryRepository,
+        private TagRepository $tagRepository,
+    ) {
+    }
+
+    /** @param array<string,mixed> $payload */
+    public function hydrateProduct(Product $product, array $payload, bool $partial = false): Product
+    {
+        if (!$partial || array_key_exists('name', $payload)) {
+            $product->setName((string) ($payload['name'] ?? ''));
+        }
+        if (!$partial || array_key_exists('price', $payload)) {
+            $product->setPrice((float) ($payload['price'] ?? 0));
+        }
+        if (!$partial || array_key_exists('sku', $payload)) {
+            $defaultSku = strtoupper(substr(md5($product->getId()), 0, 12));
+            $product->setSku((string) ($payload['sku'] ?? $defaultSku));
+        }
+        if (!$partial || array_key_exists('description', $payload)) {
+            $product->setDescription(($payload['description'] ?? null) !== null ? (string) $payload['description'] : null);
+        }
+        if (!$partial || array_key_exists('currencyCode', $payload)) {
+            $product->setCurrencyCode((string) ($payload['currencyCode'] ?? 'EUR'));
+        }
+        if (!$partial || array_key_exists('stock', $payload)) {
+            $product->setStock((int) ($payload['stock'] ?? 0));
+        }
+        if (!$partial || array_key_exists('isFeatured', $payload)) {
+            $product->setIsFeatured((bool) ($payload['isFeatured'] ?? false));
+        }
+        if (!$partial || array_key_exists('status', $payload)) {
+            $status = ProductStatus::tryFrom((string) ($payload['status'] ?? '')) ?? ProductStatus::DRAFT;
+            $product->setStatus($status);
+        }
+
+        if (!$partial || array_key_exists('categoryId', $payload)) {
+            $category = null;
+            if (is_string($payload['categoryId'] ?? null)) {
+                $category = $this->categoryRepository->find($payload['categoryId']);
+                if ($category instanceof Category && $product->getShop() instanceof Shop && $category->getShop()?->getId() !== $product->getShop()?->getId()) {
+                    $category = null;
+                }
+            }
+            $product->setCategory($category instanceof Category ? $category : null);
+        }
+
+        if (!$partial || array_key_exists('tagIds', $payload)) {
+            foreach ($product->getTags()->toArray() as $tag) {
+                $product->removeTag($tag);
+            }
+            foreach ((array) ($payload['tagIds'] ?? []) as $tagId) {
+                if (is_string($tagId) && ($tag = $this->tagRepository->find($tagId)) instanceof Tag) {
+                    $product->addTag($tag);
+                }
+            }
+        }
+
+        return $product;
+    }
+}

--- a/src/Shop/Application/Service/ShopApplicationResolverService.php
+++ b/src/Shop/Application/Service/ShopApplicationResolverService.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Service;
+
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PlatformKey;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\User\Domain\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final readonly class ShopApplicationResolverService
+{
+    public function __construct(
+        private ShopRepository $shopRepository,
+        private Security $security,
+    ) {
+    }
+
+    public function resolveOrCreateShopByApplicationSlug(string $applicationSlug): Shop
+    {
+        $shop = $this->shopRepository->findOneByApplicationSlug($applicationSlug);
+        if ($shop instanceof Shop) {
+            $this->assertApplicationAccess($shop->getApplication(), PlatformKey::SHOP);
+
+            return $shop;
+        }
+
+        $application = $this->shopRepository->findApplicationBySlug($applicationSlug);
+        if (!$application instanceof Application) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Unknown "applicationSlug".');
+        }
+
+        $this->assertApplicationAccess($application, PlatformKey::SHOP);
+
+        throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Shop root entity not found for this application.');
+    }
+
+    public function assertApplicationAccess(?Application $application, PlatformKey $platformKey): void
+    {
+        if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== $platformKey) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid "applicationSlug" for the requested platform.');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || $application->getUser()?->getId() !== $user->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot access this application scope.');
+        }
+    }
+}

--- a/src/Shop/Application/Service/SlugBuilderService.php
+++ b/src/Shop/Application/Service/SlugBuilderService.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Service;
+
+final readonly class SlugBuilderService
+{
+    public function buildSlug(string $value): string
+    {
+        return trim((string) preg_replace('/[^a-z0-9]+/', '-', strtolower($value)), '-');
+    }
+}

--- a/src/Shop/Infrastructure/Repository/ShopRepository.php
+++ b/src/Shop/Infrastructure/Repository/ShopRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shop\Infrastructure\Repository;
 
 use App\General\Infrastructure\Repository\BaseRepository;
+use App\Platform\Domain\Entity\Application;
 use App\Shop\Domain\Entity\Shop as Entity;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
@@ -37,5 +38,14 @@ class ShopRepository extends BaseRepository
             ->getOneOrNullResult();
 
         return $entity instanceof Entity ? $entity : null;
+    }
+
+    public function findApplicationBySlug(string $applicationSlug): ?Application
+    {
+        $application = $this->getEntityManager()->getRepository(Application::class)->findOneBy([
+            'slug' => $applicationSlug,
+        ]);
+
+        return $application instanceof Application ? $application : null;
     }
 }

--- a/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php
@@ -6,8 +6,8 @@ namespace App\Shop\Transport\Controller\Api\V1\ApplicationProduct;
 
 use App\General\Application\Message\EntityCreated;
 use App\Shop\Domain\Entity\Product;
-use App\Shop\Transport\Controller\Api\V1\Support\ProductPayloadHydrator;
-use App\Shop\Transport\Controller\Api\V1\Support\ShopApplicationResolver;
+use App\Shop\Application\Service\ProductHydratorService;
+use App\Shop\Application\Service\ShopApplicationResolverService;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -24,8 +24,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateApplicationProductController
 {
     public function __construct(
-        private ShopApplicationResolver $shopApplicationResolver,
-        private ProductPayloadHydrator $productPayloadHydrator,
+        private ShopApplicationResolverService $shopApplicationResolverService,
+        private ProductHydratorService $productHydratorService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -34,10 +34,10 @@ final readonly class CreateApplicationProductController
     #[Route('/v1/shop/applications/{applicationSlug}/products', methods: [Request::METHOD_POST])]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
-        $shop = $this->shopApplicationResolver->resolveOrCreateShopByApplicationSlug($applicationSlug);
+        $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
         $payload = (array) json_decode((string) $request->getContent(), true);
 
-        $product = $this->productPayloadHydrator->hydrate((new Product())->setShop($shop), $payload);
+        $product = $this->productHydratorService->hydrateProduct((new Product())->setShop($shop), $payload);
 
         $this->entityManager->persist($product);
         $this->entityManager->flush();

--- a/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/ListApplicationProductsController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/ListApplicationProductsController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Shop\Transport\Controller\Api\V1\ApplicationProduct;
 
 use App\Shop\Application\Service\ProductApplicationListService;
-use App\Shop\Transport\Controller\Api\V1\Support\ShopApplicationResolver;
+use App\Shop\Application\Service\ShopApplicationResolverService;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListApplicationProductsController
 {
     public function __construct(
-        private ShopApplicationResolver $shopApplicationResolver,
+        private ShopApplicationResolverService $shopApplicationResolverService,
         private ProductApplicationListService $productApplicationListService,
     ) {
     }
@@ -28,7 +28,7 @@ final readonly class ListApplicationProductsController
     #[Route('/v1/shop/applications/{applicationSlug}/products', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
-        $shop = $this->shopApplicationResolver->resolveOrCreateShopByApplicationSlug($applicationSlug);
+        $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
 
         return new JsonResponse($this->productApplicationListService->getList($request, $applicationSlug, $shop));
     }

--- a/src/Shop/Transport/Controller/Api/V1/Category/CreateCategoryController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Category/CreateCategoryController.php
@@ -6,6 +6,7 @@ namespace App\Shop\Transport\Controller\Api\V1\Category;
 
 use App\General\Application\Message\EntityCreated;
 use App\Shop\Domain\Entity\Category;
+use App\Shop\Application\Service\SlugBuilderService;
 use App\Shop\Infrastructure\Repository\ShopRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -24,6 +25,7 @@ final readonly class CreateCategoryController
 {
     public function __construct(
         private ShopRepository $shopRepository,
+        private SlugBuilderService $slugBuilderService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -35,7 +37,7 @@ final readonly class CreateCategoryController
         $payload = (array) json_decode((string) $request->getContent(), true);
         $category = (new Category())
             ->setName((string) ($payload['name'] ?? ''))
-            ->setSlug($this->buildSlug((string) ($payload['slug'] ?? $payload['name'] ?? '')))
+            ->setSlug($this->slugBuilderService->buildSlug((string) ($payload['slug'] ?? $payload['name'] ?? '')))
             ->setDescription(($payload['description'] ?? null) !== null ? (string) $payload['description'] : null);
 
         if (is_string($payload['shopId'] ?? null)) {
@@ -47,10 +49,5 @@ final readonly class CreateCategoryController
         $this->messageBus->dispatch(new EntityCreated('shop_category', $category->getId()));
 
         return new JsonResponse(['id' => $category->getId()], JsonResponse::HTTP_CREATED);
-    }
-
-    private function buildSlug(string $value): string
-    {
-        return trim((string) preg_replace('/[^a-z0-9]+/', '-', strtolower($value)), '-');
     }
 }

--- a/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
@@ -6,7 +6,7 @@ namespace App\Shop\Transport\Controller\Api\V1\Product;
 
 use App\General\Application\Message\EntityCreated;
 use App\Shop\Domain\Entity\Product;
-use App\Shop\Transport\Controller\Api\V1\Support\ProductPayloadHydrator;
+use App\Shop\Application\Service\ProductHydratorService;
 use App\Shop\Infrastructure\Repository\ShopRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateProductController
 {
     public function __construct(
-        private ProductPayloadHydrator $productPayloadHydrator,
+        private ProductHydratorService $productHydratorService,
         private ShopRepository $shopRepository,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
@@ -35,7 +35,7 @@ final readonly class CreateProductController
     public function __invoke(Request $request): JsonResponse
     {
         $payload = (array) json_decode((string) $request->getContent(), true);
-        $product = $this->productPayloadHydrator->hydrate(new Product(), $payload);
+        $product = $this->productHydratorService->hydrateProduct(new Product(), $payload);
 
         if (is_string($payload['shopId'] ?? null)) {
             $product->setShop($this->shopRepository->find($payload['shopId']));

--- a/src/Shop/Transport/Controller/Api/V1/Product/PatchProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/PatchProductController.php
@@ -7,7 +7,7 @@ namespace App\Shop\Transport\Controller\Api\V1\Product;
 use App\General\Application\Message\EntityCreated;
 use App\Shop\Application\Service\ProductListService;
 use App\Shop\Domain\Entity\Product;
-use App\Shop\Transport\Controller\Api\V1\Support\ProductPayloadHydrator;
+use App\Shop\Application\Service\ProductHydratorService;
 use App\Shop\Infrastructure\Repository\ProductRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -26,7 +26,7 @@ final readonly class PatchProductController
 {
     public function __construct(
         private ProductRepository $productRepository,
-        private ProductPayloadHydrator $productPayloadHydrator,
+        private ProductHydratorService $productHydratorService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -41,7 +41,7 @@ final readonly class PatchProductController
         }
 
         $payload = (array) json_decode((string) $request->getContent(), true);
-        $this->productPayloadHydrator->hydrate($product, $payload, true);
+        $this->productHydratorService->hydrateProduct($product, $payload, true);
 
         $this->entityManager->flush();
         $this->messageBus->dispatch(new EntityCreated('shop_product', $product->getId()));


### PR DESCRIPTION
### Motivation
- Extraire la logique métier hors des controllers Shop pour respecter la séparation des responsabilités et faciliter la réutilisation des règles d’application. 
- Déléguer l’accès aux données à la couche repository quand c’est pertinent et conserver la validation d’accès utilisateur dans un service applicatif.

### Description
- Création de services applicatifs sous `src/Shop/Application/Service/`: `ProductHydratorService` (hydration des payloads produit), `SlugBuilderService` (génération de slug) et `ShopApplicationResolverService` (résolution/validation d’accès par `applicationSlug`).
- Ajout de `findApplicationBySlug()` dans `src/Shop/Infrastructure/Repository/ShopRepository.php` pour centraliser l’accès aux entités `Application` depuis la couche repository.
- Mise à jour des controllers invokables pour injecter et utiliser les nouveaux services (`CreateProductController`, `PatchProductController`, `CreateApplicationProductController`, `ListApplicationProductsController`, `CreateCategoryController`) et suppression de la logique privée de build/hydratation dans ces controllers.
- Remplacement des usages de `ProductPayloadHydrator` / `ShopApplicationResolver` par les nouveaux services, et suppression de la méthode privée `buildSlug` de `CreateCategoryController`.

### Testing
- Exécution de `php -l` sur les fichiers modifiés/ajoutés (`src/Shop/Application/Service/*`, `src/Shop/Infrastructure/Repository/ShopRepository.php`, et les controllers modifiés`) et aucune erreur de syntaxe détectée.
- Vérification par recherche que les controllers Shop concernés n’exposent plus de méthodes privées de logique métier (recherche `private function` dans les controllers ciblés) et validation que la logique a bien été déplacée en services.
- Tous les contrôles automatisés exécutés pendant la refactorisation ont réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b199e25bc083269b95a12ab1cdf60a)