### PR TITLE
Return created entity IDs for blog post/comment/reaction mutations

### DIFF
--- a/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
@@ -31,7 +31,7 @@ final readonly class CreateBlogCommentCommandHandler
     ) {
     }
 
-    public function __invoke(CreateBlogCommentCommand $command): void
+    public function __invoke(CreateBlogCommentCommand $command): string
     {
         $post = $this->postRepository->find($command->postId);
         $user = $this->userRepository->find($command->actorUserId);
@@ -73,5 +73,7 @@ final readonly class CreateBlogCommentCommandHandler
         $this->commentRepository->save($comment);
         $this->blogNotificationService->notifyCommentCreated($comment);
         $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
+
+        return $comment->getId();
     }
 }

--- a/src/Blog/Application/MessageHandler/CreateBlogPostCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogPostCommandHandler.php
@@ -35,7 +35,7 @@ final readonly class CreateBlogPostCommandHandler
      * @throws OptimisticLockException
      * @throws ORMException
      */
-    public function __invoke(CreateBlogPostCommand $command): void
+    public function __invoke(CreateBlogPostCommand $command): string
     {
         $blog = $this->blogRepository->find($command->blogId);
         $user = $this->userRepository->find($command->actorUserId);
@@ -52,7 +52,9 @@ final readonly class CreateBlogPostCommandHandler
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Post requires content and/or filePath.');
         }
 
-        $this->postRepository->save(new BlogPost()
+        $post = new BlogPost();
+
+        $this->postRepository->save($post
             ->setBlog($blog)
             ->setAuthor($user)
             ->setTitle($command->title)
@@ -61,5 +63,7 @@ final readonly class CreateBlogPostCommandHandler
             ->setIsPinned($command->isPinned));
 
         $this->cacheInvalidationService->invalidateBlogCaches($blog->getApplication()?->getSlug(), $command->actorUserId);
+
+        return $post->getId();
     }
 }

--- a/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
@@ -29,7 +29,7 @@ final readonly class CreateBlogReactionCommandHandler
     ) {
     }
 
-    public function __invoke(CreateBlogReactionCommand $command): void
+    public function __invoke(CreateBlogReactionCommand $command): string
     {
         $comment = $this->commentRepository->find($command->commentId);
         $user = $this->userRepository->find($command->actorUserId);
@@ -46,15 +46,19 @@ final readonly class CreateBlogReactionCommandHandler
 
             $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
 
-            return;
+            return $existingReaction->getId();
         }
 
-        $this->reactionRepository->save((new BlogReaction())
+        $reaction = (new BlogReaction())
             ->setComment($comment)
             ->setAuthor($user)
-            ->setType($command->type));
+            ->setType($command->type);
+
+        $this->reactionRepository->save($reaction);
 
         $this->blogNotificationService->notifyReactionCreated($comment, $user, $command->type->value);
         $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
+
+        return $reaction->getId();
     }
 }

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogCommentController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogCommentController.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -33,10 +34,15 @@ final readonly class CreateBlogCommentController
         $payload = $this->requestService->extractPayload($request);
         $payload['filePath'] = $this->requestService->resolveUploadedFileUrl($request, (string)($payload['filePath'] ?? ''));
 
-        $this->messageBus->dispatch(new CreateBlogCommentCommand((string)uniqid('op_', true), $loggedInUser->getId(), $postId, $payload['content'] ?? null, $payload['filePath'] ?: null, $payload['parentCommentId'] ?? null));
+        $envelope = $this->messageBus->dispatch(new CreateBlogCommentCommand((string)uniqid('op_', true), $loggedInUser->getId(), $postId, $payload['content'] ?? null, $payload['filePath'] ?: null, $payload['parentCommentId'] ?? null));
+
+        /** @var HandledStamp|null $handled */
+        $handled = $envelope->last(HandledStamp::class);
+        $entityId = $handled?->getResult();
 
         return new JsonResponse([
             'status' => 'accepted',
+            'id' => is_string($entityId) ? $entityId : null,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostController.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -33,7 +34,7 @@ final readonly class CreateBlogPostController
         $payload = $this->requestService->extractPayload($request);
         $payload['filePath'] = $this->requestService->resolveUploadedFileUrl($request, (string)($payload['filePath'] ?? ''));
 
-        $this->messageBus->dispatch(
+        $envelope = $this->messageBus->dispatch(
             new CreateBlogPostCommand(
                 (string)uniqid('op_', true),
                 $loggedInUser->getId(),
@@ -44,8 +45,13 @@ final readonly class CreateBlogPostController
             )
         );
 
+        /** @var HandledStamp|null $handled */
+        $handled = $envelope->last(HandledStamp::class);
+        $entityId = $handled?->getResult();
+
         return new JsonResponse([
             'status' => 'accepted',
+            'id' => is_string($entityId) ? $entityId : null,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogReactionController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogReactionController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Messenger\Exception\ExceptionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -35,10 +36,15 @@ final readonly class CreateBlogReactionController
     public function __invoke(string $commentId, Request $request, User $loggedInUser): JsonResponse
     {
         $payload = $this->requestService->extractPayload($request);
-        $this->messageBus->dispatch(new CreateBlogReactionCommand((string)uniqid('op_', true), $loggedInUser->getId(), $commentId, $this->requestService->parseReactionType((string)($payload['type'] ?? 'like'))));
+        $envelope = $this->messageBus->dispatch(new CreateBlogReactionCommand((string)uniqid('op_', true), $loggedInUser->getId(), $commentId, $this->requestService->parseReactionType((string)($payload['type'] ?? 'like'))));
+
+        /** @var HandledStamp|null $handled */
+        $handled = $envelope->last(HandledStamp::class);
+        $entityId = $handled?->getResult();
 
         return new JsonResponse([
             'status' => 'accepted',
+            'id' => is_string($entityId) ? $entityId : null,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }


### PR DESCRIPTION
### Motivation
- Return the identifier of newly created or updated Blog entities so API clients can reference them immediately after creation.
- Align Blog mutation controllers with the existing `HandledStamp` pattern used elsewhere to expose handler results to HTTP responses.

### Description
- Change `CreateBlogPostCommandHandler`, `CreateBlogCommentCommandHandler` and `CreateBlogReactionCommandHandler` so `__invoke` returns the created/updated entity id as a `string` instead of `void`.
- Update `CreateBlogPostController`, `CreateBlogCommentController` and `CreateBlogReactionController` to capture the `HandledStamp` from the dispatched Messenger envelope and include an `id` field in the JSON response (`'id' => is_string($entityId) ? $entityId : null`).
- Add `HandledStamp` imports where needed and preserve the existing `202 Accepted` response and `status` field while adding the `id` payload.

### Testing
- Ran PHP syntax checks with `php -l` on all modified handlers and controllers and there were no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1fc7a49048326bf719376f80b1789)