### PR TITLE
Prevent self-notifications in BlogNotificationService

### DIFF
--- a/src/Blog/Application/Service/BlogNotificationService.php
+++ b/src/Blog/Application/Service/BlogNotificationService.php
@@ -28,24 +28,32 @@ final readonly class BlogNotificationService
         $targetLabel = $this->formatPostTitle($post);
 
         if ($comment->getParent() instanceof BlogComment) {
-            $this->notificationPublisher->publish(
-                from: $actor,
-                recipient: $comment->getParent()->getAuthor(),
-                title: $this->buildTitle($actor, 'commented your comment', $targetLabel),
-                type: self::BLOG_NOTIFICATION_TYPE,
-                description: $this->buildPostLinkDescription($post),
-            );
+            $recipient = $comment->getParent()->getAuthor();
+
+            if ($this->shouldNotify($actor, $recipient)) {
+                $this->notificationPublisher->publish(
+                    from: $actor,
+                    recipient: $recipient,
+                    title: $this->buildTitle($actor, 'commented your comment', $targetLabel),
+                    type: self::BLOG_NOTIFICATION_TYPE,
+                    description: $this->buildPostLinkDescription($post),
+                );
+            }
 
             return;
         }
 
-        $this->notificationPublisher->publish(
-            from: $actor,
-            recipient: $post->getAuthor(),
-            title: $this->buildTitle($actor, 'commented your post', $targetLabel),
-            type: self::BLOG_NOTIFICATION_TYPE,
-            description: $this->buildPostLinkDescription($post),
-        );
+        $recipient = $post->getAuthor();
+
+        if ($this->shouldNotify($actor, $recipient)) {
+            $this->notificationPublisher->publish(
+                from: $actor,
+                recipient: $recipient,
+                title: $this->buildTitle($actor, 'commented your post', $targetLabel),
+                type: self::BLOG_NOTIFICATION_TYPE,
+                description: $this->buildPostLinkDescription($post),
+            );
+        }
     }
 
     public function notifyReactionCreated(BlogComment $comment, User $actor, string $reactionType): void
@@ -53,30 +61,42 @@ final readonly class BlogNotificationService
         $actionLabel = $reactionType === 'like' ? 'liked' : ('reacted (' . $reactionType . ') to');
 
         if ($comment->getParent() instanceof BlogComment) {
-            $this->notificationPublisher->publish(
-                from: $actor,
-                recipient: $comment->getAuthor(),
-                title: $this->buildTitle($actor, $actionLabel . ' your comment', $this->formatCommentPreview($comment)),
-                type: self::BLOG_NOTIFICATION_TYPE,
-                description: $this->buildPostLinkDescription($comment->getPost()),
-            );
+            $recipient = $comment->getAuthor();
+
+            if ($this->shouldNotify($actor, $recipient)) {
+                $this->notificationPublisher->publish(
+                    from: $actor,
+                    recipient: $recipient,
+                    title: $this->buildTitle($actor, $actionLabel . ' your comment', $this->formatCommentPreview($comment)),
+                    type: self::BLOG_NOTIFICATION_TYPE,
+                    description: $this->buildPostLinkDescription($comment->getPost()),
+                );
+            }
 
             return;
         }
 
-        $this->notificationPublisher->publish(
-            from: $actor,
-            recipient: $comment->getPost()->getAuthor(),
-            title: $this->buildTitle($actor, $actionLabel . ' your post', $this->formatPostTitle($comment->getPost())),
-            type: self::BLOG_NOTIFICATION_TYPE,
-            description: $this->buildPostLinkDescription($comment->getPost()),
-        );
+        $recipient = $comment->getPost()->getAuthor();
+
+        if ($this->shouldNotify($actor, $recipient)) {
+            $this->notificationPublisher->publish(
+                from: $actor,
+                recipient: $recipient,
+                title: $this->buildTitle($actor, $actionLabel . ' your post', $this->formatPostTitle($comment->getPost())),
+                type: self::BLOG_NOTIFICATION_TYPE,
+                description: $this->buildPostLinkDescription($comment->getPost()),
+            );
+        }
     }
 
 
     public function notifyPostReactionCreated(BlogPost $post, User $actor, string $reactionType): void
     {
         $actionLabel = $reactionType === 'like' ? 'liked' : ('reacted (' . $reactionType . ') to');
+
+        if (!$this->shouldNotify($actor, $post->getAuthor())) {
+            return;
+        }
 
         $this->notificationPublisher->publish(
             from: $actor,
@@ -117,5 +137,10 @@ final readonly class BlogNotificationService
         }
 
         return '"' . mb_strimwidth($content, 0, 60, '...') . '"';
+    }
+
+    private function shouldNotify(User $actor, User $recipient): bool
+    {
+        return $actor->getId() !== $recipient->getId();
     }
 }

