### PR TITLE
Rendre le resume d'Applicant nullable et rendre la liste de candidatures null-safe

### DIFF
--- a/migrations/Version20260313110000.php
+++ b/migrations/Version20260313110000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260313110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Allow recruit applicant resume relation to be nullable.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE recruit_applicant CHANGE resume_id resume_id BINARY(16) DEFAULT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)"');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $rowsWithNullResume = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM recruit_applicant WHERE resume_id IS NULL');
+        $this->abortIf($rowsWithNullResume > 0, 'Cannot revert migration: recruit_applicant contains rows with NULL resume_id.');
+
+        $this->addSql('ALTER TABLE recruit_applicant CHANGE resume_id resume_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)"');
+    }
+}

--- a/src/Recruit/Application/Service/JobApplicationListService.php
+++ b/src/Recruit/Application/Service/JobApplicationListService.php
@@ -67,7 +67,7 @@ class JobApplicationListService
                         'email' => $applicantUser->getEmail(),
                     ],
                     'resume' => [
-                        'id' => $applicant->getResume()->getId(),
+                        'id' => $applicant->getResume()?->getId(),
                     ],
                 ],
             ];

--- a/src/Recruit/Domain/Entity/Applicant.php
+++ b/src/Recruit/Domain/Entity/Applicant.php
@@ -33,8 +33,8 @@ class Applicant implements EntityInterface
     private User $user;
 
     #[ORM\OneToOne(targetEntity: Resume::class, inversedBy: 'applicant', cascade: ['persist', 'remove'])]
-    #[ORM\JoinColumn(name: 'resume_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE', unique: true)]
-    private Resume $resume;
+    #[ORM\JoinColumn(name: 'resume_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE', unique: true)]
+    private ?Resume $resume = null;
 
     #[ORM\Column(name: 'cover_letter', type: Types::TEXT, options: [
         'default' => '',
@@ -66,11 +66,11 @@ class Applicant implements EntityInterface
 
         return $this;
     }
-    public function getResume(): Resume
+    public function getResume(): ?Resume
     {
         return $this->resume;
     }
