### PR TITLE
Add mock payment flow with PaymentTransaction, service, provider and API endpoints

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -128,6 +128,9 @@ services:
         arguments:
             $serializer: '@app.serializer.external_message'
 
+    App\Shop\Domain\Service\Interfaces\PaymentProviderInterface:
+        class: App\Shop\Infrastructure\Payment\MockPaymentProvider
+
 when@dev:
     services:
         _defaults:

--- a/src/Shop/Application/Service/PaymentService.php
+++ b/src/Shop/Application/Service/PaymentService.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Service;
+
+use App\Shop\Domain\Entity\PaymentTransaction;
+use App\Shop\Domain\Entity\Order;
+use App\Shop\Domain\Enum\OrderStatus;
+use App\Shop\Domain\Enum\PaymentStatus;
+use App\Shop\Domain\Service\Interfaces\PaymentProviderInterface;
+use App\Shop\Infrastructure\Repository\OrderRepository;
+use App\Shop\Infrastructure\Repository\PaymentTransactionRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+use function in_array;
+
+final readonly class PaymentService
+{
+    public function __construct(
+        private OrderRepository $orderRepository,
+        private PaymentTransactionRepository $paymentTransactionRepository,
+        private PaymentProviderInterface $paymentProvider,
+    ) {
+    }
+
+    public function createPaymentIntent(string $orderId): PaymentTransaction
+    {
+        $order = $this->orderRepository->find($orderId);
+        if ($order === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Order not found.');
+        }
+
+        if ($order->getStatus() !== OrderStatus::PENDING_PAYMENT) {
+            throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Order is not in pending_payment status.');
+        }
+
+        $providerIntent = $this->paymentProvider->createIntent(
+            orderId: $order->getId(),
+            amount: $order->getSubtotal(),
+            currency: 'EUR',
+            metadata: ['orderId' => $order->getId()],
+        );
+
+        $transaction = (new PaymentTransaction())
+            ->setOrder($order)
+            ->setProvider((string) $providerIntent['provider'])
+            ->setProviderReference((string) $providerIntent['providerReference'])
+            ->setAmount($order->getSubtotal())
+            ->setCurrency('EUR')
+            ->setStatus($this->resolvePaymentStatus((string) $providerIntent['status']))
+            ->setPayload((array) ($providerIntent['payload'] ?? []));
+
+        $this->paymentTransactionRepository->save($transaction, true);
+
+        return $transaction;
+    }
+
+    /** @param array<string, mixed> $payload */
+    public function confirmPayment(string $orderId, string $providerReference, array $payload = []): PaymentTransaction
+    {
+        $order = $this->orderRepository->find($orderId);
+        if ($order === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Order not found.');
+        }
+
+        $transaction = $this->paymentTransactionRepository->findOneBy([
+            'order' => $order,
+            'providerReference' => $providerReference,
+        ]);
+
+        if (!$transaction instanceof PaymentTransaction) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Payment transaction not found.');
+        }
+
+        $providerResponse = $this->paymentProvider->confirm($providerReference, $payload);
+        $transaction->setStatus($this->resolvePaymentStatus((string) $providerResponse['status']));
+        $transaction->setPayload((array) ($providerResponse['payload'] ?? []));
+
+        $this->applyOrderStateFromPayment($order, $transaction->getStatus());
+
+        $this->orderRepository->save($order, false);
+        $this->paymentTransactionRepository->save($transaction, true);
+
+        return $transaction;
+    }
+
+    /** @param array<string, mixed> $payload */
+    public function processWebhook(array $payload, ?string $signature = null): ?PaymentTransaction
+    {
+        $verifiedPayload = $this->paymentProvider->verifyWebhook($payload, $signature);
+        if ($verifiedPayload === null) {
+            return null;
+        }
+
+        if ($this->paymentTransactionRepository->findOneBy([
+            'webhookIdempotenceKey' => $verifiedPayload['webhookKey'],
+        ]) instanceof PaymentTransaction) {
+            return null;
+        }
+
+        $transaction = $this->paymentTransactionRepository->findOneBy([
+            'provider' => $verifiedPayload['provider'],
+            'providerReference' => $verifiedPayload['providerReference'],
+        ]);
+
+        if (!$transaction instanceof PaymentTransaction) {
+            return null;
+        }
+
+        $transaction
+            ->setStatus($this->resolvePaymentStatus((string) $verifiedPayload['status']))
+            ->setWebhookIdempotenceKey((string) $verifiedPayload['webhookKey'])
+            ->setPayload((array) ($verifiedPayload['payload'] ?? []));
+
+        $order = $transaction->getOrder();
+        if ($order !== null) {
+            $this->applyOrderStateFromPayment($order, $transaction->getStatus());
+            $this->orderRepository->save($order, false);
+        }
+
+        $this->paymentTransactionRepository->save($transaction, true);
+
+        return $transaction;
+    }
+
+    private function applyOrderStateFromPayment(Order $order, PaymentStatus $status): void
+    {
+        if ($status === PaymentStatus::SUCCEEDED) {
+            $order->setStatus(OrderStatus::PAID);
+
+            return;
+        }
+
+        if (in_array($status, [PaymentStatus::FAILED], true)) {
+            $order->setStatus(OrderStatus::FAILED);
+        }
+    }
+
+    private function resolvePaymentStatus(string $status): PaymentStatus
+    {
+        return match ($status) {
+            PaymentStatus::REQUIRES_CONFIRMATION->value => PaymentStatus::REQUIRES_CONFIRMATION,
+            PaymentStatus::SUCCEEDED->value => PaymentStatus::SUCCEEDED,
+            PaymentStatus::FAILED->value => PaymentStatus::FAILED,
+            default => PaymentStatus::CREATED,
+        };
+    }
+}

