### PR TITLE
Add user applications endpoints, upcoming calendar events, session fallback and john-root fixtures

### DIFF
--- a/src/Calendar/Application/Service/EventListService.php
+++ b/src/Calendar/Application/Service/EventListService.php
@@ -64,6 +64,20 @@ final readonly class EventListService
         return $this->getList('application_private', $filters, $page, $limit, $user, $applicationSlug);
     }
 
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getUpcoming(User $user, ?string $applicationSlug = null, int $limit = 3): array
+    {
+        $safeLimit = max(1, min(20, $limit));
+        $events = $applicationSlug !== null && $applicationSlug !== ''
+            ? $this->eventRepository->findUpcomingByApplicationSlugAndUser($applicationSlug, $user, $safeLimit)
+            : $this->eventRepository->findUpcomingPrivateByUser($user, $safeLimit);
+
+        return $this->normalizeEvents($events);
+    }
+
     /**
      * @param array<string, string> $filters
      *

--- a/src/Calendar/Domain/Repository/Interfaces/EventRepositoryInterface.php
+++ b/src/Calendar/Domain/Repository/Interfaces/EventRepositoryInterface.php
@@ -29,4 +29,14 @@ interface EventRepositoryInterface
     public function findByApplicationSlugAndUser(string $applicationSlug, User $user, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array;
 
     public function countByApplicationSlugAndUser(string $applicationSlug, User $user, array $filters = [], ?array $esIds = null): int;
+
+    /**
+     * @return array<int, Event>
+     */
+    public function findUpcomingPrivateByUser(User $user, int $limit = 3): array;
+
+    /**
+     * @return array<int, Event>
+     */
+    public function findUpcomingByApplicationSlugAndUser(string $applicationSlug, User $user, int $limit = 3): array;
 }

--- a/src/Calendar/Infrastructure/Repository/EventRepository.php
+++ b/src/Calendar/Infrastructure/Repository/EventRepository.php
@@ -12,6 +12,7 @@ use App\User\Domain\Entity\User;
 use Doctrine\DBAL\LockMode;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
