### PR TITLE
Implement lightweight conversation list payload

### DIFF
--- a/src/Chat/Application/Service/ConversationListService.php
+++ b/src/Chat/Application/Service/ConversationListService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Chat\Application\Service;
 
 use App\Chat\Domain\Entity\ChatMessage;
-use App\Chat\Domain\Entity\ChatMessageReaction;
 use App\Chat\Domain\Entity\Conversation;
 use App\Chat\Domain\Entity\ConversationParticipant;
 use App\Chat\Domain\Repository\Interfaces\ConversationRepositoryInterface;
@@ -260,44 +259,41 @@ final readonly class ConversationListService
                     },
                     0
                 ),
-                'messages' => array_map(
-                    function (ChatMessage $message) use ($connectedUserId): array {
-                        $sender = $message->getSender();
-                        $senderId = $sender?->getId();
-
-                        return [
-                            'id' => $message->getId(),
-                            'content' => $message->getContent(),
-                            'sender' => [
-                                'id' => $senderId,
-                                'firstName' => $sender?->getFirstName(),
-                                'lastName' => $sender?->getLastName(),
-                                'photo' => $sender?->getPhoto(),
-                                'owner' => $connectedUserId !== null && $senderId === $connectedUserId,
-                            ],
-                            'attachments' => $message->getAttachments(),
-                            'metadata' => $message->getMetadata(),
-                            'read' => $message->isRead(),
-                            'readAt' => $message->getReadAt()?->format(DATE_ATOM),
-                            'editedAt' => $message->getEditedAt()?->format(DATE_ATOM),
-                            'deletedAt' => $message->getDeletedAt()?->format(DATE_ATOM),
-                            'createdAt' => $message->getCreatedAt()?->format(DATE_ATOM),
-                            'reactions' => array_map(
-                                static fn (ChatMessageReaction $reaction): array => [
-                                    'id' => $reaction->getId(),
-                                    'userId' => $reaction->getUser()->getId(),
-                                    'reaction' => $reaction->getReaction()->value,
-                                ],
-                                $message->getReactions()->toArray()
-                            ),
-                        ];
-                    },
-                    $visibleMessages
-                ),
+                'lastMessage' => $this->normalizeLastMessage($visibleMessages, $connectedUserId),
                 'lastMessageAt' => $conversation->getLastMessageAt()?->format(DATE_ATOM),
                 'archivedAt' => $conversation->getArchivedAt()?->format(DATE_ATOM),
                 'createdAt' => $conversation->getCreatedAt()?->format(DATE_ATOM),
             ];
         }, $conversations);
+    }
+
+    /**
+     * @param array<int, ChatMessage> $visibleMessages
+     *
+     * @return array<string, mixed>|null
+     */
+    private function normalizeLastMessage(array $visibleMessages, ?string $connectedUserId): ?array
+    {
+        if ($visibleMessages === []) {
+            return null;
+        }
+
+        /** @var ChatMessage $lastMessage */
+        $lastMessage = $visibleMessages[array_key_last($visibleMessages)];
+        $sender = $lastMessage->getSender();
+        $senderId = $sender?->getId();
+
+        return [
+            'id' => $lastMessage->getId(),
+            'content' => mb_substr((string)$lastMessage->getContent(), 0, 280),
+            'createdAt' => $lastMessage->getCreatedAt()?->format(DATE_ATOM),
+            'sender' => [
+                'id' => $senderId,
+                'firstName' => $sender?->getFirstName(),
+                'lastName' => $sender?->getLastName(),
+                'photo' => $sender?->getPhoto(),
+                'owner' => $connectedUserId !== null && $senderId === $connectedUserId,
+            ],
+        ];
     }
 }

--- a/src/Chat/Infrastructure/Repository/ConversationRepository.php
+++ b/src/Chat/Infrastructure/Repository/ConversationRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Chat\Infrastructure\Repository;
 
 use App\Chat\Domain\Entity\Chat;
+use App\Chat\Domain\Entity\ChatMessage;
 use App\Chat\Domain\Entity\Conversation as Entity;
 use App\Chat\Domain\Enum\ConversationType;
 use App\Chat\Domain\Repository\Interfaces\ConversationRepositoryInterface;
@@ -47,10 +48,7 @@ class ConversationRepository extends BaseRepository implements ConversationRepos
         $offset = max(0, ($page - 1) * $limit);
 
         return $this->applyListFilters(
-            $this->createQueryBuilder('conversation')
-                ->addSelect('chat')
-                ->innerJoin('conversation.chat', 'chat')
-                ->leftJoin('conversation.messages', 'messages', 'WITH', 'messages.deletedAt IS NULL'),
+            $this->getConversationListQueryBuilder(),
             $filters,
             $esIds
         )
