### PR TITLE
Add shop checkout flow with Order/OrderItem, command, service, controller, migration and tests

### DIFF
--- a/migrations/Version20260311223000.php
+++ b/migrations/Version20260311223000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260311223000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create shop order and shop order item tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE shop_order (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", user_id BINARY(16) NOT NULL, shop_id BINARY(16) NOT NULL, status VARCHAR(30) NOT NULL, subtotal DOUBLE PRECISION NOT NULL, billing_address LONGTEXT NOT NULL, shipping_address LONGTEXT NOT NULL, email VARCHAR(190) NOT NULL, phone VARCHAR(40) NOT NULL, shipping_method VARCHAR(80) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", INDEX idx_shop_order_status (status), INDEX idx_shop_order_created_at (created_at), INDEX idx_shop_order_shop_id (shop_id), INDEX idx_shop_order_user_id (user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE shop_order_item (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", order_id BINARY(16) NOT NULL, product_id BINARY(16) NOT NULL, quantity INT NOT NULL, unit_price_snapshot DOUBLE PRECISION NOT NULL, line_total DOUBLE PRECISION NOT NULL, product_name_snapshot VARCHAR(255) NOT NULL, product_sku_snapshot VARCHAR(64) NOT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", INDEX idx_shop_order_item_order_id (order_id), INDEX idx_shop_order_item_product_id (product_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE shop_order ADD CONSTRAINT FK_6D84A701A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE shop_order ADD CONSTRAINT FK_6D84A7014D16C4DD FOREIGN KEY (shop_id) REFERENCES shop (id) ON DELETE CASCADE');
+
+        $this->addSql('ALTER TABLE shop_order_item ADD CONSTRAINT FK_6FC3D4A58D9F6D38 FOREIGN KEY (order_id) REFERENCES shop_order (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE shop_order_item ADD CONSTRAINT FK_6FC3D4A54584665A FOREIGN KEY (product_id) REFERENCES shop_product (id) ON DELETE RESTRICT');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE shop_order_item DROP FOREIGN KEY FK_6FC3D4A58D9F6D38');
+        $this->addSql('ALTER TABLE shop_order_item DROP FOREIGN KEY FK_6FC3D4A54584665A');
+        $this->addSql('ALTER TABLE shop_order DROP FOREIGN KEY FK_6D84A701A76ED395');
+        $this->addSql('ALTER TABLE shop_order DROP FOREIGN KEY FK_6D84A7014D16C4DD');
+
+        $this->addSql('DROP TABLE shop_order_item');
+        $this->addSql('DROP TABLE shop_order');
+    }
+}

--- a/src/Shop/Application/Message/CheckoutCommand.php
+++ b/src/Shop/Application/Message/CheckoutCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class CheckoutCommand implements MessageHighInterface
+{
+    public function __construct(
+        public string $operationId,
+        public string $shopId,
+        public string $userId,
+        public string $billingAddress,
+        public string $shippingAddress,
+        public string $email,
+        public string $phone,
+        public string $shippingMethod,
+    ) {
+    }
+}
+

--- a/src/Shop/Application/MessageHandler/CheckoutCommandHandler.php
+++ b/src/Shop/Application/MessageHandler/CheckoutCommandHandler.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\MessageHandler;
+
+use App\Shop\Application\Message\CheckoutCommand;
+use App\Shop\Application\Service\CheckoutService;
+use App\Shop\Domain\Entity\Order;
+use App\Shop\Infrastructure\Repository\OrderRepository;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class CheckoutCommandHandler
+{
+    public function __construct(
+        private CheckoutService $checkoutService,
+        private OrderRepository $orderRepository,
+    ) {
+    }
+
+    public function __invoke(CheckoutCommand $command): Order
+    {
+        $entityManager = $this->orderRepository->getEntityManager();
+
+        /** @var Order $order */
+        $order = $entityManager->getConnection()->transactional(fn (): Order => $this->checkoutService->checkout($command));
+
+        return $order;
+    }
+}
+

--- a/src/Shop/Application/Service/CheckoutService.php
+++ b/src/Shop/Application/Service/CheckoutService.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Service;
+
+use App\Shop\Application\Message\CheckoutCommand;
+use App\Shop\Domain\Entity\Cart;
+use App\Shop\Domain\Entity\Order;
+use App\Shop\Domain\Entity\OrderItem;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Domain\Enum\OrderStatus;
+use App\Shop\Infrastructure\Repository\CartItemRepository;
+use App\Shop\Infrastructure\Repository\CartRepository;
+use App\Shop\Infrastructure\Repository\OrderItemRepository;
+use App\Shop\Infrastructure\Repository\OrderRepository;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\DBAL\LockMode;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final readonly class CheckoutService
+{
+    public function __construct(
+        private CartRepository $cartRepository,
+        private CartItemRepository $cartItemRepository,
+        private ProductRepository $productRepository,
+        private OrderRepository $orderRepository,
+        private OrderItemRepository $orderItemRepository,
+        private ShopRepository $shopRepository,
+        private UserRepository $userRepository,
+    ) {
+    }
+
+    public function checkout(CheckoutCommand $command): Order
+    {
+        $shop = $this->shopRepository->find($command->shopId);
+        if ($shop === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Shop not found.');
+        }
+
+        $user = $this->userRepository->find($command->userId);
+        if ($user === null) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');
+        }
+
+        $cart = $this->cartRepository->findActiveByUserAndShop($user->getId(), $shop->getId());
+        if (!$cart instanceof Cart) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Active cart not found.');
+        }
+
+        if ($cart->getItems()->count() === 0) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Cart is empty.');
+        }
+
+        $order = (new Order())
+            ->setShop($shop)
+            ->setUser($user)
+            ->setStatus(OrderStatus::PENDING_PAYMENT)
+            ->setBillingAddress($command->billingAddress)
+            ->setShippingAddress($command->shippingAddress)
+            ->setEmail($command->email)
+            ->setPhone($command->phone)
+            ->setShippingMethod($command->shippingMethod);
+
+        $subtotal = 0.0;
+
+        foreach ($cart->getItems() as $cartItem) {
+            $product = $this->productRepository->find($cartItem->getProduct()?->getId() ?? '', LockMode::PESSIMISTIC_WRITE);
+            if (!$product instanceof Product || $product->getShop()?->getId() !== $shop->getId()) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Product not found for this shop.');
+            }
+
+            if ($product->getStock() < $cartItem->getQuantity()) {
+                throw new HttpException(JsonResponse::HTTP_CONFLICT, sprintf('Insufficient stock for SKU %s.', $product->getSku()));
+            }
+
+            $lineTotal = $product->getPrice() * $cartItem->getQuantity();
+            $orderItem = (new OrderItem())
+                ->setOrder($order)
+                ->setProduct($product)
+                ->setQuantity($cartItem->getQuantity())
+                ->setUnitPriceSnapshot($product->getPrice())
+                ->setLineTotal($lineTotal)
+                ->setProductNameSnapshot($product->getName())
+                ->setProductSkuSnapshot($product->getSku());
+
+            $order->addItem($orderItem);
+            $this->orderItemRepository->save($orderItem, false);
+
+            $product->setStock($product->getStock() - $cartItem->getQuantity());
+            $this->productRepository->save($product, false);
+
+            $subtotal += $lineTotal;
+        }
+
+        $order->setSubtotal($subtotal);
+        $this->orderRepository->save($order, false);
+
+        foreach ($cart->getItems()->toArray() as $item) {
+            $cart->removeItem($item);
+            $this->cartItemRepository->remove($item, false);
+        }
+
+        $cart
+            ->setSubtotal(0)
+            ->setItemsCount(0)
+            ->setIsActive(false);
+        $this->cartRepository->save($cart, false);
+
+        return $order;
+    }
+}
+

