### PR TITLE
Restreindre les contrôleurs API shop au Shop résolu par `applicationSlug`

### DIFF
--- a/src/Shop/Application/Service/ProductHydratorService.php
+++ b/src/Shop/Application/Service/ProductHydratorService.php
@@ -68,12 +68,39 @@ final readonly class ProductHydratorService
                 $product->removeTag($tag);
             }
             foreach ((array)($payload['tagIds'] ?? []) as $tagId) {
-                if (is_string($tagId) && ($tag = $this->tagRepository->find($tagId)) instanceof Tag) {
-                    $product->addTag($tag);
+                if (!is_string($tagId)) {
+                    continue;
                 }
+
+                $tag = $this->tagRepository->find($tagId);
+                if (!$tag instanceof Tag) {
+                    continue;
+                }
+
+                if ($product->getShop() instanceof Shop && !$this->isTagInShopScope($tag, $product->getShop())) {
+                    continue;
+                }
+
+                $product->addTag($tag);
             }
         }
 
         return $product;
+    }
+
+    private function isTagInShopScope(Tag $tag, Shop $shop): bool
+    {
+        $linkedProducts = $tag->getProducts();
+        if ($linkedProducts->isEmpty()) {
+            return true;
+        }
+
+        foreach ($linkedProducts as $linkedProduct) {
+            if ($linkedProduct->getShop()?->getId() === $shop->getId()) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Shop/Infrastructure/Repository/CategoryRepository.php
+++ b/src/Shop/Infrastructure/Repository/CategoryRepository.php
@@ -6,6 +6,7 @@ namespace App\Shop\Infrastructure\Repository;
 
 use App\General\Infrastructure\Repository\BaseRepository;
 use App\Shop\Domain\Entity\Category as Entity;
+use App\Shop\Domain\Entity\Shop;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -24,5 +25,36 @@ class CategoryRepository extends BaseRepository
     public function __construct(
         protected ManagerRegistry $managerRegistry
     ) {
+    }
+
+    /**
+     * @return array<int, Entity>
+     */
+    public function findByShop(Shop $shop, int $limit = 200): array
+    {
+        /** @var array<int, Entity> $categories */
+        $categories = $this->createQueryBuilder('category')
+            ->andWhere('category.shop = :shop')
+            ->setParameter('shop', $shop)
+            ->orderBy('category.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return $categories;
+    }
+
+    public function findOneByIdAndShop(string $id, Shop $shop): ?Entity
+    {
+        /** @var Entity|null $category */
+        $category = $this->createQueryBuilder('category')
+            ->andWhere('category.id = :id')
+            ->andWhere('category.shop = :shop')
+            ->setParameter('id', $id)
+            ->setParameter('shop', $shop)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $category;
     }
 }

--- a/src/Shop/Infrastructure/Repository/ProductRepository.php
+++ b/src/Shop/Infrastructure/Repository/ProductRepository.php
@@ -6,6 +6,7 @@ namespace App\Shop\Infrastructure\Repository;
 
 use App\General\Infrastructure\Repository\BaseRepository;
 use App\Shop\Domain\Entity\Product as Entity;
+use App\Shop\Domain\Entity\Shop;
 use App\Shop\Domain\Enum\ProductStatus;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
@@ -62,5 +63,19 @@ class ProductRepository extends BaseRepository
         $results = $qb->getQuery()->getResult();
 
         return $results;
+    }
+
+    public function findOneByIdAndShop(string $id, Shop $shop): ?Entity
+    {
+        /** @var Entity|null $product */
+        $product = $this->createQueryBuilder('product')
+            ->andWhere('product.id = :id')
+            ->andWhere('product.shop = :shop')
+            ->setParameter('id', $id)
+            ->setParameter('shop', $shop)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $product;
     }
 }

--- a/src/Shop/Infrastructure/Repository/TagRepository.php
+++ b/src/Shop/Infrastructure/Repository/TagRepository.php
@@ -25,4 +25,43 @@ class TagRepository extends BaseRepository
         protected ManagerRegistry $managerRegistry
     ) {
     }
