### PR TITLE
Refactor v1 API routes to require application slug scoping

### DIFF
--- a/docs/application-slug-route-migration.md
+++ b/docs/application-slug-route-migration.md
@@ -1,0 +1,17 @@
+# Migration des routes API V1 vers un scope `applicationSlug`
+
+## Nouveau format
+Toutes les routes métier v1 ciblant `crm`, `recruit`, `shop` et `school` utilisent désormais le format:
+
+`/v1/{module}/{applicationSlug}/...`
+
+## Compatibilité legacy (stratégie)
+Pour conserver la compatibilité avec les clients existants:
+
+1. **Phase 1 (immédiate)**: publier les nouvelles routes et annoncer la dépréciation des anciennes routes `/v1/{module}/...`.
+2. **Phase 2 (2-4 semaines)**: ajouter au niveau gateway/reverse proxy des redirections 307 vers les nouveaux chemins quand un `applicationSlug` par défaut est connu.
+3. **Phase 3**: journaliser les appels legacy (tag `legacy_route=true`) et contacter les clients restants.
+4. **Phase 4**: supprimer les routes legacy après la fenêtre de migration.
+
+## Recommandation technique
+Quand le slug n'est pas dérivable automatiquement, retourner `400` avec un message explicite pour forcer la migration client.

--- a/src/Crm/Transport/Controller/Api/V1/Company/CreateCompanyController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/CreateCompanyController.php
@@ -29,8 +29,9 @@ final readonly class CreateCompanyController
     ) {
     }
 
-    #[Route('/v1/crm/companies', methods: [Request::METHOD_POST])]
-    #[OA\Post(summary: 'POST /v1/crm/companies', requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['payload'], properties: [
+    #[Route('/v1/crm/{applicationSlug}/companies', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Post(summary: 'POST /v1/crm/{applicationSlug}/companies', requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['payload'], properties: [
         new OA\Property(property: 'payload', type: 'object', example: [
             'value' => 'example',
         ])], example: [
@@ -38,8 +39,9 @@ final readonly class CreateCompanyController
                 'value' => 'example',
             ],
         ])))]
-    public function __invoke(Request $request): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $company = new Company();
         $company->setName((string)($payload['name'] ?? ''))

--- a/src/Crm/Transport/Controller/Api/V1/Company/DeleteCompanyController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/DeleteCompanyController.php
@@ -29,8 +29,9 @@ final readonly class DeleteCompanyController
     ) {
     }
 
-    #[Route('/v1/crm/companies/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/companies/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         $company = $this->companyRepository->find($id);
         if (!$company instanceof Company) {

--- a/src/Crm/Transport/Controller/Api/V1/Company/ListCompaniesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/ListCompaniesController.php
@@ -24,8 +24,9 @@ final readonly class ListCompaniesController
     ) {
     }
 
