### PR TITLE
Scope CRM V1 controllers and repository access by application CRM

### DIFF
--- a/src/Crm/Infrastructure/Repository/CompanyRepository.php
+++ b/src/Crm/Infrastructure/Repository/CompanyRepository.php
@@ -28,4 +28,30 @@ class CompanyRepository extends BaseRepository
         protected ManagerRegistry $managerRegistry
     ) {
     }
+
+    public function findOneScopedById(string $id, string $crmId): ?Entity
+    {
+        $entity = $this->createQueryBuilder('company')
+            ->andWhere('company.id = :id')
+            ->andWhere('company.crm = :crmId')
+            ->setParameter('id', $id)
+            ->setParameter('crmId', $crmId)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $entity instanceof Entity ? $entity : null;
+    }
+
+    /** @return list<Entity> */
+    public function findScoped(string $crmId, int $limit = 200, int $offset = 0): array
+    {
+        return $this->createQueryBuilder('company')
+            ->andWhere('company.crm = :crmId')
+            ->setParameter('crmId', $crmId)
+            ->orderBy('company.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Crm/Infrastructure/Repository/ProjectRepository.php
+++ b/src/Crm/Infrastructure/Repository/ProjectRepository.php
@@ -26,4 +26,33 @@ class ProjectRepository extends BaseRepository
         protected ManagerRegistry $managerRegistry
     ) {
     }
+
+    public function findOneScopedById(string $id, string $crmId): ?Entity
+    {
+        $entity = $this->createQueryBuilder('project')
+            ->leftJoin('project.company', 'company')
+            ->andWhere('project.id = :id')
+            ->andWhere('company.crm = :crmId')
+            ->setParameter('id', $id)
+            ->setParameter('crmId', $crmId)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $entity instanceof Entity ? $entity : null;
+    }
+
+    /** @return list<Entity> */
+    public function findScoped(string $crmId, int $limit = 200, int $offset = 0): array
+    {
+        return $this->createQueryBuilder('project')
+            ->leftJoin('project.company', 'company')
+            ->andWhere('company.crm = :crmId')
+            ->setParameter('crmId', $crmId)
+            ->orderBy('project.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
+            ->getQuery()
+            ->getResult();
+    }
+
 }

--- a/src/Crm/Infrastructure/Repository/SprintRepository.php
+++ b/src/Crm/Infrastructure/Repository/SprintRepository.php
@@ -25,4 +25,35 @@ class SprintRepository extends BaseRepository
         protected ManagerRegistry $managerRegistry
     ) {
     }
+
+    public function findOneScopedById(string $id, string $crmId): ?Entity
+    {
+        $entity = $this->createQueryBuilder('sprint')
+            ->leftJoin('sprint.project', 'project')
+            ->leftJoin('project.company', 'company')
+            ->andWhere('sprint.id = :id')
+            ->andWhere('company.crm = :crmId')
+            ->setParameter('id', $id)
+            ->setParameter('crmId', $crmId)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $entity instanceof Entity ? $entity : null;
+    }
+
+    /** @return list<Entity> */
+    public function findScoped(string $crmId, int $limit = 200, int $offset = 0): array
+    {
+        return $this->createQueryBuilder('sprint')
+            ->leftJoin('sprint.project', 'project')
+            ->leftJoin('project.company', 'company')
+            ->andWhere('company.crm = :crmId')
+            ->setParameter('crmId', $crmId)
+            ->orderBy('sprint.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
+            ->getQuery()
+            ->getResult();
+    }
+
 }

--- a/src/Crm/Infrastructure/Repository/TaskRepository.php
+++ b/src/Crm/Infrastructure/Repository/TaskRepository.php
@@ -26,4 +26,35 @@ class TaskRepository extends BaseRepository
         protected ManagerRegistry $managerRegistry
     ) {
     }
