### PR TITLE
Return reaction ID from blog post reaction creation endpoint

### DIFF
--- a/src/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandler.php
@@ -29,7 +29,7 @@ final readonly class CreateBlogPostReactionCommandHandler
     ) {
     }
 
-    public function __invoke(CreateBlogPostReactionCommand $command): void
+    public function __invoke(CreateBlogPostReactionCommand $command): string
     {
         $post = $this->postRepository->find($command->postId);
         $user = $this->userRepository->find($command->actorUserId);
@@ -46,15 +46,19 @@ final readonly class CreateBlogPostReactionCommandHandler
 
             $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
 
-            return;
+            return $existingReaction->getId();
         }
 
-        $this->reactionRepository->save((new BlogReaction())
+        $reaction = (new BlogReaction())
             ->setPost($post)
             ->setAuthor($user)
-            ->setType($command->type));
+            ->setType($command->type);
+
+        $this->reactionRepository->save($reaction);
 
         $this->blogNotificationService->notifyPostReactionCreated($post, $user, $command->type->value);
         $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $command->actorUserId);
+
+        return $reaction->getId();
     }
 }

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostReactionController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostReactionController.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Api\V1\Mutation;
 
 use App\Blog\Application\Message\CreateBlogPostReactionCommand;
+use App\Blog\Application\MessageHandler\CreateBlogPostReactionCommandHandler;
 use App\Blog\Application\Service\BlogMutationRequestService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\Messenger\Exception\ExceptionInterface;
-use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -23,22 +22,19 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateBlogPostReactionController
 {
     public function __construct(
-        private MessageBusInterface $messageBus,
+        private CreateBlogPostReactionCommandHandler $handler,
         private BlogMutationRequestService $requestService,
     ) {
     }
-
-    /**
-     * @throws ExceptionInterface
-     */
     #[Route('/v1/private/blog/posts/{postId}/reactions', methods: [Request::METHOD_POST])]
     public function __invoke(string $postId, Request $request, User $loggedInUser): JsonResponse
     {
         $payload = $this->requestService->extractPayload($request);
-        $this->messageBus->dispatch(new CreateBlogPostReactionCommand((string)uniqid('op_', true), $loggedInUser->getId(), $postId, $this->requestService->parseReactionType((string)($payload['type'] ?? 'like'))));
+        $entityId = $this->handler->__invoke(new CreateBlogPostReactionCommand((string)uniqid('op_', true), $loggedInUser->getId(), $postId, $this->requestService->parseReactionType((string)($payload['type'] ?? 'like'))));
 
         return new JsonResponse([
             'status' => 'accepted',
+            'id' => is_string($entityId) ? $entityId : null,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }

--- a/tests/Unit/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandlerTest.php
+++ b/tests/Unit/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandlerTest.php
@@ -52,7 +52,9 @@ final class CreateBlogPostReactionCommandHandlerTest extends TestCase
             $cacheInvalidationService,
         );
 
-        $handler(new CreateBlogPostReactionCommand('op', 'actor', 'post', BlogReactionType::HEART));
+        $reactionId = $handler(new CreateBlogPostReactionCommand('op', 'actor', 'post', BlogReactionType::HEART));
+
+        self::assertNotSame('', $reactionId);
     }
 
     public function testInvokeUpdatesExistingReactionForSamePostAndAuthor(): void
@@ -89,9 +91,10 @@ final class CreateBlogPostReactionCommandHandlerTest extends TestCase
             $cacheInvalidationService,
         );
 
-        $handler(new CreateBlogPostReactionCommand('op', 'actor', 'post', BlogReactionType::LAUGH));
+        $reactionId = $handler(new CreateBlogPostReactionCommand('op', 'actor', 'post', BlogReactionType::LAUGH));
 
         self::assertSame(BlogReactionType::LAUGH, $existingReaction->getType());
+        self::assertSame($existingReaction->getId(), $reactionId);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Make the `POST /v1/private/blog/posts/{postId}/reactions` endpoint return the created/updated reaction `id` like other create endpoints to provide a consistent API shape.
- Allow callers to receive the reaction identifier immediately for follow-up actions (UI updates, links, etc.).

### Description
- Change `CreateBlogPostReactionCommandHandler::__invoke` to return `string` and return the reaction `id` for both update and create flows instead of `void` (file: `src/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandler.php`).
- Update `CreateBlogPostReactionController` to call the handler directly (injecting `CreateBlogPostReactionCommandHandler` instead of dispatching to the message bus) and include an `id` field in the JSON response (file: `src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostReactionController.php`).
- Extend unit tests to assert that an `id` is returned for both new reactions and when updating an existing reaction (file: `tests/Unit/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandlerTest.php`).

### Testing
- Attempted to run the unit test file with `php -d memory_limit=1G ./vendor/bin/phpunit tests/Unit/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandlerTest.php`, but the environment does not contain `./vendor/bin/phpunit`, so the test run could not complete and no automated tests were executed successfully.
- Updated unit tests are included in the PR and should pass in CI where `phpunit` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b207083a04832680d6ce8777ba2582)