### PR TITLE
Validate referenced entities for School create services

### DIFF
--- a/src/School/Application/Exception/SchoolRelationException.php
+++ b/src/School/Application/Exception/SchoolRelationException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Exception;
+
+use App\General\Application\Exception\Interfaces\ClientErrorInterface;
+use RuntimeException;
+
+final class SchoolRelationException extends RuntimeException implements ClientErrorInterface
+{
+    public function __construct(
+        string $message,
+        private readonly int $statusCode,
+    ) {
+        parent::__construct($message, $statusCode);
+    }
+
+    public static function notFound(string $reference): self
+    {
+        return new self($reference . ' not found', 404);
+    }
+
+    public static function unprocessable(string $message): self
+    {
+        return new self($message, 422);
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+}
+

--- a/src/School/Application/Service/CreateClassService.php
+++ b/src/School/Application/Service/CreateClassService.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityCreated;
+use App\School\Application\Exception\SchoolRelationException;
 use App\School\Domain\Entity\SchoolClass;
+use App\School\Domain\Entity\School;
 use App\School\Infrastructure\Repository\SchoolRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -21,10 +23,17 @@ final readonly class CreateClassService
 
     public function create(string $name, ?string $schoolId): SchoolClass
     {
-        $class = (new SchoolClass())->setName($name);
-        if (is_string($schoolId)) {
-            $class->setSchool($this->schoolRepository->find($schoolId));
+        if (!is_string($schoolId)) {
+            throw SchoolRelationException::unprocessable('schoolId is required');
         }
+
+        $school = $this->schoolRepository->find($schoolId);
+        if (!$school instanceof School) {
+            throw SchoolRelationException::notFound('schoolId');
+        }
+
+        $class = (new SchoolClass())->setName($name);
+        $class->setSchool($school);
 
         $this->entityManager->persist($class);
         $this->entityManager->flush();

--- a/src/School/Application/Service/CreateExamService.php
+++ b/src/School/Application/Service/CreateExamService.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityCreated;
+use App\School\Application\Exception\SchoolRelationException;
 use App\School\Domain\Entity\Exam;
+use App\School\Domain\Entity\SchoolClass;
+use App\School\Domain\Entity\Teacher;
 use App\School\Domain\Enum\ExamStatus;
 use App\School\Domain\Enum\ExamType;
 use App\School\Domain\Enum\Term;
@@ -32,18 +35,35 @@ final readonly class CreateExamService
         ExamStatus $status,
         Term $term,
     ): Exam {
+        if (!is_string($classId)) {
+            throw SchoolRelationException::unprocessable('classId is required');
+        }
+
+        if (!is_string($teacherId)) {
+            throw SchoolRelationException::unprocessable('teacherId is required');
+        }
+
+        $class = $this->classRepository->find($classId);
+        if (!$class instanceof SchoolClass) {
+            throw SchoolRelationException::notFound('classId');
+        }
+
+        $teacher = $this->teacherRepository->find($teacherId);
+        if (!$teacher instanceof Teacher) {
+            throw SchoolRelationException::notFound('teacherId');
+        }
+
+        if (!$teacher->getClasses()->contains($class)) {
+            throw SchoolRelationException::unprocessable('teacherId is not assigned to classId');
+        }
+
         $exam = (new Exam())
             ->setTitle($title)
             ->setType($type)
             ->setStatus($status)
-            ->setTerm($term);
-
-        if (is_string($classId)) {
-            $exam->setSchoolClass($this->classRepository->find($classId));
-        }
-        if (is_string($teacherId)) {
-            $exam->setTeacher($this->teacherRepository->find($teacherId));
-        }
+            ->setTerm($term)
+            ->setSchoolClass($class)
+            ->setTeacher($teacher);
 
         $this->entityManager->persist($exam);
         $this->entityManager->flush();

--- a/src/School/Application/Service/CreateGradeService.php
+++ b/src/School/Application/Service/CreateGradeService.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityCreated;
+use App\School\Application\Exception\SchoolRelationException;
+use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\Grade;
+use App\School\Domain\Entity\Student;
 use App\School\Infrastructure\Repository\ExamRepository;
 use App\School\Infrastructure\Repository\StudentRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -23,13 +26,31 @@ final readonly class CreateGradeService
 
     public function create(float $score, ?string $studentId, ?string $examId): Grade
     {
+        if (!is_string($studentId)) {
+            throw SchoolRelationException::unprocessable('studentId is required');
+        }
+
+        if (!is_string($examId)) {
+            throw SchoolRelationException::unprocessable('examId is required');
+        }
+
+        $student = $this->studentRepository->find($studentId);
+        if (!$student instanceof Student) {
+            throw SchoolRelationException::notFound('studentId');
+        }
+
+        $exam = $this->examRepository->find($examId);
+        if (!$exam instanceof Exam) {
+            throw SchoolRelationException::notFound('examId');
+        }
+
+        if ($student->getSchoolClass()?->getId() !== $exam->getSchoolClass()?->getId()) {
+            throw SchoolRelationException::unprocessable('studentId and examId must belong to the same class');
+        }
+
         $grade = (new Grade())->setScore($score);
-        if (is_string($studentId)) {
-            $grade->setStudent($this->studentRepository->find($studentId));
-        }
-        if (is_string($examId)) {
-            $grade->setExam($this->examRepository->find($examId));
-        }
+        $grade->setStudent($student);
+        $grade->setExam($exam);
 
         $this->entityManager->persist($grade);
         $this->entityManager->flush();

--- a/src/School/Application/Service/CreateStudentService.php
+++ b/src/School/Application/Service/CreateStudentService.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityCreated;
+use App\School\Application\Exception\SchoolRelationException;
+use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Student;
 use App\School\Infrastructure\Repository\SchoolClassRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -21,10 +23,17 @@ final readonly class CreateStudentService
 
     public function create(string $name, ?string $classId): Student
     {
-        $student = (new Student())->setName($name);
-        if (is_string($classId)) {
-            $student->setSchoolClass($this->classRepository->find($classId));
+        if (!is_string($classId)) {
+            throw SchoolRelationException::unprocessable('classId is required');
         }
+
+        $class = $this->classRepository->find($classId);
+        if (!$class instanceof SchoolClass) {
+            throw SchoolRelationException::notFound('classId');
+        }
+
+        $student = (new Student())->setName($name);
+        $student->setSchoolClass($class);
 
         $this->entityManager->persist($student);
         $this->entityManager->flush();

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolCreateReferenceValidationTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolCreateReferenceValidationTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\School\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
+
+final class SchoolCreateReferenceValidationTest extends WebTestCase
+{
+    private const string UNKNOWN_UUID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+    #[TestDox('School create endpoints reject missing references with stable 404 messages.')]
+    public function testCreateEndpointsRejectUnknownReferences(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/classes', [], [], [], JSON::encode([
+            'name' => 'Classe invalide',
+            'schoolId' => self::UNKNOWN_UUID,
+        ]));
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        self::assertSame('schoolId not found', $this->responsePayload($client)['message']);
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/students', [], [], [], JSON::encode([
+            'name' => 'Eleve API',
+            'classId' => self::UNKNOWN_UUID,
+        ]));
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        self::assertSame('classId not found', $this->responsePayload($client)['message']);
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams', [], [], [], JSON::encode([
+            'title' => 'Examen API',
+            'classId' => self::UNKNOWN_UUID,
+            'teacherId' => self::UNKNOWN_UUID,
+            'type' => 'quiz',
+            'status' => 'draft',
+            'term' => 'term_1',
+        ]));
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        self::assertSame('classId not found', $this->responsePayload($client)['message']);
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/grades', [], [], [], JSON::encode([
+            'score' => 12,
+            'studentId' => self::UNKNOWN_UUID,
+            'examId' => self::UNKNOWN_UUID,
+        ]));
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        self::assertSame('studentId not found', $this->responsePayload($client)['message']);
+    }
+
+    #[TestDox('School create endpoints reject cross-scope relations with stable 422 messages.')]
+    public function testCreateEndpointsRejectCrossScopeRelations(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $campusClassId = $this->firstResourceId($client, '/v1/school/applications/school-campus-core/classes');
+        $courseTeacherId = $this->firstResourceId($client, '/v1/school/applications/school-course-flow/teachers');
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams', [], [], [], JSON::encode([
+            'title' => 'Examen incoherent',
+            'classId' => $campusClassId,
+            'teacherId' => $courseTeacherId,
+            'type' => 'quiz',
+            'status' => 'draft',
+            'term' => 'term_1',
+        ]));
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+        self::assertSame('teacherId is not assigned to classId', $this->responsePayload($client)['message']);
+
+        $campusStudentId = $this->firstResourceId($client, '/v1/school/applications/school-campus-core/students');
+        $courseExamId = $this->firstResourceId($client, '/v1/school/applications/school-course-flow/exams');
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/grades', [], [], [], JSON::encode([
+            'score' => 14,
+            'studentId' => $campusStudentId,
+            'examId' => $courseExamId,
+        ]));
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+        self::assertSame('studentId and examId must belong to the same class', $this->responsePayload($client)['message']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function responsePayload(KernelBrowser $client): array
+    {
+        return JSON::decode((string)$client->getResponse()->getContent(), true);
+    }
+
+    private function firstResourceId(KernelBrowser $client, string $path): string
+    {
+        $client->request('GET', self::API_URL_PREFIX . $path);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        /** @var array{items: array<int, array{id: string}>} $payload */
+        $payload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        return $payload['items'][0]['id'];
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent creation of entities with missing or inconsistent relations by validating referenced IDs and enforcing cross-scope business rules so API clients receive stable, actionable errors.

### Description

- Added `SchoolRelationException` implementing `ClientErrorInterface` to represent controlled 404/422 business errors and be serialized by the global JSON exception handler.
- Updated `CreateClassService` to require and validate `schoolId` and to throw `schoolId not found` or `schoolId is required` when appropriate.
- Updated `CreateStudentService` to require and validate `classId` and to throw `classId not found` or `classId is required` when appropriate.
- Updated `CreateExamService` to require and validate `classId` and `teacherId`, and to enforce that the teacher is assigned to the target class (throws `teacherId is not assigned to classId`).
- Updated `CreateGradeService` to require and validate `studentId` and `examId`, and to enforce that the student and exam belong to the same class (throws `studentId and examId must belong to the same class`).
- Added API regression tests in `tests/Application/School/Transport/Controller/Api/V1/SchoolCreateReferenceValidationTest.php` covering missing referenced IDs (`404` + stable message) and incoherent relations (`422` + stable message).

### Testing

- Ran PHP syntax checks with `php -l` on changed services, exception and test file which all returned no syntax errors.
- Attempted to run the new API test file with `./vendor/bin/phpunit tests/Application/School/Transport/Controller/Api/V1/SchoolCreateReferenceValidationTest.php` but the environment lacked project dependencies so PHPUnit could not be executed (`./vendor/bin/phpunit: No such file or directory`).
- All modifications were committed locally after verification of syntax and test file addition.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3f9b721d08326855ba0547575d6e6)