### PR TITLE
refactor(blog): normalize public/private/application route scopes

### DIFF
--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogCommentController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogCommentController.php
@@ -27,7 +27,7 @@ final readonly class CreateBlogCommentController
     ) {
     }
 
-    #[Route('/v1/blog/posts/{postId}/comments', methods: [Request::METHOD_POST])]
+    #[Route('/v1/private/blog/posts/{postId}/comments', methods: [Request::METHOD_POST])]
     public function __invoke(string $postId, Request $request, User $loggedInUser): JsonResponse
     {
         $payload = $this->requestService->extractPayload($request);

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostController.php
@@ -27,7 +27,7 @@ final readonly class CreateBlogPostController
     ) {
     }
 
-    #[Route('/v1/blogs/{blogId}/posts', methods: [Request::METHOD_POST])]
+    #[Route('/v1/private/blogs/{blogId}/posts', methods: [Request::METHOD_POST])]
     public function __invoke(string $blogId, Request $request, User $loggedInUser): JsonResponse
     {
         $payload = $this->requestService->extractPayload($request);

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostReactionController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostReactionController.php
@@ -31,7 +31,7 @@ final readonly class CreateBlogPostReactionController
     /**
      * @throws ExceptionInterface
      */
-    #[Route('/v1/blog/posts/{postId}/reactions', methods: [Request::METHOD_POST])]
+    #[Route('/v1/private/blog/posts/{postId}/reactions', methods: [Request::METHOD_POST])]
     public function __invoke(string $postId, Request $request, User $loggedInUser): JsonResponse
     {
         $payload = $this->requestService->extractPayload($request);

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogReactionController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogReactionController.php
@@ -31,7 +31,7 @@ final readonly class CreateBlogReactionController
     /**
      * @throws ExceptionInterface
      */
-    #[Route('/v1/blog/comments/{commentId}/reactions', methods: [Request::METHOD_POST])]
+    #[Route('/v1/private/blog/comments/{commentId}/reactions', methods: [Request::METHOD_POST])]
     public function __invoke(string $commentId, Request $request, User $loggedInUser): JsonResponse
     {
         $payload = $this->requestService->extractPayload($request);

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateGeneralBlogController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateGeneralBlogController.php
@@ -30,7 +30,7 @@ final readonly class CreateGeneralBlogController
     ) {
     }
 
-    #[Route('/v1/blogs/general', methods: [Request::METHOD_POST])]
+    #[Route('/v1/private/blogs/general', methods: [Request::METHOD_POST])]
     public function __invoke(Request $request): JsonResponse
     {
         $user = $this->security->getUser();

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/DeleteBlogCommentController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/DeleteBlogCommentController.php
@@ -25,7 +25,7 @@ final readonly class DeleteBlogCommentController
     ) {
     }
 
-    #[Route('/v1/blog/comments/{commentId}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/private/blog/comments/{commentId}', methods: [Request::METHOD_DELETE])]
     public function __invoke(string $commentId, User $loggedInUser): JsonResponse
     {
         $this->messageBus->dispatch(new DeleteBlogCommentCommand((string)uniqid('op_', true), $loggedInUser->getId(), $commentId));

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/DeleteBlogPostController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/DeleteBlogPostController.php
@@ -25,7 +25,7 @@ final readonly class DeleteBlogPostController
     ) {
     }
 
-    #[Route('/v1/blog/posts/{postId}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/private/blog/posts/{postId}', methods: [Request::METHOD_DELETE])]
     public function __invoke(string $postId, User $loggedInUser): JsonResponse
     {
         $this->messageBus->dispatch(new DeleteBlogPostCommand((string)uniqid('op_', true), $loggedInUser->getId(), $postId));

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/DeleteBlogReactionController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/DeleteBlogReactionController.php
@@ -25,7 +25,7 @@ final readonly class DeleteBlogReactionController
     ) {
     }
 
-    #[Route('/v1/blog/reactions/{reactionId}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/private/blog/reactions/{reactionId}', methods: [Request::METHOD_DELETE])]
     public function __invoke(string $reactionId, User $loggedInUser): JsonResponse
     {
         $this->messageBus->dispatch(new DeleteBlogReactionCommand((string)uniqid('op_', true), $loggedInUser->getId(), $reactionId));

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/PatchBlogCommentController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/PatchBlogCommentController.php
@@ -27,7 +27,7 @@ final readonly class PatchBlogCommentController
     ) {
     }
 
-    #[Route('/v1/blog/comments/{commentId}', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/private/blog/comments/{commentId}', methods: [Request::METHOD_PATCH])]
     public function __invoke(string $commentId, Request $request, User $loggedInUser): JsonResponse
     {
         $payload = $this->requestService->extractPayload($request);

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/PatchBlogPostController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/PatchBlogPostController.php
@@ -27,7 +27,7 @@ final readonly class PatchBlogPostController
     ) {
     }
 
-    #[Route('/v1/blog/posts/{postId}', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/private/blog/posts/{postId}', methods: [Request::METHOD_PATCH])]
     public function __invoke(string $postId, Request $request, User $loggedInUser): JsonResponse
     {
         $payload = $this->requestService->extractPayload($request);

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/PatchBlogReactionController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/PatchBlogReactionController.php
@@ -27,7 +27,7 @@ final readonly class PatchBlogReactionController
     ) {
     }
 
-    #[Route('/v1/blog/reactions/{reactionId}', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/private/blog/reactions/{reactionId}', methods: [Request::METHOD_PATCH])]
     public function __invoke(string $reactionId, Request $request, User $loggedInUser): JsonResponse
     {
         $payload = $this->requestService->extractPayload($request);

--- a/src/Blog/Transport/Controller/Api/V1/Read/GetApplicationBlogController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Read/GetApplicationBlogController.php
@@ -23,7 +23,7 @@ final readonly class GetApplicationBlogController
     ) {
     }
 
-    #[Route('/v1/blog/applications/{applicationSlug}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/blog/{applicationSlug}/feed', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug): JsonResponse
     {
         $user = $this->security->getUser();

--- a/src/Blog/Transport/Controller/Api/V1/Read/GetBlogReactionTypesController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Read/GetBlogReactionTypesController.php
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\Attribute\Route;
 #[OA\Tag(name: 'Blog')]
 final class GetBlogReactionTypesController
 {
-    #[Route('/v1/blogs/reactions/types', methods: [Request::METHOD_GET])]
+    #[Route('/v1/public/blogs/reactions/types', methods: [Request::METHOD_GET])]
     #[OA\Get(security: [])]
     public function __invoke(): JsonResponse
     {

--- a/src/Blog/Transport/Controller/Api/V1/Read/GetGeneralBlogController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Read/GetGeneralBlogController.php
@@ -23,7 +23,7 @@ final readonly class GetGeneralBlogController
     ) {
     }
 
-    #[Route('/v1/blogs/general', methods: [Request::METHOD_GET])]
+    #[Route('/v1/private/blogs/general', methods: [Request::METHOD_GET])]
     #[OA\Get(
         parameters: [
             new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 1, minimum: 1)),

--- a/src/Blog/Transport/Controller/Api/V1/Read/GetPublicGeneralBlogController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Read/GetPublicGeneralBlogController.php
@@ -20,7 +20,7 @@ final readonly class GetPublicGeneralBlogController
     ) {
     }
 
-    #[Route('/v1/blogs/general/public', methods: [Request::METHOD_GET])]
+    #[Route('/v1/public/blogs/general', methods: [Request::METHOD_GET])]
     #[OA\Get(
         security: [],
         parameters: [

--- a/tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php
+++ b/tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php
@@ -16,7 +16,7 @@ final class BlogControllerTest extends WebTestCase
 
         $client->request(
             Request::METHOD_POST,
-            self::API_URL_PREFIX . '/v1/blogs/general',
+            self::API_URL_PREFIX . '/v1/private/blogs/general',
             [],
             [],
             $this->getJsonHeaders(),
@@ -34,7 +34,7 @@ final class BlogControllerTest extends WebTestCase
 
         $client->request(
             Request::METHOD_POST,
-            self::API_URL_PREFIX . '/v1/blogs/general',
+            self::API_URL_PREFIX . '/v1/private/blogs/general',
             [],
             [],
             $this->getJsonHeaders(),
@@ -46,17 +46,27 @@ final class BlogControllerTest extends WebTestCase
         self::assertResponseStatusCodeSame(403);
     }
 
+
+    public function testPrivateGeneralReadRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/private/blogs/general');
+
+        self::assertResponseStatusCodeSame(401);
+    }
+
     public function testApplicationReadReflectsIsAuthorWithAndWithoutAuth(): void
     {
         $anonymousClient = $this->getTestClient();
         $authenticatedClient = $this->getTestClient('john-user', 'password-user');
 
-        $anonymousClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/applications/shop-ops-center');
+        $anonymousClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
         self::assertResponseStatusCodeSame(200);
         /** @var array<string, mixed> $anonymousPayload */
         $anonymousPayload = json_decode((string)$anonymousClient->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
 
-        $authenticatedClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/applications/shop-ops-center');
+        $authenticatedClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
         self::assertResponseStatusCodeSame(200);
         /** @var array<string, mixed> $authenticatedPayload */
         $authenticatedPayload = json_decode((string)$authenticatedClient->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
@@ -76,7 +86,7 @@ final class BlogControllerTest extends WebTestCase
     {
         $client = $this->getTestClient('john-user', 'password-user');
 
-        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/applications/shop-ops-center');
+        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
         self::assertResponseStatusCodeSame(200);
         /** @var array<string, mixed> $payload */
         $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
@@ -86,7 +96,7 @@ final class BlogControllerTest extends WebTestCase
 
         $client->request(
             Request::METHOD_POST,
-            self::API_URL_PREFIX . '/v1/blog/comments/' . $targetCommentId . '/reactions',
+            self::API_URL_PREFIX . '/v1/private/blog/comments/' . $targetCommentId . '/reactions',
             [],
             [],
             $this->getJsonHeaders(),
@@ -103,7 +113,7 @@ final class BlogControllerTest extends WebTestCase
         $anonymousClient = $this->getTestClient();
         $authenticatedClient = $this->getTestClient('john-user', 'password-user');
 
-        $authenticatedClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/applications/shop-ops-center');
+        $authenticatedClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
         self::assertResponseStatusCodeSame(200);
         /** @var array<string, mixed> $payload */
         $payload = json_decode((string)$authenticatedClient->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
@@ -113,7 +123,7 @@ final class BlogControllerTest extends WebTestCase
 
         $anonymousClient->request(
             Request::METHOD_POST,
-            self::API_URL_PREFIX . '/v1/blog/comments/' . $targetCommentId . '/reactions',
+            self::API_URL_PREFIX . '/v1/private/blog/comments/' . $targetCommentId . '/reactions',
             [],
             [],
             $this->getJsonHeaders(),
@@ -129,7 +139,7 @@ final class BlogControllerTest extends WebTestCase
     {
         $client = $this->getTestClient('john-user', 'password-user');
 
-        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/applications/shop-ops-center');
+        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
         self::assertResponseStatusCodeSame(200);
         /** @var array<string, mixed> $payload */
         $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
@@ -146,7 +156,7 @@ final class BlogControllerTest extends WebTestCase
 
         $client->request(
             Request::METHOD_POST,
-            self::API_URL_PREFIX . '/v1/blog/comments/' . $targetCommentId . '/reactions',
+            self::API_URL_PREFIX . '/v1/private/blog/comments/' . $targetCommentId . '/reactions',
             [],
             [],
             $this->getJsonHeaders(),
@@ -158,7 +168,7 @@ final class BlogControllerTest extends WebTestCase
 
         $client->request(
             Request::METHOD_POST,
-            self::API_URL_PREFIX . '/v1/blog/comments/' . $targetCommentId . '/reactions',
+            self::API_URL_PREFIX . '/v1/private/blog/comments/' . $targetCommentId . '/reactions',
             [],
             [],
             $this->getJsonHeaders(),
@@ -168,7 +178,7 @@ final class BlogControllerTest extends WebTestCase
         );
         self::assertResponseStatusCodeSame(202);
 
-        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/applications/shop-ops-center');
+        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
         self::assertResponseStatusCodeSame(200);
         /** @var array<string, mixed> $updatedPayload */
         $updatedPayload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
@@ -198,7 +208,7 @@ final class BlogControllerTest extends WebTestCase
     {
         $client = $this->getTestClient('john-user', 'password-user');
 
-        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/applications/shop-ops-center');
+        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
         self::assertResponseStatusCodeSame(200);
         /** @var array<string, mixed> $payload */
         $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
@@ -215,7 +225,7 @@ final class BlogControllerTest extends WebTestCase
 
         $client->request(
             Request::METHOD_POST,
-            self::API_URL_PREFIX . '/v1/blog/posts/' . $targetPostId . '/reactions',
+            self::API_URL_PREFIX . '/v1/private/blog/posts/' . $targetPostId . '/reactions',
             [],
             [],
             $this->getJsonHeaders(),
@@ -227,7 +237,7 @@ final class BlogControllerTest extends WebTestCase
 
         $client->request(
             Request::METHOD_POST,
-            self::API_URL_PREFIX . '/v1/blog/posts/' . $targetPostId . '/reactions',
+            self::API_URL_PREFIX . '/v1/private/blog/posts/' . $targetPostId . '/reactions',
             [],
             [],
             $this->getJsonHeaders(),
@@ -237,7 +247,7 @@ final class BlogControllerTest extends WebTestCase
         );
         self::assertResponseStatusCodeSame(202);
 
-        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/applications/shop-ops-center');
+        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
         self::assertResponseStatusCodeSame(200);
         /** @var array<string, mixed> $updatedPayload */
         $updatedPayload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
### Motivation
- Clarifier et standardiser la surface HTTP du module Blog en séparant clairement les endpoints publics, privés (liés à l'utilisateur connecté) et application-scoped. 
- Renommer les routes pour rendre l'intention explicite (`/public/...`, `/private/...`, et `/{applicationSlug}/`) afin d'harmoniser l'API. 
- S'assurer que les protections et vérifications d'ownership restent en place pour les mutations authentifiées.

### Description
- Renommage des routes de lecture publique vers le préfixe `'/v1/public/...'` (ex. `'/v1/public/blogs/general'`, `'/v1/public/blogs/reactions/types'`).
- Migration des routes de lecture/écriture liées à l'utilisateur connecté vers `'/v1/private/...'` (toutes les mutations sur posts/comments/reactions et la lecture générale privée déplacées sous `'/v1/private/...'`).
- Adoption de la convention application-scoped avec `/{applicationSlug}/` pour la lecture d'une application, exposée via `'/v1/blog/{applicationSlug}/feed'`.
- Maintien des contrôles de sécurité: contrôleurs privés protégés par `IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)` et handlers conservent les vérifications d'ownership (ex. `authorId === actorUserId`).
- Mise à jour des tests fonctionnels Blog pour utiliser les nouvelles routes et ajout d'un test qui vérifie que `GET /v1/private/blogs/general` retourne `401` pour un utilisateur anonyme.

### Testing
- Syntaxe PHP vérifiée avec `php -l` sur tous les contrôleurs Blog modifiés et sur le fichier de test modifié: success ✅.
- Exécution de la suite ciblée `phpunit` impossible dans cet environnement car `./vendor/bin/phpunit` est absent (test non exécuté ⚠️).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e06222b4832694ee45cdc9cf5dc2)