### PR TITLE
feat(crm): add sprint task board and assignee-aware task endpoints

### DIFF
--- a/migrations/Version20260312100000.php
+++ b/migrations/Version20260312100000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260312100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add assignees for CRM tasks and task requests';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE crm_task_assignee (task_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", user_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", INDEX IDX_1579FBF98DB60186 (task_id), INDEX IDX_1579FBF9A76ED395 (user_id), PRIMARY KEY(task_id, user_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE crm_task_request_assignee (task_request_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", user_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", INDEX IDX_14A92EAA6322B482 (task_request_id), INDEX IDX_14A92EAAA76ED395 (user_id), PRIMARY KEY(task_request_id, user_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE crm_task_assignee ADD CONSTRAINT FK_1579FBF98DB60186 FOREIGN KEY (task_id) REFERENCES crm_task (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE crm_task_assignee ADD CONSTRAINT FK_1579FBF9A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE crm_task_request_assignee ADD CONSTRAINT FK_14A92EAA6322B482 FOREIGN KEY (task_request_id) REFERENCES crm_task_request (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE crm_task_request_assignee ADD CONSTRAINT FK_14A92EAAA76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_task_assignee DROP FOREIGN KEY FK_1579FBF98DB60186');
+        $this->addSql('ALTER TABLE crm_task_assignee DROP FOREIGN KEY FK_1579FBF9A76ED395');
+        $this->addSql('ALTER TABLE crm_task_request_assignee DROP FOREIGN KEY FK_14A92EAA6322B482');
+        $this->addSql('ALTER TABLE crm_task_request_assignee DROP FOREIGN KEY FK_14A92EAAA76ED395');
+        $this->addSql('DROP TABLE crm_task_assignee');
+        $this->addSql('DROP TABLE crm_task_request_assignee');
+    }
+}

