### PR TITLE
Return entity IDs from command handlers and include them in API responses

### DIFF
--- a/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
@@ -31,7 +31,7 @@ final readonly class CreateBlogCommentCommandHandler
     ) {
     }
 
-    public function __invoke(CreateBlogCommentCommand $command): void
+    public function __invoke(CreateBlogCommentCommand $command): string
     {
         $post = $this->postRepository->find($command->postId);
         $user = $this->userRepository->find($command->actorUserId);
@@ -73,5 +73,7 @@ final readonly class CreateBlogCommentCommandHandler
         $this->commentRepository->save($comment);
         $this->blogNotificationService->notifyCommentCreated($comment);
         $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
+
+        return $comment->getId();
     }
 }

--- a/src/Blog/Application/MessageHandler/CreateBlogPostCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogPostCommandHandler.php
@@ -35,7 +35,7 @@ final readonly class CreateBlogPostCommandHandler
      * @throws OptimisticLockException
      * @throws ORMException
      */
-    public function __invoke(CreateBlogPostCommand $command): void
+    public function __invoke(CreateBlogPostCommand $command): string
     {
         $blog = $this->blogRepository->find($command->blogId);
         $user = $this->userRepository->find($command->actorUserId);
@@ -52,7 +52,9 @@ final readonly class CreateBlogPostCommandHandler
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Post requires content and/or filePath.');
         }
 
-        $this->postRepository->save(new BlogPost()
+        $post = new BlogPost();
+
+        $this->postRepository->save($post
             ->setBlog($blog)
             ->setAuthor($user)
             ->setTitle($command->title)
@@ -61,5 +63,7 @@ final readonly class CreateBlogPostCommandHandler
             ->setIsPinned($command->isPinned));
 
         $this->cacheInvalidationService->invalidateBlogCaches($blog->getApplication()?->getSlug(), $command->actorUserId);
+
+        return $post->getId();
     }
 }

--- a/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
@@ -29,7 +29,7 @@ final readonly class CreateBlogReactionCommandHandler
     ) {
     }
 
-    public function __invoke(CreateBlogReactionCommand $command): void
+    public function __invoke(CreateBlogReactionCommand $command): string
     {
         $comment = $this->commentRepository->find($command->commentId);
         $user = $this->userRepository->find($command->actorUserId);
@@ -46,15 +46,19 @@ final readonly class CreateBlogReactionCommandHandler
 
             $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
 
-            return;
+            return $existingReaction->getId();
         }
 
-        $this->reactionRepository->save((new BlogReaction())
+        $reaction = (new BlogReaction())
             ->setComment($comment)
             ->setAuthor($user)
-            ->setType($command->type));
+            ->setType($command->type);
+
+        $this->reactionRepository->save($reaction);
 
         $this->blogNotificationService->notifyReactionCreated($comment, $user, $command->type->value);
         $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
+
+        return $reaction->getId();
     }
 }

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogCommentController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogCommentController.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -33,10 +34,15 @@ final readonly class CreateBlogCommentController
         $payload = $this->requestService->extractPayload($request);
         $payload['filePath'] = $this->requestService->resolveUploadedFileUrl($request, (string)($payload['filePath'] ?? ''));
 
