### PR TITLE
feat(blog): centralize visibility checks in read flow

### DIFF
--- a/src/Blog/Application/Service/BlogReadService.php
+++ b/src/Blog/Application/Service/BlogReadService.php
@@ -7,6 +7,7 @@ namespace App\Blog\Application\Service;
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Domain\Entity\BlogPost;
+use App\Blog\Domain\Enum\BlogVisibility;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
 use App\Blog\Infrastructure\Repository\BlogRepository;
 use App\General\Application\Service\CacheKeyConventionService;
@@ -53,7 +54,11 @@ final readonly class BlogReadService
             }
             $blog = $this->blogRepository->findGeneralBlog();
 
-            return $blog instanceof Blog ? $this->normalizeBlog($blog, $currentUser, $page, $limit) : [];
+            if (!$blog instanceof Blog || !$this->canReadBlog($blog, $currentUser)) {
+                return [];
+            }
+
+            return $this->normalizeBlog($blog, $currentUser, $page, $limit);
         });
     }
 
@@ -75,7 +80,11 @@ final readonly class BlogReadService
             }
             $blog = $this->blogRepository->findOneByApplicationSlug($applicationSlug);
 
-            return $blog instanceof Blog ? $this->normalizeBlog($blog, $currentUser) : [];
+            if (!$blog instanceof Blog || !$this->canReadBlog($blog, $currentUser)) {
+                return [];
+            }
+
+            return $this->normalizeBlog($blog, $currentUser);
         });
     }
 
@@ -84,6 +93,10 @@ final readonly class BlogReadService
         $post = $this->blogPostRepository->findOneBySlugWithDisplayRelations($slug);
 
         if (!$post instanceof BlogPost) {
+            return [];
+        }
+
+        if (!$this->canReadBlog($post->getBlog(), $currentUser)) {
             return [];
         }
 
@@ -196,6 +209,15 @@ final readonly class BlogReadService
         }
 
         return $this->cacheKeyConventionService->buildPrivateBlogKey($currentUser->getUsername(), $scope);
+    }
+
+    private function canReadBlog(Blog $blog, ?User $currentUser): bool
+    {
+        if ($blog->getVisibility() === BlogVisibility::PUBLIC) {
+            return true;
+        }
+
+        return $currentUser !== null && $blog->getOwner()->getId() === $currentUser->getId();
     }
 
     /**

--- a/tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php
+++ b/tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Tests\Application\Blog\Transport\Controller\Api\V1;
 
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Enum\BlogVisibility;
 use App\Tests\TestCase\WebTestCase;
 use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 final class BlogControllerTest extends WebTestCase
@@ -386,6 +389,81 @@ final class BlogControllerTest extends WebTestCase
             self::assertIsArray($post);
             self::assertTrue((bool)($post['isAuthor'] ?? false));
         }
+    }
+
+    public function testPrivateApplicationBlogIsHiddenForAnonymousAndNonOwner(): void
+    {
+        $this->setApplicationBlogVisibility('shop-ops-center', BlogVisibility::PRIVATE);
+
+        $anonymousClient = $this->getTestClient();
+        $anonymousClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame([], json_decode((string)$anonymousClient->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR));
+
+        $nonOwnerClient = $this->getTestClient('john-user', 'password-user');
+        $nonOwnerClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame([], json_decode((string)$nonOwnerClient->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR));
+    }
+
+    public function testPrivateApplicationBlogRemainsReadableForOwner(): void
+    {
+        $this->setApplicationBlogVisibility('shop-ops-center', BlogVisibility::PRIVATE);
+
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+        $ownerClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
+        self::assertResponseStatusCodeSame(200);
+
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string)$ownerClient->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('visibility', $payload);
+        self::assertSame('private', $payload['visibility']);
+        self::assertArrayHasKey('posts', $payload);
+        self::assertIsArray($payload['posts']);
+        self::assertNotEmpty($payload['posts']);
+    }
+
+    public function testPrivateApplicationBlogPostBySlugVisibilityGuard(): void
+    {
+        $this->setApplicationBlogVisibility('shop-ops-center', BlogVisibility::PRIVATE);
+
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+        $ownerClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
+        self::assertResponseStatusCodeSame(200);
+        /** @var array<string, mixed> $ownerPayload */
+        $ownerPayload = json_decode((string)$ownerClient->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $post = $ownerPayload['posts'][0] ?? null;
+        self::assertIsArray($post);
+        self::assertArrayHasKey('slug', $post);
+
+        $nonOwnerClient = $this->getTestClient('john-user', 'password-user');
+        $nonOwnerClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/posts/' . $post['slug']);
+        self::assertResponseStatusCodeSame(200);
+        self::assertSame([], json_decode((string)$nonOwnerClient->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR));
+
+        $ownerClient->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/posts/' . $post['slug']);
+        self::assertResponseStatusCodeSame(200);
+        /** @var array<string, mixed> $singlePost */
+        $singlePost = json_decode((string)$ownerClient->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame($post['slug'], $singlePost['slug'] ?? null);
+    }
+
+    private function setApplicationBlogVisibility(string $applicationSlug, BlogVisibility $visibility): void
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $blog = $entityManager->getRepository(Blog::class)
+            ->createQueryBuilder('blog')
+            ->innerJoin('blog.application', 'application')
+            ->where('application.slug = :applicationSlug')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        self::assertInstanceOf(Blog::class, $blog);
+        $blog->setVisibility($visibility);
+        $entityManager->flush();
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Centraliser la logique de visibilité des blogs afin d'appliquer uniformément la règle `PUBLIC` accessible et `PRIVATE` réservé au propriétaire dans les flux de lecture.

### Description

- Ajout de la méthode `canReadBlog(Blog $blog, ?User $currentUser): bool` dans `src/Blog/Application/Service/BlogReadService.php` qui autorise l'accès pour `PUBLIC` et pour `PRIVATE` uniquement au propriétaire.
- Application du garde avant normalisation dans `getGeneralBlogWithTree`, `getByApplicationSlug` et `getPostBySlug` pour retourner un payload neutre (`[]`) si l'accès est refusé.
- Ajout de scénarios de test dans `tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php` couvrant les cas : anonyme, utilisateur authentifié non propriétaire, propriétaire, et lecture d'un post par slug.
- Ajout d'une aide de test `setApplicationBlogVisibility` utilisant Doctrine pour basculer la visibilité d'un blog applicatif durant les tests.

### Testing

- Exécution des vérifications de syntaxe avec `php -l` sur les fichiers modifiés : réussite pour `src/Blog/Application/Service/BlogReadService.php` et `tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php`.
- Tentatives d'exécution de la suite via `./vendor/bin/phpunit` et `php bin/phpunit` ont échoué dans cet environnement car les binaires PHPUnit ne sont pas présents, les nouveaux tests sont toutefois ajoutés et prêts à être exécutés dans CI ou une instance locale complète.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f393fd2c832682699b4c94ba03cb)