### PR TITLE
Harmonize postedAtLabel format for recruit public job listing

### DIFF
--- a/docs/recruit.md
+++ b/docs/recruit.md
@@ -161,7 +161,9 @@ Query params disponibles:
 - `yearsExperienceMin` (int)
 - `yearsExperienceMax` (int)
 - `isPublished` (bool)
-- `postedAtLabel` (string; ex: `today`, `3d`, `7d`, `30d`)
+- `postedAtLabel` (string)
+  - Formats supportés: `today`, `3d`, `7d`, `30d`
+  - Rétrocompatibilité acceptée: `vor kurzem`, `vor <N> Tage`, `vor <N> Wochen`, `vor <N> Monate`, `vor <N> Jahre`
 - `location` (string)
 - `q` (string, recherche full-text)
 

--- a/src/Recruit/Application/Service/JobPublicListService.php
+++ b/src/Recruit/Application/Service/JobPublicListService.php
@@ -31,7 +31,6 @@ use function array_unique;
 use function array_values;
 use function ceil;
 use function count;
-use function floor;
 use function in_array;
 use function is_array;
 use function is_string;
@@ -272,31 +271,27 @@ class JobPublicListService
     private function buildPostedAtLabel(?DateTimeImmutable $createdAt): string
     {
         if ($createdAt === null) {
-            return 'vor kurzem';
+            return '30d';
         }
 
         $now = new DateTimeImmutable();
         $diff = $createdAt->diff($now);
 
-        if ($diff->y > 0) {
-            return 'vor ' . $diff->y . ' Jahr' . ($diff->y > 1 ? 'en' : '');
+        if ($diff->days !== false) {
+            if ($diff->days <= 0) {
+                return 'today';
+            }
+
+            if ($diff->days <= 3) {
+                return '3d';
+            }
+
+            if ($diff->days <= 7) {
+                return '7d';
+            }
         }
 
-        if ($diff->m > 0) {
-            return 'vor ' . $diff->m . ' Monat' . ($diff->m > 1 ? 'en' : '');
-        }
-
-        if ($diff->days !== false && $diff->days >= 7) {
-            $weeks = (int)floor($diff->days / 7);
-
-            return 'vor ' . $weeks . ' Woche' . ($weeks > 1 ? 'n' : '');
-        }
-
-        if ($diff->d > 0) {
-            return 'vor ' . $diff->d . ' Tag' . ($diff->d > 1 ? 'en' : '');
-        }
-
-        return 'vor kurzem';
+        return '30d';
     }
 
     /**
@@ -391,8 +386,32 @@ class JobPublicListService
         $now = new DateTimeImmutable();
         $label = strtolower($postedAtLabel);
 
-        if ($label === 'vor kurzem') {
+        if ($label === 'today' || $label === 'vor kurzem') {
             $from = $now->modify('-1 day');
+            $qb->andWhere('job.createdAt >= :postedAtFrom')
+                ->setParameter('postedAtFrom', $from);
+
+            return;
+        }
+
+        if ($label === '3d') {
+            $from = $now->modify('-3 day');
+            $qb->andWhere('job.createdAt >= :postedAtFrom')
+                ->setParameter('postedAtFrom', $from);
+
+            return;
+        }
+
+        if ($label === '7d') {
+            $from = $now->modify('-7 day');
+            $qb->andWhere('job.createdAt >= :postedAtFrom')
+                ->setParameter('postedAtFrom', $from);
+
+            return;
+        }
+
+        if ($label === '30d') {
+            $from = $now->modify('-30 day');
             $qb->andWhere('job.createdAt >= :postedAtFrom')
                 ->setParameter('postedAtFrom', $from);
 

--- a/tests/Application/Scoped/ScopedPaginationContractTest.php
+++ b/tests/Application/Scoped/ScopedPaginationContractTest.php
@@ -71,4 +71,28 @@ final class ScopedPaginationContractTest extends WebTestCase
         self::assertArrayHasKey('meta', $payload);
         self::assertSame('recruit-talent-core', $payload['meta']['applicationSlug']);
     }
+
+    #[TestDox('Recruit public list accepts postedAtLabel=today filter.')]
+    public function testRecruitPublicPaginationContractWithPostedAtLabelToday(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/applications/recruit-talent-core/public/jobs?page=1&limit=5&postedAtLabel=today');
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeResponse($client->getResponse());
+        self::assertArrayHasKey('meta', $payload);
+        self::assertSame('today', $payload['meta']['filters']['postedAtLabel']);
+    }
+
+    #[TestDox('Recruit public list accepts postedAtLabel=7d filter.')]
+    public function testRecruitPublicPaginationContractWithPostedAtLabelSevenDays(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/applications/recruit-talent-core/public/jobs?page=1&limit=5&postedAtLabel=7d');
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeResponse($client->getResponse());
+        self::assertArrayHasKey('meta', $payload);
+        self::assertSame('7d', $payload['meta']['filters']['postedAtLabel']);
+    }
 }


### PR DESCRIPTION
### Motivation
- Standardize the `postedAtLabel` value produced by the job listing service so filters and produced labels use a single, predictable set of formats. 
- Keep backward compatibility with existing German-style labels already parsed by the service.

### Description
- Change `JobPublicListService::buildPostedAtLabel()` to emit canonical labels: `today`, `3d`, `7d`, `30d` based on the job `createdAt` age, with `30d` as the fallback. 
- Update `JobPublicListService::applyPostedAtLabelFilter()` to accept the canonical labels (`today`, `3d`, `7d`, `30d`) and keep parsing legacy German forms like `vor kurzem`, `vor <N> Tage`, `vor <N> Wochen`, `vor <N> Monate`, and `vor <N> Jahre` for retrocompatibility. 
- Update `docs/recruit.md` to document the supported canonical formats and the accepted legacy formats exactly. 
- Add controller/listing tests in `tests/Application/Scoped/ScopedPaginationContractTest.php` that exercise the public recruit listing with `postedAtLabel=today` and `postedAtLabel=7d`.

### Testing
- Ran PHP syntax checks with `php -l` on the modified files and they passed for `src/Recruit/Application/Service/JobPublicListService.php` and `tests/Application/Scoped/ScopedPaginationContractTest.php`.
- Attempted to run the PHPUnit suite with `vendor/bin/phpunit tests/Application/Scoped/ScopedPaginationContractTest.php` but the PHPUnit binary is not available in this environment, so the new tests could not be executed here. 
- Confirmed the code changes produce no syntax errors and added tests are present in the repository for CI to run in a full environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f638200883268f47da764db1f3f7)