### PR TITLE
Harmonize shop product creation endpoints to synchronous 201 contract

### DIFF
--- a/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php
@@ -41,16 +41,14 @@ final readonly class CreateApplicationProductController
 
         $this->entityManager->persist($product);
         $this->entityManager->flush();
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
         $this->messageBus->dispatch(new EntityCreated('shop_product', $product->getId(), context: [
             'applicationSlug' => $applicationSlug,
-            'operationId' => $operationId,
         ]));
 
         return new JsonResponse([
-            'operationId' => $operationId,
+            'id' => $product->getId(),
             'shopId' => $shop->getId(),
             'applicationSlug' => $applicationSlug,
-        ], JsonResponse::HTTP_ACCEPTED);
+        ], JsonResponse::HTTP_CREATED);
     }
 }

--- a/tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php
+++ b/tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class ShopMutationControllerTest extends WebTestCase
 {
-    public function testCreateProductDispatchesCommandAndPersistsEntity(): void
+    public function testCreateProductReturnsCreatedWithIdAndPersistsEntity(): void
     {
         $client = $this->getTestClient('john-user', 'password-user');
 
@@ -26,18 +26,51 @@ final class ShopMutationControllerTest extends WebTestCase
             ], JSON_THROW_ON_ERROR)
         );
 
-        self::assertResponseStatusCodeSame(202);
+        self::assertResponseStatusCodeSame(201);
 
-        /** @var array{operationId: string} $payload */
+        /** @var array{id: string} $payload */
         $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        self::assertArrayHasKey('operationId', $payload);
-        self::assertNotSame('', $payload['operationId']);
+        self::assertArrayHasKey('id', $payload);
+        self::assertNotSame('', $payload['id']);
 
         /** @var ProductRepository $productRepository */
         $productRepository = static::getContainer()->get(ProductRepository::class);
         $products = $productRepository->findBy(['name' => 'Messenger Product']);
 
         self::assertNotEmpty($products);
+        self::assertSame($products[0]->getId(), $payload['id']);
+    }
+
+    public function testCreateApplicationProductReturnsCreatedWithIdAndPersistsEntity(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/products',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'name' => 'App Messenger Product',
+                'price' => 23.45,
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(201);
+
+        /** @var array{id: string, shopId: string, applicationSlug: string} $payload */
+        $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('id', $payload);
+        self::assertSame('shop-ops-center', $payload['applicationSlug']);
+        self::assertNotSame('', $payload['shopId']);
+
+        /** @var ProductRepository $productRepository */
+        $productRepository = static::getContainer()->get(ProductRepository::class);
+        $products = $productRepository->findBy(['name' => 'App Messenger Product']);
+
+        self::assertNotEmpty($products);
+        self::assertSame($products[0]->getId(), $payload['id']);
     }
 
     public function testDeleteProductDispatchesCommandAndRemovesEntity(): void


### PR DESCRIPTION
### Motivation
- Unify the product creation contract so both `/v1/shop/products` and `/v1/shop/applications/{applicationSlug}/products` behave the same (synchronous creation returning the created resource id). 
- Remove the risk of returning an uninitialized `operationId` and simplify client expectations by using a single contract (`201 + id`).

### Description
- Remove generation and response of `operationId` in `CreateApplicationProductController` and keep dispatching the `EntityCreated` message without `operationId` in the response context. 
- Return `201 Created` with the created product `id`, plus `shopId` and `applicationSlug`, from the application-scoped create controller. 
- Update `tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php` to assert `201` and an `id` for `/v1/shop/products` and add a new test that asserts the same `201 + id` contract for `/v1/shop/applications/{applicationSlug}/products`. 
- Leave deletion behavior unchanged (still `202` with `operationId`).

### Testing
- `php -l src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php` succeeded with no syntax errors. 
- `php -l tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php` succeeded with no syntax errors. 
- Running `./vendor/bin/phpunit tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php` failed in the current environment because the `phpunit` binary is not present. 
- Running `php bin/phpunit tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php` also failed because `bin/phpunit` is not available in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19c1c789483269cef44fd0c168c76)