### PR TITLE
Add 24h user stories: entity, API, caching and Elasticsearch support

### DIFF
--- a/migrations/Version20260313100000.php
+++ b/migrations/Version20260313100000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260313100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add user stories table for 24h stories.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE user_story (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", user_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", image_url VARCHAR(1024) NOT NULL, expires_at DATETIME NOT NULL COMMENT "(DC2Type:datetime_immutable)", created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", INDEX IDX_67CC82ECA76ED395 (user_id), INDEX IDX_67CC82EC6F7D7EFB (created_at), INDEX IDX_67CC82ECEA9FDD75 (expires_at), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE user_story ADD CONSTRAINT FK_67CC82ECA76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user_story DROP FOREIGN KEY FK_67CC82ECA76ED395');
+        $this->addSql('DROP TABLE user_story');
+    }
+}

--- a/src/General/Application/Service/CacheInvalidationService.php
+++ b/src/General/Application/Service/CacheInvalidationService.php
@@ -167,4 +167,13 @@ class CacheInvalidationService
             $this->cache->invalidateTags($tags);
         }
     }
+
+    public function invalidateUserStoryCaches(): void
+    {
+        if (!$this->cache instanceof TagAwareCacheInterface) {
+            return;
+        }
+
+        $this->cache->invalidateTags([$this->cacheKeyConventionService->tagPrivateStoryList()]);
+    }
 }

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -77,6 +77,11 @@ class CacheKeyConventionService
         return 'private_' . $this->sanitizeSegment($username) . '_blog_' . $this->sanitizeSegment($scope);
     }
 
+    public function buildPrivateStoryListKey(string $userId, int $limit): string
+    {
+        return 'private_' . $this->sanitizeSegment($userId) . '_story_list_' . $limit;
+    }
+
     /**
      * @param array<string, mixed> $filters
      */
@@ -252,6 +257,11 @@ class CacheKeyConventionService
     public function tagPrivateBlog(string $userId): string
     {
         return 'cache_private_' . $this->sanitizeSegment($userId) . '_blog';
+    }
+
+    public function tagPrivateStoryList(): string
+    {
+        return 'cache_private_story_list';
     }
 
     public function shopProductListTag(): string

