### PR TITLE
Harden CRM create endpoints with DTO validation and unified API errors

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/CreateCompanyByApplicationController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CreateCompanyByApplicationController.php
@@ -6,6 +6,8 @@ namespace App\Crm\Transport\Controller\Api\V1;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Company;
+use App\Crm\Transport\Request\CreateCompanyRequest;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityCreated;
 use Doctrine\ORM\EntityManagerInterface;
 use JsonException;
@@ -13,11 +15,11 @@ use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\Messenger\Exception\ExceptionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -26,15 +28,13 @@ final readonly class CreateCompanyByApplicationController
 {
     public function __construct(
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+        private ValidatorInterface $validator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
     }
 
-    /**
-     * @throws JsonException
-     * @throws ExceptionInterface
-     */
     #[Route('/v1/crm/applications/{applicationSlug}/companies', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Post(
@@ -60,15 +60,30 @@ final readonly class CreateCompanyByApplicationController
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        try {
+            $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        $input = CreateCompanyRequest::fromArray($payload);
+        $violations = $this->validator->validate($input);
+        if ($violations->count() > 0) {
+            return $this->errorResponseFactory->validationFailed($violations);
+        }
 
         $company = new Company()
             ->setCrm($crm)
-            ->setName((string)($payload['name'] ?? ''))
-            ->setIndustry(isset($payload['industry']) ? (string)$payload['industry'] : null)
-            ->setWebsite(isset($payload['website']) ? (string)$payload['website'] : null)
-            ->setContactEmail(isset($payload['contactEmail']) ? (string)$payload['contactEmail'] : null)
-            ->setPhone(isset($payload['phone']) ? (string)$payload['phone'] : null);
+            ->setName((string) $input->name)
+            ->setIndustry($input->industry)
+            ->setWebsite($input->website)
+            ->setContactEmail($input->contactEmail)
+            ->setPhone($input->phone);
 
         $this->entityManager->persist($company);
         $this->entityManager->flush();

--- a/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
@@ -8,9 +8,13 @@ use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Domain\Enum\ProjectStatus;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\Crm\Transport\Request\CreateProjectRequest;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityCreated;
 use DateTimeImmutable;
+use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,6 +23,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -28,6 +33,8 @@ final readonly class CreateProjectController
     public function __construct(
         private CompanyRepository $companyRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+        private ValidatorInterface $validator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -40,18 +47,45 @@ final readonly class CreateProjectController
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $payload = (array)json_decode((string)$request->getContent(), true);
+
+        try {
+            $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        $input = CreateProjectRequest::fromArray($payload);
+        $violations = $this->validator->validate($input);
+        if ($violations->count() > 0) {
+            return $this->errorResponseFactory->validationFailed($violations);
+        }
+
+        $startedAt = $this->parseDate($input->startedAt, 'startedAt');
+        if ($startedAt instanceof JsonResponse) {
+            return $startedAt;
+        }
+
+        $dueAt = $this->parseDate($input->dueAt, 'dueAt');
+        if ($dueAt instanceof JsonResponse) {
+            return $dueAt;
+        }
+
         $project = new Project();
-        $project->setName((string)($payload['name'] ?? ''))
-            ->setCode(isset($payload['code']) ? (string)$payload['code'] : null)
-            ->setDescription(isset($payload['description']) ? (string)$payload['description'] : null)
-            ->setStatus(ProjectStatus::tryFrom((string)($payload['status'] ?? '')) ?? ProjectStatus::PLANNED)
-            ->setStartedAt(isset($payload['startedAt']) ? new DateTimeImmutable((string)$payload['startedAt']) : null)
-            ->setDueAt(isset($payload['dueAt']) ? new DateTimeImmutable((string)$payload['dueAt']) : null);
-        if (is_string($payload['companyId'] ?? null)) {
-            $company = $this->companyRepository->findOneScopedById($payload['companyId'], $crm->getId());
+        $project->setName((string) $input->name)
+            ->setCode($input->code)
+            ->setDescription($input->description)
+            ->setStatus(ProjectStatus::tryFrom((string) $input->status) ?? ProjectStatus::PLANNED)
+            ->setStartedAt($startedAt)
+            ->setDueAt($dueAt);
+
+        if (is_string($input->companyId)) {
+            $company = $this->companyRepository->findOneScopedById($input->companyId, $crm->getId());
             if ($company === null) {
-                return new JsonResponse(['message' => 'Unknown "companyId" in this CRM scope.'], JsonResponse::HTTP_NOT_FOUND);
+                return $this->errorResponseFactory->notFoundReference('companyId');
             }
 
             $project->setCompany($company);
@@ -64,5 +98,19 @@ final readonly class CreateProjectController
         return new JsonResponse([
             'id' => $project->getId(),
         ], JsonResponse::HTTP_CREATED);
+    }
+
+    private function parseDate(?string $value, string $field): DateTimeImmutable|JsonResponse|null
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $date = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
+        if ($date === false) {
+            return $this->errorResponseFactory->invalidDate($field);
+        }
+
+        return $date;
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/CreateSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/CreateSprintController.php
@@ -8,9 +8,13 @@ use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Sprint;
 use App\Crm\Domain\Enum\SprintStatus;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Transport\Request\CreateSprintRequest;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityCreated;
 use DateTimeImmutable;
+use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,6 +23,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -28,6 +33,8 @@ final readonly class CreateSprintController
     public function __construct(
         private ProjectRepository $projectRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+        private ValidatorInterface $validator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -40,17 +47,44 @@ final readonly class CreateSprintController
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $payload = (array)json_decode((string)$request->getContent(), true);
+
+        try {
+            $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        $input = CreateSprintRequest::fromArray($payload);
+        $violations = $this->validator->validate($input);
+        if ($violations->count() > 0) {
+            return $this->errorResponseFactory->validationFailed($violations);
+        }
+
+        $startDate = $this->parseDate($input->startDate, 'startDate');
+        if ($startDate instanceof JsonResponse) {
+            return $startDate;
+        }
+
+        $endDate = $this->parseDate($input->endDate, 'endDate');
+        if ($endDate instanceof JsonResponse) {
+            return $endDate;
+        }
+
         $sprint = new Sprint();
-        $sprint->setName((string)($payload['name'] ?? ''))
-            ->setGoal(isset($payload['goal']) ? (string)$payload['goal'] : null)
-            ->setStatus(SprintStatus::tryFrom((string)($payload['status'] ?? '')) ?? SprintStatus::PLANNED)
-            ->setStartDate(isset($payload['startDate']) ? new DateTimeImmutable((string)$payload['startDate']) : null)
-            ->setEndDate(isset($payload['endDate']) ? new DateTimeImmutable((string)$payload['endDate']) : null);
-        if (is_string($payload['projectId'] ?? null)) {
-            $project = $this->projectRepository->findOneScopedById($payload['projectId'], $crm->getId());
+        $sprint->setName((string) $input->name)
+            ->setGoal($input->goal)
+            ->setStatus(SprintStatus::tryFrom((string) $input->status) ?? SprintStatus::PLANNED)
+            ->setStartDate($startDate)
+            ->setEndDate($endDate);
+
+        if (is_string($input->projectId)) {
+            $project = $this->projectRepository->findOneScopedById($input->projectId, $crm->getId());
             if ($project === null) {
-                return new JsonResponse(['message' => 'Unknown "projectId" in this CRM scope.'], JsonResponse::HTTP_NOT_FOUND);
+                return $this->errorResponseFactory->notFoundReference('projectId');
             }
 
             $sprint->setProject($project);
@@ -63,5 +97,19 @@ final readonly class CreateSprintController
         return new JsonResponse([
             'id' => $sprint->getId(),
         ], JsonResponse::HTTP_CREATED);
+    }
+
+    private function parseDate(?string $value, string $field): DateTimeImmutable|JsonResponse|null
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $date = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
+        if ($date === false) {
+            return $this->errorResponseFactory->invalidDate($field);
+        }
+
+        return $date;
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
@@ -10,10 +10,14 @@ use App\Crm\Domain\Enum\TaskPriority;
 use App\Crm\Domain\Enum\TaskStatus;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
 use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Transport\Request\CreateTaskRequest;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityCreated;
 use App\User\Domain\Entity\User;
 use DateTimeImmutable;
+use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,6 +26,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -32,6 +37,8 @@ final readonly class CreateTaskController
         private ProjectRepository $projectRepository,
         private SprintRepository $sprintRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+        private ValidatorInterface $validator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -52,48 +59,67 @@ final readonly class CreateTaskController
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $payload = (array)json_decode((string)$request->getContent(), true);
+
+        try {
+            $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        $input = CreateTaskRequest::fromArray($payload);
+        $violations = $this->validator->validate($input);
+        if ($violations->count() > 0) {
+            return $this->errorResponseFactory->validationFailed($violations);
+        }
+
+        $dueAt = $this->parseDate($input->dueAt, 'dueAt');
+        if ($dueAt instanceof JsonResponse) {
+            return $dueAt;
+        }
+
         $task = new Task();
-        $task->setTitle((string)($payload['title'] ?? ''))
-            ->setDescription(isset($payload['description']) ? (string)$payload['description'] : null)
-            ->setStatus(TaskStatus::tryFrom((string)($payload['status'] ?? '')) ?? TaskStatus::TODO)
-            ->setPriority(TaskPriority::tryFrom((string)($payload['priority'] ?? '')) ?? TaskPriority::MEDIUM)
-            ->setDueAt(isset($payload['dueAt']) ? new DateTimeImmutable((string)$payload['dueAt']) : null)
-            ->setEstimatedHours(isset($payload['estimatedHours']) ? (float)$payload['estimatedHours'] : null);
+        $task->setTitle((string) $input->title)
+            ->setDescription($input->description)
+            ->setStatus(TaskStatus::tryFrom((string) $input->status) ?? TaskStatus::TODO)
+            ->setPriority(TaskPriority::tryFrom((string) $input->priority) ?? TaskPriority::MEDIUM)
+            ->setDueAt($dueAt)
+            ->setEstimatedHours($input->estimatedHours !== null ? (float) $input->estimatedHours : null);
 
         $project = null;
-        if (is_string($payload['projectId'] ?? null)) {
-            $project = $this->projectRepository->findOneScopedById($payload['projectId'], $crm->getId());
+        if (is_string($input->projectId)) {
+            $project = $this->projectRepository->findOneScopedById($input->projectId, $crm->getId());
             if ($project === null) {
-                return new JsonResponse(['message' => 'Unknown "projectId" in this CRM scope.'], JsonResponse::HTTP_NOT_FOUND);
+                return $this->errorResponseFactory->notFoundReference('projectId');
             }
 
             $task->setProject($project);
         }
 
-        if (is_string($payload['sprintId'] ?? null)) {
-            $sprint = $this->sprintRepository->findOneScopedById($payload['sprintId'], $crm->getId());
+        if (is_string($input->sprintId)) {
+            $sprint = $this->sprintRepository->findOneScopedById($input->sprintId, $crm->getId());
             if ($sprint === null) {
-                return new JsonResponse(['message' => 'Unknown "sprintId" in this CRM scope.'], JsonResponse::HTTP_NOT_FOUND);
+                return $this->errorResponseFactory->notFoundReference('sprintId');
             }
 
             if ($project !== null && $sprint->getProject()?->getId() !== $project->getId()) {
-                return new JsonResponse(['message' => 'Provided "sprintId" does not belong to the provided "projectId".'], JsonResponse::HTTP_BAD_REQUEST);
+                return $this->errorResponseFactory->outOfScopeReference('Provided "sprintId" does not belong to the provided "projectId".');
             }
 
             $task->setSprint($sprint);
         }
 
-        if (is_array($payload['assigneeIds'] ?? null)) {
-            foreach ($payload['assigneeIds'] as $assigneeId) {
-                if (!is_string($assigneeId) || $assigneeId === '') {
-                    continue;
+        if (is_array($input->assigneeIds)) {
+            foreach ($input->assigneeIds as $assigneeId) {
+                $assignee = $this->entityManager->getRepository(User::class)->find($assigneeId);
+                if (!$assignee instanceof User) {
+                    return $this->errorResponseFactory->notFoundReference('assigneeIds');
                 }
 
-                $assignee = $this->entityManager->getRepository(User::class)->find($assigneeId);
-                if ($assignee instanceof User) {
-                    $task->addAssignee($assignee);
-                }
+                $task->addAssignee($assignee);
             }
         }
 
@@ -104,5 +130,19 @@ final readonly class CreateTaskController
         return new JsonResponse([
             'id' => $task->getId(),
         ], JsonResponse::HTTP_CREATED);
+    }
+
+    private function parseDate(?string $value, string $field): DateTimeImmutable|JsonResponse|null
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $date = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
+        if ($date === false) {
+            return $this->errorResponseFactory->invalidDate($field);
+        }
+
+        return $date;
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
@@ -8,10 +8,14 @@ use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Crm\Domain\Enum\TaskRequestStatus;
 use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Crm\Transport\Request\CreateTaskRequestEntryRequest;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityCreated;
 use App\User\Domain\Entity\User;
 use DateTimeImmutable;
+use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,6 +24,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -29,6 +34,8 @@ final readonly class CreateTaskRequestController
     public function __construct(
         private TaskRepository $taskRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+        private ValidatorInterface $validator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -49,30 +56,51 @@ final readonly class CreateTaskRequestController
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $payload = (array)json_decode((string)$request->getContent(), true);
+
+        try {
+            $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        $input = CreateTaskRequestEntryRequest::fromArray($payload);
+        $violations = $this->validator->validate($input);
+        if ($violations->count() > 0) {
+            return $this->errorResponseFactory->validationFailed($violations);
+        }
+
+        $resolvedAt = $this->parseDate($input->resolvedAt, 'resolvedAt');
+        if ($resolvedAt instanceof JsonResponse) {
+            return $resolvedAt;
+        }
+
         $taskRequest = new TaskRequest();
-        $taskRequest->setTitle((string)($payload['title'] ?? ''))
-            ->setDescription(isset($payload['description']) ? (string)$payload['description'] : null)
-            ->setStatus(TaskRequestStatus::tryFrom((string)($payload['status'] ?? '')) ?? TaskRequestStatus::PENDING)
-            ->setResolvedAt(isset($payload['resolvedAt']) ? new DateTimeImmutable((string)$payload['resolvedAt']) : null);
-        if (is_string($payload['taskId'] ?? null)) {
-            $task = $this->taskRepository->findOneScopedById($payload['taskId'], $crm->getId());
+        $taskRequest->setTitle((string) $input->title)
+            ->setDescription($input->description)
+            ->setStatus(TaskRequestStatus::tryFrom((string) $input->status) ?? TaskRequestStatus::PENDING)
+            ->setResolvedAt($resolvedAt);
+
+        if (is_string($input->taskId)) {
+            $task = $this->taskRepository->findOneScopedById($input->taskId, $crm->getId());
             if ($task === null) {
-                return new JsonResponse(['message' => 'Unknown "taskId" in this CRM scope.'], JsonResponse::HTTP_NOT_FOUND);
+                return $this->errorResponseFactory->notFoundReference('taskId');
             }
 
             $taskRequest->setTask($task);
         }
-        if (is_array($payload['assigneeIds'] ?? null)) {
-            foreach ($payload['assigneeIds'] as $assigneeId) {
-                if (!is_string($assigneeId) || $assigneeId === '') {
-                    continue;
+
+        if (is_array($input->assigneeIds)) {
+            foreach ($input->assigneeIds as $assigneeId) {
+                $assignee = $this->entityManager->getRepository(User::class)->find($assigneeId);
+                if (!$assignee instanceof User) {
+                    return $this->errorResponseFactory->notFoundReference('assigneeIds');
                 }
 
-                $assignee = $this->entityManager->getRepository(User::class)->find($assigneeId);
-                if ($assignee instanceof User) {
-                    $taskRequest->addAssignee($assignee);
-                }
+                $taskRequest->addAssignee($assignee);
             }
         }
 
@@ -83,5 +111,19 @@ final readonly class CreateTaskRequestController
         return new JsonResponse([
             'id' => $taskRequest->getId(),
         ], JsonResponse::HTTP_CREATED);
+    }
+
+    private function parseDate(?string $value, string $field): DateTimeImmutable|JsonResponse|null
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $date = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
+        if ($date === false) {
+            return $this->errorResponseFactory->invalidDate($field);
+        }
+
+        return $date;
     }
 }

--- a/src/Crm/Transport/Request/CreateCompanyRequest.php
+++ b/src/Crm/Transport/Request/CreateCompanyRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateCompanyRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    public ?string $name = null;
+
+    #[Assert\Length(max: 255)]
+    public ?string $industry = null;
+
+    #[Assert\Length(max: 255)]
+    public ?string $website = null;
+
+    #[Assert\Email]
+    #[Assert\Length(max: 255)]
+    public ?string $contactEmail = null;
+
+    #[Assert\Length(max: 64)]
+    public ?string $phone = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->name = isset($payload['name']) ? (string) $payload['name'] : null;
+        $request->industry = isset($payload['industry']) ? (string) $payload['industry'] : null;
+        $request->website = isset($payload['website']) ? (string) $payload['website'] : null;
+        $request->contactEmail = isset($payload['contactEmail']) ? (string) $payload['contactEmail'] : null;
+        $request->phone = isset($payload['phone']) ? (string) $payload['phone'] : null;
+
+        return $request;
+    }
+}

--- a/src/Crm/Transport/Request/CreateProjectRequest.php
+++ b/src/Crm/Transport/Request/CreateProjectRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use App\Crm\Domain\Enum\ProjectStatus;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateProjectRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    public ?string $name = null;
+
+    #[Assert\Length(max: 64)]
+    public ?string $code = null;
+
+    #[Assert\Length(max: 5000)]
+    public ?string $description = null;
+
+    #[Assert\Choice(callback: [self::class, 'statusChoices'])]
+    public ?string $status = null;
+
+    #[Assert\DateTime]
+    public ?string $startedAt = null;
+
+    #[Assert\DateTime]
+    public ?string $dueAt = null;
+
+    #[Assert\Uuid]
+    public ?string $companyId = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->name = isset($payload['name']) ? (string) $payload['name'] : null;
+        $request->code = isset($payload['code']) ? (string) $payload['code'] : null;
+        $request->description = isset($payload['description']) ? (string) $payload['description'] : null;
+        $request->status = isset($payload['status']) ? (string) $payload['status'] : null;
+        $request->startedAt = isset($payload['startedAt']) ? (string) $payload['startedAt'] : null;
+        $request->dueAt = isset($payload['dueAt']) ? (string) $payload['dueAt'] : null;
+        $request->companyId = isset($payload['companyId']) ? (string) $payload['companyId'] : null;
+
+        return $request;
+    }
+
+    /** @return list<string> */
+    public static function statusChoices(): array
+    {
+        return array_map(static fn (ProjectStatus $status): string => $status->value, ProjectStatus::cases());
+    }
+}

--- a/src/Crm/Transport/Request/CreateSprintRequest.php
+++ b/src/Crm/Transport/Request/CreateSprintRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use App\Crm\Domain\Enum\SprintStatus;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateSprintRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    public ?string $name = null;
+
+    #[Assert\Length(max: 5000)]
+    public ?string $goal = null;
+
+    #[Assert\Choice(callback: [self::class, 'statusChoices'])]
+    public ?string $status = null;
+
+    #[Assert\DateTime]
+    public ?string $startDate = null;
+
+    #[Assert\DateTime]
+    public ?string $endDate = null;
+
+    #[Assert\Uuid]
+    public ?string $projectId = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->name = isset($payload['name']) ? (string) $payload['name'] : null;
+        $request->goal = isset($payload['goal']) ? (string) $payload['goal'] : null;
+        $request->status = isset($payload['status']) ? (string) $payload['status'] : null;
+        $request->startDate = isset($payload['startDate']) ? (string) $payload['startDate'] : null;
+        $request->endDate = isset($payload['endDate']) ? (string) $payload['endDate'] : null;
+        $request->projectId = isset($payload['projectId']) ? (string) $payload['projectId'] : null;
+
+        return $request;
+    }
+
+    /** @return list<string> */
+    public static function statusChoices(): array
+    {
+        return array_map(static fn (SprintStatus $status): string => $status->value, SprintStatus::cases());
+    }
+}

--- a/src/Crm/Transport/Request/CreateTaskRequest.php
+++ b/src/Crm/Transport/Request/CreateTaskRequest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use App\Crm\Domain\Enum\TaskPriority;
+use App\Crm\Domain\Enum\TaskStatus;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateTaskRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    public ?string $title = null;
+
+    #[Assert\Length(max: 5000)]
+    public ?string $description = null;
+
+    #[Assert\Choice(callback: [self::class, 'statusChoices'])]
+    public ?string $status = null;
+
+    #[Assert\Choice(callback: [self::class, 'priorityChoices'])]
+    public ?string $priority = null;
+
+    #[Assert\DateTime]
+    public ?string $dueAt = null;
+
+    #[Assert\Type(type: 'numeric')]
+    public null|int|float|string $estimatedHours = null;
+
+    #[Assert\Uuid]
+    public ?string $projectId = null;
+
+    #[Assert\Uuid]
+    public ?string $sprintId = null;
+
+    #[Assert\Type(type: 'array')]
+    #[Assert\All([
+        new Assert\Uuid(),
+    ])]
+    public ?array $assigneeIds = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->title = isset($payload['title']) ? (string) $payload['title'] : null;
+        $request->description = isset($payload['description']) ? (string) $payload['description'] : null;
+        $request->status = isset($payload['status']) ? (string) $payload['status'] : null;
+        $request->priority = isset($payload['priority']) ? (string) $payload['priority'] : null;
+        $request->dueAt = isset($payload['dueAt']) ? (string) $payload['dueAt'] : null;
+        $request->estimatedHours = $payload['estimatedHours'] ?? null;
+        $request->projectId = isset($payload['projectId']) ? (string) $payload['projectId'] : null;
+        $request->sprintId = isset($payload['sprintId']) ? (string) $payload['sprintId'] : null;
+        $request->assigneeIds = isset($payload['assigneeIds']) && is_array($payload['assigneeIds']) ? $payload['assigneeIds'] : $payload['assigneeIds'] ?? null;
+
+        return $request;
+    }
+
+    /** @return list<string> */
+    public static function statusChoices(): array
+    {
+        return array_map(static fn (TaskStatus $status): string => $status->value, TaskStatus::cases());
+    }
+
+    /** @return list<string> */
+    public static function priorityChoices(): array
+    {
+        return array_map(static fn (TaskPriority $priority): string => $priority->value, TaskPriority::cases());
+    }
+}

--- a/src/Crm/Transport/Request/CreateTaskRequestEntryRequest.php
+++ b/src/Crm/Transport/Request/CreateTaskRequestEntryRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use App\Crm\Domain\Enum\TaskRequestStatus;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateTaskRequestEntryRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    public ?string $title = null;
+
+    #[Assert\Length(max: 5000)]
+    public ?string $description = null;
+
+    #[Assert\Choice(callback: [self::class, 'statusChoices'])]
+    public ?string $status = null;
+
+    #[Assert\DateTime]
+    public ?string $resolvedAt = null;
+
+    #[Assert\Uuid]
+    public ?string $taskId = null;
+
+    #[Assert\Type(type: 'array')]
+    #[Assert\All([
+        new Assert\Uuid(),
+    ])]
+    public ?array $assigneeIds = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->title = isset($payload['title']) ? (string) $payload['title'] : null;
+        $request->description = isset($payload['description']) ? (string) $payload['description'] : null;
+        $request->status = isset($payload['status']) ? (string) $payload['status'] : null;
+        $request->resolvedAt = isset($payload['resolvedAt']) ? (string) $payload['resolvedAt'] : null;
+        $request->taskId = isset($payload['taskId']) ? (string) $payload['taskId'] : null;
+        $request->assigneeIds = isset($payload['assigneeIds']) && is_array($payload['assigneeIds']) ? $payload['assigneeIds'] : $payload['assigneeIds'] ?? null;
+
+        return $request;
+    }
+
+    /** @return list<string> */
+    public static function statusChoices(): array
+    {
+        return array_map(static fn (TaskRequestStatus $status): string => $status->value, TaskRequestStatus::cases());
+    }
+}

