### PR TITLE
Bind `isPublished` and use UUID param in similar jobs query; add public job detail test

### DIFF
--- a/src/Recruit/Application/Service/JobPublicDetailService.php
+++ b/src/Recruit/Application/Service/JobPublicDetailService.php
@@ -8,6 +8,7 @@ use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Domain\Entity\Recruit;
 use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
@@ -108,7 +109,8 @@ class JobPublicDetailService
             ->andWhere('job.recruit = :recruit')
             ->andWhere('job.isPublished = :isPublished')
             ->andWhere('job.id IN (:ids)')
-            ->setParameter('recruit', $recruit)
+            ->setParameter('recruit', $recruit->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->setParameter('isPublished', true)
             ->setParameter('ids', $similarJobIds)
             ->getQuery()
             ->getResult();

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailControllerTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Job;
 
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\General\Domain\Utils\JSON;
 use App\Platform\Domain\Entity\Application as PlatformApplication;
+use App\Recruit\Application\Service\JobSimilarIndexerService;
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Domain\Entity\Recruit;
 use App\Tests\TestCase\WebTestCase;
@@ -18,10 +20,19 @@ class PublicJobDetailControllerTest extends WebTestCase
     #[TestDox('Test that GET /v1/recruit/applications/{applicationSlug}/public/jobs/{jobSlug} returns job detail and similar jobs list.')]
     public function testThatPublicJobDetailReturnsJobAndSimilarJobsList(): void
     {
-        [$applicationSlug, $jobSlug] = $this->getApplicationSlugAndJobSlug();
+        [$applicationSlug, $jobSlug, $jobId, $similarJobSlug, $similarJobId] = $this->getApplicationSlugAndJobDetails();
+
+        self::bootKernel();
+        /** @var ElasticsearchServiceInterface $elasticsearchService */
+        $elasticsearchService = static::getContainer()->get(ElasticsearchServiceInterface::class);
+        $elasticsearchService->index(JobSimilarIndexerService::INDEX_NAME, $jobId, [
+            'jobId' => $jobId,
+            'similarJobIds' => [$similarJobId],
+            'updatedAt' => (new \DateTimeImmutable())->format(DATE_ATOM),
+        ]);
 
         $client = $this->getTestClient();
-        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/applications/' . $applicationSlug . '/private/jobs/' . $jobSlug);
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/applications/' . $applicationSlug . '/public/jobs/' . $jobSlug);
 
         $response = $client->getResponse();
         $content = $response->getContent();
@@ -34,12 +45,14 @@ class PublicJobDetailControllerTest extends WebTestCase
         self::assertArrayHasKey('similarJobs', $payload);
         self::assertSame($jobSlug, $payload['job']['slug'] ?? null);
         self::assertIsArray($payload['similarJobs']);
+        self::assertCount(1, $payload['similarJobs']);
+        self::assertSame($similarJobSlug, $payload['similarJobs'][0]['slug'] ?? null);
     }
 
     /**
-     * @return array{0: string, 1: string}
+     * @return array{0: string, 1: string, 2: string, 3: string, 4: string}
      */
-    private function getApplicationSlugAndJobSlug(): array
+    private function getApplicationSlugAndJobDetails(): array
     {
         self::bootKernel();
 
@@ -56,11 +69,16 @@ class PublicJobDetailControllerTest extends WebTestCase
         ]);
         self::assertInstanceOf(Recruit::class, $recruit);
 
-        $job = $entityManager->getRepository(Job::class)->findOneBy([
+        /** @var list<Job> $jobs */
+        $jobs = $entityManager->getRepository(Job::class)->findBy([
             'recruit' => $recruit,
+            'isPublished' => true,
         ]);
-        self::assertInstanceOf(Job::class, $job);
+        self::assertGreaterThanOrEqual(2, count($jobs));
 
-        return [$application->getSlug(), $job->getSlug()];
+        $job = $jobs[0];
+        $similarJob = $jobs[1];
+
+        return [$application->getSlug(), $job->getSlug(), $job->getId(), $similarJob->getSlug(), $similarJob->getId()];
     }
 }


### PR DESCRIPTION
### Motivation
- Fix filtering of similar jobs so only published jobs are returned and make the `recruit` binding consistent with the rest of the module by using the UUID parameter type.
- Add integration coverage for the public job detail endpoint to ensure `similarJobs` are loaded from Elasticsearch and returned by the controller.

### Description
- In `src/Recruit/Application/Service/JobPublicDetailService.php` import `UuidBinaryOrderedTimeType` and change the query builder to pass `:recruit` as the recruit UUID with `UuidBinaryOrderedTimeType::NAME` and bind the missing `:isPublished` parameter with `true`.
- Update `tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailControllerTest.php` to call the public endpoint `GET /v1/recruit/applications/{applicationSlug}/public/jobs/{jobSlug}`, seed a `recruit_job_similar` document in Elasticsearch using `JobSimilarIndexerService::INDEX_NAME`, require at least two published jobs in the fixture helper, and assert the returned `similarJobs` contains the expected job.

### Testing
- Ran syntax checks with `php -l` on `src/Recruit/Application/Service/JobPublicDetailService.php` and the updated test file, and both reported no syntax errors (success).
- Attempted to run PHPUnit (`./vendor/bin/phpunit` and `bin/phpunit`) but the PHPUnit binary was not available in this environment, so integration test execution could not be performed here (not executed).
- Confirmed updated PHP files pass static syntax validation in the environment (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f1647a3483268949b921ed948cdf)