### PR TITLE
Add similar products service and include similarProducts in product details API

### DIFF
--- a/src/Shop/Application/Service/SimilarProductService.php
+++ b/src/Shop/Application/Service/SimilarProductService.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Service;
+
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+
+readonly class SimilarProductService
+{
+    public function __construct(private ProductRepository $productRepository)
+    {
+    }
+
+    /**
+     * @return array<int, Product>
+     */
+    public function getSimilarProducts(Product $product, int $limit = 8): array
+    {
+        return $this->productRepository->findSimilarCandidates($product, $limit);
+    }
+}

--- a/src/Shop/Infrastructure/Repository/ProductRepository.php
+++ b/src/Shop/Infrastructure/Repository/ProductRepository.php
@@ -6,6 +6,7 @@ namespace App\Shop\Infrastructure\Repository;
 
 use App\General\Infrastructure\Repository\BaseRepository;
 use App\Shop\Domain\Entity\Product as Entity;
+use App\Shop\Domain\Enum\ProductStatus;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -24,5 +25,42 @@ class ProductRepository extends BaseRepository
     public function __construct(
         protected ManagerRegistry $managerRegistry
     ) {
+    }
+
+    /**
+     * @return array<int, Entity>
+     */
+    public function findSimilarCandidates(Entity $product, int $limit = 8): array
+    {
+        $category = $product->getCategory();
+        $tagIds = array_map(static fn ($tag): string => $tag->getId(), $product->getTags()->toArray());
+
+        $qb = $this->createQueryBuilder('product')
+            ->addSelect('CASE WHEN product.category = :currentCategory THEN 1 ELSE 0 END AS HIDDEN categoryPriority')
+            ->addSelect('COUNT(DISTINCT sharedTag.id) AS HIDDEN sharedTagScore')
+            ->leftJoin('product.tags', 'sharedTag', 'WITH', 'sharedTag.id IN (:tagIds)')
+            ->where('product.id != :currentProductId')
+            ->andWhere('product.status = :activeStatus')
+            ->groupBy('product.id')
+            ->orderBy('categoryPriority', 'DESC')
+            ->addOrderBy('sharedTagScore', 'DESC')
+            ->addOrderBy('product.isFeatured', 'DESC')
+            ->addOrderBy('product.updatedAt', 'DESC')
+            ->setMaxResults($limit)
+            ->setParameter('currentCategory', $category)
+            ->setParameter('tagIds', $tagIds === [] ? ['__no_tag__'] : $tagIds)
+            ->setParameter('currentProductId', $product->getId())
+            ->setParameter('activeStatus', ProductStatus::ACTIVE);
+
+        if ($category !== null) {
+            $qb->andWhere('product.category = :currentCategory OR sharedTag.id IS NOT NULL OR product.isFeatured = true');
+        } else {
+            $qb->andWhere('sharedTag.id IS NOT NULL OR product.isFeatured = true');
+        }
+
+        /** @var array<int, Entity> $results */
+        $results = $qb->getQuery()->getResult();
+
+        return $results;
     }
 }

--- a/src/Shop/Transport/Controller/Api/V1/Product/GetProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/GetProductController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shop\Transport\Controller\Api\V1\Product;
 
 use App\Shop\Application\Service\ProductListService;
+use App\Shop\Application\Service\SimilarProductService;
 use App\Shop\Domain\Entity\Product;
 use App\Shop\Infrastructure\Repository\ProductRepository;
 use OpenApi\Attributes as OA;
@@ -20,8 +21,10 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class GetProductController
 {
-    public function __construct(private ProductRepository $productRepository)
-    {
+    public function __construct(
+        private ProductRepository $productRepository,
+        private SimilarProductService $similarProductService,
+    ) {
     }
 
     #[Route('/v1/shop/products/{id}', methods: [Request::METHOD_GET])]
@@ -32,6 +35,14 @@ final readonly class GetProductController
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }
 
-        return new JsonResponse(ProductListService::serializeProduct($product));
+        $similarProducts = array_map(
+            static fn (Product $similarProduct): array => ProductListService::serializeProduct($similarProduct),
+            $this->similarProductService->getSimilarProducts($product),
+        );
+
+        return new JsonResponse([
+            'product' => ProductListService::serializeProduct($product),
+            'similarProducts' => $similarProducts,
+        ]);
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a simple similar-products selection for product details prioritizing same category, scoring by shared tags, falling back to featured products, excluding the current product and only returning `status=active` items.
- No SKILL.md skill was required for this change since it is a direct code addition and repository/controller update.

### Description
- Add `SimilarProductService` (`src/Shop/Application/Service/SimilarProductService.php`) which delegates candidate retrieval to the repository and exposes `getSimilarProducts()` with a default limit of 8. 
- Implement `findSimilarCandidates()` in `ProductRepository` (`src/Shop/Infrastructure/Repository/ProductRepository.php`) using the QueryBuilder to exclude the current product, filter `status=active`, prioritize same-category matches, score by shared tags, fall back to `isFeatured=true`, order by priority/score/featured/updated date and limit results. 
- Update `GetProductController` (`src/Shop/Transport/Controller/Api/V1/Product/GetProductController.php`) to inject `SimilarProductService` and return an enriched JSON payload with `product` and `similarProducts` (each serialized with `ProductListService::serializeProduct`).

### Testing
- `php -l` syntax checks were executed for the three modified/added files and reported no syntax errors. 
- An attempt to run `vendor/bin/phpunit tests/Unit/ExampleTest.php` failed in this environment because the PHPUnit binary is not available. 
- No further automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1ba0fb0008326b3737d2538474982)