### PR TITLE
Add pagination and reverse-chronological ordering to general blog endpoints

### DIFF
--- a/src/Blog/Application/Service/BlogReadService.php
+++ b/src/Blog/Application/Service/BlogReadService.php
@@ -26,11 +26,14 @@ final readonly class BlogReadService
     /**
      * @throws InvalidArgumentException
      */
-    public function getGeneralBlogWithTree(?User $currentUser = null): array
+    public function getGeneralBlogWithTree(?User $currentUser = null, int $page = 1, int $limit = 20): array
     {
-        $cacheKey = $this->buildBlogCacheKey('general', $currentUser);
+        $page = max(1, $page);
+        $limit = max(1, min(100, $limit));
 
-        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($currentUser): array {
+        $cacheKey = $this->buildBlogCacheKey(sprintf('general?page=%d&limit=%d', $page, $limit), $currentUser);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($currentUser, $page, $limit): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->tagPublicBlog());
@@ -41,7 +44,7 @@ final readonly class BlogReadService
             }
             $blog = $this->blogRepository->findGeneralBlog();
 
-            return $blog instanceof Blog ? $this->normalizeBlog($blog, $currentUser) : [];
+            return $blog instanceof Blog ? $this->normalizeBlog($blog, $currentUser, $page, $limit) : [];
         });
     }
 
@@ -67,8 +70,16 @@ final readonly class BlogReadService
         });
     }
 
-    private function normalizeBlog(Blog $blog, ?User $currentUser): array
+    private function normalizeBlog(Blog $blog, ?User $currentUser, int $page = 1, int $limit = 20): array
     {
+        $posts = $blog->getPosts()->toArray();
+
+        usort($posts, static fn ($left, $right): int => $right->getCreatedAt() <=> $left->getCreatedAt());
+
+        $totalItems = count($posts);
+        $offset = ($page - 1) * $limit;
+        $posts = array_slice($posts, $offset, $limit);
+
         return [
             'id' => $blog->getId(),
             'title' => $blog->getTitle(),
@@ -96,7 +107,13 @@ final readonly class BlogReadService
                     'type' => $r->getType()->value,
                 ], $p->getReactions()->toArray()),
                 'comments' => $this->normalizeComments($p->getComments()->toArray(), null, $currentUser),
-            ], $blog->getPosts()->toArray()),
+            ], $posts),
+            'pagination' => [
+                'page' => $page,
+                'limit' => $limit,
+                'totalItems' => $totalItems,
+                'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
+            ],
         ];
     }
 

--- a/src/Blog/Transport/Controller/Api/V1/Read/GetGeneralBlogController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Read/GetGeneralBlogController.php
@@ -25,8 +25,11 @@ final readonly class GetGeneralBlogController
 
     #[Route('/v1/blogs/general', methods: [Request::METHOD_GET])]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
-    public function __invoke(User $loggedInUser): JsonResponse
+    public function __invoke(User $loggedInUser, Request $request): JsonResponse
     {
-        return new JsonResponse($this->blogReadService->getGeneralBlogWithTree($loggedInUser));
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+
+        return new JsonResponse($this->blogReadService->getGeneralBlogWithTree($loggedInUser, $page, $limit));
     }
 }

--- a/src/Blog/Transport/Controller/Api/V1/Read/GetPublicGeneralBlogController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Read/GetPublicGeneralBlogController.php
@@ -22,8 +22,11 @@ final readonly class GetPublicGeneralBlogController
 
     #[Route('/v1/blogs/general/public', methods: [Request::METHOD_GET])]
     #[OA\Get(security: [])]
-    public function __invoke(): JsonResponse
+    public function __invoke(Request $request): JsonResponse
     {
-        return new JsonResponse($this->blogReadService->getGeneralBlogWithTree());
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+
+        return new JsonResponse($this->blogReadService->getGeneralBlogWithTree(null, $page, $limit));
     }
 }


### PR DESCRIPTION
### Motivation
- Expose pagination for public and authenticated general blog endpoints so clients can request specific pages and control page size. 
- Ensure posts are returned in reverse chronological order so the first item in the response is the newest `createdAt` post. 
- Prevent cache key collisions between different pagination requests by including pagination parameters in the cache key. 

### Description
- Added `page` and `limit` query handling in `GET /v1/blogs/general` and `GET /v1/blogs/general/public` controllers and forwarded them to the service with bounds (`page >= 1`, `1 <= limit <= 100`).
- Extended `BlogReadService::getGeneralBlogWithTree` to accept `page` and `limit`, sanitize values, and include them in the cache key. 
- In `normalizeBlog` the posts are now collected, sorted by `createdAt` descending (newest first), sliced for pagination, and returned together with a `pagination` block containing `page`, `limit`, `totalItems`, and `totalPages`.
- Updated controllers and service signatures and adjusted the returned `posts` source to use the paginated/sorted slice.

### Testing
- Ran PHP syntax checks which succeeded: `php -l src/Blog/Application/Service/BlogReadService.php`, `php -l src/Blog/Transport/Controller/Api/V1/Read/GetGeneralBlogController.php`, and `php -l src/Blog/Transport/Controller/Api/V1/Read/GetPublicGeneralBlogController.php` (all reported no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1cfe8bccc8326b65371b5baf2726e)