-    #[Route('/v1/crm/companies', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/companies', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug): JsonResponse
     {
         $items = array_map(static fn (Company $company): array => [
             'id' => $company->getId(),

--- a/src/Crm/Transport/Controller/Api/V1/CreateCompanyByApplicationController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CreateCompanyByApplicationController.php
@@ -29,10 +29,12 @@ final readonly class CreateCompanyByApplicationController
     ) {
     }
 
-    #[Route('/v1/crm/applications/{applicationSlug}/companies', methods: [Request::METHOD_POST])]
-    #[OA\Post(summary: 'POST /v1/crm/applications/{applicationSlug}/companies', tags: ['Crm'])]
+    #[Route('/v1/crm/{applicationSlug}/companies', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Post(summary: 'POST /v1/crm/{applicationSlug}/companies', tags: ['Crm'])]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
 

--- a/src/Crm/Transport/Controller/Api/V1/GetCrmDashboardController.php
+++ b/src/Crm/Transport/Controller/Api/V1/GetCrmDashboardController.php
@@ -30,8 +30,9 @@ final readonly class GetCrmDashboardController
     ) {
     }
 
-    #[Route('/v1/crm/dashboard', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/dashboard', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug): JsonResponse
     {
         return new JsonResponse([
             'companies' => $this->companyRepository->count([]),

--- a/src/Crm/Transport/Controller/Api/V1/ListCompaniesByApplicationController.php
+++ b/src/Crm/Transport/Controller/Api/V1/ListCompaniesByApplicationController.php
@@ -25,11 +25,12 @@ final readonly class ListCompaniesByApplicationController
     ) {
     }
 
-    #[Route('/v1/crm/applications/{applicationSlug}/companies', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/{applicationSlug}/companies', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
     #[OA\Response(response: 200, description: 'Companies list scoped to CRM application.')]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
 
         return new JsonResponse($this->companyApplicationListService->getList($request, $applicationSlug, $crm));

--- a/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
@@ -31,10 +31,12 @@ final readonly class CreateProjectController
     ) {
     }
 
-    #[Route('/v1/crm/projects', methods: [Request::METHOD_POST])]
-    #[OA\Post(summary: 'POST /v1/crm/projects')]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/projects', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Post(summary: 'POST /v1/crm/{applicationSlug}/projects')]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $project = new Project();
         $project->setName((string)($payload['name'] ?? ''))

--- a/src/Crm/Transport/Controller/Api/V1/Project/DeleteProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/DeleteProjectController.php
@@ -29,8 +29,9 @@ final readonly class DeleteProjectController
     ) {
     }
 
-    #[Route('/v1/crm/projects/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/projects/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         $project = $this->projectRepository->find($id);
         if (!$project instanceof Project) {

--- a/src/Crm/Transport/Controller/Api/V1/Project/ListProjectsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/ListProjectsController.php
@@ -24,8 +24,9 @@ final readonly class ListProjectsController
     ) {
     }
 
-    #[Route('/v1/crm/projects', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/projects', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug): JsonResponse
     {
         $items = array_map(static fn (Project $project): array => [
             'id' => $project->getId(),

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/CreateSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/CreateSprintController.php
@@ -31,10 +31,12 @@ final readonly class CreateSprintController
     ) {
     }
 
-    #[Route('/v1/crm/sprints', methods: [Request::METHOD_POST])]
-    #[OA\Post(summary: 'POST /v1/crm/sprints')]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/sprints', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Post(summary: 'POST /v1/crm/{applicationSlug}/sprints')]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $sprint = new Sprint();
         $sprint->setName((string)($payload['name'] ?? ''))

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/DeleteSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/DeleteSprintController.php
@@ -29,8 +29,9 @@ final readonly class DeleteSprintController
     ) {
     }
 
-    #[Route('/v1/crm/sprints/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/sprints/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         $sprint = $this->sprintRepository->find($id);
         if (!$sprint instanceof Sprint) {

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/ListSprintsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/ListSprintsController.php
@@ -24,8 +24,9 @@ final readonly class ListSprintsController
     ) {
     }
 
-    #[Route('/v1/crm/sprints', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/sprints', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug): JsonResponse
     {
         $items = array_map(static fn (Sprint $sprint): array => [
             'id' => $sprint->getId(),

--- a/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
@@ -34,10 +34,12 @@ final readonly class CreateTaskController
     ) {
     }
 
-    #[Route('/v1/crm/tasks', methods: [Request::METHOD_POST])]
-    #[OA\Post(summary: 'POST /v1/crm/tasks')]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/tasks', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Post(summary: 'POST /v1/crm/{applicationSlug}/tasks')]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $task = new Task();
         $task->setTitle((string)($payload['title'] ?? ''))

--- a/src/Crm/Transport/Controller/Api/V1/Task/DeleteTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/DeleteTaskController.php
@@ -29,8 +29,9 @@ final readonly class DeleteTaskController
     ) {
     }
 
-    #[Route('/v1/crm/tasks/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/tasks/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         $task = $this->taskRepository->find($id);
         if (!$task instanceof Task) {

--- a/src/Crm/Transport/Controller/Api/V1/Task/ListTasksController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/ListTasksController.php
@@ -23,9 +23,11 @@ final readonly class ListTasksController
     ) {
     }
 
-    #[Route('/v1/crm/tasks', methods: [Request::METHOD_GET])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/tasks', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return new JsonResponse($this->taskListService->getList($request));
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
@@ -31,10 +31,12 @@ final readonly class CreateTaskRequestController
     ) {
     }
 
-    #[Route('/v1/crm/task-requests', methods: [Request::METHOD_POST])]
-    #[OA\Post(summary: 'POST /v1/crm/task-requests')]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/task-requests', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Post(summary: 'POST /v1/crm/{applicationSlug}/task-requests')]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $taskRequest = new TaskRequest();
         $taskRequest->setTitle((string)($payload['title'] ?? ''))

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/DeleteTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/DeleteTaskRequestController.php
@@ -29,8 +29,9 @@ final readonly class DeleteTaskRequestController
     ) {
     }
 
-    #[Route('/v1/crm/task-requests/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/task-requests/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         $taskRequest = $this->taskRequestRepository->find($id);
         if (!$taskRequest instanceof TaskRequest) {

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestsController.php
@@ -24,8 +24,9 @@ final readonly class ListTaskRequestsController
     ) {
     }
 
-    #[Route('/v1/crm/task-requests', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    #[Route('/v1/crm/{applicationSlug}/task-requests', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug): JsonResponse
     {
         $items = array_map(static fn (TaskRequest $taskRequest): array => [
             'id' => $taskRequest->getId(),

--- a/src/Recruit/Transport/Controller/Api/V1/Applicant/ApplicantCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Applicant/ApplicantCreateController.php
@@ -32,7 +32,8 @@ class ApplicantCreateController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/applicants', methods: [Request::METHOD_POST])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/applicants', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Post(
         summary: 'Crée un candidat lié au CV du user connecté.',
         requestBody: new OA\RequestBody(
@@ -50,8 +51,9 @@ class ApplicantCreateController
             new OA\Response(response: 400, description: 'Payload invalide.'),
         ],
     )]
-    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         /** @var array<string, mixed> $payload */
         $payload = $request->toArray();
 

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php
@@ -32,7 +32,8 @@ class ApplicationCreateController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/applications', methods: [Request::METHOD_POST])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/applications', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Post(
         summary: 'Crée une candidature pour un job.',
         requestBody: new OA\RequestBody(
@@ -50,8 +51,9 @@ class ApplicationCreateController
             new OA\Response(response: 400, description: 'Payload invalide.'),
         ],
     )]
-    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         /** @var array<string, mixed> $payload */
         $payload = $request->toArray();
 

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
@@ -28,7 +28,8 @@ class ApplicationStatusUpdateController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/private/applications/{applicationId}/status', methods: [Request::METHOD_PATCH, Request::METHOD_PUT])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/private/applications/{applicationId}/status', methods: [Request::METHOD_PATCH, Request::METHOD_PUT])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Patch(
         summary: 'Modifie le statut d\'une candidature.',
         requestBody: new OA\RequestBody(
@@ -45,8 +46,9 @@ class ApplicationStatusUpdateController
             new OA\Response(response: 403, description: 'Vous n\'êtes pas propriétaire du job.'),
         ],
     )]
-    public function __invoke(string $applicationId, Request $request, User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, string $applicationId, Request $request, User $loggedInUser): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $application = $this->applicationRepository->find($applicationId);
 
         if ($application === null) {

--- a/src/Recruit/Transport/Controller/Api/V1/Application/JobApplicationListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/JobApplicationListController.php
@@ -24,7 +24,8 @@ class JobApplicationListController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/private/job-applications', methods: [Request::METHOD_GET])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/private/job-applications', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Get(
         summary: 'Liste privée des candidatures d\'un job.',
         parameters: [
@@ -36,8 +37,9 @@ class JobApplicationListController
             new OA\Response(response: 403, description: 'Vous n\'êtes pas propriétaire du job.'),
         ],
     )]
