### PR TITLE
refactor(chat): extraire validateurs de payload et centraliser generation d'operationId

### DIFF
--- a/src/Chat/Application/Service/ConversationPayloadService.php
+++ b/src/Chat/Application/Service/ConversationPayloadService.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Application\Service;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class ConversationPayloadService
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function extractRequiredUserId(array $payload): string
+    {
+        $targetUserId = $payload['userId'] ?? null;
+        if (!is_string($targetUserId) || $targetUserId === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "userId" is required.');
+        }
+
+        return $targetUserId;
+    }
+}

--- a/src/Chat/Application/Service/MessagePayloadService.php
+++ b/src/Chat/Application/Service/MessagePayloadService.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Application\Service;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class MessagePayloadService
+{
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function extractRequiredContent(array $payload): string
+    {
+        $content = $payload['content'] ?? null;
+        if (!is_string($content) || $content === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "content" is required.');
+        }
+
+        return $content;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array{content: ?string, read: ?bool}
+     */
+    public function extractPatchFields(array $payload): array
+    {
+        $content = null;
+        if (isset($payload['content'])) {
+            if (!is_string($payload['content']) || $payload['content'] === '') {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "content" must be a non-empty string when provided.');
+            }
+
+            $content = $payload['content'];
+        }
+
+        $read = null;
+        if (array_key_exists('read', $payload)) {
+            if (!is_bool($payload['read'])) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "read" must be a boolean when provided.');
+            }
+
+            $read = $payload['read'];
+        }
+
+        return [
+            'content' => $content,
+            'read' => $read,
+        ];
+    }
+}