-        $this->messageBus->dispatch(new CreateBlogCommentCommand((string)uniqid('op_', true), $loggedInUser->getId(), $postId, $payload['content'] ?? null, $payload['filePath'] ?: null, $payload['parentCommentId'] ?? null));
+        $envelope = $this->messageBus->dispatch(new CreateBlogCommentCommand((string)uniqid('op_', true), $loggedInUser->getId(), $postId, $payload['content'] ?? null, $payload['filePath'] ?: null, $payload['parentCommentId'] ?? null));
+
+        /** @var HandledStamp|null $handled */
+        $handled = $envelope->last(HandledStamp::class);
+        $entityId = $handled?->getResult();
 
         return new JsonResponse([
             'status' => 'accepted',
+            'id' => is_string($entityId) ? $entityId : null,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostController.php
@@ -12,6 +12,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -33,7 +34,7 @@ final readonly class CreateBlogPostController
         $payload = $this->requestService->extractPayload($request);
         $payload['filePath'] = $this->requestService->resolveUploadedFileUrl($request, (string)($payload['filePath'] ?? ''));
 
-        $this->messageBus->dispatch(
+        $envelope = $this->messageBus->dispatch(
             new CreateBlogPostCommand(
                 (string)uniqid('op_', true),
                 $loggedInUser->getId(),
@@ -44,8 +45,13 @@ final readonly class CreateBlogPostController
             )
         );
 
+        /** @var HandledStamp|null $handled */
+        $handled = $envelope->last(HandledStamp::class);
+        $entityId = $handled?->getResult();
+
         return new JsonResponse([
             'status' => 'accepted',
+            'id' => is_string($entityId) ? $entityId : null,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogReactionController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogReactionController.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Messenger\Exception\ExceptionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -35,10 +36,15 @@ final readonly class CreateBlogReactionController
     public function __invoke(string $commentId, Request $request, User $loggedInUser): JsonResponse
     {
         $payload = $this->requestService->extractPayload($request);
-        $this->messageBus->dispatch(new CreateBlogReactionCommand((string)uniqid('op_', true), $loggedInUser->getId(), $commentId, $this->requestService->parseReactionType((string)($payload['type'] ?? 'like'))));
+        $envelope = $this->messageBus->dispatch(new CreateBlogReactionCommand((string)uniqid('op_', true), $loggedInUser->getId(), $commentId, $this->requestService->parseReactionType((string)($payload['type'] ?? 'like'))));
+
+        /** @var HandledStamp|null $handled */
+        $handled = $envelope->last(HandledStamp::class);
+        $entityId = $handled?->getResult();
 
         return new JsonResponse([
             'status' => 'accepted',
+            'id' => is_string($entityId) ? $entityId : null,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }

--- a/src/Chat/Application/MessageHandler/CreateMessageCommandHandler.php
+++ b/src/Chat/Application/MessageHandler/CreateMessageCommandHandler.php
@@ -32,7 +32,7 @@ final readonly class CreateMessageCommandHandler
     ) {
     }
 
-    public function __invoke(CreateMessageCommand $command): void
+    public function __invoke(CreateMessageCommand $command): string
     {
         /** @var array{chatId: string, message: ChatMessage} $result */
         $result = $this->messageRepository->getEntityManager()->getConnection()->transactional(function () use ($command): array {
@@ -72,6 +72,8 @@ final readonly class CreateMessageCommandHandler
             'attachments' => $result['message']->getAttachments(),
             'createdAt' => $result['message']->getCreatedAt()?->format(DATE_ATOM),
         ]);
+
+        return $result['message']->getId();
     }
 
     private function findParticipantConversation(string $conversationId, User $actor): Conversation

--- a/src/Chat/Transport/Controller/Api/V1/Message/CreateMessageController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/CreateMessageController.php
@@ -7,12 +7,13 @@ namespace App\Chat\Transport\Controller\Api\V1\Message;
 use App\Chat\Application\Message\CreateMessageCommand;
 use App\Chat\Application\Service\MessagePayloadService;
 use App\General\Application\Service\OperationIdGeneratorService;
-use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -40,7 +41,10 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
         new OA\Parameter(name: 'conversationId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
     ],
     responses: [
-        new OA\Response(response: 202, description: 'Commande acceptée'),
+        new OA\Response(response: 202, description: 'Commande acceptée', content: new OA\JsonContent(example: [
+            'operationId' => 'op_123',
+            'id' => '550e8400-e29b-41d4-a716-446655440000',
+        ])),
         new OA\Response(response: 400, description: 'Payload invalide'),
     ]
 )]
@@ -48,7 +52,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class CreateMessageController
 {
     public function __construct(
-        private readonly MessageServiceInterface $messageService,
+        private readonly MessageBusInterface $messageBus,
         private readonly MessagePayloadService $messagePayloadService,
         private readonly OperationIdGeneratorService $operationIdGeneratorService,
     ) {
@@ -60,15 +64,20 @@ class CreateMessageController
         $content = $this->messagePayloadService->extractRequiredContent($request->toArray());
         $operationId = $this->operationIdGeneratorService->generate();
 
-        $this->messageService->sendMessage(new CreateMessageCommand(
+        $envelope = $this->messageBus->dispatch(new CreateMessageCommand(
             operationId: $operationId,
             actorUserId: $loggedInUser->getId(),
             conversationId: $conversationId,
             content: $content,
         ));
 
+        /** @var HandledStamp|null $handled */
+        $handled = $envelope->last(HandledStamp::class);
+        $entityId = $handled?->getResult();
+
         return new JsonResponse([
             'operationId' => $operationId,
+            'id' => is_string($entityId) ? $entityId : null,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }


### PR DESCRIPTION
### Motivation

- Provide clients with the persisted entity identifier immediately when a create command is accepted so they can correlate async operations with created resources.
- Make controller-level responses include the created entity `id` when using the message bus so clients receive a stable reference for follow-up actions.

### Description

- Change several command handlers to return the created entity id by updating return types to `string` and returning `->getId()` for `CreateBlogCommentCommandHandler`, `CreateBlogPostCommandHandler`, `CreateBlogReactionCommandHandler`, and `CreateMessageCommandHandler`.
- Ensure `CreateBlogReactionCommandHandler` also returns the existing reaction id when updating an existing reaction instead of returning `void`.
- Refactor `CreateBlogPostCommandHandler` to construct a `$post` variable before saving so its id can be returned after `save`.
- Update controllers to capture the `HandledStamp` from the dispatched envelope and include an `id` field in the JSON response for `CreateBlogCommentController`, `CreateBlogPostController`, `CreateBlogReactionController`, and `CreateMessageController`.
- Replace the old `MessageServiceInterface` usage in the chat controller with `MessageBusInterface`, and add an OpenAPI response example including `operationId` and `id`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1fc7a49048326bf719376f80b1789)