+
+    /**
+     * @return array<int, Entity>
+     */
+    public function findByApplicationScope(string $applicationSlug, int $limit = 200): array
+    {
+        /** @var array<int, Entity> $tags */
+        $tags = $this->createQueryBuilder('tag')
+            ->innerJoin('tag.products', 'product')
+            ->innerJoin('product.shop', 'shop')
+            ->innerJoin('shop.application', 'application')
+            ->andWhere('application.slug = :applicationSlug')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->groupBy('tag.id')
+            ->orderBy('tag.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return $tags;
+    }
+
+    public function findOneByIdAndApplicationScope(string $id, string $applicationSlug): ?Entity
+    {
+        /** @var Entity|null $tag */
+        $tag = $this->createQueryBuilder('tag')
+            ->innerJoin('tag.products', 'product')
+            ->innerJoin('product.shop', 'shop')
+            ->innerJoin('shop.application', 'application')
+            ->andWhere('tag.id = :id')
+            ->andWhere('application.slug = :applicationSlug')
+            ->setParameter('id', $id)
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $tag;
+    }
 }

--- a/src/Shop/Transport/Controller/Api/V1/Category/CreateCategoryController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Category/CreateCategoryController.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Shop\Transport\Controller\Api\V1\Category;
 
 use App\General\Application\Message\EntityCreated;
+use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Application\Service\SlugBuilderService;
 use App\Shop\Domain\Entity\Category;