--- a/src/Chat/Application/Service/ReactionPayloadService.php
+++ b/src/Chat/Application/Service/ReactionPayloadService.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Application\Service;
+
+use App\Chat\Domain\Enum\ChatReactionType;
+
+class ReactionPayloadService
+{
+    public function __construct(
+        private readonly ReactionTypeParser $reactionTypeParser,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function extractRequiredReaction(array $payload): ChatReactionType
+    {
+        return $this->reactionTypeParser->parse($payload['reaction'] ?? null);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function extractOptionalReaction(array $payload): ?ChatReactionType
+    {
+        if (!array_key_exists('reaction', $payload)) {
+            return null;
+        }
+
+        return $this->reactionTypeParser->parse($payload['reaction']);
+    }
+}

--- a/src/Chat/Domain/Repository/Interfaces/ChatMessageReactionRepositoryInterface.php
+++ b/src/Chat/Domain/Repository/Interfaces/ChatMessageReactionRepositoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Domain\Repository\Interfaces;
+
+use App\General\Domain\Repository\Interfaces\BaseRepositoryInterface;
+
+interface ChatMessageReactionRepositoryInterface extends BaseRepositoryInterface
+{
+}

--- a/src/Chat/Infrastructure/Repository/ChatMessageReactionRepository.php
+++ b/src/Chat/Infrastructure/Repository/ChatMessageReactionRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Chat\Infrastructure\Repository;
 
 use App\Chat\Domain\Entity\ChatMessageReaction as Entity;
+use App\Chat\Domain\Repository\Interfaces\ChatMessageReactionRepositoryInterface;
 use App\General\Infrastructure\Repository\BaseRepository;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
@@ -13,7 +14,7 @@ use Doctrine\Persistence\ManagerRegistry;
  * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
  * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
  */
-class ChatMessageReactionRepository extends BaseRepository
+class ChatMessageReactionRepository extends BaseRepository implements ChatMessageReactionRepositoryInterface
 {
     protected static string $entityName = Entity::class;
 

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/CreateConversationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/CreateConversationController.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Conversation;
 
 use App\Chat\Application\Message\CreateConversationCommand;
+use App\Chat\Application\Service\ConversationPayloadService;
+use App\General\Application\Service\OperationIdGeneratorService;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -24,19 +25,17 @@ class CreateConversationController
 {
     public function __construct(
         private readonly MessageServiceInterface $messageService,
+        private readonly ConversationPayloadService $conversationPayloadService,
+        private readonly OperationIdGeneratorService $operationIdGeneratorService,
     ) {
     }
 
     #[Route(path: '/v1/chat/private/chats/{chatId}/conversations', methods: [Request::METHOD_POST])]
     public function __invoke(string $chatId, Request $request, User $loggedInUser): JsonResponse
     {
-        $payload = $request->toArray();
-        $targetUserId = $payload['userId'] ?? null;
-        if (!is_string($targetUserId) || $targetUserId === '') {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "userId" is required.');
-        }
+        $targetUserId = $this->conversationPayloadService->extractRequiredUserId($request->toArray());
+        $operationId = $this->operationIdGeneratorService->generate();
 
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
         $this->messageService->sendMessage(new CreateConversationCommand(
             operationId: $operationId,
             actorUserId: $loggedInUser->getId(),

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/DeleteConversationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/DeleteConversationController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Conversation;
 
 use App\Chat\Application\Message\DeleteConversationCommand;
+use App\General\Application\Service\OperationIdGeneratorService;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
@@ -23,13 +24,14 @@ class DeleteConversationController
 {
     public function __construct(
         private readonly MessageServiceInterface $messageService,
+        private readonly OperationIdGeneratorService $operationIdGeneratorService,
     ) {
     }
 
     #[Route(path: '/v1/chat/private/conversations/{conversationId}', methods: [Request::METHOD_DELETE])]
     public function __invoke(string $conversationId, User $loggedInUser): JsonResponse
     {
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        $operationId = $this->operationIdGeneratorService->generate();
         $this->messageService->sendMessage(new DeleteConversationCommand(
             operationId: $operationId,
             actorUserId: $loggedInUser->getId(),

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/FindOrCreateConversationWithUserController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/FindOrCreateConversationWithUserController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Conversation;
 
 use App\Chat\Application\Message\FindOrCreateConversationWithUserCommand;
+use App\General\Application\Service\OperationIdGeneratorService;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
@@ -23,13 +24,14 @@ class FindOrCreateConversationWithUserController
 {
     public function __construct(
         private readonly MessageServiceInterface $messageService,
+        private readonly OperationIdGeneratorService $operationIdGeneratorService,
     ) {
     }
 
     #[Route(path: '/v1/chat/private/conversation/{user}/user', methods: [Request::METHOD_POST])]
     public function __invoke(User $user, User $loggedInUser): JsonResponse
     {
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        $operationId = $this->operationIdGeneratorService->generate();
         $this->messageService->sendMessage(new FindOrCreateConversationWithUserCommand(
             operationId: $operationId,
             actorUserId: $loggedInUser->getId(),

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/PatchConversationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/PatchConversationController.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Conversation;
 
 use App\Chat\Application\Message\PatchConversationCommand;
+use App\Chat\Application\Service\ConversationPayloadService;
+use App\General\Application\Service\OperationIdGeneratorService;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -24,19 +25,17 @@ class PatchConversationController
 {
     public function __construct(
         private readonly MessageServiceInterface $messageService,
+        private readonly ConversationPayloadService $conversationPayloadService,
+        private readonly OperationIdGeneratorService $operationIdGeneratorService,
     ) {
     }
 
     #[Route(path: '/v1/chat/private/conversations/{conversationId}', methods: [Request::METHOD_PATCH])]
     public function __invoke(string $conversationId, Request $request, User $loggedInUser): JsonResponse
     {
-        $payload = $request->toArray();
-        $targetUserId = $payload['userId'] ?? null;
-        if (!is_string($targetUserId) || $targetUserId === '') {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "userId" is required.');
-        }
+        $targetUserId = $this->conversationPayloadService->extractRequiredUserId($request->toArray());
+        $operationId = $this->operationIdGeneratorService->generate();
 
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
         $this->messageService->sendMessage(new PatchConversationCommand(
             operationId: $operationId,
             actorUserId: $loggedInUser->getId(),

--- a/src/Chat/Transport/Controller/Api/V1/Message/CreateMessageController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/CreateMessageController.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Message;
 
 use App\Chat\Application\Message\CreateMessageCommand;
+use App\Chat\Application\Service\MessagePayloadService;
+use App\General\Application\Service\OperationIdGeneratorService;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -48,19 +49,17 @@ class CreateMessageController
 {
     public function __construct(
         private readonly MessageServiceInterface $messageService,
+        private readonly MessagePayloadService $messagePayloadService,
+        private readonly OperationIdGeneratorService $operationIdGeneratorService,
     ) {
     }
 
     #[Route(path: '/v1/chat/private/conversations/{conversationId}/messages', methods: [Request::METHOD_POST])]
     public function __invoke(string $conversationId, Request $request, User $loggedInUser): JsonResponse
     {
-        $payload = $request->toArray();
-        $content = $payload['content'] ?? null;
-        if (!is_string($content) || $content === '') {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "content" is required.');
-        }
+        $content = $this->messagePayloadService->extractRequiredContent($request->toArray());
+        $operationId = $this->operationIdGeneratorService->generate();
 
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
         $this->messageService->sendMessage(new CreateMessageCommand(
             operationId: $operationId,
             actorUserId: $loggedInUser->getId(),

--- a/src/Chat/Transport/Controller/Api/V1/Message/DeleteMessageController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/DeleteMessageController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Message;
 
 use App\Chat\Application\Message\DeleteMessageCommand;
+use App\General\Application\Service\OperationIdGeneratorService;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
@@ -23,13 +24,14 @@ class DeleteMessageController
 {
     public function __construct(
         private readonly MessageServiceInterface $messageService,
+        private readonly OperationIdGeneratorService $operationIdGeneratorService,
     ) {
     }
 
     #[Route(path: '/v1/chat/private/messages/{messageId}', methods: [Request::METHOD_DELETE])]
     public function __invoke(string $messageId, User $loggedInUser): JsonResponse
     {
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        $operationId = $this->operationIdGeneratorService->generate();
         $this->messageService->sendMessage(new DeleteMessageCommand(
             operationId: $operationId,
             actorUserId: $loggedInUser->getId(),

--- a/src/Chat/Transport/Controller/Api/V1/Message/MarkConversationAsReadController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/MarkConversationAsReadController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Message;
 
 use App\Chat\Application\Message\MarkConversationMessagesAsReadCommand;
+use App\General\Application\Service\OperationIdGeneratorService;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
@@ -35,13 +36,14 @@ class MarkConversationAsReadController
 {
     public function __construct(
         private readonly MessageServiceInterface $messageService,
+        private readonly OperationIdGeneratorService $operationIdGeneratorService,
     ) {
     }
 
     #[Route(path: '/v1/chat/private/conversations/{conversationId}/messages/read', methods: [Request::METHOD_POST])]
     public function __invoke(string $conversationId, User $loggedInUser): JsonResponse
     {
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
+        $operationId = $this->operationIdGeneratorService->generate();
         $this->messageService->sendMessage(new MarkConversationMessagesAsReadCommand(
             operationId: $operationId,
             actorUserId: $loggedInUser->getId(),

--- a/src/Chat/Transport/Controller/Api/V1/Message/PatchMessageController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/PatchMessageController.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Message;
 
 use App\Chat\Application\Message\PatchMessageCommand;
+use App\Chat\Application\Service\MessagePayloadService;
+use App\General\Application\Service\OperationIdGeneratorService;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -49,39 +50,23 @@ class PatchMessageController
 {
     public function __construct(
         private readonly MessageServiceInterface $messageService,
+        private readonly MessagePayloadService $messagePayloadService,
+        private readonly OperationIdGeneratorService $operationIdGeneratorService,
     ) {
     }
 
     #[Route(path: '/v1/chat/private/messages/{messageId}', methods: [Request::METHOD_PATCH])]
     public function __invoke(string $messageId, Request $request, User $loggedInUser): JsonResponse
     {
-        $payload = $request->toArray();
+        $fields = $this->messagePayloadService->extractPatchFields($request->toArray());
+        $operationId = $this->operationIdGeneratorService->generate();
 
-        $content = null;
-        if (isset($payload['content'])) {
-            if (!is_string($payload['content']) || $payload['content'] === '') {
-                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "content" must be a non-empty string when provided.');
-            }
-
-            $content = $payload['content'];
-        }
-
-        $read = null;
-        if (array_key_exists('read', $payload)) {
-            if (!is_bool($payload['read'])) {
-                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "read" must be a boolean when provided.');
-            }
-
-            $read = $payload['read'];
-        }
-
-        $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
         $this->messageService->sendMessage(new PatchMessageCommand(
             operationId: $operationId,
             actorUserId: $loggedInUser->getId(),
             messageId: $messageId,
-            content: $content,
-            read: $read,
+            content: $fields['content'],
+            read: $fields['read'],
         ));
 
         return new JsonResponse([

--- a/src/Chat/Transport/Controller/Api/V1/Reaction/CreateReactionController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Reaction/CreateReactionController.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Reaction;
 
 use App\Chat\Application\Service\ChatAccessResolverService;
-use App\Chat\Application\Service\ReactionTypeParser;
+use App\Chat\Application\Service\ReactionPayloadService;
 use App\Chat\Domain\Entity\ChatMessageReaction;
 use App\Chat\Domain\Enum\ChatReactionType;
-use App\Chat\Infrastructure\Repository\ChatMessageReactionRepository;
+use App\Chat\Domain\Repository\Interfaces\ChatMessageReactionRepositoryInterface;
 use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
@@ -30,9 +30,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class CreateReactionController
 {
     public function __construct(
-        private readonly ChatMessageReactionRepository $reactionRepository,
+        private readonly ChatMessageReactionRepositoryInterface $reactionRepository,
         private readonly ChatAccessResolverService $chatAccessResolverService,
-        private readonly ReactionTypeParser $reactionTypeParser,
+        private readonly ReactionPayloadService $reactionPayloadService,
         private readonly CacheInvalidationService $cacheInvalidationService,
     ) {
     }
@@ -41,9 +41,7 @@ class CreateReactionController
     public function __invoke(string $messageId, Request $request, User $loggedInUser): JsonResponse
     {
         $message = $this->chatAccessResolverService->resolveAccessibleMessage($messageId, $loggedInUser);
-        $payload = $request->toArray();
-
-        $reactionType = $this->reactionTypeParser->parse($payload['reaction'] ?? null);
+        $reactionType = $this->reactionPayloadService->extractRequiredReaction($request->toArray());
 
         $reaction = (new ChatMessageReaction())
             ->setMessage($message)

--- a/src/Chat/Transport/Controller/Api/V1/Reaction/PatchReactionController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Reaction/PatchReactionController.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Reaction;
 
 use App\Chat\Application\Service\ChatAccessResolverService;
-use App\Chat\Application\Service\ReactionTypeParser;
+use App\Chat\Application\Service\ReactionPayloadService;
 use App\Chat\Domain\Enum\ChatReactionType;
-use App\Chat\Infrastructure\Repository\ChatMessageReactionRepository;
+use App\Chat\Domain\Repository\Interfaces\ChatMessageReactionRepositoryInterface;
 use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
@@ -29,9 +29,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class PatchReactionController
 {
     public function __construct(
-        private readonly ChatMessageReactionRepository $reactionRepository,
+        private readonly ChatMessageReactionRepositoryInterface $reactionRepository,
         private readonly ChatAccessResolverService $chatAccessResolverService,
-        private readonly ReactionTypeParser $reactionTypeParser,
+        private readonly ReactionPayloadService $reactionPayloadService,
         private readonly CacheInvalidationService $cacheInvalidationService,
     ) {
     }
@@ -40,10 +40,10 @@ class PatchReactionController
     public function __invoke(string $reactionId, Request $request, User $loggedInUser): JsonResponse
     {
         $reaction = $this->chatAccessResolverService->resolveOwnReaction($reactionId, $loggedInUser);
-        $payload = $request->toArray();
+        $reactionType = $this->reactionPayloadService->extractOptionalReaction($request->toArray());
 
-        if (array_key_exists('reaction', $payload)) {
-            $reaction->setReaction($this->reactionTypeParser->parse($payload['reaction']));
+        if (null !== $reactionType) {
+            $reaction->setReaction($reactionType);
             $this->reactionRepository->save($reaction);
             $this->cacheInvalidationService->invalidateConversationCaches($reaction->getMessage()->getConversation()->getChat()->getId(), $loggedInUser->getId());
         }

--- a/src/General/Application/Service/OperationIdGeneratorService.php
+++ b/src/General/Application/Service/OperationIdGeneratorService.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\Service;
+
+use Ramsey\Uuid\Uuid;
+
+class OperationIdGeneratorService
+{
+    public function generate(): string
+    {
+        return Uuid::uuid4()->toString();
+    }
+}


### PR DESCRIPTION
### Motivation
- Éliminer la duplication de lecture/validation de payload (`userId`, `content`, `read`, `reaction`) dispersée dans les contrôleurs pour centraliser la logique.
- Simplifier les `__invoke` des contrôleurs pour ne garder que l'extraction minimale des paramètres, l'appel au service/handler et la construction de la `JsonResponse`.
- Standardiser la génération d'`operationId` avec un petit service partagé et respecter l'injection de dépendances via des interfaces pour séparer Domain/Infrastructure.

### Description
- Ajout de services applicatifs pour la validation/lecture du payload sous `src/Chat/Application/Service/`: `ConversationPayloadService`, `MessagePayloadService`, `ReactionPayloadService`.
- Ajout de `OperationIdGeneratorService` sous `src/General/Application/Service/` et remplacement des appels `Uuid::uuid4()` par `generate()` dans les contrôleurs Chat.
- Introduction de l'interface `ChatMessageReactionRepositoryInterface` dans `src/Chat/Domain/Repository/Interfaces/` et adaptation du repository d'infrastructure `ChatMessageReactionRepository` pour l'implémenter, puis injection de l'interface dans les contrôleurs de réaction.
- Refactor des contrôleurs concernés (`Conversation`, `Message`, `Reaction`) pour déléguer la validation aux nouveaux services, utiliser le service de génération d'`operationId` et maintenir la construction simple des réponses JSON.

### Testing
- `php -l` (contrôles de syntaxe) exécuté sur tous les fichiers modifiés : OK.
- `php bin/console lint:container` non exécutable dans cet environnement car les dépendances ne sont pas installées (échec lié à l'absence de `composer install`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19c14ada48326b0f4b4fc06da6a33)