### PR TITLE
Rendre la création de réaction idempotente

### DIFF
--- a/src/Chat/Domain/Repository/Interfaces/ChatMessageReactionRepositoryInterface.php
+++ b/src/Chat/Domain/Repository/Interfaces/ChatMessageReactionRepositoryInterface.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace App\Chat\Domain\Repository\Interfaces;
 
+use App\Chat\Domain\Entity\ChatMessage;
+use App\Chat\Domain\Entity\ChatMessageReaction;
+use App\Chat\Domain\Enum\ChatReactionType;
 use App\General\Domain\Repository\Interfaces\BaseRepositoryInterface;
+use App\User\Domain\Entity\User;
 
 interface ChatMessageReactionRepositoryInterface extends BaseRepositoryInterface
 {
+    public function findOneByMessageUserReaction(ChatMessage $message, User $user, ChatReactionType $reaction): ?ChatMessageReaction;
 }

--- a/src/Chat/Infrastructure/Repository/ChatMessageReactionRepository.php
+++ b/src/Chat/Infrastructure/Repository/ChatMessageReactionRepository.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Chat\Infrastructure\Repository;
 
+use App\Chat\Domain\Entity\ChatMessage;
 use App\Chat\Domain\Entity\ChatMessageReaction as Entity;
+use App\Chat\Domain\Enum\ChatReactionType;
 use App\Chat\Domain\Repository\Interfaces\ChatMessageReactionRepositoryInterface;
 use App\General\Infrastructure\Repository\BaseRepository;
+use App\User\Domain\Entity\User;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -23,5 +26,17 @@ class ChatMessageReactionRepository extends BaseRepository implements ChatMessag
     public function __construct(
         protected ManagerRegistry $managerRegistry
     ) {
+    }
+
+    public function findOneByMessageUserReaction(ChatMessage $message, User $user, ChatReactionType $reaction): ?Entity
+    {
+        /** @var Entity|null $entity */
+        $entity = $this->findOneBy([
+            'message' => $message,
+            'user' => $user,
+            'reaction' => $reaction,
+        ]);
+
+        return $entity;
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Reaction/CreateReactionController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Reaction/CreateReactionController.php
@@ -11,6 +11,7 @@ use App\Chat\Domain\Enum\ChatReactionType;
 use App\Chat\Domain\Repository\Interfaces\ChatMessageReactionRepositoryInterface;
 use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use OpenApi\Attributes as OA;
@@ -49,12 +50,33 @@ readonly class CreateReactionController
         $message = $this->chatAccessResolverService->resolveAccessibleMessage($messageId, $loggedInUser);
         $reactionType = $this->reactionPayloadService->extractRequiredReaction($request->toArray());
 
+        $existingReaction = $this->reactionRepository->findOneByMessageUserReaction($message, $loggedInUser, $reactionType);
+
+        if ($existingReaction instanceof ChatMessageReaction) {
+            return new JsonResponse([
+                'id' => $existingReaction->getId(),
+            ], JsonResponse::HTTP_OK);
+        }
+
         $reaction = new ChatMessageReaction()
             ->setMessage($message)
             ->setUser($loggedInUser)
             ->setReaction($reactionType);
 
-        $this->reactionRepository->save($reaction);
+        try {
+            $this->reactionRepository->save($reaction);
+        } catch (UniqueConstraintViolationException $e) {
+            $existingReaction = $this->reactionRepository->findOneByMessageUserReaction($message, $loggedInUser, $reactionType);
+
+            if ($existingReaction instanceof ChatMessageReaction) {
+                return new JsonResponse([
+                    'id' => $existingReaction->getId(),
+                ], JsonResponse::HTTP_OK);
+            }
+
+            throw $e;
+        }
+
         $this->cacheInvalidationService->invalidateConversationCaches($message->getConversation()->getChat()->getId(), $loggedInUser->getId());
 
         return new JsonResponse([

--- a/tests/Application/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationControllerTest.php
+++ b/tests/Application/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationControllerTest.php
@@ -41,6 +41,16 @@ final class UserReactionMutationControllerTest extends WebTestCase
         $reactionId = $payload['id'] ?? null;
         self::assertIsString($reactionId);
 
+        $client->request('POST', $this->baseUrl . '/messages/' . $messageId . '/reactions', [], [], [], JSON::encode([
+            'reaction' => 'like',
+        ]));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $duplicateContent = $client->getResponse()->getContent();
+        self::assertNotFalse($duplicateContent);
+        $duplicatePayload = JSON::decode($duplicateContent, true);
+        self::assertSame($reactionId, $duplicatePayload['id'] ?? null);
+
         $client->request('PATCH', $this->baseUrl . '/reactions/' . $reactionId, [], [], [], JSON::encode([
             'reaction' => 'love',
         ]));


### PR DESCRIPTION
### Motivation

- Prévenir les créations en double de réactions (par requêtes répétées ou conditions de course) et retourner de manière idempotente l’identifiant existant quand la même réaction a déjà été ajoutée.

### Description

- Ajout de `findOneByMessageUserReaction(ChatMessage $message, User $user, ChatReactionType $reaction): ?ChatMessageReaction` à `ChatMessageReactionRepositoryInterface` pour une recherche ciblée par message/utilisateur/type.
- Implémentation de `findOneByMessageUserReaction(...)` dans `ChatMessageReactionRepository` utilisant `findOneBy` sur le triplet `(message, user, reaction)`.
- `CreateReactionController` vérifie avant persist si la réaction existe déjà et retourne HTTP 200 avec l’id existant lorsque c’est le cas, puis tente la sauvegarde et intercepte `UniqueConstraintViolationException` pour relire l’entité en cas de conditions de course et retourner aussi l’id existant; la création nouvelle continue de retourner HTTP 201.
- Extension du test applicatif `UserReactionMutationControllerTest` pour couvrir le scénario de « création répétée » qui vérifie que le second POST retourne HTTP 200 et le même `id` que la première création.

### Testing

- Exécutions de vérification de syntaxe réussies : `php -l src/Chat/Transport/Controller/Api/V1/Reaction/CreateReactionController.php`, `php -l src/Chat/Infrastructure/Repository/ChatMessageReactionRepository.php`, `php -l src/Chat/Domain/Repository/Interfaces/ChatMessageReactionRepositoryInterface.php` et `php -l tests/Application/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationControllerTest.php` all ont signalé « No syntax errors detected ». 
- Tentative d’exécution du test applicatif via `./vendor/bin/phpunit` et `bin/phpunit` a échoué car le binaire PHPUnit n’est pas présent dans l’environnement, donc les tests PHPUnit n’ont pas pu être exécutés ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f62a57b88326ac6d0444a1596022)