--- a/src/Shop/Domain/Entity/PaymentTransaction.php
+++ b/src/Shop/Domain/Entity/PaymentTransaction.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Shop\Domain\Enum\PaymentStatus;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'shop_payment_transaction')]
+#[ORM\UniqueConstraint(name: 'uniq_shop_payment_provider_reference', columns: ['provider', 'provider_reference'])]
+#[ORM\UniqueConstraint(name: 'uniq_shop_payment_webhook_key', columns: ['webhook_idempotence_key'])]
+#[ORM\Index(name: 'idx_shop_payment_order_id', columns: ['order_id'])]
+#[ORM\Index(name: 'idx_shop_payment_status', columns: ['status'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class PaymentTransaction implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Order::class)]
+    #[ORM\JoinColumn(name: 'order_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?Order $order = null;
+
+    #[ORM\Column(name: 'provider', type: Types::STRING, length: 80)]
+    private string $provider = '';
+
+    #[ORM\Column(name: 'provider_reference', type: Types::STRING, length: 190)]
+    private string $providerReference = '';
+
+    #[ORM\Column(name: 'amount', type: Types::FLOAT)]
+    private float $amount = 0.0;
+
+    #[ORM\Column(name: 'currency', type: Types::STRING, length: 3)]
+    private string $currency = 'EUR';
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 40, enumType: PaymentStatus::class)]
+    private PaymentStatus $status = PaymentStatus::CREATED;
+
+    /** @var array<string, mixed> */
+    #[ORM\Column(name: 'payload', type: Types::JSON)]
+    private array $payload = [];
+
+    #[ORM\Column(name: 'webhook_idempotence_key', type: Types::STRING, length: 190, nullable: true)]
+    private ?string $webhookIdempotenceKey = null;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getOrder(): ?Order
+    {
+        return $this->order;
+    }
+
+    public function setOrder(?Order $order): self
+    {
+        $this->order = $order;
+
+        return $this;
+    }
+
+    public function getProvider(): string
+    {
+        return $this->provider;
+    }
+
+    public function setProvider(string $provider): self
+    {
+        $this->provider = trim($provider);
+
+        return $this;
+    }
+
+    public function getProviderReference(): string
+    {
+        return $this->providerReference;
+    }
+
+    public function setProviderReference(string $providerReference): self
+    {
+        $this->providerReference = trim($providerReference);
+
+        return $this;
+    }
+
+    public function getAmount(): float
+    {
+        return $this->amount;
+    }
+
+    public function setAmount(float $amount): self
+    {
+        $this->amount = max(0, $amount);
+
+        return $this;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function setCurrency(string $currency): self
+    {
+        $this->currency = strtoupper(trim($currency));
+
+        return $this;
+    }
+
+    public function getStatus(): PaymentStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(PaymentStatus $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function setPayload(array $payload): self
+    {
+        $this->payload = $payload;
+
+        return $this;
+    }
+
+    public function getWebhookIdempotenceKey(): ?string
+    {
+        return $this->webhookIdempotenceKey;
+    }
+
+    public function setWebhookIdempotenceKey(?string $webhookIdempotenceKey): self
+    {
+        $this->webhookIdempotenceKey = $webhookIdempotenceKey !== null ? trim($webhookIdempotenceKey) : null;
+
+        return $this;
+    }
+}

--- a/src/Shop/Domain/Enum/PaymentStatus.php
+++ b/src/Shop/Domain/Enum/PaymentStatus.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Domain\Enum;
+
+enum PaymentStatus: string
+{
+    case CREATED = 'created';
+    case REQUIRES_CONFIRMATION = 'requires_confirmation';
+    case SUCCEEDED = 'succeeded';
+    case FAILED = 'failed';
+}

--- a/src/Shop/Domain/Service/Interfaces/PaymentProviderInterface.php
+++ b/src/Shop/Domain/Service/Interfaces/PaymentProviderInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Domain\Service\Interfaces;
+
+interface PaymentProviderInterface
+{
+    /**
+     * @param array<string, mixed> $metadata
+     *
+     * @return array{provider:string,providerReference:string,status:string,payload:array<string,mixed>}
+     */
+    public function createIntent(string $orderId, float $amount, string $currency, array $metadata = []): array;
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array{provider:string,providerReference:string,status:string,payload:array<string,mixed>}
+     */
+    public function confirm(string $providerReference, array $payload = []): array;
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array{provider:string,providerReference:string,status:string,webhookKey:string,payload:array<string,mixed>}|null
+     */
+    public function verifyWebhook(array $payload, ?string $signature = null): ?array;
+}

--- a/src/Shop/Infrastructure/Payment/MockPaymentProvider.php
+++ b/src/Shop/Infrastructure/Payment/MockPaymentProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Infrastructure\Payment;
+
+use App\Shop\Domain\Service\Interfaces\PaymentProviderInterface;
+
+use function is_array;
+use function is_string;
+use function sprintf;
+use function trim;
+use function uniqid;
+
+final class MockPaymentProvider implements PaymentProviderInterface
+{
+    public function createIntent(string $orderId, float $amount, string $currency, array $metadata = []): array
+    {
+        $reference = sprintf('mock_intent_%s', uniqid('', true));
+
+        return [
+            'provider' => 'mock',
+            'providerReference' => $reference,
+            'status' => 'requires_confirmation',
+            'payload' => [
+                'orderId' => $orderId,
+                'amount' => $amount,
+                'currency' => $currency,
+                'metadata' => $metadata,
+            ],
+        ];
+    }
+
+    public function confirm(string $providerReference, array $payload = []): array
+    {
+        $shouldFail = (bool) ($payload['forceFail'] ?? false);
+
+        return [
+            'provider' => 'mock',
+            'providerReference' => trim($providerReference),
+            'status' => $shouldFail ? 'failed' : 'succeeded',
+            'payload' => [
+                'confirmed' => true,
+                'forceFail' => $shouldFail,
+                ...$payload,
+            ],
+        ];
+    }
+
+    public function verifyWebhook(array $payload, ?string $signature = null): ?array
+    {
+        $providerReference = $payload['providerReference'] ?? null;
+        $status = $payload['status'] ?? null;
+        $eventId = $payload['eventId'] ?? null;
+
+        if (!is_string($providerReference) || !is_string($status) || !is_string($eventId)) {
+            return null;
+        }
+
+        return [
+            'provider' => 'mock',
+            'providerReference' => trim($providerReference),
+            'status' => trim($status),
+            'webhookKey' => trim($eventId),
+            'payload' => is_array($payload['payload'] ?? null) ? $payload['payload'] : $payload,
+        ];
+    }
+}

--- a/src/Shop/Infrastructure/Repository/PaymentTransactionRepository.php
+++ b/src/Shop/Infrastructure/Repository/PaymentTransactionRepository.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Shop\Domain\Entity\PaymentTransaction as Entity;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity|null findOneBy(array $criteria, ?array $orderBy = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class PaymentTransactionRepository extends BaseRepository
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+        'provider',
+        'providerReference',
+        'status',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Payment/ConfirmPaymentController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/ConfirmPaymentController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Payment;
+
+use App\Shop\Application\Service\PaymentService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+final readonly class ConfirmPaymentController
+{
+    public function __construct(
+        private PaymentService $paymentService,
+    ) {
+    }
+
+    #[Route('/v1/shop/orders/{orderId}/payment-confirm', methods: [Request::METHOD_POST])]
+    public function __invoke(string $orderId, Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $providerReference = trim((string) ($payload['providerReference'] ?? ''));
+
+        if ($providerReference === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'providerReference is required.');
+        }
+
+        $transaction = $this->paymentService->confirmPayment($orderId, $providerReference, $payload);
+
+        return new JsonResponse([
+            'id' => $transaction->getId(),
+            'orderId' => $transaction->getOrder()?->getId(),
+            'provider' => $transaction->getProvider(),
+            'providerReference' => $transaction->getProviderReference(),
+            'status' => $transaction->getStatus()->value,
+        ]);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Payment/CreatePaymentIntentController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/CreatePaymentIntentController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Payment;
+
+use App\Shop\Application\Service\PaymentService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+final readonly class CreatePaymentIntentController
+{
+    public function __construct(
+        private PaymentService $paymentService,
+    ) {
+    }
+
+    #[Route('/v1/shop/orders/{orderId}/payment-intent', methods: [Request::METHOD_POST])]
+    public function __invoke(string $orderId): JsonResponse
+    {
+        $transaction = $this->paymentService->createPaymentIntent($orderId);
+
+        return new JsonResponse([
+            'id' => $transaction->getId(),
+            'orderId' => $transaction->getOrder()?->getId(),
+            'provider' => $transaction->getProvider(),
+            'providerReference' => $transaction->getProviderReference(),
+            'status' => $transaction->getStatus()->value,
+            'amount' => $transaction->getAmount(),
+            'currency' => $transaction->getCurrency(),
+        ], JsonResponse::HTTP_CREATED);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Payment/PaymentWebhookController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/PaymentWebhookController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Payment;
+
+use App\Shop\Application\Service\PaymentService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+final readonly class PaymentWebhookController
+{
+    public function __construct(
+        private PaymentService $paymentService,
+    ) {
+    }
+
+    #[Route('/v1/shop/payments/webhook', methods: [Request::METHOD_POST])]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $payload = (array) json_decode((string) $request->getContent(), true);
+        $signature = $request->headers->get('x-signature');
+
+        $transaction = $this->paymentService->processWebhook($payload, $signature);
+
+        if ($transaction === null) {
+            return new JsonResponse(['processed' => false], JsonResponse::HTTP_ACCEPTED);
+        }
+
+        return new JsonResponse([
+            'processed' => true,
+            'transactionId' => $transaction->getId(),
+            'providerReference' => $transaction->getProviderReference(),
+            'status' => $transaction->getStatus()->value,
+        ]);
+    }
+}

--- a/tests/Unit/Shop/Application/Service/PaymentServiceTest.php
+++ b/tests/Unit/Shop/Application/Service/PaymentServiceTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shop\Application\Service;
+
+use App\Shop\Application\Service\PaymentService;
+use App\Shop\Domain\Entity\Order;
+use App\Shop\Domain\Entity\PaymentTransaction;
+use App\Shop\Domain\Enum\OrderStatus;
+use App\Shop\Domain\Enum\PaymentStatus;
+use App\Shop\Domain\Service\Interfaces\PaymentProviderInterface;
+use App\Shop\Infrastructure\Repository\OrderRepository;
+use App\Shop\Infrastructure\Repository\PaymentTransactionRepository;
+use PHPUnit\Framework\TestCase;
+
+final class PaymentServiceTest extends TestCase
+{
+    public function testCreatePaymentIntentForPendingOrder(): void
+    {
+        $order = (new Order())
+            ->setStatus(OrderStatus::PENDING_PAYMENT)
+            ->setSubtotal(42.5);
+
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository->method('find')->willReturn($order);
+
+        $paymentTransactionRepository = $this->createMock(PaymentTransactionRepository::class);
+        $paymentTransactionRepository->expects(self::once())->method('save');
+
+        $paymentProvider = $this->createMock(PaymentProviderInterface::class);
+        $paymentProvider->method('createIntent')->willReturn([
+            'provider' => 'mock',
+            'providerReference' => 'mock-ref-1',
+            'status' => 'requires_confirmation',
+            'payload' => ['intent' => true],
+        ]);
+
+        $service = new PaymentService($orderRepository, $paymentTransactionRepository, $paymentProvider);
+
+        $transaction = $service->createPaymentIntent($order->getId());
+
+        self::assertSame('mock-ref-1', $transaction->getProviderReference());
+        self::assertSame(PaymentStatus::REQUIRES_CONFIRMATION, $transaction->getStatus());
+        self::assertSame(OrderStatus::PENDING_PAYMENT, $order->getStatus());
+    }
+
+    public function testConfirmPaymentMarksOrderPaid(): void
+    {
+        $order = (new Order())
+            ->setStatus(OrderStatus::PENDING_PAYMENT)
+            ->setSubtotal(99.9);
+
+        $transaction = (new PaymentTransaction())
+            ->setOrder($order)
+            ->setProvider('mock')
+            ->setProviderReference('mock-ref-2')
+            ->setStatus(PaymentStatus::REQUIRES_CONFIRMATION);
+
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository->method('find')->willReturn($order);
+        $orderRepository->expects(self::once())->method('save');
+
+        $paymentTransactionRepository = $this->createMock(PaymentTransactionRepository::class);
+        $paymentTransactionRepository->method('findOneBy')->willReturn($transaction);
+        $paymentTransactionRepository->expects(self::once())->method('save');
+
+        $paymentProvider = $this->createMock(PaymentProviderInterface::class);
+        $paymentProvider->method('confirm')->willReturn([
+            'provider' => 'mock',
+            'providerReference' => 'mock-ref-2',
+            'status' => 'succeeded',
+            'payload' => ['confirmed' => true],
+        ]);
+
+        $service = new PaymentService($orderRepository, $paymentTransactionRepository, $paymentProvider);
+        $service->confirmPayment($order->getId(), 'mock-ref-2');
+
+        self::assertSame(OrderStatus::PAID, $order->getStatus());
+        self::assertSame(PaymentStatus::SUCCEEDED, $transaction->getStatus());
+    }
+
+    public function testProcessWebhookIsIdempotentWithWebhookKey(): void
+    {
+        $order = (new Order())
+            ->setStatus(OrderStatus::PENDING_PAYMENT)
+            ->setSubtotal(25.0);
+
+        $transaction = (new PaymentTransaction())
+            ->setOrder($order)
+            ->setProvider('mock')
+            ->setProviderReference('mock-ref-3')
+            ->setStatus(PaymentStatus::REQUIRES_CONFIRMATION);
+
+        $orderRepository = $this->createMock(OrderRepository::class);
+        $orderRepository->expects(self::once())->method('save');
+
+        $paymentTransactionRepository = $this->createMock(PaymentTransactionRepository::class);
+        $paymentTransactionRepository
+            ->method('findOneBy')
+            ->willReturnCallback(static function (array $criteria) use ($transaction): ?PaymentTransaction {
+                if (isset($criteria['webhookIdempotenceKey']) && $criteria['webhookIdempotenceKey'] === 'evt-duplicated') {
+                    return new PaymentTransaction();
+                }
+
+                if (isset($criteria['providerReference']) && $criteria['providerReference'] === 'mock-ref-3') {
+                    return $transaction;
+                }
+
+                return null;
+            });
+        $paymentTransactionRepository->expects(self::once())->method('save');
+
+        $paymentProvider = $this->createMock(PaymentProviderInterface::class);
+        $paymentProvider->method('verifyWebhook')
+            ->willReturnOnConsecutiveCalls(
+                [
+                    'provider' => 'mock',
+                    'providerReference' => 'mock-ref-3',
+                    'status' => 'failed',
+                    'webhookKey' => 'evt-1',
+                    'payload' => ['a' => 1],
+                ],
+                [
+                    'provider' => 'mock',
+                    'providerReference' => 'mock-ref-3',
+                    'status' => 'failed',
+                    'webhookKey' => 'evt-duplicated',
+                    'payload' => ['a' => 1],
+                ],
+            );
+
+        $service = new PaymentService($orderRepository, $paymentTransactionRepository, $paymentProvider);
+
+        $processed = $service->processWebhook(['eventId' => 'evt-1']);
+        $ignored = $service->processWebhook(['eventId' => 'evt-duplicated']);
+
+        self::assertInstanceOf(PaymentTransaction::class, $processed);
+        self::assertNull($ignored);
+        self::assertSame(OrderStatus::FAILED, $order->getStatus());
+        self::assertSame('evt-1', $transaction->getWebhookIdempotenceKey());
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a local, testable payment flow so orders can transition from `pending_payment` to `paid`/`failed` and webhooks can be consumed without an external provider.

### Description
- Add `PaymentTransaction` entity with fields `order`, `provider`, `providerReference`, `amount`, `currency`, `status`, `payload` and `webhook_idempotence_key` plus uniqueness constraints for `(provider, provider_reference)` and `webhook_idempotence_key`.
- Add `PaymentStatus` enum and `PaymentTransactionRepository` for transaction persistence and queries.
- Define `PaymentProviderInterface` (`createIntent`, `confirm`, `verifyWebhook`) and provide a `MockPaymentProvider` implementation wired in `config/services.yaml` to allow local flows.
- Implement `PaymentService` to create payment intents, confirm payments, apply order status transitions, and process webhooks with idempotence; expose API controllers for `POST /v1/shop/orders/{orderId}/payment-intent`, `POST /v1/shop/orders/{orderId}/payment-confirm`, and `POST /v1/shop/payments/webhook`.
- Add unit tests at `tests/Unit/Shop/Application/Service/PaymentServiceTest.php` covering intent creation, confirmation -> paid, and webhook idempotence behavior.

### Testing
- Ran `php -l` syntax checks on the added/updated files and they all passed without syntax errors.
- Attempted to run PHPUnit via `./vendor/bin/phpunit` and `tools/01_phpunit/vendor/bin/phpunit` but execution failed because the phpunit binary was not available in this environment, so automated tests were not executed here.
- Added unit tests (`tests/Unit/Shop/Application/Service/PaymentServiceTest.php`) that exercise key `PaymentService` transitions and idempotence for later CI/maintainer runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1b6fb6e40832687b3c68f10a9a3f5)