### PR TITLE
Refactor application/job access checks into ApplicationJobAccessService

### DIFF
--- a/src/Recruit/Application/Service/ApplicationJobAccessService.php
+++ b/src/Recruit/Application/Service/ApplicationJobAccessService.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Entity\Recruit;
+use App\Recruit\Infrastructure\Repository\JobRepository;
+use App\User\Domain\Entity\User;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class ApplicationJobAccessService
+{
+    public function __construct(
+        private readonly RecruitResolverService $recruitResolverService,
+        private readonly JobRepository $jobRepository,
+    ) {
+    }
+
+    public function resolveOwnedRecruitByApplicationSlug(string $applicationSlug, User $loggedInUser, string $forbiddenMessage): Recruit
+    {
+        $recruit = $this->recruitResolverService->resolveByApplicationSlug($applicationSlug);
+
+        if ($recruit->getApplication()?->getUser()?->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, $forbiddenMessage);
+        }
+
+        return $recruit;
+    }
+
+    public function resolveJobForRecruit(string $jobId, Recruit $recruit): Job
+    {
+        $job = $this->jobRepository->find($jobId);
+        if (!$job instanceof Job) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Job not found.');
+        }
+
+        if ($job->getRecruit()?->getId() !== $recruit->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'This job does not belong to the given application.');
+        }
+
+        return $job;
+    }
+}
+

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
@@ -6,7 +6,7 @@ namespace App\Recruit\Transport\Controller\Api\V1\Job;
 
 use App\General\Application\Message\EntityCreated;
 use App\Recruit\Application\Service\JobPayloadHydratorService;
-use App\Recruit\Application\Service\RecruitResolverService;
+use App\Recruit\Application\Service\ApplicationJobAccessService;
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Infrastructure\Repository\JobRepository;
 use App\User\Domain\Entity\User;
@@ -29,7 +29,7 @@ use function trim;
 class JobCreateFromApplicationController
 {
     public function __construct(
-        private readonly RecruitResolverService $recruitResolverService,
+        private readonly ApplicationJobAccessService $applicationJobAccessService,
         private readonly JobRepository $jobRepository,
         private readonly MessageBusInterface $messageBus,
         private readonly JobPayloadHydratorService $jobPayloadHydratorService,
@@ -47,12 +47,12 @@ class JobCreateFromApplicationController
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "title" is required and must be a non-empty string.');
         }
 
-        $recruit = $this->recruitResolverService->resolveByApplicationSlug($applicationSlug);
+        $recruit = $this->applicationJobAccessService->resolveOwnedRecruitByApplicationSlug(
+            $applicationSlug,
+            $loggedInUser,
+            'You cannot create a job for this application.'
+        );
         $application = $recruit->getApplication();
-
-        if ($application?->getUser()?->getId() !== $loggedInUser->getId()) {
-            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot create a job for this application.');
-        }
 
         $job = (new Job())
             ->setRecruit($recruit)

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteFromApplicationController.php
@@ -5,15 +5,13 @@ declare(strict_types=1);
 namespace App\Recruit\Transport\Controller\Api\V1\Job;
 
 use App\General\Application\Message\EntityDeleted;
-use App\Recruit\Application\Service\RecruitResolverService;
-use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Application\Service\ApplicationJobAccessService;
 use App\Recruit\Infrastructure\Repository\JobRepository;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
@@ -25,7 +23,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class JobDeleteFromApplicationController
 {
     public function __construct(
-        private readonly RecruitResolverService $recruitResolverService,
+        private readonly ApplicationJobAccessService $applicationJobAccessService,
         private readonly JobRepository $jobRepository,
         private readonly MessageBusInterface $messageBus,
     ) {
@@ -46,21 +44,14 @@ class JobDeleteFromApplicationController
     )]
     public function __invoke(string $applicationSlug, string $jobId, User $loggedInUser): JsonResponse
     {
-        $recruit = $this->recruitResolverService->resolveByApplicationSlug($applicationSlug);
+        $recruit = $this->applicationJobAccessService->resolveOwnedRecruitByApplicationSlug(
+            $applicationSlug,
+            $loggedInUser,
+            'You cannot delete a job for this application.'
+        );
         $application = $recruit->getApplication();
 
-        if ($application?->getUser()?->getId() !== $loggedInUser->getId()) {
-            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot delete a job for this application.');
-        }
-
-        $job = $this->jobRepository->find($jobId);
-        if (!$job instanceof Job) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Job not found.');
-        }
-
-        if ($job->getRecruit()?->getId() !== $recruit->getId()) {
-            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'This job does not belong to the given application.');
-        }
+        $job = $this->applicationJobAccessService->resolveJobForRecruit($jobId, $recruit);
 
         $this->jobRepository->remove($job);
 

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
@@ -6,15 +6,13 @@ namespace App\Recruit\Transport\Controller\Api\V1\Job;
 
 use App\General\Application\Message\EntityPatched;
 use App\Recruit\Application\Service\JobPayloadHydratorService;