-    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return new JsonResponse($this->jobApplicationListService->getList(
             $loggedInUser,
             $request->query->getString('jobId', ''),

--- a/src/Recruit/Transport/Controller/Api/V1/Badge/BadgeController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Badge/BadgeController.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
-#[Route(path: '/v1/recruit/badge')]
+#[Route(path: '/v1/recruit/{applicationSlug}/badge')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class BadgeController extends Controller

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyCountController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyCountController.php
@@ -26,13 +26,15 @@ class CompanyCountController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/company/count',
+        path: '/v1/recruit/{applicationSlug}/company/count',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'Count company', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->countMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyCreateController.php
@@ -35,14 +35,16 @@ class CompanyCreateController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/company',
+        path: '/v1/recruit/{applicationSlug}/company',
         methods: [Request::METHOD_POST],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Post(summary: 'Create company', responses: [new OA\Response(response: 201, description: 'created')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->createMethod($request, $this->mapAndValidateDto($request, CompanyCreate::class));
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyDeleteController.php
@@ -27,7 +27,7 @@ class CompanyDeleteController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/company/{id}',
+        path: '/v1/recruit/{applicationSlug}/company/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -35,8 +35,10 @@ class CompanyDeleteController extends Controller
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Delete(summary: 'Delete company', responses: [new OA\Response(response: 200, description: 'deleted')])]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->deleteMethod($request, $id);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyIdsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyIdsController.php
@@ -26,13 +26,15 @@ class CompanyIdsController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/company/ids',
+        path: '/v1/recruit/{applicationSlug}/company/ids',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'Ids company', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->idsMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyListController.php
@@ -26,13 +26,15 @@ class CompanyListController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/company',
+        path: '/v1/recruit/{applicationSlug}/company',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'List company', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->findMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyPatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyPatchController.php
@@ -36,7 +36,7 @@ class CompanyPatchController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/company/{id}',
+        path: '/v1/recruit/{applicationSlug}/company/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -45,8 +45,10 @@ class CompanyPatchController extends Controller
     #[IsGranted('ROLE_ROOT')]
     #[OA\Patch(summary: 'Patch company', responses: [new OA\Response(response: 200, description: 'success')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->patchMethod($request, $this->mapAndValidateDto($request, CompanyPatch::class), $id);
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyUpdateController.php
@@ -36,7 +36,7 @@ class CompanyUpdateController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/company/{id}',
+        path: '/v1/recruit/{applicationSlug}/company/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -45,8 +45,10 @@ class CompanyUpdateController extends Controller
     #[IsGranted('ROLE_ROOT')]
     #[OA\Put(summary: 'Update company', responses: [new OA\Response(response: 200, description: 'success')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->updateMethod($request, $this->mapAndValidateDto($request, CompanyUpdate::class), $id);
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyViewController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyViewController.php
@@ -27,7 +27,7 @@ class CompanyViewController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/company/{id}',
+        path: '/v1/recruit/{applicationSlug}/company/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -35,8 +35,10 @@ class CompanyViewController extends Controller
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'View company', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->findOneMethod($request, $id);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCountController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCountController.php
@@ -26,13 +26,15 @@ class JobCountController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/job/count',
+        path: '/v1/recruit/{applicationSlug}/job/count',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'Count job', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->countMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateController.php
@@ -35,14 +35,16 @@ class JobCreateController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/job',
+        path: '/v1/recruit/{applicationSlug}/job',
         methods: [Request::METHOD_POST],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Post(summary: 'Create job', responses: [new OA\Response(response: 201, description: 'created')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->createMethod($request, $this->mapAndValidateDto($request, JobCreate::class));
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
@@ -36,9 +36,11 @@ readonly class JobCreateFromApplicationController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/applications/{applicationSlug}/jobs', methods: [Request::METHOD_POST])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/jobs', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         /** @var array<string, mixed> $payload */
         $payload = $request->toArray();
         $title = $payload['title'] ?? null;

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteController.php
@@ -27,7 +27,7 @@ class JobDeleteController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/job/{id}',
+        path: '/v1/recruit/{applicationSlug}/job/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -35,8 +35,10 @@ class JobDeleteController extends Controller
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Delete(summary: 'Delete job', responses: [new OA\Response(response: 200, description: 'deleted')])]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->deleteMethod($request, $id);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteFromApplicationController.php
@@ -29,7 +29,7 @@ readonly class JobDeleteFromApplicationController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/applications/{applicationSlug}/jobs/{jobId}', methods: [Request::METHOD_DELETE])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/jobs/{jobId}', methods: [Request::METHOD_DELETE])]
     #[OA\Delete(
         summary: 'Supprime un job via applicationSlug et contrôle propriétaire.',
         parameters: [

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobIdsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobIdsController.php
@@ -26,13 +26,15 @@ class JobIdsController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/job/ids',
+        path: '/v1/recruit/{applicationSlug}/job/ids',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'Ids job', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->idsMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobListController.php
@@ -26,13 +26,15 @@ class JobListController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/job',
+        path: '/v1/recruit/{applicationSlug}/job',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'List job', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->findMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchController.php
@@ -36,7 +36,7 @@ class JobPatchController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/job/{id}',
+        path: '/v1/recruit/{applicationSlug}/job/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -45,8 +45,10 @@ class JobPatchController extends Controller
     #[IsGranted('ROLE_ROOT')]
     #[OA\Patch(summary: 'Patch job', responses: [new OA\Response(response: 200, description: 'success')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->patchMethod($request, $this->mapAndValidateDto($request, JobPatch::class), $id);
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
@@ -31,10 +31,12 @@ readonly class JobPatchFromApplicationController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/applications/{applicationSlug}/jobs/{jobId}', methods: [Request::METHOD_PATCH])]
-    #[Route(path: '/v1/recruit/private/{applicationSlug}/jobs/{jobId}', methods: [Request::METHOD_PATCH])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/jobs/{jobId}', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[Route(path: '/v1/recruit/{applicationSlug}/private/jobs/{jobId}', methods: [Request::METHOD_PATCH])]
     public function __invoke(string $applicationSlug, string $jobId, Request $request, User $loggedInUser): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $recruit = $this->applicationJobAccessService->resolveOwnedRecruitByApplicationSlug(
             $applicationSlug,
             $loggedInUser,

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobUpdateController.php
@@ -36,7 +36,7 @@ class JobUpdateController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/job/{id}',
+        path: '/v1/recruit/{applicationSlug}/job/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -45,8 +45,10 @@ class JobUpdateController extends Controller
     #[IsGranted('ROLE_ROOT')]
     #[OA\Put(summary: 'Update job', responses: [new OA\Response(response: 200, description: 'success')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->updateMethod($request, $this->mapAndValidateDto($request, JobUpdate::class), $id);
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobViewController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobViewController.php
@@ -27,7 +27,7 @@ class JobViewController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/job/{id}',
+        path: '/v1/recruit/{applicationSlug}/job/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -35,8 +35,10 @@ class JobViewController extends Controller
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'View job', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->findOneMethod($request, $id);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/MyJobListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/MyJobListController.php
@@ -24,9 +24,10 @@ readonly class MyJobListController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/private/me/jobs', methods: [Request::METHOD_GET])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/private/me/jobs', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Get(summary: 'Retourne les jobs créés et les jobs postulés par le user connecté.')]
-    public function __invoke(User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, User $loggedInUser): JsonResponse
     {
         return new JsonResponse($this->myJobListService->getList($loggedInUser));
     }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/PrivateJobListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/PrivateJobListController.php
@@ -24,8 +24,8 @@ readonly class PrivateJobListController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/applications/{applicationSlug}/private/jobs', methods: [Request::METHOD_GET])]
-    #[Route(path: '/v1/recruit/private/{applicationSlug}/jobs', methods: [Request::METHOD_GET])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/private/jobs', methods: [Request::METHOD_GET])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/private/jobs', methods: [Request::METHOD_GET])]
     #[OA\Get(
         summary: 'Liste privée des offres jobs, paginée et filtrable.',
         parameters: [

--- a/src/Recruit/Transport/Controller/Api/V1/Job/PrivateJobStatsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/PrivateJobStatsController.php
@@ -27,7 +27,8 @@ readonly class PrivateJobStatsController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/private/{applicationSlug}/jobs/stats', methods: [Request::METHOD_GET])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/private/jobs/stats', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, User $loggedInUser): JsonResponse
     {
         $recruit = $this->recruitResolverService->resolveByApplicationSlug($applicationSlug);

--- a/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailController.php
@@ -20,8 +20,8 @@ readonly class PublicJobDetailController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/applications/{applicationSlug}/public/jobs/{jobSlug}', methods: [Request::METHOD_GET])]
-    #[Route(path: '/v1/recruit/public/{applicationSlug}/jobs/{jobSlug}', methods: [Request::METHOD_GET])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/public/jobs/{jobSlug}', methods: [Request::METHOD_GET])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/public/jobs/{jobSlug}', methods: [Request::METHOD_GET])]
     #[OA\Get(
         summary: 'Détail public d\'un job avec jobs similaires indexés.',
         security: [],

--- a/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/PublicJobListController.php
@@ -20,8 +20,8 @@ readonly class PublicJobListController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/applications/{applicationSlug}/public/jobs', methods: [Request::METHOD_GET])]
-    #[Route(path: '/v1/recruit/public/{applicationSlug}/jobs', methods: [Request::METHOD_GET])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/public/jobs', methods: [Request::METHOD_GET])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/public/jobs', methods: [Request::METHOD_GET])]
     #[OA\Get(
         summary: 'Liste publique des offres jobs, paginée et filtrable.',
         security: [],

--- a/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumeDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumeDeleteController.php
@@ -27,9 +27,10 @@ readonly class MyResumeDeleteController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/private/me/resumes/{resumeId}', methods: [Request::METHOD_DELETE])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/private/me/resumes/{resumeId}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Delete(summary: 'Supprime un CV appartenant au user connecté.')]
-    public function __invoke(string $resumeId, User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, string $resumeId, User $loggedInUser): JsonResponse
     {
         if (!Uuid::isValid($resumeId)) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Route "resumeId" must be a valid UUID.');

--- a/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListController.php
@@ -26,9 +26,10 @@ readonly class MyResumeListController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/private/me/resumes', methods: [Request::METHOD_GET])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/private/me/resumes', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Get(summary: 'Retourne les CV du user connecté.')]
-    public function __invoke(User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, User $loggedInUser): JsonResponse
     {
         $resumes = $this->resumeRepository->findBy([
             'owner' => $loggedInUser,

--- a/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumePatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumePatchController.php
@@ -29,10 +29,12 @@ readonly class MyResumePatchController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/private/me/resumes/{resumeId}', methods: [Request::METHOD_PATCH])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/private/me/resumes/{resumeId}', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Patch(summary: 'Met à jour un CV appartenant au user connecté.')]
-    public function __invoke(string $resumeId, Request $request, User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, string $resumeId, Request $request, User $loggedInUser): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         if (!Uuid::isValid($resumeId)) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Route "resumeId" must be a valid UUID.');
         }

--- a/src/Recruit/Transport/Controller/Api/V1/Resume/ResumeCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/ResumeCreateController.php
@@ -30,7 +30,8 @@ readonly class ResumeCreateController
     ) {
     }
 
-    #[Route(path: '/v1/recruit/resumes', methods: [Request::METHOD_POST])]
+    #[Route(path: '/v1/recruit/{applicationSlug}/resumes', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Post(summary: 'Crée un CV et permet l’upload optionnel d’un PDF.')]
     #[OA\RequestBody(
         required: false,
@@ -97,8 +98,9 @@ readonly class ResumeCreateController
     )]
     #[OA\Response(response: 400, description: 'Invalid payload or file format')]
     #[OA\Response(response: 401, description: 'Authentication required')]
-    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = $this->resumePayloadService->extractPayload($request);
 
         $resume = new Resume()->setOwner($loggedInUser);

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryCountController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryCountController.php
@@ -26,13 +26,15 @@ class SalaryCountController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/salary/count',
+        path: '/v1/recruit/{applicationSlug}/salary/count',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'Count salary', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->countMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryCreateController.php
@@ -35,14 +35,16 @@ class SalaryCreateController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/salary',
+        path: '/v1/recruit/{applicationSlug}/salary',
         methods: [Request::METHOD_POST],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Post(summary: 'Create salary', responses: [new OA\Response(response: 201, description: 'created')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->createMethod($request, $this->mapAndValidateDto($request, SalaryCreate::class));
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryDeleteController.php
@@ -27,7 +27,7 @@ class SalaryDeleteController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/salary/{id}',
+        path: '/v1/recruit/{applicationSlug}/salary/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -35,8 +35,10 @@ class SalaryDeleteController extends Controller
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Delete(summary: 'Delete salary', responses: [new OA\Response(response: 200, description: 'deleted')])]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->deleteMethod($request, $id);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryIdsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryIdsController.php
@@ -26,13 +26,15 @@ class SalaryIdsController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/salary/ids',
+        path: '/v1/recruit/{applicationSlug}/salary/ids',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'Ids salary', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->idsMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryListController.php
@@ -26,13 +26,15 @@ class SalaryListController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/salary',
+        path: '/v1/recruit/{applicationSlug}/salary',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'List salary', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->findMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryPatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryPatchController.php
@@ -36,7 +36,7 @@ class SalaryPatchController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/salary/{id}',
+        path: '/v1/recruit/{applicationSlug}/salary/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -45,8 +45,10 @@ class SalaryPatchController extends Controller
     #[IsGranted('ROLE_ROOT')]
     #[OA\Patch(summary: 'Patch salary', responses: [new OA\Response(response: 200, description: 'success')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->patchMethod($request, $this->mapAndValidateDto($request, SalaryPatch::class), $id);
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryUpdateController.php
@@ -36,7 +36,7 @@ class SalaryUpdateController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/salary/{id}',
+        path: '/v1/recruit/{applicationSlug}/salary/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -45,8 +45,10 @@ class SalaryUpdateController extends Controller
     #[IsGranted('ROLE_ROOT')]
     #[OA\Put(summary: 'Update salary', responses: [new OA\Response(response: 200, description: 'success')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->updateMethod($request, $this->mapAndValidateDto($request, SalaryUpdate::class), $id);
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryViewController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryViewController.php
@@ -27,7 +27,7 @@ class SalaryViewController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/salary/{id}',
+        path: '/v1/recruit/{applicationSlug}/salary/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -35,8 +35,10 @@ class SalaryViewController extends Controller
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'View salary', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->findOneMethod($request, $id);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagCountController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagCountController.php
@@ -26,13 +26,15 @@ class TagCountController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/tag/count',
+        path: '/v1/recruit/{applicationSlug}/tag/count',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'Count tag', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->countMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagCreateController.php
@@ -35,14 +35,16 @@ class TagCreateController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/tag',
+        path: '/v1/recruit/{applicationSlug}/tag',
         methods: [Request::METHOD_POST],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Post(summary: 'Create tag', responses: [new OA\Response(response: 201, description: 'created')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->createMethod($request, $this->mapAndValidateDto($request, TagCreate::class));
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagDeleteController.php
@@ -27,7 +27,7 @@ class TagDeleteController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/tag/{id}',
+        path: '/v1/recruit/{applicationSlug}/tag/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -35,8 +35,10 @@ class TagDeleteController extends Controller
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Delete(summary: 'Delete tag', responses: [new OA\Response(response: 200, description: 'deleted')])]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->deleteMethod($request, $id);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagIdsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagIdsController.php
@@ -26,13 +26,15 @@ class TagIdsController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/tag/ids',
+        path: '/v1/recruit/{applicationSlug}/tag/ids',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'Ids tag', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->idsMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagListController.php
@@ -26,13 +26,15 @@ class TagListController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/tag',
+        path: '/v1/recruit/{applicationSlug}/tag',
         methods: [Request::METHOD_GET],
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'List tag', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->findMethod($request);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagPatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagPatchController.php
@@ -36,7 +36,7 @@ class TagPatchController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/tag/{id}',
+        path: '/v1/recruit/{applicationSlug}/tag/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -45,8 +45,10 @@ class TagPatchController extends Controller
     #[IsGranted('ROLE_ROOT')]
     #[OA\Patch(summary: 'Patch tag', responses: [new OA\Response(response: 200, description: 'success')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->patchMethod($request, $this->mapAndValidateDto($request, TagPatch::class), $id);
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagUpdateController.php
@@ -36,7 +36,7 @@ class TagUpdateController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/tag/{id}',
+        path: '/v1/recruit/{applicationSlug}/tag/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -45,8 +45,10 @@ class TagUpdateController extends Controller
     #[IsGranted('ROLE_ROOT')]
     #[OA\Put(summary: 'Update tag', responses: [new OA\Response(response: 200, description: 'success')])]
     #[OA\RequestBody(required: true, content: new OA\JsonContent(type: 'object'))]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->updateMethod($request, $this->mapAndValidateDto($request, TagUpdate::class), $id);
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagViewController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagViewController.php
@@ -27,7 +27,7 @@ class TagViewController extends Controller
     }
 
     #[Route(
-        path: '/v1/recruit/tag/{id}',
+        path: '/v1/recruit/{applicationSlug}/tag/{id}',
         requirements: [
             'id' => Requirement::UUID_V1,
         ],
@@ -35,8 +35,10 @@ class TagViewController extends Controller
     )]
     #[IsGranted('ROLE_ROOT')]
     #[OA\Get(summary: 'View tag', responses: [new OA\Response(response: 200, description: 'success')])]
-    public function __invoke(Request $request, string $id): Response
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request, string $id): Response
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return $this->findOneMethod($request, $id);
     }
 }

