### PR TITLE
Log warning on Elasticsearch fallback in EventListService

### DIFF
--- a/src/Calendar/Application/Service/EventListService.php
+++ b/src/Calendar/Application/Service/EventListService.php
@@ -10,6 +10,7 @@ use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\User\Domain\Entity\User;
 use Psr\Cache\InvalidArgumentException;
+use Psr\Log\LoggerInterface;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
@@ -27,6 +28,7 @@ final readonly class EventListService
         private CacheInterface $cache,
         private ElasticsearchServiceInterface $elasticsearchService,
         private CacheKeyConventionService $cacheKeyConventionService,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -121,7 +123,7 @@ final readonly class EventListService
                 $item->tag($this->cacheKeyConventionService->tagPublicEventsByApplication($applicationSlug));
             }
 
-            $esIds = $this->searchIdsFromElastic($filters);
+            $esIds = $this->searchIdsFromElastic($filters, $accessContext);
             if ($esIds === []) {
                 return [
                     'items' => [],
@@ -166,7 +168,7 @@ final readonly class EventListService
      *
      * @return array<int, string>|null
      */
-    private function searchIdsFromElastic(array $filters): ?array
+    private function searchIdsFromElastic(array $filters, ?string $accessContext = null): ?array
     {
         if ($filters['title'] === '' && $filters['description'] === '' && $filters['location'] === '') {
             return null;
@@ -228,7 +230,14 @@ final readonly class EventListService
             }
 
             return array_values(array_unique($ids));
-        } catch (Throwable) {
+        } catch (Throwable $exception) {
+            $this->logger->warning('Unable to search event ids from Elasticsearch, fallback to repository filters.', [
+                'filterTypes' => array_values(array_keys(array_filter($filters, static fn (string $value): bool => $value !== ''))),
+                'exceptionClass' => $exception::class,
+                'exceptionMessage' => $exception->getMessage(),
+                'accessContext' => $accessContext,
+            ]);
+
             return null;
         }
     }


### PR DESCRIPTION
### Motivation
- Ajouter de l'observabilité lorsque la recherche d'IDs via Elasticsearch échoue tout en conservant le fallback vers les filtres de repository pour préserver la disponibilité.

### Description
- Injection de `Psr\Log\LoggerInterface` dans `EventListService`, passage du paramètre `accessContext` à `searchIdsFromElastic()` et ajout d'un `warning` dans le `catch (Throwable)` contenant `filterTypes` (clés des filtres non vides), `exceptionClass`, `exceptionMessage` et `accessContext`, en conservant le comportement de retour `null`.

### Testing
- Exécution de `php -l src/Calendar/Application/Service/EventListService.php` qui a renvoyé `No syntax errors detected`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f99b21648326ac7962d8255156dc)