### PR TITLE
Scope School API resources by application-owned school

### DIFF
--- a/src/School/Application/Service/DeleteClassService.php
+++ b/src/School/Application/Service/DeleteClassService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityDeleted;
+use App\School\Domain\Entity\School;
 use App\School\Domain\Entity\SchoolClass;
 use App\School\Infrastructure\Repository\SchoolClassRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -14,15 +15,16 @@ final readonly class DeleteClassService
 {
     public function __construct(
         private SchoolClassRepository $classRepository,
+        private SchoolResourceAccessService $resourceAccessService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
     }
 
-    public function delete(string $id): bool
+    public function delete(string $id, School $school): bool
     {
         $class = $this->classRepository->find($id);
-        if (!$class instanceof SchoolClass) {
+        if (!$class instanceof SchoolClass || !$this->resourceAccessService->belongsToSchool($class, $school)) {
             return false;
         }
 

--- a/src/School/Application/Service/DeleteExamService.php
+++ b/src/School/Application/Service/DeleteExamService.php
@@ -6,6 +6,7 @@ namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityDeleted;
 use App\School\Domain\Entity\Exam;
+use App\School\Domain\Entity\School;
 use App\School\Infrastructure\Repository\ExamRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -14,15 +15,16 @@ final readonly class DeleteExamService
 {
     public function __construct(
         private ExamRepository $examRepository,
+        private SchoolResourceAccessService $resourceAccessService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
     }
 
-    public function delete(string $id): bool
+    public function delete(string $id, School $school): bool
     {
         $exam = $this->examRepository->find($id);
-        if (!$exam instanceof Exam) {
+        if (!$exam instanceof Exam || !$this->resourceAccessService->belongsToSchool($exam, $school)) {
             return false;
         }
 

--- a/src/School/Application/Service/DeleteGradeService.php
+++ b/src/School/Application/Service/DeleteGradeService.php
@@ -6,6 +6,7 @@ namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityDeleted;
 use App\School\Domain\Entity\Grade;
+use App\School\Domain\Entity\School;
 use App\School\Infrastructure\Repository\GradeRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -14,15 +15,16 @@ final readonly class DeleteGradeService
 {
     public function __construct(
         private GradeRepository $gradeRepository,
+        private SchoolResourceAccessService $resourceAccessService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
     }
 
-    public function delete(string $id): bool
+    public function delete(string $id, School $school): bool
     {
         $grade = $this->gradeRepository->find($id);
-        if (!$grade instanceof Grade) {
+        if (!$grade instanceof Grade || !$this->resourceAccessService->belongsToSchool($grade, $school)) {
             return false;
         }
 

--- a/src/School/Application/Service/DeleteStudentService.php
+++ b/src/School/Application/Service/DeleteStudentService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityDeleted;
+use App\School\Domain\Entity\School;
 use App\School\Domain\Entity\Student;
 use App\School\Infrastructure\Repository\StudentRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -14,15 +15,16 @@ final readonly class DeleteStudentService
 {
     public function __construct(
         private StudentRepository $studentRepository,
+        private SchoolResourceAccessService $resourceAccessService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
     }
 
-    public function delete(string $id): bool
+    public function delete(string $id, School $school): bool
     {
         $student = $this->studentRepository->find($id);
-        if (!$student instanceof Student) {
+        if (!$student instanceof Student || !$this->resourceAccessService->belongsToSchool($student, $school)) {
             return false;
         }
 

--- a/src/School/Application/Service/DeleteTeacherService.php
+++ b/src/School/Application/Service/DeleteTeacherService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityDeleted;
+use App\School\Domain\Entity\School;
 use App\School\Domain\Entity\Teacher;
 use App\School\Infrastructure\Repository\TeacherRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -14,15 +15,16 @@ final readonly class DeleteTeacherService
 {
     public function __construct(
         private TeacherRepository $teacherRepository,
+        private SchoolResourceAccessService $resourceAccessService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
     }
 
-    public function delete(string $id): bool
+    public function delete(string $id, School $school): bool
     {
         $teacher = $this->teacherRepository->find($id);
-        if (!$teacher instanceof Teacher) {
+        if (!$teacher instanceof Teacher || !$this->resourceAccessService->belongsToSchool($teacher, $school)) {
             return false;
         }
 

--- a/src/School/Application/Service/ExamListService.php
+++ b/src/School/Application/Service/ExamListService.php
@@ -31,7 +31,7 @@ readonly class ExamListService
     /**
      * @return array<string,mixed>
      */
-    public function getList(Request $request): array
+    public function getList(Request $request, string $schoolId): array
     {
         $page = max(1, $request->query->getInt('page', 1));
         $limit = max(1, min(100, $request->query->getInt('limit', 20)));
@@ -39,10 +39,10 @@ readonly class ExamListService
             'q' => trim((string)$request->query->get('q', '')),
             'title' => trim((string)$request->query->get('title', '')),
         ];
-        $cacheKey = $this->cacheKeyConventionService->buildSchoolExamListKey($page, $limit, $filters);
+        $cacheKey = $this->cacheKeyConventionService->buildSchoolExamListKey($page, $limit, [...$filters, "schoolId" => $schoolId]);
 
         /** @var array<string,mixed> $result */
-        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit): array {
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit, $schoolId): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->schoolExamListTag());
@@ -59,6 +59,9 @@ readonly class ExamListService
             }
 
             $qb = $this->examRepository->createQueryBuilder('exam')->leftJoin('exam.schoolClass', 'class')->leftJoin('exam.teacher', 'teacher')
+                ->innerJoin('class.school', 'school')
+                ->andWhere('school.id = :schoolId')
+                ->setParameter('schoolId', $schoolId)
                 ->setFirstResult(($page - 1) * $limit)->setMaxResults($limit)->orderBy('exam.createdAt', 'DESC');
             if ($filters['title'] !== '') {
                 $qb->andWhere('LOWER(exam.title) LIKE LOWER(:title)')->setParameter('title', '%' . $filters['title'] . '%');
@@ -69,7 +72,11 @@ readonly class ExamListService
 
             $items = $this->viewMapper->mapExamCollection($qb->getQuery()->getResult());
 
-            $countQb = $this->examRepository->createQueryBuilder('exam')->select('COUNT(exam.id)');
+            $countQb = $this->examRepository->createQueryBuilder('exam')->select('COUNT(exam.id)')
+                ->innerJoin('exam.schoolClass', 'class')
+                ->innerJoin('class.school', 'school')
+                ->andWhere('school.id = :schoolId')
+                ->setParameter('schoolId', $schoolId);
             if ($filters['title'] !== '') {
                 $countQb->andWhere('LOWER(exam.title) LIKE LOWER(:title)')->setParameter('title', '%' . $filters['title'] . '%');
             }

--- a/src/School/Transport/Controller/Api/V1/Class/DeleteClassController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/DeleteClassController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\School\Transport\Controller\Api\V1\Class;
 
 use App\School\Application\Service\DeleteClassService;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,15 +21,18 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class DeleteClassController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private DeleteClassService $deleteClassService
     ) {
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/classes/{id}', methods: [Request::METHOD_DELETE])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $id): JsonResponse
+    public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse
     {
-        if (!$this->deleteClassService->delete($id)) {
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
+        if (!$this->deleteClassService->delete($id, $school)) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }
 

--- a/src/School/Transport/Controller/Api/V1/Class/ListClassesController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/ListClassesController.php
@@ -6,7 +6,9 @@ namespace App\School\Transport\Controller\Api\V1\Class;
 
 use App\School\Application\Serializer\SchoolApiResponseSerializer;
 use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Infrastructure\Repository\SchoolClassRepository;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -19,14 +21,20 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListClassesController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private SchoolClassRepository $classRepository,
         private SchoolViewMapper $viewMapper,
         private SchoolApiResponseSerializer $responseSerializer,
     ) {
     }
-    public function __invoke(string $applicationSlug): JsonResponse
+
+    public function __invoke(string $applicationSlug, ?User $loggedInUser): JsonResponse
     {
-        $items = $this->viewMapper->mapClassCollection($this->classRepository->findBy([], [
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
+        $items = $this->viewMapper->mapClassCollection($this->classRepository->findBy([
+            'school' => $school,
+        ], [
             'createdAt' => 'DESC',
         ], 200));
 

--- a/src/School/Transport/Controller/Api/V1/Exam/DeleteExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/DeleteExamController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\School\Transport\Controller\Api\V1\Exam;
 
 use App\School\Application\Service\DeleteExamService;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,15 +21,18 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class DeleteExamController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private DeleteExamService $deleteExamService
     ) {
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/exams/{id}', methods: [Request::METHOD_DELETE])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $id): JsonResponse
+    public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse
     {
-        if (!$this->deleteExamService->delete($id)) {
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
+        if (!$this->deleteExamService->delete($id, $school)) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }
 

--- a/src/School/Transport/Controller/Api/V1/Exam/ListExamsController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/ListExamsController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\School\Transport\Controller\Api\V1\Exam;
 
 use App\School\Application\Service\ExamListService;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,15 +21,18 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListExamsController
 {
     public function __construct(
-        private ExamListService $examListService
+        private ExamListService $examListService,
+        private SchoolApplicationScopeResolver $scopeResolver,
     ) {
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/exams', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, Request $request): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
         $request->attributes->set('applicationSlug', $applicationSlug);
-        return new JsonResponse($this->examListService->getList($request));
+
+        return new JsonResponse($this->examListService->getList($request, $school->getId()));
     }
 }

--- a/src/School/Transport/Controller/Api/V1/Grade/DeleteGradeController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/DeleteGradeController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\School\Transport\Controller\Api\V1\Grade;
 
 use App\School\Application\Service\DeleteGradeService;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,15 +21,18 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class DeleteGradeController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private DeleteGradeService $deleteGradeService
     ) {
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/grades/{id}', methods: [Request::METHOD_DELETE])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $id): JsonResponse
+    public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse
     {
-        if (!$this->deleteGradeService->delete($id)) {
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
+        if (!$this->deleteGradeService->delete($id, $school)) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }
 

--- a/src/School/Transport/Controller/Api/V1/Grade/ListGradesController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/ListGradesController.php
@@ -6,7 +6,9 @@ namespace App\School\Transport\Controller\Api\V1\Grade;
 
 use App\School\Application\Serializer\SchoolApiResponseSerializer;
 use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Infrastructure\Repository\GradeRepository;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,6 +23,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListGradesController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private GradeRepository $gradeRepository,
         private SchoolViewMapper $viewMapper,
         private SchoolApiResponseSerializer $responseSerializer,
@@ -29,11 +32,20 @@ final readonly class ListGradesController
 
     #[Route('/v1/school/applications/{applicationSlug}/grades', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug): JsonResponse
+    public function __invoke(string $applicationSlug, ?User $loggedInUser): JsonResponse
     {
-        $items = $this->viewMapper->mapGradeCollection($this->gradeRepository->findBy([], [
-            'createdAt' => 'DESC',
-        ], 200));
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
+        $items = $this->viewMapper->mapGradeCollection($this->gradeRepository->createQueryBuilder('grade')
+            ->innerJoin('grade.exam', 'exam')
+            ->innerJoin('exam.schoolClass', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $school->getId())
+            ->orderBy('grade.createdAt', 'DESC')
+            ->setMaxResults(200)
+            ->getQuery()
+            ->getResult());
 
         return new JsonResponse($this->responseSerializer->list($items));
     }

--- a/src/School/Transport/Controller/Api/V1/Student/DeleteStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/DeleteStudentController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\School\Transport\Controller\Api\V1\Student;
 
 use App\School\Application\Service\DeleteStudentService;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,15 +21,18 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class DeleteStudentController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private DeleteStudentService $deleteStudentService
     ) {
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/students/{id}', methods: [Request::METHOD_DELETE])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $id): JsonResponse
+    public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse
     {
-        if (!$this->deleteStudentService->delete($id)) {
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
+        if (!$this->deleteStudentService->delete($id, $school)) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }
 

--- a/src/School/Transport/Controller/Api/V1/Student/ListStudentsController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/ListStudentsController.php
@@ -6,7 +6,9 @@ namespace App\School\Transport\Controller\Api\V1\Student;
 
 use App\School\Application\Serializer\SchoolApiResponseSerializer;
 use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Infrastructure\Repository\StudentRepository;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,6 +23,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListStudentsController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private StudentRepository $studentRepository,
         private SchoolViewMapper $viewMapper,
         private SchoolApiResponseSerializer $responseSerializer,
@@ -29,11 +32,18 @@ final readonly class ListStudentsController
 
     #[Route('/v1/school/applications/{applicationSlug}/students', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug): JsonResponse
+    public function __invoke(string $applicationSlug, ?User $loggedInUser): JsonResponse
     {
-        $items = $this->viewMapper->mapStudentCollection($this->studentRepository->findBy([], [
-            'createdAt' => 'DESC',
-        ], 200));
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+        $items = $this->viewMapper->mapStudentCollection($this->studentRepository->createQueryBuilder('student')
+            ->innerJoin('student.schoolClass', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $school->getId())
+            ->orderBy('student.createdAt', 'DESC')
+            ->setMaxResults(200)
+            ->getQuery()
+            ->getResult());
 
         return new JsonResponse($this->responseSerializer->list($items));
     }

--- a/src/School/Transport/Controller/Api/V1/Teacher/DeleteTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/DeleteTeacherController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\School\Transport\Controller\Api\V1\Teacher;
 
 use App\School\Application\Service\DeleteTeacherService;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,15 +21,18 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class DeleteTeacherController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private DeleteTeacherService $deleteTeacherService
     ) {
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/teachers/{id}', methods: [Request::METHOD_DELETE])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $id): JsonResponse
+    public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse
     {
-        if (!$this->deleteTeacherService->delete($id)) {
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
+        if (!$this->deleteTeacherService->delete($id, $school)) {
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }
 

--- a/src/School/Transport/Controller/Api/V1/Teacher/ListTeachersController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/ListTeachersController.php
@@ -6,7 +6,9 @@ namespace App\School\Transport\Controller\Api\V1\Teacher;
 
 use App\School\Application\Serializer\SchoolApiResponseSerializer;
 use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Infrastructure\Repository\TeacherRepository;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,6 +23,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListTeachersController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private TeacherRepository $teacherRepository,
         private SchoolViewMapper $viewMapper,
         private SchoolApiResponseSerializer $responseSerializer,
@@ -29,11 +32,20 @@ final readonly class ListTeachersController
 
     #[Route('/v1/school/applications/{applicationSlug}/teachers', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug): JsonResponse
+    public function __invoke(string $applicationSlug, ?User $loggedInUser): JsonResponse
     {
-        $items = $this->viewMapper->mapTeacherCollection($this->teacherRepository->findBy([], [
-            'createdAt' => 'DESC',
-        ], 200));
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
+        $items = $this->viewMapper->mapTeacherCollection($this->teacherRepository->createQueryBuilder('teacher')
+            ->innerJoin('teacher.classes', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $school->getId())
+            ->orderBy('teacher.createdAt', 'DESC')
+            ->distinct()
+            ->setMaxResults(200)
+            ->getQuery()
+            ->getResult());
 
         return new JsonResponse($this->responseSerializer->list($items));
     }

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
@@ -79,4 +79,29 @@ final class SchoolApplicationScopedRoutesTest extends WebTestCase
         ]));
         self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
     }
+
+
+    #[TestDox('School scoped list endpoints only return data for the current school application.')]
+    public function testScopedListsAreIsolatedBySchoolApplication(): void
+    {
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+
+        foreach (['classes', 'students', 'teachers', 'exams', 'grades'] as $resource) {
+            $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/' . $resource);
+            self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+            $campus = JSON::decode((string)$ownerClient->getResponse()->getContent(), true);
+            self::assertNotEmpty($campus['items']);
+
+            $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-course-flow/' . $resource);
+            self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+            $course = JSON::decode((string)$ownerClient->getResponse()->getContent(), true);
+            self::assertNotEmpty($course['items']);
+
+            $campusIds = array_column($campus['items'], 'id');
+            $courseIds = array_column($course['items'], 'id');
+
+            self::assertEmpty(array_intersect($campusIds, $courseIds), sprintf('Resource %s leaked entities across schools.', $resource));
+        }
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Centraliser la résolution du scope applicatif (`applicationSlug` → `School`) pour éviter des lectures/mutations cross-school et simplifier la logique d’accès.
- Empêcher les fuites de données entre écoles causées par des `findBy([])` globaux et un cache partagé pour les listes d’examens.
- Renforcer la sécurité des opérations destructives en vérifiant explicitement que la ressource appartient à l’école courante.

### Description
- Les contrôleurs de listes ont été mis à jour pour résoudre le `School` via `SchoolApplicationScopeResolver` et filtrer les requêtes Doctrine par `school.id` au lieu d’utiliser `findBy([])`, incluant `ListStudentsController`, `ListTeachersController`, `ListGradesController`, `ListExamsController` et le contrôleur legacy `ListClassesController`.
- `ExamListService::getList` prend maintenant un paramètre `string $schoolId`, applique un `INNER JOIN`/`andWhere('school.id = :schoolId')` pour la liste et le `COUNT`, et la clé de cache inclut `schoolId` pour éviter les payloads mis en cache entre écoles.
- Les services de suppression (`DeleteStudentService`, `DeleteTeacherService`, `DeleteClassService`, `DeleteExamService`, `DeleteGradeService`) exigent désormais un `School` en paramètre et appellent `SchoolResourceAccessService::belongsToSchool(...)` avant toute mutation; les contrôleurs `DELETE` résolvent le `School` et transmettent l’argument.
- Ajout d’un test de non-régression `testScopedListsAreIsolatedBySchoolApplication` dans `SchoolApplicationScopedRoutesTest` qui vérifie que les listes `classes/students/teachers/exams/grades` entre deux applications scolaires ne partagent pas d’IDs.

### Testing
- `php -l` a été exécuté sur tous les fichiers modifiés et a signalé aucune erreur de syntaxe (succès).
- Exécution de la suite ciblée avec `./vendor/bin/phpunit tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php` impossible dans cet environnement car `vendor/bin/phpunit` est absent (échec d’exécution auto-test).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f631c9748326ac1674b68f0f5aab)