### PR TITLE
Align CreateMessageController to async MessageService flow and update tests/OpenAPI

### DIFF
--- a/src/Chat/Transport/Controller/Api/V1/Message/CreateMessageController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/CreateMessageController.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Chat\Transport\Controller\Api\V1\Message;
 
 use App\Chat\Application\Message\CreateMessageCommand;
-use App\Chat\Application\MessageHandler\CreateMessageCommandHandler;
 use App\Chat\Application\Service\MessagePayloadService;
 use App\General\Application\Service\OperationIdGeneratorService;
+use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -43,7 +43,6 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
     responses: [
         new OA\Response(response: 202, description: 'Commande acceptée', content: new OA\JsonContent(example: [
             'operationId' => 'op_123',
-            'id' => '550e8400-e29b-41d4-a716-446655440000',
         ])),
         new OA\Response(response: 400, description: 'Payload invalide'),
     ]
@@ -52,7 +51,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 class CreateMessageController
 {
     public function __construct(
-        private readonly CreateMessageCommandHandler $handler,
+        private readonly MessageServiceInterface $messageService,
         private readonly MessagePayloadService $messagePayloadService,
         private readonly OperationIdGeneratorService $operationIdGeneratorService,
     ) {
@@ -64,7 +63,7 @@ class CreateMessageController
         $content = $this->messagePayloadService->extractRequiredContent($request->toArray());
         $operationId = $this->operationIdGeneratorService->generate();
 
-        $entityId = $this->handler->__invoke(new CreateMessageCommand(
+        $this->messageService->sendMessage(new CreateMessageCommand(
             operationId: $operationId,
             actorUserId: $loggedInUser->getId(),
             conversationId: $conversationId,
@@ -73,7 +72,6 @@ class CreateMessageController
 
         return new JsonResponse([
             'operationId' => $operationId,
-            'id' => is_string($entityId) ? $entityId : null,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }

--- a/tests/Application/Chat/Transport/Controller/Api/V1/Message/UserMessageControllerTest.php
+++ b/tests/Application/Chat/Transport/Controller/Api/V1/Message/UserMessageControllerTest.php
@@ -42,6 +42,12 @@ final class UserMessageControllerTest extends WebTestCase
             'content' => 'Nouveau message de test fonctionnel',
         ]));
         self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+        $createContent = $client->getResponse()->getContent();
+        self::assertNotFalse($createContent);
+        $createPayload = JSON::decode($createContent, true);
+        self::assertIsArray($createPayload);
+        self::assertArrayHasKey('operationId', $createPayload);
+        self::assertArrayNotHasKey('id', $createPayload);
 
         $client->request('POST', $this->baseUrl . '/conversations/' . $conversationId . '/messages', [], [], [], JSON::encode([
             'content' => '',
@@ -53,6 +59,12 @@ final class UserMessageControllerTest extends WebTestCase
             'content' => 'Message édité via test',
         ]));
         self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+        $patchContent = $client->getResponse()->getContent();
+        self::assertNotFalse($patchContent);
+        $patchPayload = JSON::decode($patchContent, true);
+        self::assertIsArray($patchPayload);
+        self::assertArrayHasKey('operationId', $patchPayload);
+        self::assertArrayHasKey('id', $patchPayload);
 
         $client->request('PATCH', $this->baseUrl . '/messages/' . $messageId, [], [], [], JSON::encode([
             'read' => 'yes',
@@ -69,5 +81,11 @@ final class UserMessageControllerTest extends WebTestCase
 
         $client->request('DELETE', $this->baseUrl . '/messages/' . $messageId);
         self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+        $deleteContent = $client->getResponse()->getContent();
+        self::assertNotFalse($deleteContent);
+        $deletePayload = JSON::decode($deleteContent, true);
+        self::assertIsArray($deletePayload);
+        self::assertArrayHasKey('operationId', $deletePayload);
+        self::assertArrayHasKey('id', $deletePayload);
     }
 }


### PR DESCRIPTION
### Motivation
- Unifier la stratégie de création de message autour d'un flux asynchrone pour éviter des comportements divergents entre create/patch/delete.
- Aligner la documentation OpenAPI sur le comportement asynchrone afin de ne pas exposer un `id` immédiat dans la réponse de création.
- Mettre à jour les tests fonctionnels concernés pour vérifier la nouvelle forme des réponses.

### Description
- Remplacement de l'appel direct au `CreateMessageCommandHandler` par un dispatch asynchrone via `MessageServiceInterface` dans `CreateMessageController`.
- Mise à jour de l'exemple de réponse OpenAPI (`chat_message_create`) pour supprimer `id` et ne conserver que `operationId` dans le `202`.
- Ajustement de `tests/Application/Chat/Transport/Controller/Api/V1/Message/UserMessageControllerTest.php` pour s'assurer que la création retourne `operationId` sans `id`, et que les réponses de `PATCH` et `DELETE` contiennent `operationId` et `id`.

### Testing
- Vérification de la syntaxe PHP avec `php -l` sur les fichiers modifiés, sans erreurs détectées.
- Tentatives d'exécution des tests via `vendor/bin/phpunit` et `php bin/phpunit` ont échoué car l'exécutable PHPUnit n'est pas présent dans l'environnement.
- Les assertions de test ont été mises à jour localement dans le fichier de test cité, mais la suite PHPUnit complète n'a pas été lancée ici en raison de l'environnement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f9a1e1188326815a63dd405f27c8)