-use App\Recruit\Application\Service\RecruitResolverService;
-use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Application\Service\ApplicationJobAccessService;
 use App\Recruit\Infrastructure\Repository\JobRepository;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
@@ -26,7 +24,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class JobPatchFromApplicationController
 {
     public function __construct(
-        private readonly RecruitResolverService $recruitResolverService,
+        private readonly ApplicationJobAccessService $applicationJobAccessService,
         private readonly JobRepository $jobRepository,
         private readonly MessageBusInterface $messageBus,
         private readonly JobPayloadHydratorService $jobPayloadHydratorService,
@@ -37,21 +35,14 @@ class JobPatchFromApplicationController
     #[Route(path: '/v1/recruit/private/{applicationSlug}/jobs/{jobId}', methods: [Request::METHOD_PATCH])]
     public function __invoke(string $applicationSlug, string $jobId, Request $request, User $loggedInUser): JsonResponse
     {
-        $recruit = $this->recruitResolverService->resolveByApplicationSlug($applicationSlug);
+        $recruit = $this->applicationJobAccessService->resolveOwnedRecruitByApplicationSlug(
+            $applicationSlug,
+            $loggedInUser,
+            'You cannot update a job for this application.'
+        );
         $application = $recruit->getApplication();
 
-        if ($application?->getUser()?->getId() !== $loggedInUser->getId()) {
-            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot update a job for this application.');
-        }
-
-        $job = $this->jobRepository->find($jobId);
-        if (!$job instanceof Job) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Job not found.');
-        }
-
-        if ($job->getRecruit()?->getId() !== $recruit->getId()) {
-            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'This job does not belong to the given application.');
-        }
+        $job = $this->applicationJobAccessService->resolveJobForRecruit($jobId, $recruit);
 
         /** @var array<string, mixed> $payload */
         $payload = $request->toArray();

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobPatchDeleteFromApplicationControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobPatchDeleteFromApplicationControllerTest.php
@@ -41,6 +41,37 @@ class JobPatchDeleteFromApplicationControllerTest extends WebTestCase
         self::assertSame('Updated job title', $payload['title']);
     }
 
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that PATCH /v1/recruit/applications/{applicationSlug}/jobs/{jobId} returns bad request for unknown application slug.')]
+    public function testThatPatchFromApplicationRejectsUnknownApplicationSlug(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('PATCH', self::API_URL_PREFIX . '/v1/recruit/applications/unknown-slug/jobs/11111111-1111-1111-1111-111111111111', content: JSON::encode([
+            'title' => 'Should fail',
+        ]));
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that PATCH /v1/recruit/applications/{applicationSlug}/jobs/{jobId} returns not found for missing job.')]
+    public function testThatPatchFromApplicationReturnsNotFoundWhenJobIsMissing(): void
+    {
+        [$applicationSlug, ] = $this->getApplicationSlugAndJobIdForUsername('john-root');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('PATCH', self::API_URL_PREFIX . '/v1/recruit/applications/' . $applicationSlug . '/jobs/11111111-1111-1111-1111-111111111111', content: JSON::encode([
+            'title' => 'Should fail',
+        ]));
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+    }
+
     /**
      * @throws Throwable
      */
@@ -76,6 +107,48 @@ class JobPatchDeleteFromApplicationControllerTest extends WebTestCase
         $deletedJob = $entityManager->getRepository(Job::class)->find($jobId);
         self::assertNull($deletedJob);
     }