+
+    public function findOneScopedById(string $id, string $crmId): ?Entity
+    {
+        $entity = $this->createQueryBuilder('task')
+            ->leftJoin('task.project', 'project')
+            ->leftJoin('project.company', 'company')
+            ->andWhere('task.id = :id')
+            ->andWhere('company.crm = :crmId')
+            ->setParameter('id', $id)
+            ->setParameter('crmId', $crmId)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $entity instanceof Entity ? $entity : null;
+    }
+
+    /** @return list<Entity> */
+    public function findScoped(string $crmId, int $limit = 200, int $offset = 0): array
+    {
+        return $this->createQueryBuilder('task')
+            ->leftJoin('task.project', 'project')
+            ->leftJoin('project.company', 'company')
+            ->andWhere('company.crm = :crmId')
+            ->setParameter('crmId', $crmId)
+            ->orderBy('task.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
+            ->getQuery()
+            ->getResult();
+    }
+
 }

--- a/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
+++ b/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
@@ -26,4 +26,37 @@ class TaskRequestRepository extends BaseRepository
         protected ManagerRegistry $managerRegistry
     ) {
     }
+
+    public function findOneScopedById(string $id, string $crmId): ?Entity
+    {
+        $entity = $this->createQueryBuilder('taskRequest')
+            ->leftJoin('taskRequest.task', 'task')
+            ->leftJoin('task.project', 'project')
+            ->leftJoin('project.company', 'company')
+            ->andWhere('taskRequest.id = :id')
+            ->andWhere('company.crm = :crmId')
+            ->setParameter('id', $id)
+            ->setParameter('crmId', $crmId)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $entity instanceof Entity ? $entity : null;
+    }
+
+    /** @return list<Entity> */
+    public function findScoped(string $crmId, int $limit = 200, int $offset = 0): array
+    {
+        return $this->createQueryBuilder('taskRequest')
+            ->leftJoin('taskRequest.task', 'task')
+            ->leftJoin('task.project', 'project')
+            ->leftJoin('project.company', 'company')
+            ->andWhere('company.crm = :crmId')
+            ->setParameter('crmId', $crmId)
+            ->orderBy('taskRequest.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
+            ->getQuery()
+            ->getResult();
+    }
+
 }