--- a/src/School/Transport/Controller/Api/V1/Application/GetSchoolApplicationResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/Application/GetSchoolApplicationResourceController.php
@@ -27,9 +27,10 @@ final readonly class GetSchoolApplicationResourceController
         private SchoolResourceViewService $resourceViewService,
     ) {
     }
-    #[Route('/v1/school/applications/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_GET], requirements: [
+    #[Route('/v1/school/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_GET], requirements: [
         'resource' => 'classes|students|teachers|exams|grades',
     ])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $resource, string $id): JsonResponse
     {
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);

--- a/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
@@ -32,11 +32,13 @@ final readonly class PatchSchoolApplicationResourceController
         private MessageBusInterface $messageBus,
     ) {
     }
-    #[Route('/v1/school/applications/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_PATCH], requirements: [
+    #[Route('/v1/school/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_PATCH], requirements: [
         'resource' => 'classes|students|teachers|exams|grades',
     ])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $resource, string $id, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
         $entity = $this->resourceViewService->findOr404($resource, $id);
         if (!$this->resourceAccessService->belongsToSchool($entity, $school)) {

--- a/src/School/Transport/Controller/Api/V1/Class/AssignClassTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/AssignClassTeacherController.php
@@ -22,8 +22,9 @@ final readonly class AssignClassTeacherController
         private ClassTeacherAssignmentService $assignmentService
     ) {
     }
