### PR TITLE
Ajout du panier (entités, repository, service et API)

### DIFF
--- a/migrations/Version20260311213000.php
+++ b/migrations/Version20260311213000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260311213000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create shop cart and cart item tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE shop_cart (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", user_id BINARY(16) NOT NULL, shop_id BINARY(16) NOT NULL, is_active TINYINT(1) NOT NULL DEFAULT 1, subtotal DOUBLE PRECISION NOT NULL DEFAULT 0, items_count INT NOT NULL DEFAULT 0, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", INDEX idx_shop_cart_user_id (user_id), INDEX idx_shop_cart_shop_id (shop_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE shop_cart_item (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", cart_id BINARY(16) NOT NULL, product_id BINARY(16) NOT NULL, quantity INT NOT NULL DEFAULT 1, unit_price_snapshot DOUBLE PRECISION NOT NULL, line_total DOUBLE PRECISION NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", INDEX idx_shop_cart_item_product_id (product_id), INDEX idx_shop_cart_item_cart_id (cart_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE shop_cart ADD CONSTRAINT FK_898B0D12A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE shop_cart ADD CONSTRAINT FK_898B0D124D16C4DD FOREIGN KEY (shop_id) REFERENCES shop (id) ON DELETE CASCADE');
+
+        $this->addSql('ALTER TABLE shop_cart_item ADD CONSTRAINT FK_55409D321AD5CDBF FOREIGN KEY (cart_id) REFERENCES shop_cart (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE shop_cart_item ADD CONSTRAINT FK_55409D324584665A FOREIGN KEY (product_id) REFERENCES shop_product (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE shop_cart_item DROP FOREIGN KEY FK_55409D321AD5CDBF');
+        $this->addSql('ALTER TABLE shop_cart_item DROP FOREIGN KEY FK_55409D324584665A');
+        $this->addSql('ALTER TABLE shop_cart DROP FOREIGN KEY FK_898B0D12A76ED395');
+        $this->addSql('ALTER TABLE shop_cart DROP FOREIGN KEY FK_898B0D124D16C4DD');
+
+        $this->addSql('DROP TABLE shop_cart_item');
+        $this->addSql('DROP TABLE shop_cart');
+    }
+}

--- a/src/Shop/Application/Service/CartService.php
+++ b/src/Shop/Application/Service/CartService.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Service;
+
+use App\Shop\Domain\Entity\Cart;
+use App\Shop\Domain\Entity\CartItem;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\CartItemRepository;
+use App\Shop\Infrastructure\Repository\CartRepository;
+use App\User\Domain\Entity\User;
+
+readonly class CartService
+{
+    public function __construct(
+        private CartRepository $cartRepository,
+        private CartItemRepository $cartItemRepository,
+    ) {
+    }
+
+    public function getOrCreateActiveCart(User $user, Shop $shop): Cart
+    {
+        $cart = $this->cartRepository->findActiveByUserAndShop($user->getId(), $shop->getId());
+        if ($cart instanceof Cart) {
+            return $cart;
+        }
+
+        $cart = (new Cart())
+            ->setUser($user)
+            ->setShop($shop)
+            ->setIsActive(true)
+            ->setItemsCount(0)
+            ->setSubtotal(0);
+
+        $this->cartRepository->save($cart, false);
+        $this->cartRepository->getEntityManager()->flush();
+
+        return $cart;
+    }
+
+    public function addProduct(Cart $cart, Product $product, int $quantity): Cart
+    {
+        $quantity = max(1, $quantity);
+
+        foreach ($cart->getItems() as $existingItem) {
+            if ($existingItem->getProduct()?->getId() !== $product->getId()) {
+                continue;
+            }
+
+            $existingItem->setQuantity($existingItem->getQuantity() + $quantity);
+            $existingItem->setUnitPriceSnapshot($product->getPrice());
+            $existingItem->setLineTotal($existingItem->getQuantity() * $existingItem->getUnitPriceSnapshot());
+            $this->cartItemRepository->save($existingItem, false);
+
+            return $this->recalculate($cart);
+        }
+
+        $item = (new CartItem())
+            ->setCart($cart)
+            ->setProduct($product)
+            ->setQuantity($quantity)
+            ->setUnitPriceSnapshot($product->getPrice())
+            ->setLineTotal($product->getPrice() * $quantity);
+
+        $cart->addItem($item);
+        $this->cartItemRepository->save($item, false);
+
+        return $this->recalculate($cart);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function serializeCart(Cart $cart): array
+    {
+        return [
+            'id' => $cart->getId(),
+            'shopId' => $cart->getShop()?->getId(),
+            'userId' => $cart->getUser()?->getId(),
+            'subtotal' => $cart->getSubtotal(),
+            'itemsCount' => $cart->getItemsCount(),
+            'currencyCode' => $cart->getItems()->first() instanceof CartItem
+                ? $cart->getItems()->first()->getProduct()?->getCurrencyCode()
+                : null,
+            'updatedAt' => $cart->getUpdatedAt()?->format(DATE_ATOM),
+            'items' => array_map(function (CartItem $item): array {
+                $product = $item->getProduct();
+                $serializedProduct = $product instanceof Product ? ProductListService::serializeProduct($product) : [];
+
+                return [
+                    'id' => $item->getId(),
+                    'productId' => $product?->getId(),
+                    'quantity' => $item->getQuantity(),
+                    'unitPriceSnapshot' => $item->getUnitPriceSnapshot(),
+                    'lineTotal' => $item->getLineTotal(),
+                    'updatedAt' => $item->getUpdatedAt()?->format(DATE_ATOM),
+                    'product' => [
+                        'id' => $serializedProduct['id'] ?? null,
+                        'name' => $serializedProduct['name'] ?? null,
+                        'sku' => $serializedProduct['sku'] ?? null,
+                        'price' => $serializedProduct['price'] ?? null,
+                        'currencyCode' => $serializedProduct['currencyCode'] ?? null,
+                        'stock' => $serializedProduct['stock'] ?? null,
+                        'status' => $serializedProduct['status'] ?? null,
+                    ],
+                ];
+            }, $cart->getItems()->toArray()),
+        ];
+    }
+
+    public function updateItemQuantity(Cart $cart, CartItem $item, int $quantity): Cart
+    {
+        if ($item->getCart()?->getId() !== $cart->getId()) {
+            return $cart;
+        }
+
+        $quantity = max(1, $quantity);
+        $item->setQuantity($quantity);
+        $item->setLineTotal($item->getUnitPriceSnapshot() * $quantity);
+
+        $this->cartItemRepository->save($item, false);
+
+        return $this->recalculate($cart);
+    }
+
+    public function removeItem(Cart $cart, CartItem $item): Cart
+    {
+        if ($item->getCart()?->getId() !== $cart->getId()) {
+            return $cart;
+        }
+
+        $cart->removeItem($item);
+        $this->cartItemRepository->remove($item, false);
+
+        return $this->recalculate($cart);
+    }
+
+    public function recalculate(Cart $cart): Cart
+    {
+        $subtotal = 0.0;
+        $itemsCount = 0;
+
+        foreach ($cart->getItems() as $item) {
+            $lineTotal = $item->getQuantity() * $item->getUnitPriceSnapshot();
+            $item->setLineTotal($lineTotal);
+            $subtotal += $lineTotal;
+            $itemsCount += $item->getQuantity();
+        }
+
+        $cart->setSubtotal($subtotal);
+        $cart->setItemsCount($itemsCount);
+
+        $this->cartRepository->save($cart, false);
+        $this->cartRepository->getEntityManager()->flush();
+
+        return $cart;
+    }
+}

--- a/src/Shop/Domain/Entity/Cart.php
+++ b/src/Shop/Domain/Entity/Cart.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'shop_cart')]
+#[ORM\Index(name: 'idx_shop_cart_user_id', columns: ['user_id'])]
+#[ORM\Index(name: 'idx_shop_cart_shop_id', columns: ['shop_id'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Cart implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?User $user = null;
+
+    #[ORM\ManyToOne(targetEntity: Shop::class)]
+    #[ORM\JoinColumn(name: 'shop_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?Shop $shop = null;
+
+    #[ORM\Column(name: 'is_active', type: Types::BOOLEAN, options: ['default' => true])]
+    private bool $isActive = true;
+
+    #[ORM\Column(name: 'subtotal', type: Types::FLOAT, options: ['default' => 0])]
+    private float $subtotal = 0.0;
+
+    #[ORM\Column(name: 'items_count', type: Types::INTEGER, options: ['default' => 0])]
+    private int $itemsCount = 0;
+
+    /** @var Collection<int, CartItem>|ArrayCollection<int, CartItem> */
+    #[ORM\OneToMany(targetEntity: CartItem::class, mappedBy: 'cart', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $items;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->items = new ArrayCollection();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getShop(): ?Shop
+    {
+        return $this->shop;
+    }
+
+    public function setShop(?Shop $shop): self
+    {
+        $this->shop = $shop;
+
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function setIsActive(bool $isActive): self
+    {
+        $this->isActive = $isActive;
+
+        return $this;
+    }
+
+    public function getSubtotal(): float
+    {
+        return $this->subtotal;
+    }
+
+    public function setSubtotal(float $subtotal): self
+    {
+        $this->subtotal = max(0, $subtotal);
+
+        return $this;
+    }
+
+    public function getItemsCount(): int
+    {
+        return $this->itemsCount;
+    }
+
+    public function setItemsCount(int $itemsCount): self
+    {
+        $this->itemsCount = max(0, $itemsCount);
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, CartItem>|ArrayCollection<int, CartItem>
+     */
+    public function getItems(): Collection|ArrayCollection
+    {
+        return $this->items;
+    }
+
+    public function addItem(CartItem $item): self
+    {
+        if (!$this->items->contains($item)) {
+            $this->items->add($item);
+            $item->setCart($this);
+        }
+
+        return $this;
+    }
+
+    public function removeItem(CartItem $item): self
+    {
+        if ($this->items->removeElement($item) && $item->getCart() === $this) {
+            $item->setCart(null);
+        }
+
+        return $this;
+    }
+}

--- a/src/Shop/Domain/Entity/CartItem.php
+++ b/src/Shop/Domain/Entity/CartItem.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'shop_cart_item')]
+#[ORM\Index(name: 'idx_shop_cart_item_product_id', columns: ['product_id'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class CartItem implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Cart::class, inversedBy: 'items')]
+    #[ORM\JoinColumn(name: 'cart_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?Cart $cart = null;
+
+    #[ORM\ManyToOne(targetEntity: Product::class)]
+    #[ORM\JoinColumn(name: 'product_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?Product $product = null;
+
+    #[ORM\Column(name: 'quantity', type: Types::INTEGER, options: ['default' => 1])]
+    private int $quantity = 1;
+
+    #[ORM\Column(name: 'unit_price_snapshot', type: Types::FLOAT)]
+    private float $unitPriceSnapshot = 0.0;
+
+    #[ORM\Column(name: 'line_total', type: Types::FLOAT)]
+    private float $lineTotal = 0.0;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getCart(): ?Cart
+    {
+        return $this->cart;
+    }
+
+    public function setCart(?Cart $cart): self
+    {
+        $this->cart = $cart;
+
+        return $this;
+    }
+
+    public function getProduct(): ?Product
+    {
+        return $this->product;
+    }
+
+    public function setProduct(?Product $product): self
+    {
+        $this->product = $product;
+
+        return $this;
+    }
+
+    public function getQuantity(): int
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(int $quantity): self
+    {
+        $this->quantity = max(0, $quantity);
+
+        return $this;
+    }
+
+    public function getUnitPriceSnapshot(): float
+    {
+        return $this->unitPriceSnapshot;
+    }
+
+    public function setUnitPriceSnapshot(float $unitPriceSnapshot): self
+    {
+        $this->unitPriceSnapshot = max(0, $unitPriceSnapshot);
+
+        return $this;
+    }
+
+    public function getLineTotal(): float
+    {
+        return $this->lineTotal;
+    }
+
+    public function setLineTotal(float $lineTotal): self
+    {
+        $this->lineTotal = max(0, $lineTotal);
+
+        return $this;
+    }
+}