--- a/src/Crm/Transport/Request/CrmApiErrorResponseFactory.php
+++ b/src/Crm/Transport/Request/CrmApiErrorResponseFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+use function iterator_to_array;
+
+final class CrmApiErrorResponseFactory
+{
+    public function invalidJson(): JsonResponse
+    {
+        return $this->response(JsonResponse::HTTP_BAD_REQUEST, 'Invalid JSON payload.');
+    }
+
+    public function invalidDate(string $field): JsonResponse
+    {
+        return $this->response(JsonResponse::HTTP_BAD_REQUEST, sprintf('Invalid date format for "%s".', $field));
+    }
+
+    public function notFoundReference(string $field): JsonResponse
+    {
+        return $this->response(JsonResponse::HTTP_NOT_FOUND, sprintf('Unknown "%s" in this CRM scope.', $field));
+    }
+
+    public function outOfScopeReference(string $message): JsonResponse
+    {
+        return $this->response(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, $message);
+    }
+
+    public function validationFailed(ConstraintViolationListInterface $violations): JsonResponse
+    {
+        return $this->response(
+            JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+            'Validation failed.',
+            array_map(
+                static fn (ConstraintViolationInterface $violation): array => [
+                    'propertyPath' => $violation->getPropertyPath(),
+                    'message' => $violation->getMessage(),
+                    'code' => $violation->getCode(),
+                ],
+                iterator_to_array($violations),
+            ),
+        );
+    }
+
+    private function response(int $statusCode, string $message, array $errors = []): JsonResponse
+    {
+        return new JsonResponse([
+            'message' => $message,
+            'errors' => $errors,
+        ], $statusCode);
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce strong input validation and consistent error responses for CRM create endpoints to avoid silent failures and unclear error shapes.
- Ensure JSON parsing and date handling are explicit and return readable client errors for malformed payloads or invalid date formats.
- Fail fast on unknown or out-of-scope references and invalid assignee references to keep data consistent across CRM scope boundaries.

### Description
- Added request DTOs under `src/Crm/Transport/Request` (`CreateCompanyRequest`, `CreateProjectRequest`, `CreateSprintRequest`, `CreateTaskRequest`, `CreateTaskRequestEntryRequest`) with Symfony Validator constraints like `NotBlank`, `Length`, `Choice`, `DateTime`, and `Uuid` to model and validate incoming payloads.
- Added `CrmApiErrorResponseFactory` (`src/Crm/Transport/Request/CrmApiErrorResponseFactory.php`) to standardize API error payloads as `{message, errors}` and to provide helpers for invalid JSON, invalid dates, validation failures, not-found references and out-of-scope references.
- Updated controllers `CreateCompanyByApplicationController`, `CreateProjectController`, `CreateSprintController`, `CreateTaskController`, and `CreateTaskRequestController` to parse JSON with `JSON_THROW_ON_ERROR` and return 400 on parse errors, validate DTOs and return 422 on violations, safely parse date fields using `DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, ...)` with readable 400 errors, and explicitly reject unknown references (404) or cross-resource scope mismatches (422), and to reject unknown `assigneeIds` instead of ignoring them.

### Testing
- Ran `php -l` on all modified and newly added PHP files (all files reported no syntax errors).
- Attempted to run `vendor/bin/phpunit` but the PHPUnit binary is not available in this environment, so no test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f646dd0883268ec0b98c438a57f5)