@@ -81,7 +79,7 @@ class ConversationRepository extends BaseRepository implements ConversationRepos
     {
         $offset = max(0, ($page - 1) * $limit);
 
-        return $this->applyListFilters($this->getConversationQueryBuilder(), $filters, $esIds)
+        return $this->applyListFilters($this->getConversationListQueryBuilder(), $filters, $esIds)
             ->andWhere('chat.id = :chatId')
             ->andWhere('conversation.archivedAt IS NULL')
             ->setParameter('chatId', $chatId, UuidBinaryOrderedTimeType::NAME)
@@ -107,7 +105,7 @@ class ConversationRepository extends BaseRepository implements ConversationRepos
     {
         $offset = max(0, ($page - 1) * $limit);
 
-        return $this->applyListFilters($this->getConversationQueryBuilder(), $filters, $esIds)
+        return $this->applyListFilters($this->getConversationListQueryBuilder(), $filters, $esIds)
             ->innerJoin('conversation.participants', 'participant')
             ->andWhere('chat.id = :chatId')
             ->andWhere('participant.user = :user')
@@ -178,12 +176,29 @@ class ConversationRepository extends BaseRepository implements ConversationRepos
             ->distinct();
     }
 
+    private function getConversationListQueryBuilder(): QueryBuilder
+    {
+        return $this->createQueryBuilder('conversation')
+            ->addSelect('chat', 'participants', 'participantUser', 'lastMessage', 'lastMessageSender')
+            ->innerJoin('conversation.chat', 'chat')
+            ->leftJoin('conversation.participants', 'participants')
+            ->leftJoin('participants.user', 'participantUser')
+            ->leftJoin(
+                'conversation.messages',
+                'lastMessage',
+                'WITH',
+                'lastMessage.deletedAt IS NULL AND lastMessage.createdAt = conversation.lastMessageAt'
+            )
+            ->leftJoin('lastMessage.sender', 'lastMessageSender')
+            ->andWhere('conversation.archivedAt IS NULL')
+            ->distinct();
+    }
+
     private function getConversationCountQueryBuilder(): QueryBuilder
     {
         return $this->createQueryBuilder('conversation')
             ->select('COUNT(DISTINCT conversation.id)')
             ->innerJoin('conversation.chat', 'chat')
-            ->leftJoin('conversation.messages', 'messages', 'WITH', 'messages.deletedAt IS NULL')
             ->andWhere('conversation.archivedAt IS NULL');
     }
 
@@ -197,7 +212,10 @@ class ConversationRepository extends BaseRepository implements ConversationRepos
 
         if (($filters['message'] ?? '') !== '') {
             $queryBuilder
-                ->andWhere('LOWER(messages.content) LIKE LOWER(:message)')
+                ->andWhere(sprintf(
+                    'EXISTS (SELECT 1 FROM %s filterMessage WHERE filterMessage.conversation = conversation AND filterMessage.deletedAt IS NULL AND LOWER(filterMessage.content) LIKE LOWER(:message))',
+                    ChatMessage::class
+                ))
                 ->setParameter('message', '%' . $filters['message'] . '%');
         }
 

--- a/tests/Unit/Chat/Application/Service/ConversationListServiceTest.php
+++ b/tests/Unit/Chat/Application/Service/ConversationListServiceTest.php
@@ -6,10 +6,8 @@ namespace App\Tests\Unit\Chat\Application\Service;
 
 use App\Chat\Application\Service\ConversationListService;
 use App\Chat\Domain\Entity\ChatMessage;
-use App\Chat\Domain\Entity\ChatMessageReaction;
 use App\Chat\Domain\Entity\Conversation;
 use App\Chat\Domain\Entity\ConversationParticipant;
-use App\Chat\Domain\Enum\ChatReactionType;
 use App\Chat\Domain\Enum\ConversationType;
 use App\Chat\Domain\Repository\Interfaces\ConversationRepositoryInterface;
 use App\General\Application\Service\CacheKeyConventionService;
@@ -105,12 +103,9 @@ final class ConversationListServiceTest extends TestCase
         self::assertSame([], $result['items']);
     }
 