-use App\Shop\Infrastructure\Repository\ShopRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateCategoryController
 {
     public function __construct(
-        private ShopRepository $shopRepository,
+        private ShopApplicationResolverService $shopApplicationResolverService,
         private SlugBuilderService $slugBuilderService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
@@ -36,15 +36,13 @@ final readonly class CreateCategoryController
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
+        $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $category = (new Category())
+            ->setShop($shop)
             ->setName((string)($payload['name'] ?? ''))
             ->setSlug($this->slugBuilderService->buildSlug((string)($payload['slug'] ?? $payload['name'] ?? '')))
             ->setDescription(($payload['description'] ?? null) !== null ? (string)$payload['description'] : null);
-
-        if (is_string($payload['shopId'] ?? null)) {
-            $category->setShop($this->shopRepository->find($payload['shopId']));
-        }
 
         $this->entityManager->persist($category);
         $this->entityManager->flush();

--- a/src/Shop/Transport/Controller/Api/V1/Category/DeleteCategoryController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Category/DeleteCategoryController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shop\Transport\Controller\Api\V1\Category;
 
 use App\General\Application\Message\EntityDeleted;
+use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Category;
 use App\Shop\Infrastructure\Repository\CategoryRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -23,6 +24,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class DeleteCategoryController
 {
     public function __construct(
+        private ShopApplicationResolverService $shopApplicationResolverService,
         private CategoryRepository $categoryRepository,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
@@ -33,7 +35,8 @@ final readonly class DeleteCategoryController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
-        $category = $this->categoryRepository->find($id);
+        $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
+        $category = $this->categoryRepository->findOneByIdAndShop($id, $shop);
         if (!$category instanceof Category) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }

--- a/src/Shop/Transport/Controller/Api/V1/Category/ListCategoriesController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Category/ListCategoriesController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shop\Transport\Controller\Api\V1\Category;
 
+use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Category;
 use App\Shop\Infrastructure\Repository\CategoryRepository;
 use OpenApi\Attributes as OA;
@@ -20,7 +21,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListCategoriesController
 {
     public function __construct(
-        private CategoryRepository $categoryRepository
+        private ShopApplicationResolverService $shopApplicationResolverService,
+        private CategoryRepository $categoryRepository,
     ) {
     }
 
@@ -28,14 +30,14 @@ final readonly class ListCategoriesController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug): JsonResponse
     {
+        $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
+
         $items = array_map(static fn (Category $category): array => [
             'id' => $category->getId(),
             'name' => $category->getName(),
             'slug' => $category->getSlug(),
             'description' => $category->getDescription(),
-        ], $this->categoryRepository->findBy([], [
-            'createdAt' => 'DESC',
-        ], 200));
+        ], $this->categoryRepository->findByShop($shop));
 
         return new JsonResponse([
             'items' => $items,

--- a/src/Shop/Transport/Controller/Api/V1/Product/DeleteProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/DeleteProductController.php
@@ -6,6 +6,9 @@ namespace App\Shop\Transport\Controller\Api\V1\Product;
 
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\Shop\Application\Message\DeleteProductCommand;
+use App\Shop\Application\Service\ShopApplicationResolverService;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Infrastructure\Repository\ProductRepository;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +23,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class DeleteProductController
 {
     public function __construct(
-        private MessageServiceInterface $messageService
+        private ShopApplicationResolverService $shopApplicationResolverService,
+        private ProductRepository $productRepository,
+        private MessageServiceInterface $messageService,
     ) {
     }
 
@@ -28,6 +33,12 @@ final readonly class DeleteProductController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
+        $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
+        $product = $this->productRepository->findOneByIdAndShop($id, $shop);
+        if (!$product instanceof Product) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
         $operationId = \Ramsey\Uuid\Uuid::uuid4()->toString();
         $this->messageService->sendMessage(new DeleteProductCommand(
             operationId: $operationId,

--- a/src/Shop/Transport/Controller/Api/V1/Product/GetProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/GetProductController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shop\Transport\Controller\Api\V1\Product;
 
 use App\Shop\Application\Service\ProductListService;
+use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Application\Service\SimilarProductService;
 use App\Shop\Domain\Entity\Product;
 use App\Shop\Infrastructure\Repository\ProductRepository;
@@ -22,6 +23,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class GetProductController
 {
     public function __construct(
+        private ShopApplicationResolverService $shopApplicationResolverService,
         private ProductRepository $productRepository,
         private SimilarProductService $similarProductService,
     ) {
@@ -31,7 +33,8 @@ final readonly class GetProductController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
-        $product = $this->productRepository->find($id);
+        $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
+        $product = $this->productRepository->findOneByIdAndShop($id, $shop);
         if (!$product instanceof Product) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }

--- a/src/Shop/Transport/Controller/Api/V1/Product/PatchProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/PatchProductController.php
@@ -7,6 +7,7 @@ namespace App\Shop\Transport\Controller\Api\V1\Product;
 use App\General\Application\Message\EntityCreated;
 use App\Shop\Application\Service\ProductHydratorService;
 use App\Shop\Application\Service\ProductListService;
+use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Product;
 use App\Shop\Infrastructure\Repository\ProductRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -25,6 +26,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class PatchProductController
 {
     public function __construct(
+        private ShopApplicationResolverService $shopApplicationResolverService,
         private ProductRepository $productRepository,
         private ProductHydratorService $productHydratorService,
         private EntityManagerInterface $entityManager,
@@ -37,7 +39,8 @@ final readonly class PatchProductController
     public function __invoke(string $applicationSlug, string $id, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
-        $product = $this->productRepository->find($id);
+        $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
+        $product = $this->productRepository->findOneByIdAndShop($id, $shop);
         if (!$product instanceof Product) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }

--- a/src/Shop/Transport/Controller/Api/V1/Tag/CreateTagController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Tag/CreateTagController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shop\Transport\Controller\Api\V1\Tag;
 
 use App\General\Application\Message\EntityCreated;
+use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Tag;
 use App\Shop\Domain\Enum\TagType;
 use Doctrine\ORM\EntityManagerInterface;
@@ -23,6 +24,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateTagController
 {
     public function __construct(
+        private ShopApplicationResolverService $shopApplicationResolverService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -33,6 +35,8 @@ final readonly class CreateTagController
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
+        $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
+
         $payload = (array)json_decode((string)$request->getContent(), true);
         $tag = (new Tag())
             ->setLabel((string)($payload['label'] ?? ''))

--- a/src/Shop/Transport/Controller/Api/V1/Tag/DeleteTagController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Tag/DeleteTagController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shop\Transport\Controller\Api\V1\Tag;
 
 use App\General\Application\Message\EntityDeleted;
+use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Tag;
 use App\Shop\Infrastructure\Repository\TagRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -23,6 +24,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class DeleteTagController
 {
     public function __construct(
+        private ShopApplicationResolverService $shopApplicationResolverService,
         private TagRepository $tagRepository,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
@@ -33,7 +35,9 @@ final readonly class DeleteTagController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
-        $tag = $this->tagRepository->find($id);
+        $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
+
+        $tag = $this->tagRepository->findOneByIdAndApplicationScope($id, $applicationSlug);
         if (!$tag instanceof Tag) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }

--- a/src/Shop/Transport/Controller/Api/V1/Tag/ListTagsController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Tag/ListTagsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shop\Transport\Controller\Api\V1\Tag;
 
+use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Tag;
 use App\Shop\Infrastructure\Repository\TagRepository;
 use OpenApi\Attributes as OA;
@@ -20,7 +21,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListTagsController
 {
     public function __construct(
-        private TagRepository $tagRepository
+        private ShopApplicationResolverService $shopApplicationResolverService,
+        private TagRepository $tagRepository,
     ) {
     }
 
@@ -28,13 +30,13 @@ final readonly class ListTagsController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug): JsonResponse
     {
+        $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
+
         $items = array_map(static fn (Tag $tag): array => [
             'id' => $tag->getId(),
             'label' => $tag->getLabel(),
             'type' => $tag->getType()->value,
-        ], $this->tagRepository->findBy([], [
-            'createdAt' => 'DESC',
-        ], 200));
+        ], $this->tagRepository->findByApplicationScope($applicationSlug));
 
         return new JsonResponse([
             'items' => $items,


### PR DESCRIPTION
### Motivation
- Garantir que toutes les routes API qui reçoivent `applicationSlug` résolvent explicitement le `Shop` associé et n’autorisent pas d’accès ou de modifications hors du périmètre applicatif.
- Empêcher les associations Doctrine et les lectures cross-shop implicites pour les produits, catégories et tags.
- Uniformiser le comportement HTTP pour les ressources hors scope (retour `404`) et conserver `403` pour le refus d’accès à l’application.

### Description
- Injection de `ShopApplicationResolverService` et résolution du `Shop` dans les contrôleurs application-scopés pour produits, catégories et tags (ex. `GetProductController`, `PatchProductController`, `DeleteProductController`, `Create/List/Delete` pour catégories et tags). 
- Ajout de garde-fous repository Doctrine : `ProductRepository::findOneByIdAndShop`, `CategoryRepository::findByShop` et `findOneByIdAndShop`, et `TagRepository::findByApplicationScope` / `findOneByIdAndApplicationScope` pour scoper les requêtes SQL au `Shop`/`Application`.
- Vérification d’appartenance du produit au `Shop` résolu avant actions dans `GetProductController`, `PatchProductController` et `DeleteProductController` (retour `404` si hors scope).
- Durcissement de l’hydratation produit (`ProductHydratorService`) pour n’attacher que des `Tag` valides dans le scope du `Shop` (ou non liés), via une méthode interne `isTagInShopScope`.
- Politique d’erreurs : `403` = accès refusé par le resolver, `404` = ressource introuvable / hors scope.

### Testing
- Exécution de contrôle de syntaxe PHP sur les fichiers modifiés avec `php -l` (tous les fichiers modifiés passent `php -l`).
- Tentative d’exécution des tests unitaires avec `vendor/bin/phpunit` échouée car `phpunit` n’est pas disponible dans cet environnement. 
- Les modifications ont été revues pour cohérence des signatures et des requêtes Doctrine et les fichiers modifiés n’ont pas d’erreurs de syntaxe détectées par le linter.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f3b7b248832692eb15a2807d6457)