### PR TITLE
feat(fixtures): add chat scenario for chat-enabled applications

### DIFF
--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -63,6 +63,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
 
         foreach ($chatEnabledApplications as $application) {
             $chat = $this->ensureChat($manager, $application);
+            $this->ensureApplicationChatScenario($manager, $application, $chat);
 
             if ($application->getTitle() === 'Recruit Talent Hub') {
                 $calendar = $this->ensureCalendar($manager, $application);
@@ -330,6 +331,40 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
 
         $this->ensureReaction($manager, $replyMessage, $john, 'like');
         $this->ensureReaction($manager, $introMessage, $johnAdmin, 'love');
+    }
+
+    private function ensureApplicationChatScenario(ObjectManager $manager, PlatformApplication $application, Chat $chat): void
+    {
+        /** @var User $johnRoot */
+        $johnRoot = $this->getReference('User-john-root', User::class);
+        /** @var User $johnAdmin */
+        $johnAdmin = $this->getReference('User-john-admin', User::class);
+
+        $conversation = $this->ensureConversation($manager, $chat);
+
+        $this->ensureParticipant($manager, $conversation, $johnRoot);
+        if ($johnRoot->getId() !== $johnAdmin->getId()) {
+            $this->ensureParticipant($manager, $conversation, $johnAdmin);
+        }
+
+        $introMessage = $this->ensureMessage(
+            $manager,
+            $conversation,
+            $johnRoot,
+            sprintf('Chat plugin activé pour %s, je lance un fil de suivi.', $application->getTitle()),
+            []
+        );
+
+        $replyMessage = $this->ensureMessage(
+            $manager,
+            $conversation,
+            $johnAdmin,
+            sprintf('Parfait, je confirme la modération pour %s.', $application->getTitle()),
+            []
+        );
+
+        $this->ensureReaction($manager, $introMessage, $johnAdmin, 'like');
+        $this->ensureReaction($manager, $replyMessage, $johnRoot, 'love');
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Ensure that when an application is created with the chat plugin enabled, the fixtures also create a baseline chat scenario (conversation, participants, messages and reactions) so tests have chat data available per-application. 
- Provide parity with existing blog/calendar/quiz fixtures which already create domain data for apps that enable those plugins.

### Description

- Added `ensureApplicationChatScenario()` in `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` to create/ensure a conversation, participants (`john-root`, `john-admin`), two messages and reactions for a chat-enabled application.
- Wired the new scenario into the fixture `load()` loop so it runs for every application returned by `getApplicationsByPlugin()` for the chat plugin by calling `ensureApplicationChatScenario()` after `ensureChat()`.
- Reused existing helpers (`ensureConversation()`, `ensureMessage()`, `ensureParticipant()`, `ensureReaction()`) to keep behaviour consistent with other recruit chat scenarios.
- Confirmed that blog, calendar and quiz fixtures already create related entities (blogs + posts + comments, calendars + events, quizzes + questions/answers) for applications using those plugins.

### Testing

- Ran a PHP syntax check with `php -l src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` which reported no syntax errors.
- No other automated test failures were introduced by this change based on the local static/syntax validation run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1e9cdc4108326952e6cf1937b0ea5)