-    public function testGetByUserNormalizesReactionUserIdAsUuidString(): void
+    public function testGetByUserReturnsLightConversationStructureWithLastMessage(): void
     {
         $connectedUser = $this->mockUser();
-
-        $reactionAuthor = $this->createMock(User::class);
-        $reactionAuthor->method('getId')->willReturn('550e8400-e29b-41d4-a716-446655440000');
 
         $sender = $this->createMock(User::class);
         $sender->method('getId')->willReturn('sender-id');
@@ -118,23 +113,12 @@ final class ConversationListServiceTest extends TestCase
         $sender->method('getLastName')->willReturn('User');
         $sender->method('getPhoto')->willReturn(null);
 
-        $reaction = $this->createMock(ChatMessageReaction::class);
-        $reaction->method('getId')->willReturn('reaction-id');
-        $reaction->method('getUser')->willReturn($reactionAuthor);
-        $reaction->method('getReaction')->willReturn(ChatReactionType::LIKE);
-
         $message = $this->createMock(ChatMessage::class);
         $message->method('getId')->willReturn('message-id');
-        $message->method('getContent')->willReturn('hello');
+        $message->method('getContent')->willReturn(str_repeat('hello', 80));
         $message->method('getSender')->willReturn($sender);
-        $message->method('getAttachments')->willReturn([]);
-        $message->method('getMetadata')->willReturn([]);
-        $message->method('isRead')->willReturn(true);
-        $message->method('getReadAt')->willReturn(null);
-        $message->method('getEditedAt')->willReturn(null);
         $message->method('getDeletedAt')->willReturn(null);
-        $message->method('getCreatedAt')->willReturn(new \DateTimeImmutable('2024-01-01T00:00:00+00:00'));
-        $message->method('getReactions')->willReturn(new ArrayCollection([$reaction]));
+        $message->method('getCreatedAt')->willReturn(new \DateTimeImmutable('2024-01-01T10:00:00+00:00'));
 
         $participant = $this->createMock(ConversationParticipant::class);
         $participant->method('getUser')->willReturn($connectedUser);
@@ -175,8 +159,11 @@ final class ConversationListServiceTest extends TestCase
         $service = new ConversationListService($repo, $cache, $elastic, $cacheKeyConventionService);
         $result = $service->getByUser($connectedUser, [], 1, 20);
 
-        self::assertSame('550e8400-e29b-41d4-a716-446655440000', $result['items'][0]['messages'][0]['reactions'][0]['userId']);
-        self::assertIsString($result['items'][0]['messages'][0]['reactions'][0]['userId']);
+        self::assertArrayNotHasKey('messages', $result['items'][0]);
+        self::assertSame('message-id', $result['items'][0]['lastMessage']['id']);
+        self::assertSame(280, mb_strlen($result['items'][0]['lastMessage']['content']));
+        self::assertSame('sender-id', $result['items'][0]['lastMessage']['sender']['id']);
+        self::assertSame('2024-01-01T10:00:00+00:00', $result['items'][0]['lastMessage']['createdAt']);
     }
 
     private function mockUser(): User


### PR DESCRIPTION
### Motivation
- Reduce payload and ORM overhead for conversation list endpoints by avoiding loading full `messages`/`reactions` collections on list queries. 
- Still allow full-detail endpoints to paginate messages when needed.

### Description
- Add a dedicated list-oriented query builder `getConversationListQueryBuilder()` that selects `chat`, `participants`, and a join to the single `lastMessage` plus its `sender`, and switch list methods (`findByUser`, `findByChatId`, `findByChatIdAndUser`) to use it in `ConversationRepository`. 
- Keep the existing full `getConversationQueryBuilder()` for detailed endpoints and add `getConversationCountQueryBuilder()` adjustments to avoid joining full messages. 
- Change message filtering in list queries to use an `EXISTS` subquery against `ChatMessage` so message search works without joining the full messages collection. 
- In `ConversationListService` replace the full `messages` payload with a `lastMessage` summary (id, truncated `content` up to 280 chars, `createdAt`, `sender` minimal info) and add `normalizeLastMessage()` to produce the light representation. 
- Update the unit test in `tests/Unit/Chat/Application/Service/ConversationListServiceTest.php` to assert the new light structure (no `messages`, presence and truncation of `lastMessage`).

### Testing
- Added/updated unit test `tests/Unit/Chat/Application/Service/ConversationListServiceTest.php` to validate the new response shape and content truncation. 
- Attempted to run `vendor/bin/phpunit tests/Unit/Chat/Application/Service/ConversationListServiceTest.php` but the environment returned an error because `vendor/bin/phpunit` is not present, so tests could not be executed here. 
- Existing CI/unit test expectations should be satisfied locally or in CI where `phpunit` is available given the updated test assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f3a5c1648326b5c0be935f2c96af)