--- a/src/Crm/Transport/Controller/Api/V1/Company/DeleteCompanyController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/DeleteCompanyController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Company;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Company;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\General\Application\Message\EntityDeleted;
@@ -24,6 +25,7 @@ final readonly class DeleteCompanyController
 {
     public function __construct(
         private CompanyRepository $companyRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -33,7 +35,8 @@ final readonly class DeleteCompanyController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
-        $company = $this->companyRepository->find($id);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $company = $this->companyRepository->findOneScopedById($id, $crm->getId());
         if (!$company instanceof Company) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }

--- a/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Project;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Domain\Enum\ProjectStatus;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
@@ -26,6 +27,7 @@ final readonly class CreateProjectController
 {
     public function __construct(
         private CompanyRepository $companyRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -37,6 +39,7 @@ final readonly class CreateProjectController
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $project = new Project();
         $project->setName((string)($payload['name'] ?? ''))
@@ -46,7 +49,12 @@ final readonly class CreateProjectController
             ->setStartedAt(isset($payload['startedAt']) ? new DateTimeImmutable((string)$payload['startedAt']) : null)
             ->setDueAt(isset($payload['dueAt']) ? new DateTimeImmutable((string)$payload['dueAt']) : null);
         if (is_string($payload['companyId'] ?? null)) {
-            $project->setCompany($this->companyRepository->find($payload['companyId']));
+            $company = $this->companyRepository->findOneScopedById($payload['companyId'], $crm->getId());
+            if ($company === null) {
+                return new JsonResponse(['message' => 'Unknown "companyId" in this CRM scope.'], JsonResponse::HTTP_NOT_FOUND);
+            }
+
+            $project->setCompany($company);
         }
 
         $this->entityManager->persist($project);

--- a/src/Crm/Transport/Controller/Api/V1/Project/DeleteProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/DeleteProjectController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Project;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
 use App\General\Application\Message\EntityDeleted;
@@ -24,6 +25,7 @@ final readonly class DeleteProjectController
 {
     public function __construct(
         private ProjectRepository $projectRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -33,7 +35,8 @@ final readonly class DeleteProjectController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
-        $project = $this->projectRepository->find($id);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $project = $this->projectRepository->findOneScopedById($id, $crm->getId());
         if (!$project instanceof Project) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }

--- a/src/Crm/Transport/Controller/Api/V1/Project/ListProjectsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/ListProjectsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Project;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
 use OpenApi\Attributes as OA;
@@ -20,7 +21,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListProjectsController
 {
     public function __construct(
-        private ProjectRepository $projectRepository
+        private ProjectRepository $projectRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
     ) {
     }
 
@@ -28,14 +30,13 @@ final readonly class ListProjectsController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug): JsonResponse
     {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $items = array_map(static fn (Project $project): array => [
             'id' => $project->getId(),
             'name' => $project->getName(),
             'companyId' => $project->getCompany()?->getId(),
             'status' => $project->getStatus()->value,
-        ], $this->projectRepository->findBy([], [
-            'createdAt' => 'DESC',
-        ], 200));
+        ], $this->projectRepository->findScoped($crm->getId()));
 
         return new JsonResponse([
             'items' => $items,

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/CreateSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/CreateSprintController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Sprint;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Sprint;
 use App\Crm\Domain\Enum\SprintStatus;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
@@ -26,6 +27,7 @@ final readonly class CreateSprintController
 {
     public function __construct(
         private ProjectRepository $projectRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -37,6 +39,7 @@ final readonly class CreateSprintController
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $sprint = new Sprint();
         $sprint->setName((string)($payload['name'] ?? ''))
@@ -45,7 +48,12 @@ final readonly class CreateSprintController
             ->setStartDate(isset($payload['startDate']) ? new DateTimeImmutable((string)$payload['startDate']) : null)
             ->setEndDate(isset($payload['endDate']) ? new DateTimeImmutable((string)$payload['endDate']) : null);
         if (is_string($payload['projectId'] ?? null)) {
-            $sprint->setProject($this->projectRepository->find($payload['projectId']));
+            $project = $this->projectRepository->findOneScopedById($payload['projectId'], $crm->getId());
+            if ($project === null) {
+                return new JsonResponse(['message' => 'Unknown "projectId" in this CRM scope.'], JsonResponse::HTTP_NOT_FOUND);
+            }
+
+            $sprint->setProject($project);
         }
 
         $this->entityManager->persist($sprint);

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/DeleteSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/DeleteSprintController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Sprint;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Sprint;
 use App\Crm\Infrastructure\Repository\SprintRepository;
 use App\General\Application\Message\EntityDeleted;
@@ -24,6 +25,7 @@ final readonly class DeleteSprintController
 {
     public function __construct(
         private SprintRepository $sprintRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -33,7 +35,8 @@ final readonly class DeleteSprintController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
-        $sprint = $this->sprintRepository->find($id);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $sprint = $this->sprintRepository->findOneScopedById($id, $crm->getId());
         if (!$sprint instanceof Sprint) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/ListSprintsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/ListSprintsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Sprint;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Sprint;
 use App\Crm\Infrastructure\Repository\SprintRepository;
 use OpenApi\Attributes as OA;
@@ -20,7 +21,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListSprintsController
 {
     public function __construct(
-        private SprintRepository $sprintRepository
+        private SprintRepository $sprintRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
     ) {
     }
 
@@ -28,6 +30,7 @@ final readonly class ListSprintsController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug): JsonResponse
     {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $items = array_map(static fn (Sprint $sprint): array => [
             'id' => $sprint->getId(),
             'name' => $sprint->getName(),
@@ -36,9 +39,7 @@ final readonly class ListSprintsController
             'status' => $sprint->getStatus()->value,
             'startDate' => $sprint->getStartDate()?->format('Y-m-d'),
             'endDate' => $sprint->getEndDate()?->format('Y-m-d'),
-        ], $this->sprintRepository->findBy([], [
-            'createdAt' => 'DESC',
-        ], 200));
+        ], $this->sprintRepository->findScoped($crm->getId()));
 
         return new JsonResponse([
             'items' => $items,

--- a/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Task;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Enum\TaskPriority;
 use App\Crm\Domain\Enum\TaskStatus;
@@ -30,6 +31,7 @@ final readonly class CreateTaskController
     public function __construct(
         private ProjectRepository $projectRepository,
         private SprintRepository $sprintRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -49,6 +51,7 @@ final readonly class CreateTaskController
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $task = new Task();
         $task->setTitle((string)($payload['title'] ?? ''))
@@ -57,12 +60,30 @@ final readonly class CreateTaskController
             ->setPriority(TaskPriority::tryFrom((string)($payload['priority'] ?? '')) ?? TaskPriority::MEDIUM)
             ->setDueAt(isset($payload['dueAt']) ? new DateTimeImmutable((string)$payload['dueAt']) : null)
             ->setEstimatedHours(isset($payload['estimatedHours']) ? (float)$payload['estimatedHours'] : null);
+
+        $project = null;
         if (is_string($payload['projectId'] ?? null)) {
-            $task->setProject($this->projectRepository->find($payload['projectId']));
+            $project = $this->projectRepository->findOneScopedById($payload['projectId'], $crm->getId());
+            if ($project === null) {
+                return new JsonResponse(['message' => 'Unknown "projectId" in this CRM scope.'], JsonResponse::HTTP_NOT_FOUND);
+            }
+
+            $task->setProject($project);
         }
+
         if (is_string($payload['sprintId'] ?? null)) {
-            $task->setSprint($this->sprintRepository->find($payload['sprintId']));
+            $sprint = $this->sprintRepository->findOneScopedById($payload['sprintId'], $crm->getId());
+            if ($sprint === null) {
+                return new JsonResponse(['message' => 'Unknown "sprintId" in this CRM scope.'], JsonResponse::HTTP_NOT_FOUND);
+            }
+
+            if ($project !== null && $sprint->getProject()?->getId() !== $project->getId()) {
+                return new JsonResponse(['message' => 'Provided "sprintId" does not belong to the provided "projectId".'], JsonResponse::HTTP_BAD_REQUEST);
+            }
+
+            $task->setSprint($sprint);
         }
+
         if (is_array($payload['assigneeIds'] ?? null)) {
             foreach ($payload['assigneeIds'] as $assigneeId) {
                 if (!is_string($assigneeId) || $assigneeId === '') {

--- a/src/Crm/Transport/Controller/Api/V1/Task/DeleteTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/DeleteTaskController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Task;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\General\Application\Message\EntityDeleted;
@@ -24,6 +25,7 @@ final readonly class DeleteTaskController
 {
     public function __construct(
         private TaskRepository $taskRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -33,7 +35,8 @@ final readonly class DeleteTaskController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
-        $task = $this->taskRepository->find($id);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $task = $this->taskRepository->findOneScopedById($id, $crm->getId());
         if (!$task instanceof Task) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Crm\Domain\Enum\TaskRequestStatus;
 use App\Crm\Infrastructure\Repository\TaskRepository;
@@ -27,6 +28,7 @@ final readonly class CreateTaskRequestController
 {
     public function __construct(
         private TaskRepository $taskRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -46,6 +48,7 @@ final readonly class CreateTaskRequestController
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $payload = (array)json_decode((string)$request->getContent(), true);
         $taskRequest = new TaskRequest();
         $taskRequest->setTitle((string)($payload['title'] ?? ''))
@@ -53,7 +56,12 @@ final readonly class CreateTaskRequestController
             ->setStatus(TaskRequestStatus::tryFrom((string)($payload['status'] ?? '')) ?? TaskRequestStatus::PENDING)
             ->setResolvedAt(isset($payload['resolvedAt']) ? new DateTimeImmutable((string)$payload['resolvedAt']) : null);
         if (is_string($payload['taskId'] ?? null)) {
-            $taskRequest->setTask($this->taskRepository->find($payload['taskId']));
+            $task = $this->taskRepository->findOneScopedById($payload['taskId'], $crm->getId());
+            if ($task === null) {
+                return new JsonResponse(['message' => 'Unknown "taskId" in this CRM scope.'], JsonResponse::HTTP_NOT_FOUND);
+            }
+
+            $taskRequest->setTask($task);
         }
         if (is_array($payload['assigneeIds'] ?? null)) {
             foreach ($payload['assigneeIds'] as $assigneeId) {

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/DeleteTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/DeleteTaskRequestController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Crm\Infrastructure\Repository\TaskRequestRepository;
 use App\General\Application\Message\EntityDeleted;
@@ -24,6 +25,7 @@ final readonly class DeleteTaskRequestController
 {
     public function __construct(
         private TaskRequestRepository $taskRequestRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -33,7 +35,8 @@ final readonly class DeleteTaskRequestController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
-        $taskRequest = $this->taskRequestRepository->find($id);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $taskRequest = $this->taskRequestRepository->findOneScopedById($id, $crm->getId());
         if (!$taskRequest instanceof TaskRequest) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Crm\Infrastructure\Repository\TaskRequestRepository;
 use OpenApi\Attributes as OA;
@@ -20,7 +21,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListTaskRequestsController
 {
     public function __construct(
-        private TaskRequestRepository $taskRequestRepository
+        private TaskRequestRepository $taskRequestRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
     ) {
     }
 
@@ -28,6 +30,7 @@ final readonly class ListTaskRequestsController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug): JsonResponse
     {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $items = array_map(static fn (TaskRequest $taskRequest): array => [
             'id' => $taskRequest->getId(),
             'title' => $taskRequest->getTitle(),
@@ -40,9 +43,7 @@ final readonly class ListTaskRequestsController
                 'username' => $assignee->getUsername(),
                 'email' => $assignee->getEmail(),
             ], $taskRequest->getAssignees()->toArray()),
-        ], $this->taskRequestRepository->findBy([], [
-            'createdAt' => 'DESC',
-        ], 200));
+        ], $this->taskRequestRepository->findScoped($crm->getId()));
 
         return new JsonResponse([
             'items' => $items,


### PR DESCRIPTION
### Motivation

- Garantir l'isolation par CRM pour toutes les opérations HTTP V1 exposées sous `/v1/crm/applications/{applicationSlug}` afin d'éviter les accès globaux entre applications/CRMs.
- Valider systématiquement que les relations entrantes (`companyId`, `projectId`, `sprintId`, `taskId`) appartiennent au même scope CRM et refuser les opérations sinon.

### Description

- Ajout de méthodes scoped aux repositories CRM (`Company`, `Project`, `Sprint`, `Task`, `TaskRequest`): `findOneScopedById(string $id, string $crmId)` et `findScoped(string $crmId, int $limit = 200, int $offset = 0)`.
- Dans les contrôleurs V1 pour `Company`, `Project`, `Sprint`, `Task` et `TaskRequest`, résolution systématique du CRM via `CrmApplicationScopeResolver::resolveOrFail($applicationSlug)` avant tout accès aux données.
- Remplacement des accès globaux (`find`, `findBy`) par les appels scoped pour les listes et suppressions, et vérification `404` si l'entité n'appartient pas au CRM de l'application.
- Renforcement des endpoints `CREATE` pour valider que les identifiants liés sont dans le même CRM scope (ex: `CreateProjectController` vérifie `companyId`, `CreateSprintController` vérifie `projectId`, `CreateTaskController` vérifie `projectId` et `sprintId` + cohérence `sprint.project`).

### Testing

- Exécution de la vérification de syntaxe PHP sur tous les fichiers modifiés avec `php -l` (tous les fichiers modifiés retournent "No syntax errors detected").
- Les modifications ont été commitées et regroupées dans une PR locale intitulée `Scope CRM V1 controllers and repository access by application CRM`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f3c061f083268425bfb33b75aa4f)