-    #[Route('/v1/school/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_POST])]
-    public function __invoke(string $id, string $teacherId): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id, string $teacherId): JsonResponse
     {
         $this->assignmentService->assign($id, $teacherId);
 

--- a/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
@@ -28,9 +28,11 @@ final readonly class CreateClassByApplicationController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_POST])]
+    #[Route('/v1/school/{applicationSlug}/classes', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
         $payload = $request->toArray();
 

--- a/src/School/Transport/Controller/Api/V1/Class/CreateClassController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/CreateClassController.php
@@ -26,9 +26,11 @@ final readonly class CreateClassController
     ) {
     }
 
-    #[Route('/v1/school/classes', methods: [Request::METHOD_POST])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/classes', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = $request->toArray();
 
         $input = new CreateClassInput();

--- a/src/School/Transport/Controller/Api/V1/Class/DeleteClassController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/DeleteClassController.php
@@ -23,8 +23,9 @@ final readonly class DeleteClassController
     ) {
     }
 
-    #[Route('/v1/school/classes/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/classes/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         if (!$this->deleteClassService->delete($id)) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);

--- a/src/School/Transport/Controller/Api/V1/Class/ListClassesByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/ListClassesByApplicationController.php
@@ -25,9 +25,11 @@ final readonly class ListClassesByApplicationController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_GET])]
+    #[Route('/v1/school/{applicationSlug}/classes', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
 
         return new JsonResponse($this->classApplicationListService->getList($request, $applicationSlug, $school));

