### PR TITLE
Add multipart image upload for story creation endpoint

### DIFF
--- a/src/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryController.php
+++ b/src/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryController.php
@@ -4,20 +4,21 @@ declare(strict_types=1);
 
 namespace App\User\Transport\Controller\Api\V1\UserStory;
 
+use App\General\Application\Service\PhotoUploaderService;
 use App\User\Application\Service\UserStoryService;
 use App\User\Domain\Entity\User;
-use JsonException;
 use OpenApi\Attributes as OA;
+use OpenApi\Attributes\JsonContent;
+use OpenApi\Attributes\Property;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-
-use function is_array;
-use function trim;
 
 #[AsController]
 #[OA\Tag(name: 'Stories')]
@@ -25,34 +26,49 @@ final readonly class CreateUserStoryController
 {
     public function __construct(
         private UserStoryService $userStoryService,
+        private PhotoUploaderService $photoUploaderService,
     ) {
     }
 
     #[Route('/v1/private/stories', methods: [Request::METHOD_POST])]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\MediaType(
+            mediaType: 'multipart/form-data',
+            schema: new OA\Schema(
+                type: 'object',
+                required: ['photo'],
+                properties: [
+                    new OA\Property(property: 'photo', type: 'string', format: 'binary'),
+                ],
+            ),
+        ),
+    )]
+    #[OA\Response(
+        response: 201,
+        description: 'Created story',
+        content: new JsonContent(
+            type: 'object',
+            properties: [
+                new Property(property: 'id', type: 'string'),
+                new Property(property: 'imageUrl', type: 'string'),
+                new Property(property: 'createdAt', type: 'string', format: 'date-time'),
+                new Property(property: 'expiresAt', type: 'string', format: 'date-time'),
+            ],
+        ),
+    )]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
     public function __invoke(User $loggedInUser, Request $request): JsonResponse
     {
-        $payload = $this->extractPayload($request);
-        $story = $this->userStoryService->createStory($loggedInUser, trim((string)($payload['imageUrl'] ?? '')));
+        /** @var UploadedFile|null $photo */
+        $photo = $request->files->get('photo');
+        if (!$photo instanceof UploadedFile) {
+            throw new HttpException(Response::HTTP_BAD_REQUEST, 'Missing "photo" file.');
+        }
+
+        $photoUrl = $this->photoUploaderService->upload($request, $photo, '/uploads/stories');
+        $story = $this->userStoryService->createStory($loggedInUser, $photoUrl);
 
         return new JsonResponse($story, JsonResponse::HTTP_CREATED);
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function extractPayload(Request $request): array
-    {
-        try {
-            $payload = $request->toArray();
-        } catch (JsonException) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid JSON payload.');
-        }
-
-        if (!is_array($payload)) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Payload must be a JSON object.');
-        }
-
-        return $payload;
     }
 }

--- a/tests/Application/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryControllerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\UserStory;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+use function file_exists;
+use function file_put_contents;
+use function parse_url;
+use function random_bytes;
+use function sys_get_temp_dir;
+use function unlink;
+
+class CreateUserStoryControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/private/stories';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `POST /v1/private/stories` requires authentication.')]
+    public function testThatCreateStoryRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('POST', $this->baseUrl);
+        $response = $client->getResponse();
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that authenticated user can upload a story photo and create a story.')]
+    public function testThatAuthenticatedUserCanCreateStoryWithUploadedPhoto(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root', null, [
+            'CONTENT_TYPE' => 'multipart/form-data',
+        ]);
+
+        $tmpImage = sys_get_temp_dir() . '/story_upload_' . bin2hex(random_bytes(8)) . '.png';
+        file_put_contents($tmpImage, base64_decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO6p8b8AAAAASUVORK5CYII=', true));
+
+        $photoFile = new UploadedFile(
+            $tmpImage,
+            'story.png',
+            'application/octet-stream',
+            null,
+            true
+        );
+
+        $client->request(
+            'POST',
+            $this->baseUrl,
+            [],
+            [
+                'photo' => $photoFile,
+            ],
+        );
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_CREATED, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertArrayHasKey('id', $responseData);
+        self::assertArrayHasKey('imageUrl', $responseData);
+        self::assertIsString($responseData['imageUrl']);
+        self::assertStringContainsString('/uploads/stories/', $responseData['imageUrl']);
+
+        $photoPath = parse_url($responseData['imageUrl'], PHP_URL_PATH);
+        self::assertIsString($photoPath);
+
+        $projectDir = (string)static::getContainer()->getParameter('kernel.project_dir');
+        $absolutePhotoPath = $projectDir . '/public' . $photoPath;
+
+        self::assertFileExists($absolutePhotoPath);
+
+        if (file_exists($absolutePhotoPath)) {
+            unlink($absolutePhotoPath);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Align story creation with the existing profile photo upload flow so clients can upload an image file and have the system persist the generated URL as the story `imageUrl`.
- Simplify client usage by switching from a JSON `imageUrl` payload to a `multipart/form-data` `photo` upload.

### Description
- Updated `CreateUserStoryController` to accept an uploaded `photo` (`UploadedFile`) from `multipart/form-data` and validate presence of the file before processing. 
- Reused `PhotoUploaderService` to upload story images under `/uploads/stories` and pass the resulting URL to `UserStoryService::createStory`.
- Added OpenAPI request/response annotations documenting the new multipart contract and returned story fields.
- Added integration-style controller tests at `tests/Application/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryControllerTest.php` covering authentication requirement and successful story creation with an uploaded image.

### Testing
- Ran syntax checks with `php -l` on `src/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryController.php` and `tests/Application/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryControllerTest.php`, both succeeded.
- Attempted to run the test file with `vendor/bin/phpunit tests/Application/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryControllerTest.php`, but it could not be executed in this environment because `vendor/bin/phpunit` is not available (so PHPUnit was not run here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b391f6fadc8326bbdbc7c964093fd1)