-    public function setResume(Resume $resume): self
+    public function setResume(?Resume $resume): self
     {
         $this->resume = $resume;
 

--- a/src/Recruit/Transport/Controller/Api/V1/Application/JobApplicationListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/JobApplicationListController.php
@@ -33,7 +33,47 @@ class JobApplicationListController
             new OA\Parameter(name: 'jobSlug', description: 'Slug du job', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
         ],
         responses: [
-            new OA\Response(response: 200, description: 'Liste des candidatures du job.'),
+            new OA\Response(
+                response: 200,
+                description: 'Liste des candidatures du job.',
+                content: new OA\JsonContent(
+                    type: 'array',
+                    items: new OA\Items(
+                        type: 'object',
+                        properties: [
+                            new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                            new OA\Property(property: 'status', type: 'string'),
+                            new OA\Property(property: 'createdAt', type: 'string', format: 'date-time', nullable: true),
+                            new OA\Property(
+                                property: 'applicant',
+                                type: 'object',
+                                properties: [
+                                    new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                                    new OA\Property(property: 'coverLetter', type: 'string'),
+                                    new OA\Property(
+                                        property: 'user',
+                                        type: 'object',
+                                        properties: [
+                                            new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                                            new OA\Property(property: 'username', type: 'string', nullable: true),
+                                            new OA\Property(property: 'firstName', type: 'string', nullable: true),
+                                            new OA\Property(property: 'lastName', type: 'string', nullable: true),
+                                            new OA\Property(property: 'email', type: 'string', format: 'email', nullable: true),
+                                        ],
+                                    ),
+                                    new OA\Property(
+                                        property: 'resume',
+                                        type: 'object',
+                                        properties: [
+                                            new OA\Property(property: 'id', type: 'string', format: 'uuid', nullable: true),
+                                        ],
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ),
+            ),
             new OA\Response(response: 403, description: 'Vous n\'êtes pas propriétaire du job.'),
         ],
     )]

--- a/tests/Unit/Recruit/Application/Service/JobApplicationListServiceTest.php
+++ b/tests/Unit/Recruit/Application/Service/JobApplicationListServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Recruit\Application\Service;
+
+use App\Recruit\Application\Service\JobApplicationListService;
+use App\Recruit\Domain\Entity\Applicant;
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Infrastructure\Repository\JobRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class JobApplicationListServiceTest extends TestCase
+{
+    public function testGetListReturnsNullResumeIdWhenApplicantHasNoResume(): void
+    {
+        $loggedInUser = $this->createMock(User::class);
+        $owner = $this->createMock(User::class);
+        $job = $this->createMock(Job::class);
+        $application = $this->createMock(Application::class);
+        $applicant = $this->createMock(Applicant::class);
+        $applicantUser = $this->createMock(User::class);
+
+        $loggedInUser->method('getId')->willReturn('owner-id');
+        $owner->method('getId')->willReturn('owner-id');
+        $job->method('getOwner')->willReturn($owner);
+
+        $application->method('getId')->willReturn('application-id');
+        $application->method('getStatusValue')->willReturn('in_progress');
+        $application->method('getCreatedAt')->willReturn(null);
+        $application->method('getApplicant')->willReturn($applicant);
+
+        $applicant->method('getId')->willReturn('applicant-id');
+        $applicant->method('getCoverLetter')->willReturn('cover-letter');
+        $applicant->method('getUser')->willReturn($applicantUser);
+        $applicant->method('getResume')->willReturn(null);
+
+        $applicantUser->method('getId')->willReturn('user-id');
+        $applicantUser->method('getUsername')->willReturn('applicant-user');
+        $applicantUser->method('getFirstName')->willReturn('John');
+        $applicantUser->method('getLastName')->willReturn('Doe');
+        $applicantUser->method('getEmail')->willReturn('john@example.test');
+
+        $jobRepository = $this->createMock(JobRepository::class);
+        $jobRepository->method('find')->with('job-id')->willReturn($job);
+
+        $query = $this->createMock(AbstractQuery::class);
+        $query->method('getResult')->willReturn([$application]);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('innerJoin')->willReturnSelf();
+        $queryBuilder->method('addSelect')->willReturnSelf();
+        $queryBuilder->method('leftJoin')->willReturnSelf();
+        $queryBuilder->method('andWhere')->willReturnSelf();
+        $queryBuilder->method('setParameter')->willReturnSelf();
+        $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->method('addOrderBy')->willReturnSelf();
+        $queryBuilder->method('getQuery')->willReturn($query);
+
+        $repository = $this->createMock(EntityRepository::class);
+        $repository->method('createQueryBuilder')->with('application')->willReturn($queryBuilder);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->with(Application::class)->willReturn($repository);
+
+        $service = new JobApplicationListService($jobRepository, $entityManager);
+
+        $result = $service->getList($loggedInUser, 'job-id', null);
+
+        self::assertSame([
+            [
+                'id' => 'application-id',
+                'status' => 'in_progress',
+                'createdAt' => null,
+                'applicant' => [
+                    'id' => 'applicant-id',
+                    'coverLetter' => 'cover-letter',
+                    'user' => [
+                        'id' => 'user-id',
+                        'username' => 'applicant-user',
+                        'firstName' => 'John',
+                        'lastName' => 'Doe',
+                        'email' => 'john@example.test',
+                    ],
+                    'resume' => [
+                        'id' => null,
+                    ],
+                ],
+            ],
+        ], $result);
+    }
+}


### PR DESCRIPTION
### Motivation
- Eviter une erreur fatale lors du mapping des candidatures quand un applicant n'a pas de resume associé. 
- Aligner le modèle de domaine et la documentation OpenAPI avec le comportement nullable attendu pour `applicant.resume.id`.
- Prévenir les régressions en ajoutant un test couvrant un applicant sans resume.

### Description
- Remplacement de l'accès direct à `$applicant->getResume()->getId()` par l'accès null-safe `$applicant->getResume()?->getId()` dans `src/Recruit/Application/Service/JobApplicationListService.php`.
- Mise à jour de l'entité `Applicant` pour autoriser `resume` nullable (`JoinColumn nullable`, propriété `?Resume`, getter/setter acceptant `null`) dans `src/Recruit/Domain/Entity/Applicant.php`.
- Ajout d'une migration `migrations/Version20260313110000.php` qui rend la colonne `recruit_applicant.resume_id` nullable et protège le rollback si des lignes NULL existent.
- Enrichissement de la documentation OpenAPI du endpoint privé de listing (`JobApplicationListController`) pour documenter la réponse et marquer `applicant.resume.id` comme nullable.
- Ajout d'un test unitaire `tests/Unit/Recruit/Application/Service/JobApplicationListServiceTest.php` qui vérifie que la sortie contient `resume => ['id' => null]` quand l'applicant n'a pas de resume.

### Testing
- `php -l` a été exécuté et a validé la syntaxe pour `src/Recruit/Application/Service/JobApplicationListService.php`, `src/Recruit/Domain/Entity/Applicant.php`, `src/Recruit/Transport/Controller/Api/V1/Application/JobApplicationListController.php`, `tests/Unit/Recruit/Application/Service/JobApplicationListServiceTest.php` et `migrations/Version20260313110000.php` (tous réussis).
- Un test unitaire a été ajouté dans `tests/Unit/Recruit/Application/Service/JobApplicationListServiceTest.php` mais l'exécution via `vendor/bin/phpunit` n'a pas pu être réalisée car le binaire `phpunit` n'est pas disponible dans cet environnement.
- Création de la migration vérifiée par `php -l` et le `down()` inclut une vérification empêchant le revert si des enregistrements avec `NULL` existent (protection ajoutée).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f9bd99cc8326a13470429601cdcd)