### PR TITLE
Add effective date-range validation for partial event patch updates

### DIFF
--- a/src/Calendar/Application/MessageHandler/PatchEventCommandHandler.php
+++ b/src/Calendar/Application/MessageHandler/PatchEventCommandHandler.php
@@ -8,6 +8,7 @@ use App\Calendar\Application\Message\PatchEventCommand;
 use App\Calendar\Domain\Entity\Event;
 use App\Calendar\Infrastructure\Repository\EventRepository;
 use App\General\Application\Service\CacheInvalidationService;
+use App\General\Transport\Http\ValidationErrorFactory;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Infrastructure\Repository\ApplicationRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -54,6 +55,13 @@ final readonly class PatchEventCommandHandler
             if ($command->description !== null) {
                 $event->setDescription($command->description);
             }
+
+            $effectiveStartAt = $command->startAt ?? $event->getStartAt();
+            $effectiveEndAt = $command->endAt ?? $event->getEndAt();
+            if ($effectiveEndAt < $effectiveStartAt) {
+                throw ValidationErrorFactory::unprocessable('Field "endAt" must be greater than or equal to "startAt".');
+            }
+
             if ($command->startAt !== null) {
                 $event->setStartAt($command->startAt);
             }

--- a/tests/Unit/Calendar/Application/MessageHandler/PatchEventCommandHandlerTest.php
+++ b/tests/Unit/Calendar/Application/MessageHandler/PatchEventCommandHandlerTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Calendar\Application\MessageHandler;
+
+use App\Calendar\Application\Message\PatchEventCommand;
+use App\Calendar\Application\MessageHandler\PatchEventCommandHandler;
+use App\Calendar\Domain\Entity\Event;
+use App\Calendar\Infrastructure\Repository\EventRepository;
+use App\General\Application\Service\CacheInvalidationService;
+use App\Platform\Infrastructure\Repository\ApplicationRepository;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class PatchEventCommandHandlerTest extends TestCase
+{
+    public function testInvokeRejectsInvalidPartialPatchWithOnlyEndAt(): void
+    {
+        $event = $this->createOwnedEvent(
+            startAt: new DateTimeImmutable('2030-01-01T10:00:00+00:00'),
+            endAt: new DateTimeImmutable('2030-01-01T11:00:00+00:00'),
+        );
+
+        [$handler] = $this->createHandlerWithEvent($event);
+
+        $command = $this->createPatchCommand(
+            actorUserId: $event->getUser()?->getId() ?? '',
+            eventId: $event->getId(),
+            startAt: null,
+            endAt: new DateTimeImmutable('2030-01-01T09:00:00+00:00'),
+        );
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(JsonResponse::HTTP_UNPROCESSABLE_ENTITY);
+        $this->expectExceptionMessage('Field "endAt" must be greater than or equal to "startAt".');
+
+        $handler($command);
+    }
+
+    public function testInvokeRejectsInvalidPartialPatchWithOnlyStartAt(): void
+    {
+        $event = $this->createOwnedEvent(
+            startAt: new DateTimeImmutable('2030-01-01T10:00:00+00:00'),
+            endAt: new DateTimeImmutable('2030-01-01T11:00:00+00:00'),
+        );
+
+        [$handler] = $this->createHandlerWithEvent($event);
+
+        $command = $this->createPatchCommand(
+            actorUserId: $event->getUser()?->getId() ?? '',
+            eventId: $event->getId(),
+            startAt: new DateTimeImmutable('2030-01-01T12:00:00+00:00'),
+            endAt: null,
+        );
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(JsonResponse::HTTP_UNPROCESSABLE_ENTITY);
+        $this->expectExceptionMessage('Field "endAt" must be greater than or equal to "startAt".');
+
+        $handler($command);
+    }
+
+    public function testInvokeAcceptsValidPartialPatch(): void
+    {
+        $event = $this->createOwnedEvent(
+            startAt: new DateTimeImmutable('2030-01-01T10:00:00+00:00'),
+            endAt: new DateTimeImmutable('2030-01-01T11:00:00+00:00'),
+        );
+
+        [$handler, $eventRepository, $cacheInvalidationService] = $this->createHandlerWithEvent($event);
+
+        $command = $this->createPatchCommand(
+            actorUserId: $event->getUser()?->getId() ?? '',
+            eventId: $event->getId(),
+            startAt: null,
+            endAt: new DateTimeImmutable('2030-01-01T12:00:00+00:00'),
+        );
+
+        $eventRepository->expects(self::once())->method('save')->with($event);
+        $cacheInvalidationService->expects(self::once())->method('invalidateEventCaches')->with(null, $command->actorUserId);
+
+        $handler($command);
+
+        self::assertSame('2030-01-01T10:00:00+00:00', $event->getStartAt()->format(DATE_ATOM));
+        self::assertSame('2030-01-01T12:00:00+00:00', $event->getEndAt()->format(DATE_ATOM));
+    }
+
+    private function createOwnedEvent(DateTimeImmutable $startAt, DateTimeImmutable $endAt): Event
+    {
+        $user = new User();
+        $event = new Event();
+        $event->setUser($user);
+        $event->setStartAt($startAt);
+        $event->setEndAt($endAt);
+
+        return $event;
+    }
+
+    /**
+     * @return array{PatchEventCommandHandler, EventRepository, CacheInvalidationService}
+     */
+    private function createHandlerWithEvent(Event $event): array
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection
+            ->method('transactional')
+            ->willReturnCallback(static fn (callable $callback) => $callback());
+
+        $entityManager = $this->createMock(EntityManager::class);
+        $entityManager->method('getConnection')->willReturn($connection);
+
+        $eventRepository = $this->createMock(EventRepository::class);
+        $eventRepository->method('getEntityManager')->willReturn($entityManager);
+        $eventRepository->method('find')->willReturn($event);
+
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+
+        $handler = new PatchEventCommandHandler(
+            eventRepository: $eventRepository,
+            applicationRepository: $this->createMock(ApplicationRepository::class),
+            cacheInvalidationService: $cacheInvalidationService,
+        );
+
+        return [$handler, $eventRepository, $cacheInvalidationService];
+    }
+
+    private function createPatchCommand(
+        string $actorUserId,
+        string $eventId,
+        ?DateTimeImmutable $startAt,
+        ?DateTimeImmutable $endAt,
+    ): PatchEventCommand {
+        return new PatchEventCommand(
+            operationId: 'op-id',
+            actorUserId: $actorUserId,
+            eventId: $eventId,
+            title: null,
+            description: null,
+            startAt: $startAt,
+            endAt: $endAt,
+            visibility: null,
+            location: null,
+            isAllDay: null,
+            timezone: null,
+            url: null,
+            color: null,
+            backgroundColor: null,
+            borderColor: null,
+            textColor: null,
+            organizerName: null,
+            organizerEmail: null,
+            attendees: null,
+            rrule: null,
+            recurrenceExceptions: null,
+            recurrenceEndAt: null,
+            recurrenceCount: null,
+            reminders: null,
+            metadata: null,
+            applicationSlug: null,
+        );
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure partial `PATCH` updates cannot produce an event where `endAt` is before `startAt` when only one side of the range is updated. 
- Keep existing validation in `EventMutationInputFactory::buildPatchCommand` untouched for payloads that include both `startAt` and `endAt`.
- Move the complementary validation closer to persistence so the handler can compute and validate the effective date range using current entity values.

### Description
- Add handler-level validation in `PatchEventCommandHandler` that computes `effectiveStartAt = $command->startAt ?? $event->getStartAt()` and `effectiveEndAt = $command->endAt ?? $event->getEndAt()` and rejects updates where `effectiveEndAt < effectiveStartAt` using `ValidationErrorFactory::unprocessable(...)`.
- Import `ValidationErrorFactory` into `src/Calendar/Application/MessageHandler/PatchEventCommandHandler.php` and perform the check just before applying `setStartAt` / `setEndAt`.
- Add unit tests in `tests/Unit/Calendar/Application/MessageHandler/PatchEventCommandHandlerTest.php` covering an invalid patch with only `endAt`, an invalid patch with only `startAt`, and a valid partial patch that updates `endAt`.

### Testing
- Ran PHP syntax checks with `php -l` on the modified files `src/Calendar/Application/MessageHandler/PatchEventCommandHandler.php` and the new test file, both succeeded. 
- Attempted to execute the new PHPUnit test but the project PHPUnit runner was not available in this environment (`vendor/bin/phpunit` and `bin/phpunit` not present), so tests could not be executed here. 
- The added unit tests are present and should pass when run in CI or a local environment with the project test runner installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f13c06748326830f232f7fcebbf8)