### PR TITLE
feat(chat): scope chat routes by application slug and validate chat ownership

### DIFF
--- a/src/Chat/Application/Service/ChatApplicationScopeValidator.php
+++ b/src/Chat/Application/Service/ChatApplicationScopeValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Application\Service;
+
+use App\Chat\Domain\Entity\Chat;
+use App\Chat\Infrastructure\Repository\ChatRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final readonly class ChatApplicationScopeValidator
+{
+    public function __construct(
+        private ChatRepository $chatRepository,
+    ) {
+    }
+
+    public function validate(string $chatId, string $applicationSlug): Chat
+    {
+        $chat = $this->chatRepository->findOneByIdAndApplicationSlug($chatId, $applicationSlug);
+        if (!$chat instanceof Chat) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Chat not found for this application.');
+        }
+
+        return $chat;
+    }
+}

--- a/src/Chat/Domain/Repository/Interfaces/ChatRepositoryInterface.php
+++ b/src/Chat/Domain/Repository/Interfaces/ChatRepositoryInterface.php
@@ -12,5 +12,7 @@ interface ChatRepositoryInterface
 {
     public function findOneByApplication(Application $application): ?Chat;
 
+    public function findOneByIdAndApplicationSlug(string $chatId, string $applicationSlug): ?Chat;
+
     public function findChatForDirectConversation(User $actor, User $targetUser): ?Chat;
 }

--- a/src/Chat/Infrastructure/Repository/ChatRepository.php
+++ b/src/Chat/Infrastructure/Repository/ChatRepository.php
@@ -40,6 +40,16 @@ class ChatRepository extends BaseRepository implements ChatRepositoryInterface
         return $chat instanceof Entity ? $chat : null;
     }
 