--- a/src/Crm/Application/Service/TaskBoardService.php
+++ b/src/Crm/Application/Service/TaskBoardService.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+
+final readonly class TaskBoardService
+{
+    public function __construct(
+        private TaskRepository $taskRepository,
+        private EntityManagerInterface $entityManager,
+        private CrmApplicationScopeResolver $applicationScopeResolver,
+    ) {
+    }
+
+    /** @return array{items:list<array<string,mixed>>} */
+    public function listBySprint(string $applicationSlug): array
+    {
+        $crm = $this->applicationScopeResolver->resolveOrFail($applicationSlug);
+
+        /** @var list<Task> $tasks */
+        $tasks = $this->taskRepository->createQueryBuilder('task')
+            ->leftJoin('task.sprint', 'sprint')->addSelect('sprint')
+            ->leftJoin('task.taskRequests', 'taskRequest')->addSelect('taskRequest')
+            ->leftJoin('task.assignees', 'taskAssignee')->addSelect('taskAssignee')
+            ->leftJoin('taskRequest.assignees', 'taskRequestAssignee')->addSelect('taskRequestAssignee')
+            ->leftJoin('task.project', 'project')
+            ->leftJoin('project.company', 'company')
+            ->andWhere('company.crm = :crm')
+            ->setParameter('crm', $crm)
+            ->orderBy('sprint.createdAt', 'DESC')
+            ->addOrderBy('task.createdAt', 'DESC')
+            ->addOrderBy('taskRequest.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        $items = [];
+        foreach ($tasks as $task) {
+            $sprintId = $task->getSprint()?->getId() ?? 'no-sprint';
+            if (!isset($items[$sprintId])) {
+                $items[$sprintId] = [
+                    'sprint' => [
+                        'id' => $task->getSprint()?->getId(),
+                        'name' => $task->getSprint()?->getName(),
+                        'status' => $task->getSprint()?->getStatus()->value,
+                    ],
+                    'tasks' => [],
+                ];
+            }
+
+            $items[$sprintId]['tasks'][] = $this->normalizeTask($task);
+        }
+
+        return [
+            'items' => array_values($items),
+        ];
+    }
+
+    /** @return array{items:array{tasks:list<array<string,mixed>>,taskRequests:list<array<string,mixed>>}} */
+    public function listMine(string $applicationSlug, User $loggedInUser): array
+    {
+        $crm = $this->applicationScopeResolver->resolveOrFail($applicationSlug);
+
+        /** @var list<Task> $tasks */
+        $tasks = $this->taskRepository->createQueryBuilder('task')
+            ->leftJoin('task.assignees', 'taskAssignee')->addSelect('taskAssignee')
+            ->leftJoin('task.taskRequests', 'taskRequest')->addSelect('taskRequest')
+            ->leftJoin('taskRequest.assignees', 'taskRequestAssignee')->addSelect('taskRequestAssignee')
+            ->leftJoin('task.project', 'project')
+            ->leftJoin('project.company', 'company')
+            ->andWhere('company.crm = :crm')
+            ->andWhere('taskAssignee = :user OR taskRequestAssignee = :user')
+            ->setParameter('crm', $crm)
+            ->setParameter('user', $loggedInUser)
+            ->orderBy('task.createdAt', 'DESC')
+            ->addOrderBy('taskRequest.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        $taskItems = [];
+        $taskRequestItems = [];
+        foreach ($tasks as $task) {
+            if ($task->getAssignees()->contains($loggedInUser)) {
+                $taskItems[$task->getId()] = $this->normalizeTask($task);
+            }
+
+            foreach ($task->getTaskRequests() as $taskRequest) {
+                if (!$taskRequest->getAssignees()->contains($loggedInUser)) {
+                    continue;
+                }
+
+                $taskRequestItems[$taskRequest->getId()] = $this->normalizeTaskRequest($taskRequest);
+            }
+        }
+
+        return [
+            'items' => [
+                'tasks' => array_values($taskItems),
+                'taskRequests' => array_values($taskRequestItems),
+            ],
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function normalizeTask(Task $task): array
+    {
+        return [
+            'id' => $task->getId(),
+            'title' => $task->getTitle(),
+            'status' => $task->getStatus()->value,
+            'priority' => $task->getPriority()->value,
+            'sprintId' => $task->getSprint()?->getId(),
+            'projectId' => $task->getProject()?->getId(),
+            'assignees' => array_map(static fn (User $user): array => [
+                'id' => $user->getId(),
+                'username' => $user->getUsername(),
+                'email' => $user->getEmail(),
+            ], $task->getAssignees()->toArray()),
+            'children' => array_map(fn (TaskRequest $taskRequest): array => $this->normalizeTaskRequest($taskRequest), $task->getTaskRequests()->toArray()),
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function normalizeTaskRequest(TaskRequest $taskRequest): array
+    {
+        return [
+            'id' => $taskRequest->getId(),
+            'taskId' => $taskRequest->getTask()?->getId(),
+            'title' => $taskRequest->getTitle(),
+            'status' => $taskRequest->getStatus()->value,
+            'requestedAt' => $taskRequest->getRequestedAt()->format(DATE_ATOM),
+            'resolvedAt' => $taskRequest->getResolvedAt()?->format(DATE_ATOM),
+            'assignees' => array_map(static fn (User $user): array => [
+                'id' => $user->getId(),
+                'username' => $user->getUsername(),
+                'email' => $user->getEmail(),
+            ], $taskRequest->getAssignees()->toArray()),
+        ];
+    }
+}

--- a/src/Crm/Application/Service/TaskListService.php
+++ b/src/Crm/Application/Service/TaskListService.php
@@ -8,6 +8,7 @@ use App\Crm\Application\Projection\CrmTaskProjection;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\General\Application\Service\CacheKeyConventionService;
+use App\User\Domain\Entity\User;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -22,6 +23,7 @@ readonly class TaskListService
         private CacheInterface $cache,
         private ElasticsearchServiceInterface $elasticsearchService,
         private CacheKeyConventionService $cacheKeyConventionService,
+        private CrmApplicationScopeResolver $applicationScopeResolver,
     ) {
     }
 
@@ -38,10 +40,12 @@ readonly class TaskListService
             'status' => trim((string)$request->query->get('status', '')),
             'priority' => trim((string)$request->query->get('priority', '')),
         ];
-        $cacheKey = $this->cacheKeyConventionService->buildCrmTaskListKey($page, $limit, $filters);
+        $applicationSlug = (string)$request->attributes->get('applicationSlug', '');
+        $crm = $this->applicationScopeResolver->resolveOrFail($applicationSlug);
+        $cacheKey = $this->cacheKeyConventionService->buildCrmTaskListKey($page, $limit, array_merge($filters, ['applicationSlug' => $applicationSlug]));
 
         /** @var array<string,mixed> $result */
-        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit): array {
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit, $crm): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->crmTaskListTag());
@@ -57,10 +61,16 @@ readonly class TaskListService
                         'totalItems' => 0,
                         'totalPages' => 0,
                     ],
+                    'meta' => [
+                        'module' => 'crm',
+                    ],
                 ];
             }
 
             $qb = $this->taskRepository->createQueryBuilder('task')->leftJoin('task.project', 'project')->leftJoin('task.sprint', 'sprint')
