### PR TITLE
Fix reaction userId projection in conversation list

### DIFF
--- a/src/Chat/Application/Service/ConversationListService.php
+++ b/src/Chat/Application/Service/ConversationListService.php
@@ -285,7 +285,7 @@ final readonly class ConversationListService
                             'reactions' => array_map(
                                 static fn (ChatMessageReaction $reaction): array => [
                                     'id' => $reaction->getId(),
-                                    'userId' => $reaction->getUser(),
+                                    'userId' => $reaction->getUser()->getId(),
                                     'reaction' => $reaction->getReaction()->value,
                                 ],
                                 $message->getReactions()->toArray()

--- a/tests/Unit/Chat/Application/Service/ConversationListServiceTest.php
+++ b/tests/Unit/Chat/Application/Service/ConversationListServiceTest.php
@@ -5,9 +5,17 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Chat\Application\Service;
 
 use App\Chat\Application\Service\ConversationListService;
+use App\Chat\Domain\Entity\ChatMessage;
+use App\Chat\Domain\Entity\ChatMessageReaction;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Domain\Enum\ChatReactionType;
+use App\Chat\Domain\Enum\ConversationType;
 use App\Chat\Domain\Repository\Interfaces\ConversationRepositoryInterface;
+use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\User\Domain\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -33,7 +41,7 @@ final class ConversationListServiceTest extends TestCase
                 ],
             ]);
 
-        $service = new ConversationListService($repo, $cache, $elastic);
+        $service = new ConversationListService($repo, $cache, $elastic, $this->createMock(CacheKeyConventionService::class));
         $result = $service->getByUser($this->mockUser(), [
             'message' => 'foo',
         ], 1, 20);
@@ -64,7 +72,7 @@ final class ConversationListServiceTest extends TestCase
             return $callback($item);
         });
 
-        $service = new ConversationListService($repo, $cache, $elastic);
+        $service = new ConversationListService($repo, $cache, $elastic, $this->createMock(CacheKeyConventionService::class));
         $result = $service->getByUser($this->mockUser(), [
             'message' => 'foo',
         ], 1, 20);
@@ -89,7 +97,7 @@ final class ConversationListServiceTest extends TestCase
             return $callback($item);
         });
 
-        $service = new ConversationListService($repo, $cache, $elastic);
+        $service = new ConversationListService($repo, $cache, $elastic, $this->createMock(CacheKeyConventionService::class));
         $result = $service->getByUser($this->mockUser(), [
             'message' => 'foo',
         ], 1, 20);
@@ -97,10 +105,85 @@ final class ConversationListServiceTest extends TestCase
         self::assertSame([], $result['items']);
     }
 