--- a/tests/Unit/Blog/Application/Service/BlogNotificationServiceTest.php
+++ b/tests/Unit/Blog/Application/Service/BlogNotificationServiceTest.php
@@ -77,6 +77,62 @@ final class BlogNotificationServiceTest extends TestCase
         (new BlogNotificationService($publisher))->notifyReactionCreated($reply, $reactor, 'like');
     }
 
+    public function testNotifyCommentCreatedSkipsPublishWhenActorIsRecipient(): void
+    {
+        $actor = $this->createUser('Rami', 'User');
+
+        $post = (new BlogPost())
+            ->setAuthor($actor)
+            ->setBlog(new Blog())
+            ->setContent('My own post');
+
+        $comment = (new BlogComment())
+            ->setPost($post)
+            ->setAuthor($actor)
+            ->setContent('self comment');
+
+        $publisher = $this->createMock(NotificationPublisher::class);
+        $publisher->expects(self::never())->method('publish');
+
+        (new BlogNotificationService($publisher))->notifyCommentCreated($comment);
+    }
+
+    public function testNotifyReactionCreatedSkipsPublishWhenActorIsRecipient(): void
+    {
+        $postAuthor = $this->createUser('Adam', 'Author');
+        $actor = $this->createUser('Rami', 'User');
+
+        $post = (new BlogPost())
+            ->setAuthor($postAuthor)
+            ->setBlog(new Blog())
+            ->setContent('General update');
+
+        $comment = (new BlogComment())
+            ->setPost($post)
+            ->setAuthor($actor)
+            ->setContent('my own comment');
+
+        $publisher = $this->createMock(NotificationPublisher::class);
+        $publisher->expects(self::never())->method('publish');
+
+        (new BlogNotificationService($publisher))->notifyReactionCreated($comment, $actor, 'like');
+    }
+
+    public function testNotifyPostReactionCreatedSkipsPublishWhenActorIsRecipient(): void
+    {
+        $actor = $this->createUser('Rami', 'User');
+
+        $post = (new BlogPost())
+            ->setAuthor($actor)
+            ->setBlog(new Blog())
+            ->setContent('Self post');
+
+        $publisher = $this->createMock(NotificationPublisher::class);
+        $publisher->expects(self::never())->method('publish');
+
+        (new BlogNotificationService($publisher))->notifyPostReactionCreated($post, $actor, 'like');
+    }
+
     private function createUser(string $firstName, string $lastName): User
     {
         return (new User())


### PR DESCRIPTION
### Motivation
- Prevent the system from publishing notifications when the actor and the recipient are the same user to avoid self-notifications.
- Keep existing notification title and description generation unchanged while adding a simple guard to skip publishes for self-actions.

### Description
- Added a private helper `shouldNotify(User $actor, User $recipient): bool` that returns `true` when `actor->getId() !== recipient->getId()`.
- Applied the guard before each `notificationPublisher->publish(...)` call in `notifyCommentCreated`, `notifyReactionCreated`, and `notifyPostReactionCreated` so publishes are skipped for self-actions.
- Preserved existing title/description construction by reusing `buildTitle`, `formatPostTitle`, `formatCommentPreview`, and `buildPostLinkDescription` unchanged.

### Testing
- Added unit tests in `tests/Unit/Blog/Application/Service/BlogNotificationServiceTest.php` that assert `publish` is never called when actor equals recipient for comment creation, comment reaction, and post reaction scenarios.
- Attempted to run `./vendor/bin/phpunit tests/Unit/Blog/Application/Service/BlogNotificationServiceTest.php` but the test binary is not available in this environment (`vendor/bin/phpunit` missing), so tests were not executed here.
- The new tests use `expects(self::never())` on the `NotificationPublisher` mock to validate the guard behavior when run in a proper test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f994d4348326b39751998788ba67)