+                ->leftJoin('project.company', 'company')
+                ->leftJoin('task.assignees', 'assignee')->addSelect('assignee')
+                ->andWhere('company.crm = :crm')->setParameter('crm', $crm)
                 ->setFirstResult(($page - 1) * $limit)->setMaxResults($limit)->orderBy('task.createdAt', 'DESC');
 
             if ($filters['title'] !== '') {
@@ -88,9 +98,17 @@ readonly class TaskListService
                 'dueAt' => $task->getDueAt()?->format(DATE_ATOM),
                 'estimatedHours' => $task->getEstimatedHours(),
                 'updatedAt' => $task->getUpdatedAt()?->format(DATE_ATOM),
+                'assignees' => array_map(static fn (User $assignee): array => [
+                    'id' => $assignee->getId(),
+                    'username' => $assignee->getUsername(),
+                    'email' => $assignee->getEmail(),
+                ], $task->getAssignees()->toArray()),
             ], $qb->getQuery()->getResult());
 
-            $countQb = $this->taskRepository->createQueryBuilder('task')->select('COUNT(task.id)');
+            $countQb = $this->taskRepository->createQueryBuilder('task')->select('COUNT(task.id)')
+                ->leftJoin('task.project', 'project')
+                ->leftJoin('project.company', 'company')
+                ->andWhere('company.crm = :crm')->setParameter('crm', $crm);
             if ($filters['title'] !== '') {
                 $countQb->andWhere('LOWER(task.title) LIKE LOWER(:title)')->setParameter('title', '%' . $filters['title'] . '%');
             }

--- a/src/Crm/Domain/Entity/Task.php
+++ b/src/Crm/Domain/Entity/Task.php
@@ -9,6 +9,7 @@ use App\Crm\Domain\Enum\TaskStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
 use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -64,10 +65,18 @@ class Task implements EntityInterface
     #[ORM\OneToMany(targetEntity: TaskRequest::class, mappedBy: 'task')]
     private Collection|ArrayCollection $taskRequests;
 
+    /** @var Collection<int, User>|ArrayCollection<int, User> */
+    #[ORM\ManyToMany(targetEntity: User::class)]
+    #[ORM\JoinTable(name: 'crm_task_assignee')]
+    #[ORM\JoinColumn(name: 'task_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    private Collection|ArrayCollection $assignees;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
         $this->taskRequests = new ArrayCollection();
+        $this->assignees = new ArrayCollection();
     }
 
     #[Override]
@@ -178,5 +187,22 @@ class Task implements EntityInterface
     public function getTaskRequests(): Collection|ArrayCollection
     {
         return $this->taskRequests;
+    }
+
+    /**
+     * @return Collection<int, User>|ArrayCollection<int, User>
+     */
+    public function getAssignees(): Collection|ArrayCollection
+    {
+        return $this->assignees;
+    }
+
+    public function addAssignee(User $user): self
+    {
+        if (!$this->assignees->contains($user)) {
+            $this->assignees->add($user);
+        }
+
+        return $this;
     }
 }

--- a/src/Crm/Domain/Entity/TaskRequest.php
+++ b/src/Crm/Domain/Entity/TaskRequest.php
@@ -8,7 +8,10 @@ use App\Crm\Domain\Enum\TaskRequestStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
 use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
@@ -48,10 +51,18 @@ class TaskRequest implements EntityInterface
     #[ORM\Column(name: 'resolved_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?DateTimeImmutable $resolvedAt = null;
 