--- a/src/Shop/Infrastructure/Repository/CartItemRepository.php
+++ b/src/Shop/Infrastructure/Repository/CartItemRepository.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Shop\Domain\Entity\CartItem as Entity;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class CartItemRepository extends BaseRepository
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+}

--- a/src/Shop/Infrastructure/Repository/CartRepository.php
+++ b/src/Shop/Infrastructure/Repository/CartRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Shop\Domain\Entity\Cart as Entity;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class CartRepository extends BaseRepository
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+
+    public function findActiveByUserAndShop(string $userId, string $shopId): ?Entity
+    {
+        /** @var Entity|null $cart */
+        $cart = $this->findOneBy([
+            'user' => $userId,
+            'shop' => $shopId,
+            'isActive' => true,
+        ]);
+
+        return $cart;
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Cart/AddCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Cart/AddCartItemController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Cart;
+
+use App\Shop\Application\Service\CartService;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class AddCartItemController
+{
+    public function __construct(
+        private Security $security,
+        private ShopRepository $shopRepository,
+        private ProductRepository $productRepository,
+        private CartService $cartService,
+    ) {
+    }
+
+    #[Route('/v1/shop/carts/{shopId}/items', methods: [Request::METHOD_POST])]
+    public function __invoke(string $shopId, Request $request): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');
+        }
+
+        $shop = $this->shopRepository->find($shopId);
+        if (!$shop instanceof Shop) {
+            return new JsonResponse(['message' => 'Shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $productId = (string) ($payload['productId'] ?? '');
+        $quantity = max(1, (int) ($payload['quantity'] ?? 1));
+
+        $product = $this->productRepository->find($productId);
+        if (!$product instanceof Product || $product->getShop()?->getId() !== $shop->getId()) {
+            return new JsonResponse(['message' => 'Product not found for this shop.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $cart = $this->cartService->getOrCreateActiveCart($user, $shop);
+        $cart = $this->cartService->addProduct($cart, $product, $quantity);
+
+        return new JsonResponse($this->cartService->serializeCart($cart), JsonResponse::HTTP_CREATED);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Cart/DeleteCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Cart/DeleteCartItemController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Cart;
+
+use App\Shop\Application\Service\CartService;
+use App\Shop\Domain\Entity\CartItem;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\CartItemRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class DeleteCartItemController
+{
+    public function __construct(
+        private Security $security,
+        private ShopRepository $shopRepository,
+        private CartItemRepository $cartItemRepository,
+        private CartService $cartService,
+    ) {
+    }
+
+    #[Route('/v1/shop/carts/{shopId}/items/{itemId}', methods: [Request::METHOD_DELETE])]
+    public function __invoke(string $shopId, string $itemId): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');
+        }
+
+        $shop = $this->shopRepository->find($shopId);
+        if (!$shop instanceof Shop) {
+            return new JsonResponse(['message' => 'Shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $cart = $this->cartService->getOrCreateActiveCart($user, $shop);
+
+        $item = $this->cartItemRepository->find($itemId);
+        if (!$item instanceof CartItem || $item->getCart()?->getId() !== $cart->getId()) {
+            return new JsonResponse(['message' => 'Cart item not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $cart = $this->cartService->removeItem($cart, $item);
+
+        return new JsonResponse($this->cartService->serializeCart($cart));
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Cart/GetCartController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Cart/GetCartController.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Cart;
+
+use App\Shop\Application\Service\CartService;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class GetCartController
+{
+    public function __construct(
+        private Security $security,
+        private ShopRepository $shopRepository,
+        private CartService $cartService,
+    ) {
+    }
+
+    #[Route('/v1/shop/carts/{shopId}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $shopId): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');
+        }
+
+        $shop = $this->shopRepository->find($shopId);
+        if (!$shop instanceof Shop) {
+            return new JsonResponse(['message' => 'Shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $cart = $this->cartService->getOrCreateActiveCart($user, $shop);
+        $cart = $this->cartService->recalculate($cart);
+
+        return new JsonResponse($this->cartService->serializeCart($cart));
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Cart/PatchCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Cart/PatchCartItemController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Cart;
+
+use App\Shop\Application\Service\CartService;
+use App\Shop\Domain\Entity\CartItem;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\CartItemRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class PatchCartItemController
+{
+    public function __construct(
+        private Security $security,
+        private ShopRepository $shopRepository,
+        private CartItemRepository $cartItemRepository,
+        private CartService $cartService,
+    ) {
+    }
+
+    #[Route('/v1/shop/carts/{shopId}/items/{itemId}', methods: [Request::METHOD_PATCH])]
+    public function __invoke(string $shopId, string $itemId, Request $request): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');
+        }
+
+        $shop = $this->shopRepository->find($shopId);
+        if (!$shop instanceof Shop) {
+            return new JsonResponse(['message' => 'Shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $cart = $this->cartService->getOrCreateActiveCart($user, $shop);
+
+        $item = $this->cartItemRepository->find($itemId);
+        if (!$item instanceof CartItem || $item->getCart()?->getId() !== $cart->getId()) {
+            return new JsonResponse(['message' => 'Cart item not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $quantity = (int) ($payload['quantity'] ?? 0);
+        if ($quantity <= 0) {
+            return new JsonResponse(['message' => 'Quantity must be greater than 0.'], JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        $cart = $this->cartService->updateItemQuantity($cart, $item, $quantity);
+
+        return new JsonResponse($this->cartService->serializeCart($cart));
+    }
+}


### PR DESCRIPTION
### Motivation
- Implémenter la fonctionnalité de panier pour les boutiques en ajoutant les entités, la persistance, la logique applicative et les endpoints API nécessaires.

### Description
- Ajout des entités Doctrine `Cart` et `CartItem` dans `src/Shop/Domain/Entity/` avec relations vers `User`, `Shop`, `Product`, champs `quantity`, `unit_price_snapshot`, `line_total` et timestamps, et index ORM sur `user_id`, `shop_id`, `product_id`.
- Création des repositories `CartRepository` et `CartItemRepository` dans `src/Shop/Infrastructure/Repository/`, incluant `CartRepository::findActiveByUserAndShop`.
- Création du service applicatif `CartService` dans `src/Shop/Application/Service/` fournissant `getOrCreateActiveCart`, `addProduct` (fusionne les lignes si nécessaire), `updateItemQuantity`, `removeItem`, `recalculate` et `serializeCart` (réutilise `ProductListService::serializeProduct` pour le résumé produit).
- Ajout des controllers API dans `src/Shop/Transport/Controller/Api/V1/Cart/` exposant les routes `POST /v1/shop/carts/{shopId}/items`, `PATCH /v1/shop/carts/{shopId}/items/{itemId}`, `DELETE /v1/shop/carts/{shopId}/items/{itemId}` et `GET /v1/shop/carts/{shopId}` et d’une migration Doctrine `Version20260311213000` créant les tables `shop_cart` et `shop_cart_item` avec les index et clés étrangères demandés.

### Testing
- Linting PHP des fichiers ajoutés avec `php -l` (tous les fichiers nouvellement ajoutés passent la vérification de syntaxe).
- Tentative de validation du schéma Doctrine avec `php bin/console doctrine:schema:validate --skip-sync` a échoué pour raison environnementale (dépendances manquantes, message: `Dependencies are missing. Try running "composer install"`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b2cb9a688326b1d6aab92c461fd9)