+use DateTimeImmutable;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 
 /**
@@ -116,6 +117,40 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
             ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
             ->getQuery()
             ->getSingleScalarResult();
+    }
+
+
+    public function findUpcomingPrivateByUser(User $user, int $limit = 3): array
+    {
+        return $this->createBaseQueryBuilder()
+            ->andWhere('event.user = :user OR calendar.user = :user')
+            ->andWhere('event.visibility = :visibilityPrivate')
+            ->andWhere('event.isCancelled = false')
+            ->andWhere('event.startAt >= :now')
+            ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->setParameter('visibilityPrivate', EventVisibility::PRIVATE->value)
+            ->setParameter('now', new DateTimeImmutable())
+            ->orderBy('event.startAt', 'ASC')
+            ->setMaxResults(max(1, min(20, $limit)))
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findUpcomingByApplicationSlugAndUser(string $applicationSlug, User $user, int $limit = 3): array
+    {
+        return $this->createBaseQueryBuilder()
+            ->innerJoin('calendar.application', 'application')
+            ->andWhere('application.slug = :applicationSlug')
+            ->andWhere('event.user = :user OR calendar.user = :user')
+            ->andWhere('event.isCancelled = false')
+            ->andWhere('event.startAt >= :now')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->setParameter('now', new DateTimeImmutable())
+            ->orderBy('event.startAt', 'ASC')
+            ->setMaxResults(max(1, min(20, $limit)))
+            ->getQuery()
+            ->getResult();
     }
 
     private function createBaseQueryBuilder(): QueryBuilder

--- a/src/Calendar/Transport/Controller/Api/V1/Event/UpcomingEventListController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/UpcomingEventListController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Calendar\Transport\Controller\Api\V1\Event;
+
+use App\Calendar\Application\Service\EventListService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Calendar Event')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+class UpcomingEventListController
+{
+    public function __construct(
+        public readonly EventListService $eventListService
+    ) {
+    }
+
+    #[Route(path: '/v1/calendar/events/upcoming', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        path: '/v1/calendar/events/upcoming',
+        operationId: 'calendar_upcoming_event_list',
+        summary: 'Lister mes 3 événements les plus proches (optionnellement par application)',
+        tags: ['Calendar Event'],
+        parameters: [
+            new OA\Parameter(name: 'applicationSlug', in: 'query', required: false, schema: new OA\Schema(type: 'string', example: 'crm-pipeline-pro')),
+            new OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 20, example: 3)),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Liste des événements à venir'),
+            new OA\Response(response: 401, description: 'Authentification requise'),
+        ],
+    )]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        $applicationSlug = trim((string)$request->query->get('applicationSlug', ''));
+        $limit = max(1, min(20, $request->query->getInt('limit', 3)));
+
+        return new JsonResponse($this->eventListService->getUpcoming(
+            $loggedInUser,
+            $applicationSlug !== '' ? $applicationSlug : null,
+            $limit,
+        ));
+    }
+}

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -78,6 +78,8 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             $this->ensureJohnRootPrivateEvents($manager, $application, $calendar, $johnRoot);
         }
 
+        $this->ensureJohnRootStandalonePrivateEvents($manager, $johnRoot);
+
         $this->createJohnRootPrivateDirectMessageScenarios($manager);
         $this->createDedicatedDirectConversationFixture($manager);
 
@@ -488,6 +490,20 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         }
     }
 
+
+    private function ensureJohnRootStandalonePrivateEvents(ObjectManager $manager, User $johnRoot): void
+    {
+        for ($dayOffset = 1; $dayOffset <= 3; $dayOffset++) {
+            $this->ensureStandaloneEvent(
+                $manager,
+                $johnRoot,
+                sprintf('John Root standalone private event #%d', $dayOffset),
+                $dayOffset,
+                sprintf('Standalone private event #%d for john-root without application calendar.', $dayOffset),
+            );
+        }
+    }
+
     private function ensureJohnRootScenarioEvent(ObjectManager $manager, Calendar $calendar, User $johnRoot): Event
     {
         return $this->ensureEvent(
@@ -498,6 +514,45 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             3,
             'Event dédié au scénario fixtures john-root pour tests fonctionnels.'
         );
+    }
+
+
+    private function ensureStandaloneEvent(
+        ObjectManager $manager,
+        User $owner,
+        string $title,
+        int $daysInFuture,
+        string $description
+    ): Event {
+        $existing = $manager->getRepository(Event::class)->findOneBy([
+            'calendar' => null,
+            'user' => $owner,
+            'title' => $title,
+        ]);
+
+        if ($existing instanceof Event) {
+            return $existing;
+        }
+
+        $startAt = (new DateTimeImmutable())->modify(sprintf('+%d day', $daysInFuture));
+
+        $event = (new Event())
+            ->setTitle($title)
+            ->setDescription($description)
+            ->setLocation('Remote')
+            ->setStartAt($startAt)
+            ->setEndAt($startAt->modify('+45 minutes'))
+            ->setTimezone('Europe/Paris')
+            ->setOrganizerName('John Root')
+            ->setOrganizerEmail('john.root@example.com')
+            ->setStatus(EventStatus::CONFIRMED)
+            ->setVisibility(EventVisibility::PRIVATE)
+            ->setUser($owner)
+            ->setCalendar(null);
+
+        $manager->persist($event);
+
+        return $event;
     }
 
     private function ensureEvent(

--- a/src/User/Application/Service/UserMeService.php
+++ b/src/User/Application/Service/UserMeService.php
@@ -9,6 +9,7 @@ use App\General\Application\Message\EntityPatched;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\Log\Domain\Entity\LogLogin;
 use App\Log\Infrastructure\Repository\LogLoginRepository;
+use App\Platform\Domain\Entity\Application;
 use App\User\Application\Security\SecurityUser;
 use App\User\Domain\Entity\Social;
 use App\User\Domain\Entity\User;
@@ -80,7 +81,52 @@ readonly class UserMeService
             }, $qb->getQuery()->getResult());
         });
 
+        if ($sessions === []) {
+            return [[
+                'icon' => 'mdi-account-circle',
+                'title' => 'Current session',
+                'description' => '',
+                'badge' => 'Active',
+                'city' => 'Unknown',
+                'ip' => 'Unknown',
+            ]];
+        }
+
         return $sessions;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function getApplications(User $user, int $limit = 0): array
+    {
+        $qb = $this->entityManager->getRepository(Application::class)
+            ->createQueryBuilder('application')
+            ->leftJoin('application.platform', 'platform')
+            ->addSelect('platform')
+            ->andWhere('application.user = :user')
+            ->setParameter('user', $user)
+            ->orderBy('application.createdAt', 'DESC');
+
+        if ($limit > 0) {
+            $qb->setMaxResults($limit);
+        }
+
+        /** @var array<int, Application> $applications */
+        $applications = $qb->getQuery()->getResult();
+
+        return array_map(static fn (Application $application): array => [
+            'id' => $application->getId(),
+            'platformId' => $application->getPlatform()?->getId(),
+            'platformName' => $application->getPlatform()?->getName(),
+            'title' => $application->getTitle(),
+            'slug' => $application->getSlug(),
+            'description' => $application->getDescription(),
+            'status' => $application->getStatus()->value,
+            'private' => $application->isPrivate(),
+            'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
+            'updatedAt' => $application->getUpdatedAt()?->format(DATE_ATOM),
+        ], $applications);
     }
 
     /**

--- a/src/User/Transport/Controller/Api/V1/User/UserMeController.php
+++ b/src/User/Transport/Controller/Api/V1/User/UserMeController.php
@@ -38,6 +38,21 @@ class UserMeController
         return new JsonResponse($this->userMeService->getSessions($loggedInUser));
     }
 
+
+    #[Route(path: '/v1/users/me/applications', methods: [Request::METHOD_GET])]
+    #[OA\Response(response: 200, description: 'Applications created by current user')]
+    public function applications(User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userMeService->getApplications($loggedInUser));
+    }
+
+    #[Route(path: '/v1/users/me/applications/latest', methods: [Request::METHOD_GET])]
+    #[OA\Response(response: 200, description: 'Latest applications created by current user')]
+    public function latestApplications(User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->userMeService->getApplications($loggedInUser, 3));
+    }
+
     #[Route(path: '/v1/users/me/profile', methods: [Request::METHOD_GET])]
     #[OA\Response(response: 200, description: 'Current user profile')]
     public function profile(User $loggedInUser): JsonResponse

--- a/tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php
+++ b/tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php
@@ -50,4 +50,29 @@ final class ApplicationEventListControllerTest extends WebTestCase
         self::assertArrayHasKey('items', $responseData);
         self::assertNotEmpty($responseData['items']);
     }
+
+    #[TestDox('GET /api/v1/calendar/events/upcoming returns up to three nearest events for logged user.')]
+    public function testUpcomingEventsEndpointReturnsNearestItems(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/events/upcoming');
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:
+" . $response);
+
+        $responseData = JSON::decode($content, true);
+
+        self::assertIsArray($responseData);
+        self::assertLessThanOrEqual(3, count($responseData));
+
+        if ($responseData !== []) {
+            self::assertArrayHasKey('title', $responseData[0]);
+            self::assertArrayHasKey('startAt', $responseData[0]);
+        }
+    }
+
 }

--- a/tests/Application/User/Transport/Controller/Api/V1/User/UserMeControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/User/UserMeControllerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\User;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+final class UserMeControllerTest extends WebTestCase
+{
+    #[TestDox('GET /api/v1/users/me/sessions returns at least one session item for authenticated user.')]
+    public function testSessionsAlwaysReturnsAtLeastOneItem(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/users/me/sessions');
+        $response = $client->getResponse();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode((string)$response->getContent(), true);
+
+        self::assertIsArray($payload);
+        self::assertNotEmpty($payload);
+        self::assertArrayHasKey('title', $payload[0]);
+        self::assertArrayHasKey('badge', $payload[0]);
+    }
+
+    #[TestDox('GET /api/v1/users/me/applications/latest returns at most three items.')]
+    public function testLatestApplicationsEndpointReturnsThreeItemsMax(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/users/me/applications/latest');
+        $response = $client->getResponse();
+
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode((string)$response->getContent(), true);
+
+        self::assertIsArray($payload);
+        self::assertLessThanOrEqual(3, count($payload));
+
+        if ($payload !== []) {
+            self::assertArrayHasKey('slug', $payload[0]);
+            self::assertArrayHasKey('createdAt', $payload[0]);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure `GET /v1/users/me/sessions` always returns at least one session item when login logs are absent to avoid empty responses.
- Provide endpoints to list applications created by the authenticated user and to return the latest three created applications for quick access.
- Add an endpoint to return the nearest upcoming calendar events (either user private events or application-scoped events) as requested.
- Add fixtures to create standalone private events for `john-root` that are not attached to any application calendar for testing.

### Description
- Added a fallback response in `UserMeService::getSessions()` that returns a default "Current session" entry when no `LogLogin` rows are found.
- Implemented `UserMeService::getApplications(User $user, int $limit = 0)` and exposed two controller routes in `UserMeController`: `GET /v1/users/me/applications` and `GET /v1/users/me/applications/latest` (returns up to 3 items).
- Added `EventListService::getUpcoming(User $user, ?string $applicationSlug = null, int $limit = 3)` and a new controller `UpcomingEventListController` with route `GET /v1/calendar/events/upcoming` that accepts optional `applicationSlug` and `limit` query params.
- Extended `EventRepositoryInterface` and `EventRepository` with `findUpcomingPrivateByUser()` and `findUpcomingByApplicationSlugAndUser()` to support upcoming-event queries, ordering by `startAt` and filtering out cancelled events.
- Added standalone private event fixtures for `john-root` in `LoadRecruitChatCalendarScenarioData` via `ensureJohnRootStandalonePrivateEvents()` / `ensureStandaloneEvent()` to create events without an application calendar.
- Added/updated functional tests: new `tests/Application/User/Transport/Controller/Api/V1/User/UserMeControllerTest.php` (sessions + latest apps) and an added upcoming-events case in `tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php`.

### Testing
- Ran PHP syntax checks with `php -l` on all modified files and confirmed there are no syntax errors.
- Attempted to run the new PHPUnit functional tests but `./vendor/bin/phpunit` is not available in this environment so the suite could not be executed here.
- Static verification: all modified PHP files were lint-checked successfully, and local `php -l` checks passed for the updated controllers, services, repository, fixtures and tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3464e0c5083268db10f80ea96fe97)