### PR TITLE
Align school application scope resolver user handling across V1 controllers

### DIFF
--- a/src/School/Application/Service/SchoolApplicationScopeResolver.php
+++ b/src/School/Application/Service/SchoolApplicationScopeResolver.php
@@ -21,7 +21,7 @@ final readonly class SchoolApplicationScopeResolver
     ) {
     }
 
-    public function resolveOrCreateSchoolByApplicationSlug(string $applicationSlug, User $user): School
+    public function resolveOrCreateSchoolByApplicationSlug(string $applicationSlug, ?User $user): School
     {
         $school = $this->schoolRepository->findOneByApplicationSlug($applicationSlug);
         if ($school instanceof School) {

--- a/src/School/Transport/Controller/Api/V1/Application/GetSchoolApplicationResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/Application/GetSchoolApplicationResourceController.php
@@ -7,6 +7,7 @@ namespace App\School\Transport\Controller\Api\V1\Application;
 use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Application\Service\SchoolResourceAccessService;
 use App\School\Application\Service\SchoolResourceViewService;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,9 +32,9 @@ final readonly class GetSchoolApplicationResourceController
         'resource' => 'classes|students|teachers|exams|grades',
     ])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $resource, string $id): JsonResponse
+    public function __invoke(string $applicationSlug, string $resource, string $id, ?User $loggedInUser): JsonResponse
     {
-        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
         $entity = $this->resourceViewService->findOr404($resource, $id);
         if (!$this->resourceAccessService->belongsToSchool($entity, $school)) {
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found in application scope.');

--- a/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
@@ -9,6 +9,7 @@ use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Application\Service\SchoolResourceAccessService;
 use App\School\Application\Service\SchoolResourcePatchService;
 use App\School\Application\Service\SchoolResourceViewService;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -36,10 +37,10 @@ final readonly class PatchSchoolApplicationResourceController
         'resource' => 'classes|students|teachers|exams|grades',
     ])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $resource, string $id, Request $request): JsonResponse
+    public function __invoke(string $applicationSlug, string $resource, string $id, Request $request, ?User $loggedInUser): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
-        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
         $entity = $this->resourceViewService->findOr404($resource, $id);
         if (!$this->resourceAccessService->belongsToSchool($entity, $school)) {
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found in application scope.');

--- a/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
@@ -8,6 +8,7 @@ use App\School\Application\Service\CreateClassByApplicationService;
 use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Transport\Controller\Api\V1\Input\CreateClassByApplicationInput;
 use App\School\Transport\Controller\Api\V1\Input\SchoolInputValidator;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -30,10 +31,10 @@ final readonly class CreateClassByApplicationController
 
     #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, Request $request): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
-        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
         $payload = $request->toArray();
 
         $input = new CreateClassByApplicationInput();

--- a/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php
+++ b/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php
@@ -7,6 +7,7 @@ namespace App\School\Transport\Controller\Api\V1;
 use App\School\Application\Serializer\SchoolApiResponseSerializer;
 use App\School\Application\Service\SchoolApplicationResourceListService;
 use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -31,9 +32,9 @@ final readonly class SchoolApplicationResourceListController
         'resource' => 'students|teachers|exams|grades',
     ])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $resource): JsonResponse
+    public function __invoke(string $applicationSlug, string $resource, ?User $loggedInUser): JsonResponse
     {
-        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug);
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
         $items = $this->resourceListService->listByResource($resource, $school->getId());
 
         return new JsonResponse($this->responseSerializer->list($items, null, [

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
@@ -34,6 +34,7 @@ final class SchoolApplicationScopedRoutesTest extends WebTestCase
 
         $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/teachers');
         self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+        self::assertStringContainsString('Forbidden application scope access.', (string)$forbiddenClient->getResponse()->getContent());
 
         $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams');
         self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
@@ -56,6 +57,7 @@ final class SchoolApplicationScopedRoutesTest extends WebTestCase
 
         $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes/' . $classId);
         self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+        self::assertStringContainsString('Forbidden application scope access.', (string)$forbiddenClient->getResponse()->getContent());
 
         $ownerClient->request('PATCH', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes/' . $classId, [], [], [], JSON::encode([
             'name' => 'Classe Scoped Updated',


### PR DESCRIPTION
### Motivation
- Make `SchoolApplicationScopeResolver::resolveOrCreateSchoolByApplicationSlug` signature consistent with controller injection patterns by accepting a nullable `?User`, while keeping authorization enforcement in `assertApplicationAccess` (403 if user is absent or not owner). 

### Description
- Change `resolveOrCreateSchoolByApplicationSlug` to accept `?User $user` in `src/School/Application/Service/SchoolApplicationScopeResolver.php`. 
- Update V1 controllers to accept and forward the optional logged-in user (`?User $loggedInUser`) to the resolver in `src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php`, `src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php`, `src/School/Transport/Controller/Api/V1/Application/GetSchoolApplicationResourceController.php`, and `src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php`. 
- Keep authorization logic in `assertApplicationAccess` unchanged so it still returns `403` when the user is missing or not the application's owner. 
- Add assertions in `tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php` to verify the forbidden response includes the resolver message for representative routes. 

### Testing
- Ran `php -l` syntax checks on all modified source files and the updated test file and they succeeded. 
- Attempted to run the targeted PHPUnit test but the PHPUnit executable was not available in this environment (`vendor/bin/phpunit` and `bin/phpunit` missing). 
- Static checks and syntax validation completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f3aaf3a08326a1748005723f1a4b)