+    public function testGetByUserNormalizesReactionUserIdAsUuidString(): void
+    {
+        $connectedUser = $this->mockUser();
+
+        $reactionAuthor = $this->createMock(User::class);
+        $reactionAuthor->method('getId')->willReturn('550e8400-e29b-41d4-a716-446655440000');
+
+        $sender = $this->createMock(User::class);
+        $sender->method('getId')->willReturn('sender-id');
+        $sender->method('getFirstName')->willReturn('Sender');
+        $sender->method('getLastName')->willReturn('User');
+        $sender->method('getPhoto')->willReturn(null);
+
+        $reaction = $this->createMock(ChatMessageReaction::class);
+        $reaction->method('getId')->willReturn('reaction-id');
+        $reaction->method('getUser')->willReturn($reactionAuthor);
+        $reaction->method('getReaction')->willReturn(ChatReactionType::LIKE);
+
+        $message = $this->createMock(ChatMessage::class);
+        $message->method('getId')->willReturn('message-id');
+        $message->method('getContent')->willReturn('hello');
+        $message->method('getSender')->willReturn($sender);
+        $message->method('getAttachments')->willReturn([]);
+        $message->method('getMetadata')->willReturn([]);
+        $message->method('isRead')->willReturn(true);
+        $message->method('getReadAt')->willReturn(null);
+        $message->method('getEditedAt')->willReturn(null);
+        $message->method('getDeletedAt')->willReturn(null);
+        $message->method('getCreatedAt')->willReturn(new \DateTimeImmutable('2024-01-01T00:00:00+00:00'));
+        $message->method('getReactions')->willReturn(new ArrayCollection([$reaction]));
+
+        $participant = $this->createMock(ConversationParticipant::class);
+        $participant->method('getUser')->willReturn($connectedUser);
+        $participant->method('getId')->willReturn('participant-id');
+        $participant->method('getLastReadMessageAt')->willReturn(null);
+
+        $conversation = $this->createMock(Conversation::class);
+        $conversation->method('getId')->willReturn('conversation-id');
+        $conversation->method('getChat')->willReturn(null);
+        $conversation->method('getType')->willReturn(ConversationType::DIRECT);
+        $conversation->method('getTitle')->willReturn('Conversation');
+        $conversation->method('getParticipants')->willReturn(new ArrayCollection([$participant]));
+        $conversation->method('getMessages')->willReturn(new ArrayCollection([$message]));
+        $conversation->method('getLastMessageAt')->willReturn(null);
+        $conversation->method('getArchivedAt')->willReturn(null);
+        $conversation->method('getCreatedAt')->willReturn(new \DateTimeImmutable('2024-01-01T00:00:00+00:00'));
+
+        $repo = $this->createMock(ConversationRepositoryInterface::class);
+        $repo->expects(self::once())->method('findByUser')->willReturn([$conversation]);
+        $repo->expects(self::once())->method('countByUser')->willReturn(1);
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $elastic->expects(self::never())->method('search');
+
+        $cacheKeyConventionService = $this->createMock(CacheKeyConventionService::class);
+        $cacheKeyConventionService->expects(self::once())
+            ->method('buildPrivateConversationKey')
+            ->willReturn('cache-key');
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects(self::once())->method('expiresAfter')->with(120);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('get')->willReturnCallback(static function (string $key, callable $callback) use ($item): array {
+            return $callback($item);
+        });
+
+        $service = new ConversationListService($repo, $cache, $elastic, $cacheKeyConventionService);
+        $result = $service->getByUser($connectedUser, [], 1, 20);
+
+        self::assertSame('550e8400-e29b-41d4-a716-446655440000', $result['items'][0]['messages'][0]['reactions'][0]['userId']);
+        self::assertIsString($result['items'][0]['messages'][0]['reactions'][0]['userId']);
+    }
+
     private function mockUser(): User
     {
         $user = $this->createMock(User::class);
         $user->method('getId')->willReturn('user-id');
+        $user->method('getUsername')->willReturn('john-doe');
 
         return $user;
     }


### PR DESCRIPTION
### Motivation
- Corriger la projection des réactions dans la liste de conversations pour renvoyer un identifiant (UUID string) au lieu de l'objet Doctrine `User`, afin d'aligner la sortie avec le contrat API attendu.
- Renforcer la couverture unitaire pour éviter toute régression future sur la normalisation des `reactions`.

### Description
- Dans `src/Chat/Application/Service/ConversationListService.php` la ligne de projection des réactions a été modifiée pour utiliser `'$reaction->getUser()->getId()'` au lieu de retourner l'objet `User` brut.
- Ajout d'un test ciblé `testGetByUserNormalizesReactionUserIdAsUuidString()` dans `tests/Unit/Chat/Application/Service/ConversationListServiceTest.php` qui vérifie que `userId` est bien une chaîne UUID dans le payload normalisé.
- Mise à jour des tests existants pour fournir une instance mockée de `CacheKeyConventionService` lors de la création de `ConversationListService` afin d'aligner l'instanciation avec la signature réelle du service.
- Audit rapide des autres normalisations de réactions a été effectué et les projections du blog utilisent déjà des scalaires (`authorId` / `author` normalisé) et ne renvoient pas d'objet Doctrine brut.

### Testing
- Syntaxe PHP vérifiée avec `php -l` pour `src/Chat/Application/Service/ConversationListService.php` et `tests/Unit/Chat/Application/Service/ConversationListServiceTest.php`, les deux fichiers sont valides.
- Nouveau test unitaire ajouté (`tests/Unit/Chat/Application/Service/ConversationListServiceTest.php`).
- Exécution de `phpunit` impossible dans cet environnement car le binaire/dependances PHPUnit ne sont pas disponibles, donc les tests unitaires n'ont pas été lancés ici (attempts to run `./vendor/bin/phpunit` and the project toolchain returned unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f146ee248326a5726a4fcb78314c)