--- a/src/School/Transport/Controller/Api/V1/Class/ListClassesController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/ListClassesController.php
@@ -27,8 +27,9 @@ final readonly class ListClassesController
     ) {
     }
 
-    #[Route('/v1/school/classes', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/classes', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug): JsonResponse
     {
         $items = $this->viewMapper->mapClassCollection($this->classRepository->findBy([], [
             'createdAt' => 'DESC',

--- a/src/School/Transport/Controller/Api/V1/Class/UnassignClassTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/UnassignClassTeacherController.php
@@ -22,8 +22,9 @@ final readonly class UnassignClassTeacherController
         private ClassTeacherAssignmentService $assignmentService
     ) {
     }
-    #[Route('/v1/school/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id, string $teacherId): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id, string $teacherId): JsonResponse
     {
         $this->assignmentService->unassign($id, $teacherId);
 

--- a/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
@@ -30,7 +30,7 @@ final readonly class CreateExamController
     }
 
     #[OA\Post(
-        path: '/v1/school/exams',
+        path: '/v1/school/{applicationSlug}/exams',
         summary: 'Créer un examen',
         tags: ['School'],
         requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
@@ -49,9 +49,11 @@ final readonly class CreateExamController
             new OA\Response(response: 422, description: 'Validation failed'),
         ],
     )]
-    #[Route('/v1/school/exams', methods: [Request::METHOD_POST])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/exams', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = $request->toArray();
 
         $input = new CreateExamInput();

--- a/src/School/Transport/Controller/Api/V1/Exam/DeleteExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/DeleteExamController.php
@@ -23,8 +23,9 @@ final readonly class DeleteExamController
     ) {
     }
 
-    #[Route('/v1/school/exams/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/exams/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         if (!$this->deleteExamService->delete($id)) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);

--- a/src/School/Transport/Controller/Api/V1/Exam/ListExamsController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/ListExamsController.php
@@ -23,9 +23,11 @@ final readonly class ListExamsController
     ) {
     }
 
-    #[Route('/v1/school/exams', methods: [Request::METHOD_GET])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/exams', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return new JsonResponse($this->examListService->getList($request));
     }
 }

--- a/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
@@ -26,9 +26,11 @@ final readonly class CreateGradeController
     ) {
     }
 
-    #[Route('/v1/school/grades', methods: [Request::METHOD_POST])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/grades', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = $request->toArray();
 
         $input = new CreateGradeInput();

--- a/src/School/Transport/Controller/Api/V1/Grade/DeleteGradeController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/DeleteGradeController.php
@@ -23,8 +23,9 @@ final readonly class DeleteGradeController
     ) {
     }
 
-    #[Route('/v1/school/grades/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/grades/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         if (!$this->deleteGradeService->delete($id)) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);

--- a/src/School/Transport/Controller/Api/V1/Grade/ListGradesController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/ListGradesController.php
@@ -27,8 +27,9 @@ final readonly class ListGradesController
     ) {
     }
 
-    #[Route('/v1/school/grades', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/grades', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug): JsonResponse
     {
         $items = $this->viewMapper->mapGradeCollection($this->gradeRepository->findBy([], [
             'createdAt' => 'DESC',

--- a/src/School/Transport/Controller/Api/V1/School/GetSchoolResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/School/GetSchoolResourceController.php
@@ -22,10 +22,11 @@ final readonly class GetSchoolResourceController
         private SchoolResourceViewService $resourceViewService
     ) {
     }
-    #[Route('/v1/school/{resource}/{id}', methods: [Request::METHOD_GET], requirements: [
+    #[Route('/v1/school/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_GET], requirements: [
         'resource' => 'classes|students|teachers|exams|grades',
     ])]
-    public function __invoke(string $resource, string $id): JsonResponse
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $resource, string $id): JsonResponse
     {
         $entity = $this->resourceViewService->findOr404($resource, $id);
 

--- a/src/School/Transport/Controller/Api/V1/School/PatchSchoolResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/School/PatchSchoolResourceController.php
@@ -27,11 +27,13 @@ final readonly class PatchSchoolResourceController
         private MessageBusInterface $messageBus,
     ) {
     }
-    #[Route('/v1/school/{resource}/{id}', methods: [Request::METHOD_PATCH], requirements: [
+    #[Route('/v1/school/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_PATCH], requirements: [
         'resource' => 'classes|students|teachers|exams|grades',
     ])]
-    public function __invoke(string $resource, string $id, Request $request): JsonResponse
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $resource, string $id, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $entity = $this->resourceViewService->findOr404($resource, $id);
         $this->resourcePatchService->patch($entity, $resource, $request->toArray());
         $this->messageBus->dispatch(new EntityPatched('school_' . substr($resource, 0, -1), $id));

--- a/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php
+++ b/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php
@@ -27,9 +27,10 @@ final readonly class SchoolApplicationResourceListController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/{resource}', methods: [Request::METHOD_GET], requirements: [
+    #[Route('/v1/school/{applicationSlug}/{resource}', methods: [Request::METHOD_GET], requirements: [
         'resource' => 'students|teachers|exams|grades',
     ])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $resource): JsonResponse
     {
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);

--- a/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
@@ -26,9 +26,11 @@ final readonly class CreateStudentController
     ) {
     }
 
-    #[Route('/v1/school/students', methods: [Request::METHOD_POST])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/students', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = $request->toArray();
 
         $input = new CreateStudentInput();

--- a/src/School/Transport/Controller/Api/V1/Student/DeleteStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/DeleteStudentController.php
@@ -23,8 +23,9 @@ final readonly class DeleteStudentController
     ) {
     }
 
-    #[Route('/v1/school/students/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/students/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         if (!$this->deleteStudentService->delete($id)) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);

--- a/src/School/Transport/Controller/Api/V1/Student/ListStudentsController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/ListStudentsController.php
@@ -27,8 +27,9 @@ final readonly class ListStudentsController
     ) {
     }
 