+    /** @var Collection<int, User>|ArrayCollection<int, User> */
+    #[ORM\ManyToMany(targetEntity: User::class)]
+    #[ORM\JoinTable(name: 'crm_task_request_assignee')]
+    #[ORM\JoinColumn(name: 'task_request_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    private Collection|ArrayCollection $assignees;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
         $this->requestedAt = new DateTimeImmutable();
+        $this->assignees = new ArrayCollection();
     }
 
     #[Override]
@@ -128,6 +139,24 @@ class TaskRequest implements EntityInterface
     public function setResolvedAt(?DateTimeImmutable $resolvedAt): self
     {
         $this->resolvedAt = $resolvedAt;
+
+        return $this;
+    }
+
+
+    /**
+     * @return Collection<int, User>|ArrayCollection<int, User>
+     */
+    public function getAssignees(): Collection|ArrayCollection
+    {
+        return $this->assignees;
+    }
+
+    public function addAssignee(User $user): self
+    {
+        if (!$this->assignees->contains($user)) {
+            $this->assignees->add($user);
+        }
 
         return $this;
     }

--- a/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
@@ -10,6 +10,7 @@ use App\Crm\Domain\Enum\TaskStatus;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
 use App\Crm\Infrastructure\Repository\SprintRepository;
 use App\General\Application\Message\EntityCreated;
+use App\User\Domain\Entity\User;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -37,6 +38,14 @@ final readonly class CreateTaskController
     #[Route('/v1/crm/applications/{applicationSlug}/tasks', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Post(summary: 'POST /v1/crm/applications/{applicationSlug}/tasks')]
+
+    #[OA\RequestBody(required: false, content: new OA\JsonContent(
+        properties: [
+            new OA\Property(property: 'title', type: 'string'),
+            new OA\Property(property: 'description', type: 'string', nullable: true),
+            new OA\Property(property: 'assigneeIds', type: 'array', items: new OA\Items(type: 'string', format: 'uuid'), nullable: true),
+        ]
+    ))]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
@@ -53,6 +62,18 @@ final readonly class CreateTaskController
         }
         if (is_string($payload['sprintId'] ?? null)) {
             $task->setSprint($this->sprintRepository->find($payload['sprintId']));
+        }
+        if (is_array($payload['assigneeIds'] ?? null)) {
+            foreach ($payload['assigneeIds'] as $assigneeId) {
+                if (!is_string($assigneeId) || $assigneeId === '') {
+                    continue;
+                }
+
+                $assignee = $this->entityManager->getRepository(User::class)->find($assigneeId);
+                if ($assignee instanceof User) {
+                    $task->addAssignee($assignee);
+                }
+            }
         }
 
         $this->entityManager->persist($task);

