### PR TITLE
Enrich EventRepository base listing query with application join

### DIFF
--- a/src/Calendar/Infrastructure/Repository/EventRepository.php
+++ b/src/Calendar/Infrastructure/Repository/EventRepository.php
@@ -64,7 +64,6 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
         $offset = max(0, ($page - 1) * $limit);
 
         return $this->applyListFilters($this->createBaseQueryBuilder(), $filters, $esIds)
-            ->innerJoin('calendar.application', 'application')
             ->andWhere('application.slug = :applicationSlug')
             ->andWhere('event.visibility = :visibilityPublic')
             ->andWhere('event.isCancelled = false')
@@ -95,7 +94,6 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
         $offset = max(0, ($page - 1) * $limit);
 
         return $this->applyListFilters($this->createBaseQueryBuilder(), $filters, $esIds)
-            ->innerJoin('calendar.application', 'application')
             ->andWhere('application.slug = :applicationSlug')
             ->andWhere('event.user = :user OR calendar.user = :user')
             ->setParameter('applicationSlug', $applicationSlug)
@@ -139,7 +137,6 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
     public function findUpcomingByApplicationSlugAndUser(string $applicationSlug, User $user, int $limit = 3): array
     {
         return $this->createBaseQueryBuilder()
-            ->innerJoin('calendar.application', 'application')
             ->andWhere('application.slug = :applicationSlug')
             ->andWhere('event.user = :user OR calendar.user = :user')
             ->andWhere('event.isCancelled = false')
@@ -157,7 +154,9 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
     {
         return $this->createQueryBuilder('event')
             ->addSelect('calendar')
+            ->addSelect('application')
             ->leftJoin('event.calendar', 'calendar')
+            ->leftJoin('calendar.application', 'application')
             ->distinct();
     }
 

--- a/tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php
+++ b/tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php
@@ -75,4 +75,61 @@ final class ApplicationEventListControllerTest extends WebTestCase
         }
     }
 
+
+    #[TestDox('GET listing endpoints keep business results after repository joins enrichment.')]
+    public function testEventListingEndpointsKeepExpectedBusinessBehavior(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/private/events?limit=50');
+        $privateResponse = $client->getResponse();
+        $privateContent = $privateResponse->getContent();
+
+        self::assertNotFalse($privateContent);
+        self::assertSame(Response::HTTP_OK, $privateResponse->getStatusCode(), "Response:\n" . $privateResponse);
+
+        $privateData = JSON::decode($privateContent, true);
+
+        self::assertIsArray($privateData);
+        self::assertArrayHasKey('items', $privateData);
+        self::assertArrayHasKey('pagination', $privateData);
+        self::assertGreaterThan(0, $privateData['pagination']['totalItems']);
+
+        $privateTitles = array_map(
+            static fn (array $item): string => (string) ($item['title'] ?? ''),
+            $privateData['items'],
+        );
+        self::assertContains('John Root standalone private event #1', $privateTitles);
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/applications/crm-support-desk/events/me?limit=50');
+        $applicationPrivateResponse = $client->getResponse();
+        $applicationPrivateContent = $applicationPrivateResponse->getContent();
+
+        self::assertNotFalse($applicationPrivateContent);
+        self::assertSame(Response::HTTP_OK, $applicationPrivateResponse->getStatusCode(), "Response:\n" . $applicationPrivateResponse);
+
+        $applicationPrivateData = JSON::decode($applicationPrivateContent, true);
+
+        self::assertIsArray($applicationPrivateData);
+        self::assertArrayHasKey('items', $applicationPrivateData);
+        self::assertNotEmpty($applicationPrivateData['items']);
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/events/upcoming?applicationSlug=crm-support-desk&limit=3');
+        $upcomingResponse = $client->getResponse();
+        $upcomingContent = $upcomingResponse->getContent();
+
+        self::assertNotFalse($upcomingContent);
+        self::assertSame(Response::HTTP_OK, $upcomingResponse->getStatusCode(), "Response:\n" . $upcomingResponse);
+
+        $upcomingData = JSON::decode($upcomingContent, true);
+
+        self::assertIsArray($upcomingData);
+        self::assertLessThanOrEqual(3, count($upcomingData));
+
+        if ($upcomingData !== []) {
+            self::assertArrayHasKey('title', $upcomingData[0]);
+            self::assertArrayHasKey('startAt', $upcomingData[0]);
+        }
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Centraliser la jonction vers `calendar.application` dans le `QueryBuilder` de base pour éviter les `innerJoin` répétés et permettre aux filtres/endpoints d'utiliser `application` sans double-join.

### Description

- Ajout de `->addSelect('application')` et `->leftJoin('calendar.application', 'application')` dans `EventRepository::createBaseQueryBuilder()` pour toujours sélectionner et joindre l'entité `application`.
- Suppression des `->innerJoin('calendar.application', 'application')` redondants dans `findByApplicationSlug`, `findByApplicationSlugAndUser` et `findUpcomingByApplicationSlugAndUser` puisque la jointure est désormais fournie par le `createBaseQueryBuilder()`.
- Ajout d'un test d'intégration dans `tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php` qui vérifie que les endpoints de listing (`/private/events`, `/applications/{slug}/events/me`, `/events/upcoming?applicationSlug=...`) conservent le comportement métier attendu.

### Testing

- `php -l src/Calendar/Infrastructure/Repository/EventRepository.php` a renvoyé sans erreur de syntaxe.
- `php -l tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php` a renvoyé sans erreur de syntaxe et le test d'intégration a été ajouté.
- Tentative d'exécution complète de la suite (`composer install` / `phpunit`) impossible dans cet environnement en raison d'extensions PHP manquantes (`ext-amqp`, `ext-sodium`) et d'échecs réseau lors du téléchargement des dépendances, donc les tests automatisés n'ont pas pu être lancés ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f39e975c83269ce5305670270e89)