-    #[Route('/v1/school/students', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/students', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug): JsonResponse
     {
         $items = $this->viewMapper->mapStudentCollection($this->studentRepository->findBy([], [
             'createdAt' => 'DESC',

--- a/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
@@ -26,9 +26,11 @@ final readonly class CreateTeacherController
     ) {
     }
 
-    #[Route('/v1/school/teachers', methods: [Request::METHOD_POST])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/teachers', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = $request->toArray();
 
         $input = new CreateTeacherInput();

--- a/src/School/Transport/Controller/Api/V1/Teacher/DeleteTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/DeleteTeacherController.php
@@ -23,8 +23,9 @@ final readonly class DeleteTeacherController
     ) {
     }
 
-    #[Route('/v1/school/teachers/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/teachers/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         if (!$this->deleteTeacherService->delete($id)) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);

--- a/src/School/Transport/Controller/Api/V1/Teacher/ListTeachersController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/ListTeachersController.php
@@ -27,8 +27,9 @@ final readonly class ListTeachersController
     ) {
     }
 
-    #[Route('/v1/school/teachers', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    #[Route('/v1/school/{applicationSlug}/teachers', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug): JsonResponse
     {
         $items = $this->viewMapper->mapTeacherCollection($this->teacherRepository->findBy([], [
             'createdAt' => 'DESC',

--- a/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php
@@ -31,9 +31,11 @@ final readonly class CreateApplicationProductController
     ) {
     }
 
-    #[Route('/v1/shop/applications/{applicationSlug}/products', methods: [Request::METHOD_POST])]
+    #[Route('/v1/shop/{applicationSlug}/products', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
 

--- a/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/ListApplicationProductsController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/ListApplicationProductsController.php
@@ -25,9 +25,11 @@ final readonly class ListApplicationProductsController
     ) {
     }
 
-    #[Route('/v1/shop/applications/{applicationSlug}/products', methods: [Request::METHOD_GET])]
+    #[Route('/v1/shop/{applicationSlug}/products', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
 
         return new JsonResponse($this->productApplicationListService->getList($request, $applicationSlug, $shop));

--- a/src/Shop/Transport/Controller/Api/V1/Cart/AddCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Cart/AddCartItemController.php
@@ -33,9 +33,11 @@ final readonly class AddCartItemController
     ) {
     }
 
-    #[Route('/v1/shop/carts/{shopId}/items', methods: [Request::METHOD_POST])]
-    public function __invoke(string $shopId, Request $request): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/carts/{shopId}/items', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $shopId, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $user = $this->security->getUser();
         if (!$user instanceof User) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');

--- a/src/Shop/Transport/Controller/Api/V1/Cart/DeleteCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Cart/DeleteCartItemController.php
@@ -33,8 +33,9 @@ final readonly class DeleteCartItemController
     ) {
     }
 
-    #[Route('/v1/shop/carts/{shopId}/items/{itemId}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $shopId, string $itemId): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/carts/{shopId}/items/{itemId}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $shopId, string $itemId): JsonResponse
     {
         $user = $this->security->getUser();
         if (!$user instanceof User) {

--- a/src/Shop/Transport/Controller/Api/V1/Cart/GetCartController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Cart/GetCartController.php
@@ -30,8 +30,9 @@ final readonly class GetCartController
     ) {
     }
 
-    #[Route('/v1/shop/carts/{shopId}', methods: [Request::METHOD_GET])]
-    public function __invoke(string $shopId): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/carts/{shopId}', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $shopId): JsonResponse
     {
         $user = $this->security->getUser();
         if (!$user instanceof User) {

--- a/src/Shop/Transport/Controller/Api/V1/Cart/PatchCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Cart/PatchCartItemController.php
@@ -33,9 +33,11 @@ final readonly class PatchCartItemController
     ) {
     }
 
-    #[Route('/v1/shop/carts/{shopId}/items/{itemId}', methods: [Request::METHOD_PATCH])]
-    public function __invoke(string $shopId, string $itemId, Request $request): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/carts/{shopId}/items/{itemId}', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $shopId, string $itemId, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $user = $this->security->getUser();
         if (!$user instanceof User) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');

--- a/src/Shop/Transport/Controller/Api/V1/Category/CreateCategoryController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Category/CreateCategoryController.php
@@ -31,9 +31,11 @@ final readonly class CreateCategoryController
     ) {
     }
 
-    #[Route('/v1/shop/categories', methods: [Request::METHOD_POST])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/categories', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $category = (new Category())
             ->setName((string)($payload['name'] ?? ''))

--- a/src/Shop/Transport/Controller/Api/V1/Category/DeleteCategoryController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Category/DeleteCategoryController.php
@@ -29,8 +29,9 @@ final readonly class DeleteCategoryController
     ) {
     }
 
-    #[Route('/v1/shop/categories/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/categories/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         $category = $this->categoryRepository->find($id);
         if (!$category instanceof Category) {

--- a/src/Shop/Transport/Controller/Api/V1/Category/ListCategoriesController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Category/ListCategoriesController.php
@@ -24,8 +24,9 @@ final readonly class ListCategoriesController
     ) {
     }
 
-    #[Route('/v1/shop/categories', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/categories', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug): JsonResponse
     {
         $items = array_map(static fn (Category $category): array => [
             'id' => $category->getId(),

--- a/src/Shop/Transport/Controller/Api/V1/Checkout/CheckoutController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Checkout/CheckoutController.php
@@ -30,9 +30,11 @@ final readonly class CheckoutController
     ) {
     }
 
-    #[Route('/v1/shop/checkout/{shopId}', methods: [Request::METHOD_POST])]
-    public function __invoke(string $shopId, Request $request): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/checkout/{shopId}', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $shopId, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $user = $this->security->getUser();
         if (!$user instanceof User) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');

--- a/src/Shop/Transport/Controller/Api/V1/Payment/ConfirmPaymentController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/ConfirmPaymentController.php
@@ -21,9 +21,11 @@ final readonly class ConfirmPaymentController
     ) {
     }
 
-    #[Route('/v1/shop/orders/{orderId}/payment-confirm', methods: [Request::METHOD_POST])]
-    public function __invoke(string $orderId, Request $request): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/orders/{orderId}/payment-confirm', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $orderId, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $providerReference = trim((string)($payload['providerReference'] ?? ''));
 

--- a/src/Shop/Transport/Controller/Api/V1/Payment/CreatePaymentIntentController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/CreatePaymentIntentController.php
@@ -20,8 +20,9 @@ final readonly class CreatePaymentIntentController
     ) {
     }
 
-    #[Route('/v1/shop/orders/{orderId}/payment-intent', methods: [Request::METHOD_POST])]
-    public function __invoke(string $orderId): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/orders/{orderId}/payment-intent', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $orderId): JsonResponse
     {
         $transaction = $this->paymentService->createPaymentIntent($orderId);
 

--- a/src/Shop/Transport/Controller/Api/V1/Payment/PaymentWebhookController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/PaymentWebhookController.php
@@ -20,9 +20,11 @@ final readonly class PaymentWebhookController
     ) {
     }
 
-    #[Route('/v1/shop/payments/webhook', methods: [Request::METHOD_POST])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/payments/webhook', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $signature = $request->headers->get('x-signature');
 

--- a/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
@@ -31,9 +31,11 @@ final readonly class CreateProductController
     ) {
     }
 