--- a/src/Crm/Transport/Controller/Api/V1/Task/ListMyTasksController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/ListMyTasksController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Task;
+
+use App\Crm\Application\Service\TaskBoardService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ListMyTasksController
+{
+    public function __construct(
+        private TaskBoardService $taskBoardService,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/me/tasks', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Get(summary: 'Liste mes tasks et task-requests assignées')]
+    public function __invoke(string $applicationSlug, User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->taskBoardService->listMine($applicationSlug, $loggedInUser));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Task/ListTasksBySprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/ListTasksBySprintController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Task;
+
+use App\Crm\Application\Service\TaskBoardService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ListTasksBySprintController
+{
+    public function __construct(
+        private TaskBoardService $taskBoardService,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/tasks/by-sprint', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Get(summary: 'Liste les tasks et task-requests regroupées par sprint')]
+    public function __invoke(string $applicationSlug): JsonResponse
+    {
+        return new JsonResponse($this->taskBoardService->listBySprint($applicationSlug));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
@@ -8,6 +8,7 @@ use App\Crm\Domain\Entity\TaskRequest;
 use App\Crm\Domain\Enum\TaskRequestStatus;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\General\Application\Message\EntityCreated;
+use App\User\Domain\Entity\User;
 use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -34,6 +35,14 @@ final readonly class CreateTaskRequestController
     #[Route('/v1/crm/applications/{applicationSlug}/task-requests', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Post(summary: 'POST /v1/crm/applications/{applicationSlug}/task-requests')]
+
+    #[OA\RequestBody(required: false, content: new OA\JsonContent(
+        properties: [
+            new OA\Property(property: 'title', type: 'string'),
+            new OA\Property(property: 'description', type: 'string', nullable: true),
+            new OA\Property(property: 'assigneeIds', type: 'array', items: new OA\Items(type: 'string', format: 'uuid'), nullable: true),
+        ]
+    ))]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
@@ -45,6 +54,18 @@ final readonly class CreateTaskRequestController
             ->setResolvedAt(isset($payload['resolvedAt']) ? new DateTimeImmutable((string)$payload['resolvedAt']) : null);
         if (is_string($payload['taskId'] ?? null)) {
             $taskRequest->setTask($this->taskRepository->find($payload['taskId']));
+        }
+        if (is_array($payload['assigneeIds'] ?? null)) {
+            foreach ($payload['assigneeIds'] as $assigneeId) {
+                if (!is_string($assigneeId) || $assigneeId === '') {
+                    continue;
+                }
+
+                $assignee = $this->entityManager->getRepository(User::class)->find($assigneeId);
+                if ($assignee instanceof User) {
+                    $taskRequest->addAssignee($assignee);
+                }
+            }
         }
 
         $this->entityManager->persist($taskRequest);

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestsController.php
@@ -35,6 +35,11 @@ final readonly class ListTaskRequestsController
             'requestedAt' => $taskRequest->getRequestedAt()->format(DATE_ATOM),
             'resolvedAt' => $taskRequest->getResolvedAt()?->format(DATE_ATOM),
             'taskId' => $taskRequest->getTask()?->getId(),
+            'assignees' => array_map(static fn (\App\User\Domain\Entity\User $assignee): array => [
+                'id' => $assignee->getId(),
+                'username' => $assignee->getUsername(),
+                'email' => $assignee->getEmail(),
+            ], $taskRequest->getAssignees()->toArray()),
         ], $this->taskRequestRepository->findBy([], [
             'createdAt' => 'DESC',
         ], 200));


### PR DESCRIPTION
### Motivation
- Permettre l'assignation d'une ou plusieurs users sur les `Task` et `TaskRequest` et exposer des listes utiles par sprint et par user pour le module CRM.
- Fournir des endpoints REST testables via la documentation OpenAPI (`/api/doc`) pour consulter les tasks groupées par sprint et celles assignées au user connecté.
- Isoler les listes de tasks au scope d'une `applicationSlug` CRM pour éviter de mélanger les données d'applications différentes.

### Description
- Ajout d'une relation many-to-many `assignees` sur `Task` et `TaskRequest` avec les helpers `getAssignees()` et `addAssignee()` et création de la migration `migrations/Version20260312100000.php` pour les tables de jointure `crm_task_assignee` et `crm_task_request_assignee`.
- Les endpoints de création `POST /v1/crm/applications/{applicationSlug}/tasks` et `POST /v1/crm/applications/{applicationSlug}/task-requests` acceptent désormais `assigneeIds` et incluent une annotation OpenAPI `RequestBody` pour pouvoir les tester via `/api/doc`.
- Ajout de `TaskBoardService` qui regroupe les tasks par sprint (`listBySprint`) et retourne les tasks/task-requests assignées au user connecté (`listMine`), plus les controllers `ListTasksBySprintController` et `ListMyTasksController` exposant ces routes.
- Le service de listing `TaskListService` est désormais scoped par `applicationSlug` (via `CrmApplicationScopeResolver`) et inclut les `assignees` dans la réponse, et la liste des `task-requests` a été enrichie pour retourner aussi les assignees.

### Testing
- Exécution de vérifications de syntaxe PHP sur les fichiers modifiés et la migration via `php -l` (pas d'erreurs détectées sur les fichiers vérifiés).
- Tentative d'exécuter `php bin/console debug:router` pour valider les routes, mais impossible dans cet environnement car les dépendances Composer ne sont pas installées, donc la vérification d'exécution des routes n'a pas été réalisée.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2499aaf1c8326814f77cf4cb1cf2e)