+
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that DELETE /v1/recruit/applications/{applicationSlug}/jobs/{jobId} returns bad request for unknown application slug.')]
+    public function testThatDeleteFromApplicationRejectsUnknownApplicationSlug(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('DELETE', self::API_URL_PREFIX . '/v1/recruit/applications/unknown-slug/jobs/11111111-1111-1111-1111-111111111111');
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that DELETE /v1/recruit/applications/{applicationSlug}/jobs/{jobId} returns forbidden for foreign application.')]
+    public function testThatDeleteFromApplicationRejectsForeignApplication(): void
+    {
+        [$applicationSlug, $jobId] = $this->createDedicatedJobForUser('john-root');
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request('DELETE', self::API_URL_PREFIX . '/v1/recruit/applications/' . $applicationSlug . '/jobs/' . $jobId);
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that DELETE /v1/recruit/applications/{applicationSlug}/jobs/{jobId} returns not found for missing job.')]
+    public function testThatDeleteFromApplicationReturnsNotFoundWhenJobIsMissing(): void
+    {
+        [$applicationSlug, ] = $this->getApplicationSlugAndJobIdForUsername('john-root');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('DELETE', self::API_URL_PREFIX . '/v1/recruit/applications/' . $applicationSlug . '/jobs/11111111-1111-1111-1111-111111111111');
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+    }
+
 
     /**
      * @return array{0: string, 1: string}

--- a/tests/Unit/Recruit/Application/Service/ApplicationJobAccessServiceTest.php
+++ b/tests/Unit/Recruit/Application/Service/ApplicationJobAccessServiceTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Recruit\Application\Service;
+
+use App\Platform\Domain\Entity\Application as PlatformApplication;
+use App\Recruit\Application\Service\ApplicationJobAccessService;
+use App\Recruit\Application\Service\RecruitResolverService;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Entity\Recruit;
+use App\Recruit\Infrastructure\Repository\JobRepository;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ApplicationJobAccessServiceTest extends TestCase
+{
+    public function testResolveOwnedRecruitByApplicationSlugReturnsRecruitForOwner(): void
+    {
+        $loggedInUser = $this->createMock(User::class);
+        $owner = $this->createMock(User::class);
+        $application = $this->createMock(PlatformApplication::class);
+        $recruit = $this->createMock(Recruit::class);
+
+        $loggedInUser->method('getId')->willReturn('user-id');
+        $owner->method('getId')->willReturn('user-id');
+        $application->method('getUser')->willReturn($owner);
+        $recruit->method('getApplication')->willReturn($application);
+
+        $recruitResolverService = $this->createMock(RecruitResolverService::class);
+        $jobRepository = $this->createMock(JobRepository::class);
+        $recruitResolverService->method('resolveByApplicationSlug')->with('app-slug')->willReturn($recruit);
+
+        $service = new ApplicationJobAccessService($recruitResolverService, $jobRepository);
+
+        self::assertSame($recruit, $service->resolveOwnedRecruitByApplicationSlug('app-slug', $loggedInUser, 'forbidden'));
+    }
+
+    public function testResolveOwnedRecruitByApplicationSlugThrowsForbiddenForNonOwner(): void
+    {
+        $loggedInUser = $this->createMock(User::class);
+        $owner = $this->createMock(User::class);
+        $application = $this->createMock(PlatformApplication::class);
+        $recruit = $this->createMock(Recruit::class);
+
+        $loggedInUser->method('getId')->willReturn('user-id');
+        $owner->method('getId')->willReturn('other-id');
+        $application->method('getUser')->willReturn($owner);
+        $recruit->method('getApplication')->willReturn($application);
+
+        $recruitResolverService = $this->createMock(RecruitResolverService::class);
+        $jobRepository = $this->createMock(JobRepository::class);
+        $recruitResolverService->method('resolveByApplicationSlug')->willReturn($recruit);
+
+        $service = new ApplicationJobAccessService($recruitResolverService, $jobRepository);
+
+        try {
+            $service->resolveOwnedRecruitByApplicationSlug('app-slug', $loggedInUser, 'forbidden');
+            self::fail('Expected HttpException was not thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(403, $exception->getStatusCode());
+            self::assertSame('forbidden', $exception->getMessage());
+        }
+    }
+
+    public function testResolveJobForRecruitThrowsNotFoundWhenJobIsMissing(): void
+    {
+        $recruitResolverService = $this->createMock(RecruitResolverService::class);
+        $jobRepository = $this->createMock(JobRepository::class);
+        $recruit = $this->createMock(Recruit::class);
+
+        $jobRepository->method('find')->with('job-id')->willReturn(null);
+
+        $service = new ApplicationJobAccessService($recruitResolverService, $jobRepository);
+
+        try {
+            $service->resolveJobForRecruit('job-id', $recruit);
+            self::fail('Expected HttpException was not thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(404, $exception->getStatusCode());
+            self::assertSame('Job not found.', $exception->getMessage());
+        }
+    }
+
+    public function testResolveJobForRecruitThrowsForbiddenWhenJobBelongsToAnotherRecruit(): void
+    {
+        $jobRecruit = $this->createMock(Recruit::class);
+        $requestedRecruit = $this->createMock(Recruit::class);
+        $job = $this->createMock(Job::class);
+
+        $jobRecruit->method('getId')->willReturn('recruit-a');
+        $requestedRecruit->method('getId')->willReturn('recruit-b');
+        $job->method('getRecruit')->willReturn($jobRecruit);
+
+        $recruitResolverService = $this->createMock(RecruitResolverService::class);
+        $jobRepository = $this->createMock(JobRepository::class);
+        $jobRepository->method('find')->with('job-id')->willReturn($job);
+
+        $service = new ApplicationJobAccessService($recruitResolverService, $jobRepository);
+
+        try {
+            $service->resolveJobForRecruit('job-id', $requestedRecruit);
+            self::fail('Expected HttpException was not thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(403, $exception->getStatusCode());
+            self::assertSame('This job does not belong to the given application.', $exception->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Remove duplicated access and ownership checks scattered across job controllers to improve maintainability.
- Centralize the logic that resolves a `Recruit` from an `applicationSlug`, verifies application ownership and validates that a `Job` belongs to the resolved `Recruit`.
- Preserve current HTTP semantics (400/403/404) for the existing endpoints while making the checks reusable.

### Description

- Add a new service `App\Recruit\Application\Service\ApplicationJobAccessService` with `resolveOwnedRecruitByApplicationSlug(...)` and `resolveJobForRecruit(...)` to encapsulate recruit/job resolution and access validation.
- Update `JobCreateFromApplicationController`, `JobPatchFromApplicationController` and `JobDeleteFromApplicationController` to call the new service instead of duplicating ownership and job-belonging checks.
- Add unit tests `tests/Unit/Recruit/Application/Service/ApplicationJobAccessServiceTest.php` covering success and error paths (403 ownership, 404 missing job, 403 job belongs to another recruit). 
- Extend functional tests in `tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobPatchDeleteFromApplicationControllerTest.php` to assert expected HTTP status codes for unknown application slug (400), missing job (404) and forbidden access (403).

### Testing

- Ran PHP syntax checks with `php -l` on modified source and test files which returned "No syntax errors detected." for all changed files.
- Attempted to run the test suite with `./vendor/bin/phpunit` and `phpunit`, but no PHPUnit binary is available in this environment so tests were not executed here.
- Unit and functional tests were added and are expected to be executed in CI or a local environment with PHPUnit installed to validate behavior and HTTP codes (400/403/404).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b19c1f83288326b2230f595ff73d20)