### PR TITLE
Add cache support and invalidation for /v1/users/me payloads

### DIFF
--- a/src/User/Application/Service/UserFriendService.php
+++ b/src/User/Application/Service/UserFriendService.php
@@ -411,6 +411,10 @@ readonly class UserFriendService
     private function invalidateUserCaches(User $user): void
     {
         $userId = $user->getId();
+        $this->cache->delete('user_me_' . $userId);
+        $this->cache->delete('user_sessions_' . $userId);
+        $this->cache->delete('user_applications_' . $userId . '_0');
+        $this->cache->delete('user_applications_' . $userId . '_3');
         $this->cache->delete('user_friends_accepted_' . $userId);
         $this->cache->delete('user_friends_incoming_' . $userId);
         $this->cache->delete('user_friends_sent_' . $userId);

--- a/src/User/Application/Service/UserMeService.php
+++ b/src/User/Application/Service/UserMeService.php
@@ -37,6 +37,7 @@ use function uniqid;
 readonly class UserMeService
 {
     private const string USER_ENTITY_TYPE = 'user_user';
+    private const int CACHE_TTL_SECONDS = 120;
 
     public function __construct(
         private LogLoginRepository $logLoginRepository,
@@ -60,7 +61,7 @@ readonly class UserMeService
 
         /** @var array<int,array<string,string>> $sessions */
         $sessions = $this->cache->get($cacheKey, function (ItemInterface $item) use ($user): array {
-            $item->expiresAfter(120);
+            $item->expiresAfter(self::CACHE_TTL_SECONDS);
 
             $qb = $this->logLoginRepository->createQueryBuilder('log')
                 ->andWhere('log.user = :user')
@@ -102,33 +103,42 @@ readonly class UserMeService
      */
     public function getApplications(User $user, int $limit = 0): array
     {
-        $qb = $this->entityManager->getRepository(Application::class)
-            ->createQueryBuilder('application')
-            ->leftJoin('application.platform', 'platform')
-            ->addSelect('platform')
-            ->andWhere('application.user = :user')
-            ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
-            ->orderBy('application.createdAt', 'DESC');
+        $cacheKey = sprintf('user_applications_%s_%d', $user->getId(), $limit);
 
-        if ($limit > 0) {
-            $qb->setMaxResults($limit);
-        }
+        /** @var array<int,array<string,mixed>> $applications */
+        $applications = $this->cache->get($cacheKey, function (ItemInterface $item) use ($user, $limit): array {
+            $item->expiresAfter(self::CACHE_TTL_SECONDS);
 
-        /** @var array<int, Application> $applications */
-        $applications = $qb->getQuery()->getResult();
+            $qb = $this->entityManager->getRepository(Application::class)
+                ->createQueryBuilder('application')
+                ->leftJoin('application.platform', 'platform')
+                ->addSelect('platform')
+                ->andWhere('application.user = :user')
+                ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
+                ->orderBy('application.createdAt', 'DESC');
 
-        return array_map(static fn (Application $application): array => [
-            'id' => $application->getId(),
-            'platformId' => $application->getPlatform()?->getId(),
-            'platformName' => $application->getPlatform()?->getName(),
-            'title' => $application->getTitle(),
-            'slug' => $application->getSlug(),
-            'description' => $application->getDescription(),
-            'status' => $application->getStatus()->value,
-            'private' => $application->isPrivate(),
-            'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
-            'updatedAt' => $application->getUpdatedAt()?->format(DATE_ATOM),
-        ], $applications);
+            if ($limit > 0) {
+                $qb->setMaxResults($limit);
+            }
+
+            /** @var array<int, Application> $entities */
+            $entities = $qb->getQuery()->getResult();
+
+            return array_map(static fn (Application $application): array => [
+                'id' => $application->getId(),
+                'platformId' => $application->getPlatform()?->getId(),
+                'platformName' => $application->getPlatform()?->getName(),
+                'title' => $application->getTitle(),
+                'slug' => $application->getSlug(),
+                'description' => $application->getDescription(),
+                'status' => $application->getStatus()->value,
+                'private' => $application->isPrivate(),
+                'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
+                'updatedAt' => $application->getUpdatedAt()?->format(DATE_ATOM),
+            ], $entities);
+        });
+
+        return $applications;
     }
 
     /**
@@ -138,27 +148,16 @@ readonly class UserMeService
      */
     public function getMe(User $user): array
     {
-        $profile = $this->ensureProfile($user);
+        $cacheKey = sprintf('user_me_%s', $user->getId());
 
-        return [
-            'id' => $user->getId(),
-            'username' => $user->getUsername(),
-            'email' => $user->getEmail(),
-            'firstName' => $user->getFirstName(),
-            'lastName' => $user->getLastName(),
-            'photo' => $user->getPhoto(),
-            'profile' => $this->normalizeProfile($profile),
-            'socials' => array_map(static fn (Social $social): array => [
-                'provider' => $social->getProvider(),
-                'providerId' => $social->getProviderId(),
-            ], $user->getSocials()->toArray()),
-            'sessions' => $this->getSessions($user),
-            'applications' => $this->getApplications($user),
-            'friends' => $this->userFriendService->getMyFriends($user),
-            'friendRequests' => $this->userFriendService->getMySentRequests($user),
-            'blockedUsers' => $this->userFriendService->getMyBlockedUsers($user),
-            'incomingRequests' => $this->userFriendService->getMyIncomingRequests($user),
-        ];
+        /** @var array<string,mixed> $payload */
+        $payload = $this->cache->get($cacheKey, function (ItemInterface $item) use ($user): array {
+            $item->expiresAfter(self::CACHE_TTL_SECONDS);
+
+            return $this->buildMePayload($user);
+        });
+
+        return $payload;
     }
 
     /**
@@ -231,6 +230,7 @@ readonly class UserMeService
 
         $this->messageBus->dispatch(new EntityPatched(uniqid('op_', true), self::USER_ENTITY_TYPE, $user->getId()));
         $this->indexUser($user, $profile);
+        $this->invalidateMeCaches($user->getId());
 
         return $this->normalizeProfile($profile);
     }
@@ -250,11 +250,15 @@ readonly class UserMeService
         $user->setPlainPassword($newPassword);
         $this->entityManager->persist($user);
         $this->entityManager->flush();
+
+        $this->indexUser($user, $this->ensureProfile($user));
+        $this->invalidateMeCaches($user->getId());
     }
 
     public function deleteMe(User $user): void
     {
         $userId = $user->getId();
+        $this->invalidateMeCaches($userId);
         $this->entityManager->remove($user);
         $this->entityManager->flush();
 
@@ -264,6 +268,35 @@ readonly class UserMeService
             $this->elasticsearchService->delete('users', $userId);
         } catch (Throwable) {
         }
+    }
+
+    /**
+     * @return array<string,mixed>
+     * @throws InvalidArgumentException
+     */
+    private function buildMePayload(User $user): array
+    {
+        $profile = $this->ensureProfile($user);
+
+        return [
+            'id' => $user->getId(),
+            'username' => $user->getUsername(),
+            'email' => $user->getEmail(),
+            'firstName' => $user->getFirstName(),
+            'lastName' => $user->getLastName(),
+            'photo' => $user->getPhoto(),
+            'profile' => $this->normalizeProfile($profile),
+            'socials' => array_map(static fn (Social $social): array => [
+                'provider' => $social->getProvider(),
+                'providerId' => $social->getProviderId(),
+            ], $user->getSocials()->toArray()),
+            'sessions' => $this->getSessions($user),
+            'applications' => $this->getApplications($user),
+            'friends' => $this->userFriendService->getMyFriends($user),
+            'friendRequests' => $this->userFriendService->getMySentRequests($user),
+            'blockedUsers' => $this->userFriendService->getMyBlockedUsers($user),
+            'incomingRequests' => $this->userFriendService->getMyIncomingRequests($user),
+        ];
     }
 
     private function ensureProfile(User $user): UserProfile
@@ -323,5 +356,13 @@ readonly class UserMeService
         $normalized = trim((string)$value);
 
         return $normalized === '' ? null : $normalized;
+    }
+
+    private function invalidateMeCaches(string $userId): void
+    {
+        $this->cache->delete(sprintf('user_me_%s', $userId));
+        $this->cache->delete(sprintf('user_sessions_%s', $userId));
+        $this->cache->delete(sprintf('user_applications_%s_0', $userId));
+        $this->cache->delete(sprintf('user_applications_%s_3', $userId));
     }
 }


### PR DESCRIPTION
### Motivation

- Make the `/v1/users/me` endpoint and related user reads use cache for faster responses and reduced DB load. 
- Ensure cached data stays consistent by invalidating caches when user-related writes occur. 
- Keep Elasticsearch user index in sync with critical write operations so searches remain accurate.

### Description

- Introduced a `CACHE_TTL_SECONDS` constant and applied it to session, applications and `me` caches in `UserMeService`.
- Cached the full `getMe()` payload under `user_me_<id>` by extracting the response assembly to a new private `buildMePayload()` method and serving it via the cache.
- Cached `getApplications()` results under `user_applications_<id>_<limit>` and aligned session TTL to the shared TTL constant.
- Added `invalidateMeCaches()` to `UserMeService` and wired cache invalidation calls after `patchProfile()`, `changePassword()` and `deleteMe()` so the `user_me_*`, `user_sessions_*`, and `user_applications_*` keys are cleared on writes.
- Updated `UserFriendService::invalidateUserCaches()` to also clear the `user_me_*`, `user_sessions_*` and `user_applications_*` cache keys when friend relations change.
- Ensured `indexUser()` is called after password changes so the `users` Elasticsearch index is re-synchronized with the latest user data.

### Testing

- `php -l src/User/Application/Service/UserMeService.php` succeeded with no syntax errors.
- `php -l src/User/Application/Service/UserFriendService.php` succeeded with no syntax errors.
- Attempted unit run: attempted `./vendor/bin/phpunit --filter UserMeService --testdox` but `./vendor/bin/phpunit` is not present in the execution environment so PHPUnit could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b36fa6c504832683cdcd6fcc508100)