### PR TITLE
Harden shop payment endpoint security policies

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -130,6 +130,8 @@ services:
 
     App\Shop\Domain\Service\Interfaces\PaymentProviderInterface:
         class: App\Shop\Infrastructure\Payment\MockPaymentProvider
+        arguments:
+            $appSecret: '%kernel.secret%'
 
 when@dev:
     services:

--- a/src/Shop/Application/Service/PaymentService.php
+++ b/src/Shop/Application/Service/PaymentService.php
@@ -11,10 +11,14 @@ use App\Shop\Domain\Enum\PaymentStatus;
 use App\Shop\Domain\Service\Interfaces\PaymentProviderInterface;
 use App\Shop\Infrastructure\Repository\OrderRepository;
 use App\Shop\Infrastructure\Repository\PaymentTransactionRepository;
+use App\User\Domain\Entity\User;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 use function in_array;
+use function is_string;
+use function trim;
 
 final readonly class PaymentService
 {
@@ -22,15 +26,19 @@ final readonly class PaymentService
         private OrderRepository $orderRepository,
         private PaymentTransactionRepository $paymentTransactionRepository,
         private PaymentProviderInterface $paymentProvider,
+        private Security $security,
+        private string $environment,
     ) {
     }
 
-    public function createPaymentIntent(string $orderId): PaymentTransaction
+    public function createPaymentIntent(string $applicationSlug, string $orderId): PaymentTransaction
     {
         $order = $this->orderRepository->find($orderId);
         if ($order === null) {
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Order not found.');
         }
+
+        $this->assertOrderAccess($order, $applicationSlug);
 
         if ($order->getStatus() !== OrderStatus::PENDING_PAYMENT) {
             throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Order is not in pending_payment status.');
@@ -62,12 +70,14 @@ final readonly class PaymentService
     /**
      * @param array<string, mixed> $payload
      */
-    public function confirmPayment(string $orderId, string $providerReference, array $payload = []): PaymentTransaction
+    public function confirmPayment(string $applicationSlug, string $orderId, string $providerReference, array $payload = []): PaymentTransaction
     {
         $order = $this->orderRepository->find($orderId);
         if ($order === null) {
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Order not found.');
         }
+
+        $this->assertOrderAccess($order, $applicationSlug);
 
         $transaction = $this->paymentTransactionRepository->findOneBy([
             'order' => $order,
@@ -95,9 +105,14 @@ final readonly class PaymentService
      */
     public function processWebhook(array $payload, ?string $signature = null): ?PaymentTransaction
     {
-        $verifiedPayload = $this->paymentProvider->verifyWebhook($payload, $signature);
+        $normalizedSignature = is_string($signature) ? trim($signature) : '';
+        if ($this->environment === 'prod' && $normalizedSignature === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Webhook signature is required in production.');
+        }
+
+        $verifiedPayload = $this->paymentProvider->verifyWebhook($payload, $normalizedSignature !== '' ? $normalizedSignature : null);
         if ($verifiedPayload === null) {
-            return null;
+            throw new HttpException(JsonResponse::HTTP_UNAUTHORIZED, 'Invalid webhook signature or payload.');
         }
 
         if (
@@ -131,6 +146,19 @@ final readonly class PaymentService
         $this->paymentTransactionRepository->save($transaction, true);
 
         return $transaction;
+    }
+
+    private function assertOrderAccess(Order $order, string $applicationSlug): void
+    {
+        $orderApplicationSlug = $order->getShop()?->getApplication()?->getSlug();
+        if ($orderApplicationSlug !== trim($applicationSlug)) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'This order does not belong to the requested application scope.');
+        }
+
+        $user = $this->security->getUser();
+        if (!$user instanceof User || $order->getUser()?->getId() !== $user->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'This order does not belong to the authenticated user.');
+        }
     }
 
     private function applyOrderStateFromPayment(Order $order, PaymentStatus $status): void

--- a/src/Shop/Infrastructure/Payment/MockPaymentProvider.php
+++ b/src/Shop/Infrastructure/Payment/MockPaymentProvider.php
@@ -6,14 +6,23 @@ namespace App\Shop\Infrastructure\Payment;
 
 use App\Shop\Domain\Service\Interfaces\PaymentProviderInterface;
 
+use function hash_equals;
+use function hash_hmac;
 use function is_array;
 use function is_string;
+use function json_encode;
 use function sprintf;
+use function strtolower;
 use function trim;
 use function uniqid;
 
-final class MockPaymentProvider implements PaymentProviderInterface
+final readonly class MockPaymentProvider implements PaymentProviderInterface
 {
+    public function __construct(
+        private string $appSecret,
+    ) {
+    }
+
     public function createIntent(string $orderId, float $amount, string $currency, array $metadata = []): array
     {
         $reference = sprintf('mock_intent_%s', uniqid('', true));
@@ -55,6 +64,18 @@ final class MockPaymentProvider implements PaymentProviderInterface
 
         if (!is_string($providerReference) || !is_string($status) || !is_string($eventId)) {
             return null;
+        }
+
+        if (is_string($signature) && trim($signature) !== '') {
+            $encodedPayload = json_encode($payload);
+            if (!is_string($encodedPayload)) {
+                return null;
+            }
+
+            $expectedSignature = hash_hmac('sha256', $encodedPayload, $this->appSecret);
+            if (!hash_equals($expectedSignature, strtolower(trim($signature)))) {
+                return null;
+            }
         }
 
         return [

--- a/src/Shop/Transport/Controller/Api/V1/Payment/ConfirmPaymentController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/ConfirmPaymentController.php
@@ -11,8 +11,11 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Shop')]
 final readonly class ConfirmPaymentController
 {
@@ -23,6 +26,11 @@ final readonly class ConfirmPaymentController
 
     #[Route('/v1/shop/applications/{applicationSlug}/orders/{orderId}/payment-confirm', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Post(
+        security: [['Bearer' => []]],
+        summary: 'Confirm a payment for an order (private endpoint, full authentication required).',
+    )]
+    #[OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Forbidden. The order does not belong to the authenticated user or requested application.')]
     public function __invoke(string $applicationSlug, string $orderId, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
@@ -33,7 +41,7 @@ final readonly class ConfirmPaymentController
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'providerReference is required.');
         }
 
-        $transaction = $this->paymentService->confirmPayment($orderId, $providerReference, $payload);
+        $transaction = $this->paymentService->confirmPayment($applicationSlug, $orderId, $providerReference, $payload);
 
         return new JsonResponse([
             'id' => $transaction->getId(),

--- a/src/Shop/Transport/Controller/Api/V1/Payment/CreatePaymentIntentController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/CreatePaymentIntentController.php
@@ -10,8 +10,11 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Shop')]
 final readonly class CreatePaymentIntentController
 {
@@ -22,9 +25,14 @@ final readonly class CreatePaymentIntentController
 
     #[Route('/v1/shop/applications/{applicationSlug}/orders/{orderId}/payment-intent', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Post(
+        security: [['Bearer' => []]],
+        summary: 'Create a payment intent for an order (private endpoint, full authentication required).',
+    )]
+    #[OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Forbidden. The order does not belong to the authenticated user or requested application.')]
     public function __invoke(string $applicationSlug, string $orderId): JsonResponse
     {
-        $transaction = $this->paymentService->createPaymentIntent($orderId);
+        $transaction = $this->paymentService->createPaymentIntent($applicationSlug, $orderId);
 
         return new JsonResponse([
             'id' => $transaction->getId(),

--- a/src/Shop/Transport/Controller/Api/V1/Payment/PaymentWebhookController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/PaymentWebhookController.php
@@ -22,6 +22,12 @@ final readonly class PaymentWebhookController
 
     #[Route('/v1/shop/applications/{applicationSlug}/payments/webhook', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Post(
+        security: [],
+        summary: 'Handle payment provider webhook (public endpoint with strict signature verification).',
+    )]
+    #[OA\Response(response: JsonResponse::HTTP_BAD_REQUEST, description: 'Webhook signature is required in production.')]
+    #[OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Invalid webhook signature or payload.')]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);


### PR DESCRIPTION
### Motivation
- Séparer clairement les politiques de sécurité entre les endpoints privés (intent/confirm) et le webhook public tout en renforçant les contrôles d'accès et la vérification des webhooks.
- Empêcher les actions de paiement sur des commandes qui n'appartiennent pas à l'application ciblée ou à l'utilisateur authentifié.

### Description
- Ajout de `#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]` et d'annotations OpenAPI `security: [['Bearer' => []]]` aux contrôleurs `CreatePaymentIntentController` et `ConfirmPaymentController`, et documentation d'une `403` explicite en cas d'accès non autorisé.
- Modification de `PaymentService` pour vérifier que l'`Order` appartient bien à l'`applicationSlug` demandé et à l'utilisateur authentifié via la nouvelle méthode `assertOrderAccess` utilisée avant `createPaymentIntent` et `confirmPayment`.
- Conservation de l'endpoint webhook public mais durcissement de `processWebhook` pour exiger la signature en production (`400` si absente) et rejeter explicitement les webhooks non vérifiés (`401`).
- Renforcement de `MockPaymentProvider::verifyWebhook()` pour effectuer une vérification HMAC SHA-256 basée sur le secret de l'app injecté (`%kernel.secret%`) et ajout de l'argument `$appSecret` dans `config/services.yaml`.
- Ajout d'annotations OpenAPI pour l'endpoint webhook indiquant qu'il est public (`security: []`) mais que la signature est requise/enregistrée et que des statuts `400`/`401` peuvent être retournés.

### Testing
- Exécution des vérifications de syntaxe PHP réussies avec `php -l` sur les fichiers modifiés (`PaymentService.php`, `MockPaymentProvider.php`, `CreatePaymentIntentController.php`, `ConfirmPaymentController.php`, `PaymentWebhookController.php`).
- Tentative de lint du container avec `php bin/console lint:container --no-debug` échouée pour des raisons d'environnement (dépendances manquantes), message suggérant d'exécuter `composer install` pour poursuivre la validation de conteneur.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f63f5e648326a534f92d8a709dca)