+    public function findOneByIdAndApplicationSlug(string $chatId, string $applicationSlug): ?Entity
+    {
+        $chat = $this->findOneBy([
+            'id' => $chatId,
+            'applicationSlug' => $applicationSlug,
+        ]);
+
+        return $chat instanceof Entity ? $chat : null;
+    }
+
     public function findChatForDirectConversation(User $actor, User $targetUser): ?Entity
     {
         $sharedConversationChat = $this->createQueryBuilder('chat')

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Chat\Transport\Controller\Api\V1\Conversation;
 
+use App\Chat\Application\Service\ChatApplicationScopeValidator;
 use App\Chat\Application\Service\ConversationListService;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -14,11 +15,12 @@ use Symfony\Component\Routing\Attribute\Route;
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
 #[OA\Get(
-    path: '/v1/chat/chats/{chatId}/conversations',
+    path: '/v1/chat/{applicationSlug}/chats/{chatId}/conversations',
     operationId: 'chat_conversation_public_chat_list',
     summary: "Lister les conversations d'un chat",
     tags: ['Chat Conversation'],
     parameters: [
+        new OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string', example: 'bro-world')),
         new OA\Parameter(name: 'chatId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
         new OA\Parameter(name: 'page', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, default: 1)),
         new OA\Parameter(name: 'limit', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20)),
@@ -31,13 +33,16 @@ use Symfony\Component\Routing\Attribute\Route;
 class ApplicationConversationListController
 {
     public function __construct(
-        private readonly ConversationListService $conversationListService
+        private readonly ConversationListService $conversationListService,
+        private readonly ChatApplicationScopeValidator $chatApplicationScopeValidator
     ) {
     }
 
-    #[Route(path: '/v1/chat/chats/{chatId}/conversations', methods: [Request::METHOD_GET])]
-    public function __invoke(string $chatId, Request $request): JsonResponse
+    #[Route(path: '/v1/chat/{applicationSlug}/chats/{chatId}/conversations', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, string $chatId, Request $request): JsonResponse
     {
+        $this->chatApplicationScopeValidator->validate($chatId, $applicationSlug);
+
         $page = max(1, $request->query->getInt('page', 1));
         $limit = max(1, min(100, $request->query->getInt('limit', 20)));
         $filters = [

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Chat\Transport\Controller\Api\V1\Conversation;
 
+use App\Chat\Application\Service\ChatApplicationScopeValidator;
 use App\Chat\Application\Service\ConversationListService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
@@ -17,11 +18,12 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
 #[OA\Get(
-    path: '/v1/chat/private/chats/{chatId}/conversations',
+    path: '/v1/chat/{applicationSlug}/private/chats/{chatId}/conversations',
     operationId: 'chat_conversation_private_chat_list',
     summary: "Lister les conversations privées d'un chat pour l'utilisateur connecté",
     tags: ['Chat Conversation'],
     parameters: [
+        new OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string', example: 'bro-world')),
         new OA\Parameter(name: 'chatId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
         new OA\Parameter(name: 'page', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, default: 1)),
         new OA\Parameter(name: 'limit', in: 'query', schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20)),
@@ -35,13 +37,16 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class ApplicationUserConversationListController
 {
     public function __construct(
-        private readonly ConversationListService $conversationListService
+        private readonly ConversationListService $conversationListService,
+        private readonly ChatApplicationScopeValidator $chatApplicationScopeValidator
     ) {
     }
 
-    #[Route(path: '/v1/chat/private/chats/{chatId}/conversations', methods: [Request::METHOD_GET])]
-    public function __invoke(string $chatId, Request $request, User $loggedInUser): JsonResponse
+    #[Route(path: '/v1/chat/{applicationSlug}/private/chats/{chatId}/conversations', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, string $chatId, Request $request, User $loggedInUser): JsonResponse
     {
+        $this->chatApplicationScopeValidator->validate($chatId, $applicationSlug);
+
         $page = max(1, $request->query->getInt('page', 1));
         $limit = max(1, min(100, $request->query->getInt('limit', 20)));
         $filters = [

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/CreateConversationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/CreateConversationController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Conversation;
 
 use App\Chat\Application\Message\CreateConversationCommand;
+use App\Chat\Application\Service\ChatApplicationScopeValidator;
 use App\Chat\Application\Service\ConversationPayloadService;
 use App\General\Application\Service\OperationIdGeneratorService;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
@@ -19,7 +20,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
-#[OA\Post(path: '/v1/chat/private/chats/{chatId}/conversations', operationId: 'chat_conversation_create', summary: 'Créer une conversation', requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['userId'], properties: [new OA\Property(property: 'userId', type: 'string', format: 'uuid')])))]
+#[OA\Post(path: '/v1/chat/{applicationSlug}/private/chats/{chatId}/conversations', operationId: 'chat_conversation_create', summary: 'Créer une conversation', tags: ['Chat Conversation'], parameters: [new OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string', example: 'bro-world')), new OA\Parameter(name: 'chatId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['userId'], properties: [new OA\Property(property: 'userId', type: 'string', format: 'uuid')])))]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 class CreateConversationController
 {
@@ -27,12 +28,15 @@ class CreateConversationController
         private readonly MessageServiceInterface $messageService,
         private readonly ConversationPayloadService $conversationPayloadService,
         private readonly OperationIdGeneratorService $operationIdGeneratorService,
+        private readonly ChatApplicationScopeValidator $chatApplicationScopeValidator,
     ) {
     }
 
-    #[Route(path: '/v1/chat/private/chats/{chatId}/conversations', methods: [Request::METHOD_POST])]
-    public function __invoke(string $chatId, Request $request, User $loggedInUser): JsonResponse
+    #[Route(path: '/v1/chat/{applicationSlug}/private/chats/{chatId}/conversations', methods: [Request::METHOD_POST])]
+    public function __invoke(string $applicationSlug, string $chatId, Request $request, User $loggedInUser): JsonResponse
     {
+        $this->chatApplicationScopeValidator->validate($chatId, $applicationSlug);
+
         $targetUserId = $this->conversationPayloadService->extractRequiredUserId($request->toArray());
         $operationId = $this->operationIdGeneratorService->generate();
 


### PR DESCRIPTION
### Motivation

- Enforce that a `chatId` is always resolved within the context of an `applicationSlug` to prevent cross-application access.
- Make application-scoped chat endpoints include `/{applicationSlug}/` in both Symfony routes and OpenAPI documentation for clarity and consistency.
- Skills used: none.

### Description

- Added `ChatApplicationScopeValidator` service that verifies `chatId` belongs to the provided `applicationSlug` and throws a `404` when it does not (`src/Chat/Application/Service/ChatApplicationScopeValidator.php`).
- Extended the chat repository contract and implementation with `findOneByIdAndApplicationSlug(string $chatId, string $applicationSlug)` to efficiently resolve chats scoped to an application (`src/Chat/Domain/Repository/Interfaces/ChatRepositoryInterface.php`, `src/Chat/Infrastructure/Repository/ChatRepository.php`).
- Updated application-scoped conversation controllers to include `/{applicationSlug}/` in both route attributes and OpenAPI annotations and to call the scope validator before processing: `ApplicationConversationListController`, `ApplicationUserConversationListController`, and `CreateConversationController` under `src/Chat/Transport/Controller/Api/V1/Conversation`.
- Preserved naming conventions so user-scoped endpoints remain under `/private/...` while application-scoped endpoints now follow `/{applicationSlug}/...` (or `/{applicationSlug}/private/...` when both apply).

### Testing

- Performed PHP syntax checks (`php -l`) on all modified files and they reported no syntax errors.
- Attempted to run PHPUnit, but test runner is unavailable in this environment (`vendor/bin/phpunit` / `bin/phpunit` missing), so unit tests could not be executed here.
- Confirmed changed controllers include OpenAPI path parameter additions and validator calls via local file inspection and linting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1deac5c9883268342e496d5df8727)