--- a/src/Shop/Domain/Entity/Order.php
+++ b/src/Shop/Domain/Entity/Order.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Shop\Domain\Enum\OrderStatus;
+use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'shop_order')]
+#[ORM\Index(name: 'idx_shop_order_status', columns: ['status'])]
+#[ORM\Index(name: 'idx_shop_order_created_at', columns: ['created_at'])]
+#[ORM\Index(name: 'idx_shop_order_shop_id', columns: ['shop_id'])]
+#[ORM\Index(name: 'idx_shop_order_user_id', columns: ['user_id'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Order implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?User $user = null;
+
+    #[ORM\ManyToOne(targetEntity: Shop::class)]
+    #[ORM\JoinColumn(name: 'shop_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?Shop $shop = null;
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 30, enumType: OrderStatus::class)]
+    private OrderStatus $status = OrderStatus::DRAFT;
+
+    #[ORM\Column(name: 'subtotal', type: Types::FLOAT)]
+    private float $subtotal = 0.0;
+
+    #[ORM\Column(name: 'billing_address', type: Types::TEXT)]
+    private string $billingAddress = '';
+
+    #[ORM\Column(name: 'shipping_address', type: Types::TEXT)]
+    private string $shippingAddress = '';
+
+    #[ORM\Column(name: 'email', type: Types::STRING, length: 190)]
+    private string $email = '';
+
+    #[ORM\Column(name: 'phone', type: Types::STRING, length: 40)]
+    private string $phone = '';
+
+    #[ORM\Column(name: 'shipping_method', type: Types::STRING, length: 80)]
+    private string $shippingMethod = '';
+
+    /** @var Collection<int, OrderItem>|ArrayCollection<int, OrderItem> */
+    #[ORM\OneToMany(targetEntity: OrderItem::class, mappedBy: 'order', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $items;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->items = new ArrayCollection();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getShop(): ?Shop
+    {
+        return $this->shop;
+    }
+
+    public function setShop(?Shop $shop): self
+    {
+        $this->shop = $shop;
+
+        return $this;
+    }
+
+    public function getStatus(): OrderStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(OrderStatus $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    public function getSubtotal(): float
+    {
+        return $this->subtotal;
+    }
+
+    public function setSubtotal(float $subtotal): self
+    {
+        $this->subtotal = max(0, $subtotal);
+
+        return $this;
+    }
+
+    public function getBillingAddress(): string
+    {
+        return $this->billingAddress;
+    }
+
+    public function setBillingAddress(string $billingAddress): self
+    {
+        $this->billingAddress = trim($billingAddress);
+
+        return $this;
+    }
+
+    public function getShippingAddress(): string
+    {
+        return $this->shippingAddress;
+    }
+
+    public function setShippingAddress(string $shippingAddress): self
+    {
+        $this->shippingAddress = trim($shippingAddress);
+
+        return $this;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = trim($email);
+
+        return $this;
+    }
+
+    public function getPhone(): string
+    {
+        return $this->phone;
+    }
+
+    public function setPhone(string $phone): self
+    {
+        $this->phone = trim($phone);
+
+        return $this;
+    }
+
+    public function getShippingMethod(): string
+    {
+        return $this->shippingMethod;
+    }
+
+    public function setShippingMethod(string $shippingMethod): self
+    {
+        $this->shippingMethod = trim($shippingMethod);
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, OrderItem>|ArrayCollection<int, OrderItem>
+     */
+    public function getItems(): Collection|ArrayCollection
+    {
+        return $this->items;
+    }
+
+    public function addItem(OrderItem $item): self
+    {
+        if (!$this->items->contains($item)) {
+            $this->items->add($item);
+            $item->setOrder($this);
+        }
+
+        return $this;
+    }
+}
+

--- a/src/Shop/Domain/Entity/OrderItem.php
+++ b/src/Shop/Domain/Entity/OrderItem.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'shop_order_item')]
+#[ORM\Index(name: 'idx_shop_order_item_order_id', columns: ['order_id'])]
+#[ORM\Index(name: 'idx_shop_order_item_product_id', columns: ['product_id'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class OrderItem implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Order::class, inversedBy: 'items')]
+    #[ORM\JoinColumn(name: 'order_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?Order $order = null;
+
+    #[ORM\ManyToOne(targetEntity: Product::class)]
+    #[ORM\JoinColumn(name: 'product_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
+    private ?Product $product = null;
+
+    #[ORM\Column(name: 'quantity', type: Types::INTEGER)]
+    private int $quantity = 1;
+
+    #[ORM\Column(name: 'unit_price_snapshot', type: Types::FLOAT)]
+    private float $unitPriceSnapshot = 0.0;
+
+    #[ORM\Column(name: 'line_total', type: Types::FLOAT)]
+    private float $lineTotal = 0.0;
+
+    #[ORM\Column(name: 'product_name_snapshot', type: Types::STRING, length: 255)]
+    private string $productNameSnapshot = '';
+
+    #[ORM\Column(name: 'product_sku_snapshot', type: Types::STRING, length: 64)]
+    private string $productSkuSnapshot = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getOrder(): ?Order
+    {
+        return $this->order;
+    }
+
+    public function setOrder(?Order $order): self
+    {
+        $this->order = $order;
+
+        return $this;
+    }
+
+    public function getProduct(): ?Product
+    {
+        return $this->product;
+    }
+
+    public function setProduct(?Product $product): self
+    {
+        $this->product = $product;
+
+        return $this;
+    }
+
+    public function getQuantity(): int
+    {
+        return $this->quantity;
+    }
+
+    public function setQuantity(int $quantity): self
+    {
+        $this->quantity = max(1, $quantity);
+
+        return $this;
+    }
+
+    public function getUnitPriceSnapshot(): float
+    {
+        return $this->unitPriceSnapshot;
+    }
+
+    public function setUnitPriceSnapshot(float $unitPriceSnapshot): self
+    {
+        $this->unitPriceSnapshot = max(0, $unitPriceSnapshot);
+
+        return $this;
+    }
+
+    public function getLineTotal(): float
+    {
+        return $this->lineTotal;
+    }
+
+    public function setLineTotal(float $lineTotal): self
+    {
+        $this->lineTotal = max(0, $lineTotal);
+
+        return $this;
+    }
+
+    public function getProductNameSnapshot(): string
+    {
+        return $this->productNameSnapshot;
+    }
+
+    public function setProductNameSnapshot(string $productNameSnapshot): self
+    {
+        $this->productNameSnapshot = trim($productNameSnapshot);
+
+        return $this;
+    }
+
+    public function getProductSkuSnapshot(): string
+    {
+        return $this->productSkuSnapshot;
+    }
+
+    public function setProductSkuSnapshot(string $productSkuSnapshot): self
+    {
+        $this->productSkuSnapshot = strtoupper(trim($productSkuSnapshot));
+
+        return $this;
+    }
+}
+