--- a/src/User/Application/Service/UserStoryService.php
+++ b/src/User/Application/Service/UserStoryService.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Application\Service;
+
+use App\General\Application\Service\CacheInvalidationService;
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserFriendRelation;
+use App\User\Domain\Entity\UserStory;
+use App\User\Domain\Enum\FriendStatus;
+use App\User\Infrastructure\Repository\UserStoryRepository;
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function array_unique;
+use function count;
+
+readonly class UserStoryService
+{
+    private const string ELASTIC_INDEX = 'user_stories';
+
+    public function __construct(
+        private UserStoryRepository $userStoryRepository,
+        private EntityManagerInterface $entityManager,
+        private CacheInterface $cache,
+        private CacheKeyConventionService $cacheKeyConventionService,
+        private CacheInvalidationService $cacheInvalidationService,
+        private ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getActiveStories(User $loggedInUser, int $limit): array
+    {
+        $visibleUserIds = $this->findVisibleUserIds($loggedInUser);
+        $cacheKey = $this->cacheKeyConventionService->buildPrivateStoryListKey($loggedInUser->getId(), $limit);
+
+        /** @var array<int, array<string, mixed>> $stories */
+        $stories = $this->cache->get($cacheKey, function (ItemInterface $item) use ($loggedInUser, $visibleUserIds, $limit): array {
+            $item->expiresAfter(60);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->tagPrivateStoryList());
+            }
+
+            $esIds = $this->searchActiveStoryIdsFromElastic($visibleUserIds, $limit);
+            if ($esIds === []) {
+                return [];
+            }
+
+            return $this->findActiveStories($loggedInUser, $visibleUserIds, $limit, $esIds);
+        });
+
+        return $stories;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function createStory(User $user, string $imageUrl): array
+    {
+        if ($imageUrl === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "imageUrl" is required.');
+        }
+
+        $story = new UserStory();
+        $story
+            ->setUser($user)
+            ->setImageUrl($imageUrl)
+            ->setExpiresAt((new DateTimeImmutable())->add(new DateInterval('PT24H')));
+
+        $this->userStoryRepository->save($story);
+        $this->indexStory($story);
+        $this->cacheInvalidationService->invalidateUserStoryCaches();
+
+        return $this->mapStory($story);
+    }
+
+    public function deleteStory(User $user, string $storyId): void
+    {
+        $story = $this->userStoryRepository->find($storyId);
+        if (!$story instanceof UserStory) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Story not found.');
+        }
+
+        if ($story->getUser()->getId() !== $user->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You can delete only your own stories.');
+        }
+
+        $this->userStoryRepository->delete($story);
+
+        try {
+            $this->elasticsearchService->delete(self::ELASTIC_INDEX, $storyId);
+        } catch (Throwable) {
+        }
+
+        $this->cacheInvalidationService->invalidateUserStoryCaches();
+    }
+
+    /**
+     * @param array<int, string> $visibleUserIds
+     * @param array<int, string>|null $esIds
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function findActiveStories(User $loggedInUser, array $visibleUserIds, int $limit, ?array $esIds): array
+    {
+        $since = new DateTimeImmutable('-24 hours');
+
+        $qb = $this->userStoryRepository->createQueryBuilder('story')
+            ->select('story', 'user')
+            ->innerJoin('story.user', 'user')
+            ->andWhere('story.createdAt >= :since')
+            ->andWhere('user.id IN (:visibleUserIds)')
+            ->setParameter('since', $since)
+            ->setParameter('visibleUserIds', $visibleUserIds)
+            ->orderBy('story.createdAt', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($esIds !== null) {
+            $qb->andWhere('story.id IN (:ids)')
+                ->setParameter('ids', $esIds);
+        }
+
+        /** @var array<int, UserStory> $stories */
+        $stories = $qb->getQuery()->getResult();
+
+        if ($esIds !== null && count($stories) > 1) {
+            $order = array_flip($esIds);
+            usort($stories, static fn (UserStory $a, UserStory $b): int => ($order[$a->getId()] ?? PHP_INT_MAX) <=> ($order[$b->getId()] ?? PHP_INT_MAX));
+        }
+
+        $groupedStories = [];
+        foreach ($stories as $story) {
+            $user = $story->getUser();
+            $userId = $user->getId();
+
+            if (!isset($groupedStories[$userId])) {
+                $groupedStories[$userId] = [
+                    'owner' => $userId === $loggedInUser->getId(),
+                    'user' => [
+                        'id' => $userId,
+                        'username' => $user->getUsername(),
+                        'photo' => $user->getPhoto(),
+                    ],
+                    'stories' => [],
+                ];
+            }
+
+            $groupedStories[$userId]['stories'][] = $this->mapStory($story);
+        }
+
+        $ordered = [];
+        if (isset($groupedStories[$loggedInUser->getId()])) {
+            $ordered[] = $groupedStories[$loggedInUser->getId()];
+            unset($groupedStories[$loggedInUser->getId()]);
+        }
+
+        return array_values([...$ordered, ...$groupedStories]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function mapStory(UserStory $story): array
+    {
+        return [
+            'id' => $story->getId(),
+            'imageUrl' => $story->getImageUrl(),
+            'createdAt' => $story->getCreatedAt()?->format(DateTimeInterface::ATOM),
+            'expiresAt' => $story->getExpiresAt()->format(DateTimeInterface::ATOM),
+        ];
+    }
+
+    private function indexStory(UserStory $story): void
+    {
+        try {
+            $this->elasticsearchService->index(self::ELASTIC_INDEX, $story->getId(), [
+                'id' => $story->getId(),
+                'userId' => $story->getUser()->getId(),
+                'imageUrl' => $story->getImageUrl(),
+                'createdAt' => $story->getCreatedAt()?->format(DateTimeInterface::ATOM),
+                'expiresAt' => $story->getExpiresAt()->format(DateTimeInterface::ATOM),
+            ]);
+        } catch (Throwable) {
+        }
+    }
+
+    /**
+     * @param array<int, string> $visibleUserIds
+     * @return array<int, string>|null
+     */
+    private function searchActiveStoryIdsFromElastic(array $visibleUserIds, int $limit): ?array
+    {
+        try {
+            $response = $this->elasticsearchService->search(self::ELASTIC_INDEX, [
+                'query' => [
+                    'bool' => [
+                        'filter' => [
+                            [
+                                'range' => [
+                                    'expiresAt' => [
+                                        'gte' => (new DateTimeImmutable())->format(DateTimeInterface::ATOM),
+                                    ],
+                                ],
+                            ],
+                            [
+                                'terms' => [
+                                    'userId' => $visibleUserIds,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                'sort' => [
+                    ['createdAt' => ['order' => 'desc']],
+                ],
+                '_source' => ['id'],
+            ], 0, $limit);
+        } catch (Throwable) {
+            return null;
+        }
+
+        $hits = $response['hits']['hits'] ?? [];
+
+        return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function findVisibleUserIds(User $loggedInUser): array
+    {
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('relation, requester, addressee')
+            ->from(UserFriendRelation::class, 'relation')
+            ->join('relation.requester', 'requester')
+            ->join('relation.addressee', 'addressee')
+            ->where('(relation.requester = :me OR relation.addressee = :me)')
+            ->andWhere('relation.status = :status')
+            ->setParameter('me', $loggedInUser)
+            ->setParameter('status', FriendStatus::ACCEPTED->value);
+
+        /** @var array<int, UserFriendRelation> $relations */
+        $relations = $qb->getQuery()->getResult();
+
+        $userIds = [$loggedInUser->getId()];
+        foreach ($relations as $relation) {
+            $friend = $relation->getRequester()->getId() === $loggedInUser->getId()
+                ? $relation->getAddressee()
+                : $relation->getRequester();
+
+            $userIds[] = $friend->getId();
+        }
+
+        return array_values(array_unique($userIds));
+    }
+}

--- a/src/User/Domain/Entity/UserStory.php
+++ b/src/User/Domain/Entity/UserStory.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'user_story')]
+class UserStory implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $user;
+
+    #[ORM\Column(name: 'image_url', type: Types::STRING, length: 1024)]
+    private string $imageUrl = '';
+
+    #[ORM\Column(name: 'expires_at', type: Types::DATETIME_IMMUTABLE)]
+    private DateTimeImmutable $expiresAt;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getImageUrl(): string
+    {
+        return $this->imageUrl;
+    }
+
+    public function setImageUrl(string $imageUrl): self
+    {
+        $this->imageUrl = $imageUrl;
+
+        return $this;
+    }
+
+    public function getExpiresAt(): DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+
+    public function setExpiresAt(DateTimeImmutable $expiresAt): self
+    {
+        $this->expiresAt = $expiresAt;
+
+        return $this;
+    }
+}

--- a/src/User/Infrastructure/DataFixtures/ORM/LoadUserStoryData.php
+++ b/src/User/Infrastructure/DataFixtures/ORM/LoadUserStoryData.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\DataFixtures\ORM;
+
+use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserStory;
+use DateInterval;
+use DateTimeImmutable;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+
+final class LoadUserStoryData extends Fixture implements DependentFixtureInterface
+{
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        /** @var User $johnRoot */
+        $johnRoot = $this->getReference('User-john-root', User::class);
+        /** @var User $emma */
+        $emma = $this->getReference('User-emma', User::class);
+        /** @var User $felix */
+        $felix = $this->getReference('User-felix', User::class);
+        /** @var User $alice */
+        $alice = $this->getReference('User-alice', User::class);
+
+        $now = new DateTimeImmutable();
+
+        $activeMine = (new UserStory())
+            ->setUser($johnRoot)
+            ->setImageUrl('https://cdn.example.com/stories/john-1.jpg')
+            ->setCreatedAt($now->sub(new DateInterval('PT2H')))
+            ->setExpiresAt($now->add(new DateInterval('PT22H')));
+
+        $activeMineSecond = (new UserStory())
+            ->setUser($johnRoot)
+            ->setImageUrl('https://cdn.example.com/stories/john-2.jpg')
+            ->setCreatedAt($now->sub(new DateInterval('PT5H')))
+            ->setExpiresAt($now->add(new DateInterval('PT19H')));
+
+        $activeEmma = (new UserStory())
+            ->setUser($emma)
+            ->setImageUrl('https://cdn.example.com/stories/emma-1.jpg')
+            ->setCreatedAt($now->sub(new DateInterval('PT3H')))
+            ->setExpiresAt($now->add(new DateInterval('PT21H')));
+
+        $activeFelix = (new UserStory())
+            ->setUser($felix)
+            ->setImageUrl('https://cdn.example.com/stories/felix-1.jpg')
+            ->setCreatedAt($now->sub(new DateInterval('PT8H')))
+            ->setExpiresAt($now->add(new DateInterval('PT16H')));
+
+        $expiredAlice = (new UserStory())
+            ->setUser($alice)
+            ->setImageUrl('https://cdn.example.com/stories/alice-expired.jpg')
+            ->setCreatedAt($now->sub(new DateInterval('PT30H')))
+            ->setExpiresAt($now->sub(new DateInterval('PT6H')));
+
+        foreach ([$activeMine, $activeMineSecond, $activeEmma, $activeFelix, $expiredAlice] as $story) {
+            $manager->persist($story);
+        }
+
+        $manager->flush();
+    }
+
+    /**
+     * @return array<int, class-string>
+     */
+    #[Override]
+    public function getDependencies(): array
+    {
+        return [
+            LoadUserData::class,
+            LoadUserFriendRelationData::class,
+        ];
+    }
+}

--- a/src/User/Infrastructure/Repository/UserStoryRepository.php
+++ b/src/User/Infrastructure/Repository/UserStoryRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\User\Domain\Entity\UserStory;
+use Doctrine\Persistence\ManagerRegistry;
+
+class UserStoryRepository extends BaseRepository
+{
+    protected static string $entityName = UserStory::class;
+    protected static array $searchColumns = ['imageUrl'];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry
+    ) {
+    }
+}

--- a/src/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryController.php
+++ b/src/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Transport\Controller\Api\V1\UserStory;
+
+use App\User\Application\Service\UserStoryService;
+use App\User\Domain\Entity\User;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_array;
+use function trim;
+
+#[AsController]
+#[OA\Tag(name: 'Stories')]
+final readonly class CreateUserStoryController
+{
+    public function __construct(
+        private UserStoryService $userStoryService,
+    ) {
+    }
+
+    #[Route('/v1/private/stories', methods: [Request::METHOD_POST])]
+    #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+    public function __invoke(User $loggedInUser, Request $request): JsonResponse
+    {
+        $payload = $this->extractPayload($request);
+        $story = $this->userStoryService->createStory($loggedInUser, trim((string)($payload['imageUrl'] ?? '')));
+
+        return new JsonResponse($story, JsonResponse::HTTP_CREATED);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function extractPayload(Request $request): array
+    {
+        try {
+            $payload = $request->toArray();
+        } catch (JsonException) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid JSON payload.');
+        }
+
+        if (!is_array($payload)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Payload must be a JSON object.');
+        }
+
+        return $payload;
+    }
+}

--- a/src/User/Transport/Controller/Api/V1/UserStory/DeleteUserStoryController.php
+++ b/src/User/Transport/Controller/Api/V1/UserStory/DeleteUserStoryController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Transport\Controller\Api\V1\UserStory;
+
+use App\User\Application\Service\UserStoryService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Stories')]
+final readonly class DeleteUserStoryController
+{
+    public function __construct(
+        private UserStoryService $userStoryService,
+    ) {
+    }
+
+    #[Route('/v1/private/stories/{id}', methods: [Request::METHOD_DELETE])]
+    #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+    public function __invoke(User $loggedInUser, string $id): JsonResponse
+    {
+        $this->userStoryService->deleteStory($loggedInUser, $id);
+
+        return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesController.php
+++ b/src/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\User\Transport\Controller\Api\V1\UserStory;
+
+use App\User\Application\Service\UserStoryService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Stories')]
+final readonly class GetActiveStoriesController
+{
+    public function __construct(
+        private UserStoryService $userStoryService,
+    ) {
+    }
+
+    #[Route('/v1/private/stories', methods: [Request::METHOD_GET])]
+    #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+    public function __invoke(User $loggedInUser, Request $request): JsonResponse
+    {
+        $limit = max(1, min(100, $request->query->getInt('limit', 50)));
+
+        return new JsonResponse([
+            'stories' => $this->userStoryService->getActiveStories($loggedInUser, $limit),
+        ]);
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce ephemeral "stories" that expire after 24 hours and are visible to a user's friends and themselves.  
- Provide API endpoints to create, list and delete stories and ensure fast responses via caching.  
- Keep story search and ordering efficient by indexing stories in Elasticsearch and invalidating caches on changes.  

### Description

- Add a new Doctrine migration `Version20260313100000` and the `user_story` table with `user_id`, `image_url`, `expires_at`, and timestamps.  
- Introduce the `UserStory` entity, `UserStoryRepository`, and data fixtures in `LoadUserStoryData` to seed example stories.  
- Implement `UserStoryService` which handles creation, deletion, retrieval of active (last 24h) stories, Elasticsearch indexing/search, and cache tagging.  
- Add three API controllers: `GetActiveStoriesController`, `CreateUserStoryController`, and `DeleteUserStoryController`, and extend caching helpers by adding `buildPrivateStoryListKey` and `tagPrivateStoryList` and an invalidation call in `CacheInvalidationService`.  

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3858de8a88326a725ba729d9f929a)