### PR TITLE
Remove duplicate legacy School/Class route declarations

### DIFF
--- a/src/School/Transport/Controller/Api/V1/Class/CreateClassController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/CreateClassController.php
@@ -11,7 +11,6 @@ use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -25,9 +24,6 @@ final readonly class CreateClassController
         private SchoolInputValidator $inputValidator,
     ) {
     }
-
-    #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);

--- a/src/School/Transport/Controller/Api/V1/Class/ListClassesController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/ListClassesController.php
@@ -9,9 +9,7 @@ use App\School\Application\Serializer\SchoolViewMapper;
 use App\School\Infrastructure\Repository\SchoolClassRepository;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -26,9 +24,6 @@ final readonly class ListClassesController
         private SchoolApiResponseSerializer $responseSerializer,
     ) {
     }
-
-    #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug): JsonResponse
     {
         $items = $this->viewMapper->mapClassCollection($this->classRepository->findBy([], [

--- a/src/School/Transport/Controller/Api/V1/School/GetSchoolResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/School/GetSchoolResourceController.php
@@ -7,9 +7,7 @@ namespace App\School\Transport\Controller\Api\V1\School;
 use App\School\Application\Service\SchoolResourceViewService;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -22,10 +20,6 @@ final readonly class GetSchoolResourceController
         private SchoolResourceViewService $resourceViewService
     ) {
     }
-    #[Route('/v1/school/applications/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_GET], requirements: [
-        'resource' => 'classes|students|teachers|exams|grades',
-    ])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $resource, string $id): JsonResponse
     {
         $entity = $this->resourceViewService->findOr404($resource, $id);

--- a/src/School/Transport/Controller/Api/V1/School/PatchSchoolResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/School/PatchSchoolResourceController.php
@@ -12,7 +12,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Messenger\MessageBusInterface;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -27,10 +26,6 @@ final readonly class PatchSchoolResourceController
         private MessageBusInterface $messageBus,
     ) {
     }
-    #[Route('/v1/school/applications/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_PATCH], requirements: [
-        'resource' => 'classes|students|teachers|exams|grades',
-    ])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $resource, string $id, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);


### PR DESCRIPTION
### Motivation

- Prevent duplicate route registrations for the same path + HTTP method and centralise application-scoped behaviour in the `Application/*` controllers.

### Description

- Removed `#[Route]` attributes from legacy controllers `src/School/Transport/Controller/Api/V1/School/GetSchoolResourceController.php`, `src/School/Transport/Controller/Api/V1/School/PatchSchoolResourceController.php`, `src/School/Transport/Controller/Api/V1/Class/ListClassesController.php`, and `src/School/Transport/Controller/Api/V1/Class/CreateClassController.php` so that scoped `Application/*` controllers remain the source of truth.
- Removed now-unused routing-related imports tied to the deleted attributes (cleaned `use` lines).
- Left scoped controllers (`Application/GetSchoolApplicationResourceController`, `Application/PatchSchoolApplicationResourceController`, `ListClassesByApplicationController`, `CreateClassByApplicationController`) and their routes intact.

### Testing

- Ran PHP syntax lint on modified files with `php -l` which reported no syntax errors for the changed files (success).
- Executed a small scan script to detect duplicate `# [Route]` registrations (path + method) under `src/School/Transport/Controller/Api/V1` which returned no duplicates (success).
- Attempted to run integration/unit test commands but test runner was not available in the environment: `composer test` is not defined and `vendor/bin/phpunit` was not present (tests not executed due to missing dependencies).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f150d6048326a7633c9a6adfd766)