--- a/src/Shop/Domain/Enum/OrderStatus.php
+++ b/src/Shop/Domain/Enum/OrderStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Domain\Enum;
+
+enum OrderStatus: string
+{
+    case DRAFT = 'draft';
+    case PENDING_PAYMENT = 'pending_payment';
+    case PAID = 'paid';
+    case FAILED = 'failed';
+    case CANCELLED = 'cancelled';
+}
+

--- a/src/Shop/Infrastructure/Repository/OrderItemRepository.php
+++ b/src/Shop/Infrastructure/Repository/OrderItemRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Shop\Domain\Entity\OrderItem as Entity;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class OrderItemRepository extends BaseRepository
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+}
+

--- a/src/Shop/Infrastructure/Repository/OrderRepository.php
+++ b/src/Shop/Infrastructure/Repository/OrderRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Shop\Domain\Entity\Order as Entity;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class OrderRepository extends BaseRepository
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+}
+

--- a/src/Shop/Transport/Controller/Api/V1/Checkout/CheckoutController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Checkout/CheckoutController.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Checkout;
+
+use App\Shop\Application\Message\CheckoutCommand;
+use App\Shop\Domain\Entity\Order;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class CheckoutController
+{
+    public function __construct(
+        private Security $security,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    #[Route('/v1/shop/checkout/{shopId}', methods: [Request::METHOD_POST])]
+    public function __invoke(string $shopId, Request $request): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');
+        }
+
+        $payload = (array) json_decode((string) $request->getContent(), true);
+
+        $billingAddress = trim((string) ($payload['billingAddress'] ?? ''));
+        $shippingAddress = trim((string) ($payload['shippingAddress'] ?? ''));
+        $email = trim((string) ($payload['email'] ?? ''));
+        $phone = trim((string) ($payload['phone'] ?? ''));
+        $shippingMethod = trim((string) ($payload['shippingMethod'] ?? ''));
+
+        if ($billingAddress === '' || $shippingAddress === '' || $email === '' || $phone === '' || $shippingMethod === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Missing required checkout payload.');
+        }
+
+        $envelope = $this->messageBus->dispatch(new CheckoutCommand(
+            operationId: $request->headers->get('x-request-id', uniqid('checkout-', true)),
+            shopId: $shopId,
+            userId: $user->getId(),
+            billingAddress: $billingAddress,
+            shippingAddress: $shippingAddress,
+            email: $email,
+            phone: $phone,
+            shippingMethod: $shippingMethod,
+        ));
+
+        /** @var HandledStamp|null $handled */
+        $handled = $envelope->last(HandledStamp::class);
+        $order = $handled?->getResult();
+        if (!$order instanceof Order) {
+            return new JsonResponse(['message' => 'Checkout command accepted.'], JsonResponse::HTTP_ACCEPTED);
+        }
+
+        return new JsonResponse([
+            'id' => $order->getId(),
+            'status' => $order->getStatus()->value,
+            'subtotal' => $order->getSubtotal(),
+            'itemsCount' => $order->getItems()->count(),
+            'createdAt' => $order->getCreatedAt()?->format(DATE_ATOM),
+        ], JsonResponse::HTTP_CREATED);
+    }
+}

