### PR TITLE
Resolve duplicated `/applications/{applicationSlug}/products` controllers

### DIFF
--- a/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
@@ -31,12 +31,10 @@ final readonly class CreateProductController
     ) {
     }
 
-    #[Route('/v1/shop/applications/{applicationSlug}/products', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, Request $request): JsonResponse
+    #[Route('/v1/shop/products', methods: [Request::METHOD_POST])]
+    public function __invoke(Request $request): JsonResponse
     {
-        $request->attributes->set('applicationSlug', $applicationSlug);
-        $payload = (array)json_decode((string)$request->getContent(), true);
+        $payload = (array) json_decode((string) $request->getContent(), true);
         $product = $this->productHydratorService->hydrateProduct(new Product(), $payload);
 
         if (is_string($payload['shopId'] ?? null)) {

--- a/src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php
@@ -23,11 +23,9 @@ final readonly class ListProductsController
     ) {
     }
 
-    #[Route('/v1/shop/applications/{applicationSlug}/products', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, Request $request): JsonResponse
+    #[Route('/v1/shop/products', methods: [Request::METHOD_GET])]
+    public function __invoke(Request $request): JsonResponse
     {
-        $request->attributes->set('applicationSlug', $applicationSlug);
         return new JsonResponse($this->productListService->getList($request));
     }
 }


### PR DESCRIPTION
### Motivation
- The codebase exposed the same application-scoped collection endpoints from two controller sets which caused routing ambiguity and duplicated OpenAPI operations.
- The `ApplicationProduct` controllers already perform application/shop resolution and include richer response/context, so they should remain the canonical flow.

### Description
- Moved the generic `Product` collection routes from `GET/POST /v1/shop/applications/{applicationSlug}/products` to `GET/POST /v1/shop/products` by updating `ListProductsController` and `CreateProductController` and removing the `applicationSlug` parameter usage.
- Preserved the `ApplicationProduct` controllers and their logic (shop resolution, hydration, `EntityCreated` dispatch with context, and enriched response) as the canonical handlers for `GET/POST /v1/shop/applications/{applicationSlug}/products`.
- Removed the duplicate OpenAPI path parameter annotations from the generic `Product` controllers so only the `ApplicationProduct` controllers expose the application-scoped operations.
- Changes applied to `src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php` and `src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php` and committed.

### Testing
- Ran PHP syntax checks with `php -l` on the four related controllers which completed successfully.
- Verified the routes with `rg "Route\('/v1/shop/applications/\{applicationSlug\}/products'|Route\('/v1/shop/products'" -n src/Shop/Transport/Controller/Api/V1` which shows `ApplicationProduct` keeping the application-scoped routes and `Product` now using `/v1/shop/products`.
- All automated checks above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f16ae49c8326aa1698772b0a6684)