-    #[Route('/v1/shop/products', methods: [Request::METHOD_POST])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/products', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $product = $this->productHydratorService->hydrateProduct(new Product(), $payload);
 

--- a/src/Shop/Transport/Controller/Api/V1/Product/DeleteProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/DeleteProductController.php
@@ -24,8 +24,9 @@ final readonly class DeleteProductController
     ) {
     }
 
-    #[Route('/v1/shop/products/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/products/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
         $this->messageService->sendMessage(new DeleteProductCommand(

--- a/src/Shop/Transport/Controller/Api/V1/Product/GetProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/GetProductController.php
@@ -27,8 +27,9 @@ final readonly class GetProductController
     ) {
     }
 
-    #[Route('/v1/shop/products/{id}', methods: [Request::METHOD_GET])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/products/{id}', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         $product = $this->productRepository->find($id);
         if (!$product instanceof Product) {

--- a/src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php
@@ -23,9 +23,11 @@ final readonly class ListProductsController
     ) {
     }
 
-    #[Route('/v1/shop/products', methods: [Request::METHOD_GET])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/products', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         return new JsonResponse($this->productListService->getList($request));
     }
 }

--- a/src/Shop/Transport/Controller/Api/V1/Product/PatchProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/PatchProductController.php
@@ -32,9 +32,11 @@ final readonly class PatchProductController
     ) {
     }
 
-    #[Route('/v1/shop/products/{id}', methods: [Request::METHOD_PATCH])]
-    public function __invoke(string $id, Request $request): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/products/{id}', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $product = $this->productRepository->find($id);
         if (!$product instanceof Product) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);

--- a/src/Shop/Transport/Controller/Api/V1/Tag/CreateTagController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Tag/CreateTagController.php
@@ -28,9 +28,11 @@ final readonly class CreateTagController
     ) {
     }
 
-    #[Route('/v1/shop/tags', methods: [Request::METHOD_POST])]
-    public function __invoke(Request $request): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/tags', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
+        $request->attributes->set('applicationSlug', $applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $tag = (new Tag())
             ->setLabel((string)($payload['label'] ?? ''))

--- a/src/Shop/Transport/Controller/Api/V1/Tag/DeleteTagController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Tag/DeleteTagController.php
@@ -29,8 +29,9 @@ final readonly class DeleteTagController
     ) {
     }
 
-    #[Route('/v1/shop/tags/{id}', methods: [Request::METHOD_DELETE])]
-    public function __invoke(string $id): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/tags/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
         $tag = $this->tagRepository->find($id);
         if (!$tag instanceof Tag) {

--- a/src/Shop/Transport/Controller/Api/V1/Tag/ListTagsController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Tag/ListTagsController.php
@@ -24,8 +24,9 @@ final readonly class ListTagsController
     ) {
     }
 
-    #[Route('/v1/shop/tags', methods: [Request::METHOD_GET])]
-    public function __invoke(): JsonResponse
+    #[Route('/v1/shop/{applicationSlug}/tags', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug): JsonResponse
     {
         $items = array_map(static fn (Tag $tag): array => [
             'id' => $tag->getId(),


### PR DESCRIPTION
### Motivation
- Unifier les routes API v1 pour les modules `crm`, `recruit`, `shop` et `school` en introduisant un scope `applicationSlug` immédiatement après le module afin de supporter le filtrage par application.
- Faire remonter le `applicationSlug` jusqu'aux contrôleurs et permettre aux services/repositories d'appliquer un filtrage par application sans casser les contrats OpenAPI.
- Préparer une stratégie de migration pour garder la compatibilité avec les clients legacy pendant la phase de transition.

### Description
- Tous les contrôleurs sous `src/Crm/Transport/Controller/Api/V1`, `src/Recruit/Transport/Controller/Api/V1`, `src/Shop/Transport/Controller/Api/V1` et `src/School/Transport/Controller/Api/V1` ont leurs routes modifiées de `/v1/{module}/...` vers `/v1/{module}/{applicationSlug}/...` et les signatures `__invoke(...)` mises à jour pour injecter `string $applicationSlug` lorsque nécessaire.
- Ajout des annotations OpenAPI `#[OA\Parameter(name: 'applicationSlug', in: 'path', ...)]` sur les endpoints mis à jour et adaptation des messages `#[Route(...)]`/`#[OA\Get|Post|Patch|Delete]` pour refléter le nouveau chemin.
- Lorsque le contrôleur reçoit un `Request`, le `applicationSlug` est propagé via `$request->attributes->set('applicationSlug', $applicationSlug);` pour que les services/ressources puissent appliquer le filtrage applicatif, et les résolveurs d'application (`ShopApplicationResolverService`, `SchoolApplicationScopeResolver`, `CrmApplicationScopeResolver`, etc.) sont utilisés quand présent dans le flux.
- Document de migration ajouté en `docs/application-slug-route-migration.md` avec une stratégie en phases (dépréciation → redirections temporaires → observabilité → suppression).

### Testing
- Vérification de la syntaxe PHP sur tous les fichiers modifiés via `php -l` (exécuté sur la liste des fichiers modifiés), toutes les vérifications sont passées.
- Recherches automatisées (`rg`) utilisées pour détecter et normaliser les patterns de route et s'assurer que les routes legacy ciblées ont été remplacées, sans résultats restants pour les patterns ciblés.
- Les contrôleurs modifiés ont été ajoutés et commités (`Refactor v1 module routes to require application slug`) et le nouveau document de migration a été créé.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1d7b70a6883268a996c54b8a242a7)