--- a/tests/Unit/Shop/Application/MessageHandler/CheckoutCommandHandlerTest.php
+++ b/tests/Unit/Shop/Application/MessageHandler/CheckoutCommandHandlerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shop\Application\MessageHandler;
+
+use App\Shop\Application\Message\CheckoutCommand;
+use App\Shop\Application\MessageHandler\CheckoutCommandHandler;
+use App\Shop\Application\Service\CheckoutService;
+use App\Shop\Domain\Entity\Order;
+use App\Shop\Infrastructure\Repository\OrderRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
+
+final class CheckoutCommandHandlerTest extends TestCase
+{
+    public function testInvokeExecutesCheckoutInTransaction(): void
+    {
+        $command = new CheckoutCommand('op', 'shop-id', 'user-id', 'a', 'b', 'c@d.test', '123', 'pickup');
+        $order = new Order();
+
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->expects(self::once())
+            ->method('transactional')
+            ->willReturnCallback(static fn (callable $callback) => $callback());
+
+        $entityManager = $this->createMock(EntityManager::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository->method('getEntityManager')->willReturn($entityManager);
+
+        $checkoutService = $this->createMock(CheckoutService::class);
+        $checkoutService->expects(self::once())->method('checkout')->with($command)->willReturn($order);
+
+        $handler = new CheckoutCommandHandler($checkoutService, $orderRepository);
+
+        self::assertSame($order, $handler($command));
+    }
+}

--- a/tests/Unit/Shop/Application/MessageHandler/CheckoutServiceTest.php
+++ b/tests/Unit/Shop/Application/MessageHandler/CheckoutServiceTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shop\Application\MessageHandler;
+
+use App\Shop\Application\Message\CheckoutCommand;
+use App\Shop\Application\Service\CheckoutService;
+use App\Shop\Domain\Entity\Cart;
+use App\Shop\Domain\Entity\CartItem;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\CartItemRepository;
+use App\Shop\Infrastructure\Repository\CartRepository;
+use App\Shop\Infrastructure\Repository\OrderItemRepository;
+use App\Shop\Infrastructure\Repository\OrderRepository;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class CheckoutServiceTest extends TestCase
+{
+    public function testCheckoutSuccessCreatesOrderAndClearsCart(): void
+    {
+        $shop = (new Shop())->setName('Shop');
+        $user = (new User())->setEmail('john@doe.test');
+        $product = (new Product())
+            ->setShop($shop)
+            ->setName('Gaming Keyboard')
+            ->setSku('kb-01')
+            ->setPrice(49.9)
+            ->setStock(10);
+
+        $cartItem = (new CartItem())
+            ->setProduct($product)
+            ->setQuantity(2)
+            ->setUnitPriceSnapshot($product->getPrice())
+            ->setLineTotal(99.8);
+
+        $cart = (new Cart())
+            ->setShop($shop)
+            ->setUser($user)
+            ->setIsActive(true)
+            ->setItemsCount(2)
+            ->setSubtotal(99.8)
+            ->addItem($cartItem);
+
+        $service = $this->buildService($shop, $user, $cart, $product);
+
+        $order = $service->checkout($this->command($shop, $user));
+
+        self::assertSame(8, $product->getStock());
+        self::assertFalse($cart->isActive());
+        self::assertSame(0, $cart->getItemsCount());
+        self::assertSame(0.0, $cart->getSubtotal());
+        self::assertSame(99.8, $order->getSubtotal());
+        self::assertCount(1, $order->getItems());
+    }
+
+    public function testCheckoutThrowsWhenStockIsInsufficient(): void
+    {
+        $shop = (new Shop())->setName('Shop');
+        $user = new User();
+        $product = (new Product())
+            ->setShop($shop)
+            ->setName('Mouse')
+            ->setSku('mouse-01')
+            ->setPrice(10)
+            ->setStock(1);
+
+        $cart = (new Cart())
+            ->setShop($shop)
+            ->setUser($user)
+            ->setIsActive(true)
+            ->addItem((new CartItem())->setProduct($product)->setQuantity(2));
+
+        $service = $this->buildService($shop, $user, $cart, $product);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Insufficient stock');
+
+        try {
+            $service->checkout($this->command($shop, $user));
+        } catch (HttpException $exception) {
+            self::assertSame(JsonResponse::HTTP_CONFLICT, $exception->getStatusCode());
+            throw $exception;
+        }
+    }
+
+    public function testCheckoutThrowsWhenCartIsEmpty(): void
+    {
+        $shop = (new Shop())->setName('Shop');
+        $user = new User();
+        $cart = (new Cart())
+            ->setShop($shop)
+            ->setUser($user)
+            ->setIsActive(true);
+
+        $service = $this->buildService($shop, $user, $cart, null);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Cart is empty.');
+
+        $service->checkout($this->command($shop, $user));
+    }
+
+    private function buildService(Shop $shop, User $user, Cart $cart, ?Product $product): CheckoutService
+    {
+        $cartRepository = $this->createMock(CartRepository::class);
+        $cartRepository->method('findActiveByUserAndShop')->willReturn($cart);
+        $cartRepository->method('save');
+
+        $cartItemRepository = $this->createMock(CartItemRepository::class);
+        $cartItemRepository->method('remove');
+
+        $productRepository = $this->createMock(ProductRepository::class);
+        $productRepository->method('find')->willReturn($product);
+        $productRepository->method('save');
+
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository->method('save');
+
+        $orderItemRepository = $this->createMock(OrderItemRepository::class);
+        $orderItemRepository->method('save');
+
+        $shopRepository = $this->createMock(ShopRepository::class);
+        $shopRepository->method('find')->willReturn($shop);
+
+        $userRepository = $this->createMock(UserRepository::class);
+        $userRepository->method('find')->willReturn($user);
+
+        return new CheckoutService(
+            cartRepository: $cartRepository,
+            cartItemRepository: $cartItemRepository,
+            productRepository: $productRepository,
+            orderRepository: $orderRepository,
+            orderItemRepository: $orderItemRepository,
+            shopRepository: $shopRepository,
+            userRepository: $userRepository,
+        );
+    }
+
+    private function command(Shop $shop, User $user): CheckoutCommand
+    {
+        return new CheckoutCommand(
+            operationId: 'op',
+            shopId: $shop->getId(),
+            userId: $user->getId(),
+            billingAddress: '10 Main street',
+            shippingAddress: '20 Main street',
+            email: 'john@doe.test',
+            phone: '123456',
+            shippingMethod: 'express',
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Skills used: none — implementation performed directly in repository files.
- Introduce a first-class `Order` aggregate to persist completed purchases and track lifecycle (`draft` → `pending_payment` → `paid`/`failed`/`cancelled`) and to enable stock-safe checkouts.
- Provide an application-level checkout flow that validates cart contents, reserves/decrements stock transactionally and clears the cart upon success.

### Description
- Add `OrderStatus` enum with values `draft`, `pending_payment`, `paid`, `failed`, `cancelled` in `src/Shop/Domain/Enum/OrderStatus.php`.
- Add Doctrine entities `Order` and `OrderItem` with snapshots (`product_name_snapshot`, `product_sku_snapshot`, `unit_price_snapshot`), relations and indexes in `src/Shop/Domain/Entity/Order.php` and `src/Shop/Domain/Entity/OrderItem.php`.
- Add repositories `OrderRepository` and `OrderItemRepository` in `src/Shop/Infrastructure/Repository/` for consistent persistence usage.
- Implement `CheckoutCommand` and a synchronous `CheckoutCommandHandler` (transaction wrapped) and a `CheckoutService` that: loads the active cart, validates non-empty cart, checks product stock with `PESSIMISTIC_WRITE`, creates `Order` + `OrderItem` snapshots, decrements product stock, and clears/deactivates the cart; files: `src/Shop/Application/Message/CheckoutCommand.php`, `src/Shop/Application/MessageHandler/CheckoutCommandHandler.php`, `src/Shop/Application/Service/CheckoutService.php`.
- Expose API endpoint `POST /v1/shop/checkout/{shopId}` in `src/Shop/Transport/Controller/Api/V1/Checkout/CheckoutController.php` which validates minimal payload (`billingAddress`, `shippingAddress`, `email`, `phone`, `shippingMethod`) and returns `201` with order summary or `202` if the message is handled asynchronously.
- Add Doctrine migration `migrations/Version20260311223000.php` to create `shop_order` and `shop_order_item` tables with FK constraints and indexes (`status`, `created_at`, `shop_id`, `user_id`).
- Add unit tests under `tests/Unit/Shop/Application/MessageHandler/` covering success, insufficient stock, empty cart, and transaction wrapping by the handler.

### Testing
- Static PHP linting was run with `php -l` on all added files and returned `No syntax errors detected` for each added file.
- Unit tests could not be executed in this environment because project test binaries are not available; attempts to run `vendor/bin/phpunit` and `tools/01_phpunit/vendor/bin/phpunit` failed due to missing executables. 
- The transactional behavior of the handler is covered by `tests/Unit/Shop/Application/MessageHandler/CheckoutCommandHandlerTest.php` and business scenarios by `tests/Unit/Shop/Application/MessageHandler/CheckoutServiceTest.php` (tests added to the repo, but not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b49e10088326b30ed7fe10c3be9f)