### PR TITLE
feat(quiz): add quiz submission flow with score calculation

### DIFF
--- a/src/Quiz/Application/Service/QuizSubmissionService.php
+++ b/src/Quiz/Application/Service/QuizSubmissionService.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Application\Service;
+
+use App\Quiz\Domain\Entity\Quiz;
+use App\Quiz\Infrastructure\Repository\QuizRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+use function array_fill_keys;
+use function array_intersect_key;
+use function array_key_exists;
+use function count;
+use function in_array;
+use function is_array;
+use function is_string;
+use function round;
+
+final readonly class QuizSubmissionService
+{
+    public function __construct(
+        private QuizRepository $quizRepository,
+        private QuizReadService $quizReadService,
+    ) {
+    }
+
+    /**
+     * @param array<mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    public function submitByApplicationSlug(string $applicationSlug, array $payload): array
+    {
+        $quiz = $this->quizRepository->createQueryBuilder('q')
+            ->leftJoin('q.application', 'application')->addSelect('application')
+            ->andWhere('application.slug = :slug')->setParameter('slug', $applicationSlug)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if (!$quiz instanceof Quiz) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Quiz not found for this application.');
+        }
+
+        if (!array_key_exists('answers', $payload) || !is_array($payload['answers'])) {
+            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "answers" must be an array.');
+        }
+
+        $quizData = $this->quizReadService->getByApplicationSlug($applicationSlug);
+        if ($quizData === []) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Quiz not found for this application.');
+        }
+
+        $questionById = [];
+        foreach ($quizData['questions'] as $question) {
+            if (!is_array($question)) {
+                continue;
+            }
+
+            $questionById[(string) $question['id']] = $question;
+        }
+
+        $submittedAnswersByQuestionId = [];
+
+        foreach ($payload['answers'] as $entry) {
+            if (!is_array($entry) || !is_string($entry['questionId'] ?? null) || !is_string($entry['answerId'] ?? null)) {
+                throw new HttpException(
+                    JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+                    'Each answer must contain string fields "questionId" and "answerId".'
+                );
+            }
+
+            $submittedAnswersByQuestionId[$entry['questionId']] = $entry['answerId'];
+        }
+
+        $submittedAnswersByQuestionId = array_intersect_key(
+            $submittedAnswersByQuestionId,
+            array_fill_keys(array_keys($questionById), true)
+        );
+
+        $totalPoints = 0;
+        $earnedPoints = 0;
+        $correctAnswers = 0;
+        $results = [];
+
+        foreach ($questionById as $questionId => $question) {
+            $questionPoints = (int) ($question['points'] ?? 0);
+            $totalPoints += $questionPoints;
+
+            $selectedAnswerId = $submittedAnswersByQuestionId[$questionId] ?? null;
+            $isCorrect = false;
+            $correctAnswerIds = [];
+
+            foreach ($question['answers'] as $answer) {
+                if (!is_array($answer)) {
+                    continue;
+                }
+
+                if (($answer['correct'] ?? false) === true) {
+                    $correctAnswerIds[] = (string) $answer['id'];
+                }
+            }
+
+            if (is_string($selectedAnswerId)) {
+                $isCorrect = in_array($selectedAnswerId, $correctAnswerIds, true);
+                if ($isCorrect) {
+                    $correctAnswers++;
+                    $earnedPoints += $questionPoints;
+                }
+            }
+
+            $results[] = [
+                'questionId' => $questionId,
+                'selectedAnswerId' => $selectedAnswerId,
+                'isCorrect' => $isCorrect,
+                'correctAnswerIds' => $correctAnswerIds,
+                'points' => $questionPoints,
+                'earnedPoints' => $isCorrect ? $questionPoints : 0,
+            ];
+        }
+
+        $score = $totalPoints > 0 ? round(($earnedPoints / $totalPoints) * 100, 2) : 0.0;
+
+        return [
+            'quizId' => $quiz->getId(),
+            'applicationSlug' => $applicationSlug,
+            'passScore' => $quiz->getPassScore(),
+            'score' => $score,
+            'passed' => $score >= $quiz->getPassScore(),
+            'totalQuestions' => count($questionById),
+            'answeredQuestions' => count($submittedAnswersByQuestionId),
+            'correctAnswers' => $correctAnswers,
+            'totalPoints' => $totalPoints,
+            'earnedPoints' => $earnedPoints,
+            'results' => $results,
+        ];
+    }
+}

--- a/src/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Transport\Controller\Api\V1;
+
+use App\Quiz\Application\Service\QuizSubmissionService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Quiz')]
+final class SubmitQuizByApplicationController
+{
+    #[Route('/v1/quiz/application/{applicationSlug}/submit', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'POST /v1/quiz/application/{applicationSlug}/submit', tags: ['Quiz'])]
+    public function __invoke(string $applicationSlug, Request $request, QuizSubmissionService $quizSubmissionService): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+
+        return new JsonResponse($quizSubmissionService->submitByApplicationSlug($applicationSlug, $payload));
+    }
+}

--- a/tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php
+++ b/tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Quiz\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Quiz\Domain\Entity\Quiz;
+use App\Quiz\Domain\Entity\QuizAnswer;
+use App\Quiz\Domain\Entity\QuizQuestion;
+use App\Tests\TestCase\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SubmitQuizByApplicationControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/quiz/application';
+
+    #[TestDox('A user can submit a quiz and receive a computed score.')]
+    public function testSubmitQuizReturnsScore(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $quiz = $this->getAnyPublishedQuiz($entityManager);
+        $questions = $entityManager->getRepository(QuizQuestion::class)->findBy(['quiz' => $quiz], ['position' => 'ASC']);
+
+        $answersPayload = [];
+        foreach ($questions as $question) {
+            $correctAnswerId = null;
+            foreach ($question->getAnswers() as $answer) {
+                if ($answer instanceof QuizAnswer && $answer->isCorrect()) {
+                    $correctAnswerId = $answer->getId();
+                    break;
+                }
+            }
+
+            self::assertNotNull($correctAnswerId);
+            $answersPayload[] = [
+                'questionId' => $question->getId(),
+                'answerId' => $correctAnswerId,
+            ];
+        }
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request(
+            'POST',
+            $this->baseUrl . '/' . $quiz->getApplication()->getSlug() . '/submit',
+            content: JSON::encode(['answers' => $answersPayload])
+        );
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertSame(100.0, (float) $responseData['score']);
+        self::assertTrue((bool) $responseData['passed']);
+        self::assertSame(count($questions), (int) $responseData['totalQuestions']);
+        self::assertSame(count($questions), (int) $responseData['correctAnswers']);
+    }
+
+    #[TestDox('Submitting invalid quiz payload returns 422.')]
+    public function testSubmitQuizWithInvalidPayloadReturnsValidationError(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $quiz = $this->getAnyPublishedQuiz($entityManager);
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request(
+            'POST',
+            $this->baseUrl . '/' . $quiz->getApplication()->getSlug() . '/submit',
+            content: JSON::encode(['answers' => [['questionId' => 12]]])
+        );
+
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+    }
+
+    private function getAnyPublishedQuiz(EntityManagerInterface $entityManager): Quiz
+    {
+        $quiz = $entityManager->getRepository(Quiz::class)->createQueryBuilder('quiz')
+            ->leftJoin('quiz.application', 'application')->addSelect('application')
+            ->andWhere('quiz.isPublished = true')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        self::assertInstanceOf(Quiz::class, $quiz);
+
+        return $quiz;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a complete quiz submission flow so a user can submit answers for an application's quiz and receive a computed score and per-question feedback.

### Description
- Add `QuizSubmissionService` that validates the `answers` payload, evaluates submitted answers against quiz data, computes `earnedPoints`, `totalPoints`, `score` (percentage) and `passed` based on `passScore`, and returns per-question results.
- Add `SubmitQuizByApplicationController` exposing `POST /api/v1/quiz/application/{applicationSlug}/submit` which delegates submission handling to `QuizSubmissionService`.
- Use existing `QuizReadService` and `QuizRepository` to load quiz and questions and produce the returned structure that includes `quizId`, `applicationSlug`, `passScore`, `score`, `passed`, `totalQuestions`, `answeredQuestions`, `correctAnswers`, `totalPoints`, `earnedPoints`, and `results` per question.
- Add integration tests `tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php` covering a full correct submission (expecting 100% score and pass) and an invalid payload returning HTTP 422.

### Testing
- Linted new files with `php -l` for `src/Quiz/Application/Service/QuizSubmissionService.php`, `src/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationController.php` and the new test file, and all returned no syntax errors.
- Attempted to run the new integration test with `php bin/phpunit tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php` but the environment lacks `bin/phpunit`/installed dependencies so PHPUnit could not be executed.
- Integration tests were added and are ready to run in CI or a developer environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b470a1608326be67ff47826c0e4d)