### PR TITLE
test: mock CacheKeyConventionService in EventListService unit tests

### DIFF
--- a/tests/Unit/Calendar/Application/Service/EventListServiceTest.php
+++ b/tests/Unit/Calendar/Application/Service/EventListServiceTest.php
@@ -9,6 +9,7 @@ use App\Calendar\Domain\Repository\Interfaces\EventRepositoryInterface;
 use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\User\Domain\Entity\User;
+use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -17,6 +18,7 @@ final class EventListServiceTest extends TestCase
 {
     public function testGetByUserReturnsCacheHitWithoutRepositoryCall(): void
     {
+        $user = $this->mockUser();
         $repo = $this->createMock(EventRepositoryInterface::class);
         $repo->expects(self::never())->method('findByUser');
 
@@ -34,8 +36,9 @@ final class EventListServiceTest extends TestCase
                 ],
             ]);
 
-        $service = new EventListService($repo, $cache, $elastic, $this->cacheKeyConventionService());
-        $result = $service->getByUser($this->mockUser(), [
+        $cacheKeyConvention = $this->cacheKeyConventionService($user);
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class));
+        $result = $service->getByUser($user, [
             'title' => 'foo',
         ], 1, 20);
 
@@ -46,6 +49,7 @@ final class EventListServiceTest extends TestCase
 
     public function testGetByUserCacheMissCallsRepository(): void
     {
+        $user = $this->mockUser();
         $repo = $this->createMock(EventRepositoryInterface::class);
         $repo->expects(self::once())->method('findByUser')->willReturn([]);
         $repo->expects(self::once())->method('countByUser')->willReturn(0);
@@ -69,8 +73,9 @@ final class EventListServiceTest extends TestCase
             return $callback($item);
         });
 
-        $service = new EventListService($repo, $cache, $elastic, $this->cacheKeyConventionService());
-        $result = $service->getByUser($this->mockUser(), [
+        $cacheKeyConvention = $this->cacheKeyConventionService($user);
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class));
+        $result = $service->getByUser($user, [
             'title' => 'foo',
         ], 1, 20);
 
@@ -79,6 +84,7 @@ final class EventListServiceTest extends TestCase
 
     public function testGetByUserFallsBackToDatabaseWhenElasticThrows(): void
     {
+        $user = $this->mockUser();
         $repo = $this->createMock(EventRepositoryInterface::class);
         $repo->expects(self::once())->method('findByUser')->with(self::anything(), self::anything(), 1, 20, null)->willReturn([]);
         $repo->expects(self::once())->method('countByUser')->with(self::anything(), self::anything(), null)->willReturn(0);
@@ -94,8 +100,9 @@ final class EventListServiceTest extends TestCase
             return $callback($item);
         });
 
-        $service = new EventListService($repo, $cache, $elastic, $this->cacheKeyConventionService());
-        $result = $service->getByUser($this->mockUser(), [
+        $cacheKeyConvention = $this->cacheKeyConventionService($user);
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class));
+        $result = $service->getByUser($user, [
             'title' => 'foo',
         ], 1, 20);
 
@@ -104,6 +111,7 @@ final class EventListServiceTest extends TestCase
 
     public function testGetByUserFallsBackToDatabaseWhenElasticReturnsMoreThan1000Hits(): void
     {
+        $user = $this->mockUser();
         $repo = $this->createMock(EventRepositoryInterface::class);
         $repo->expects(self::once())->method('findByUser')->with(self::anything(), self::anything(), 2, 20, null)->willReturn([]);
         $repo->expects(self::once())->method('countByUser')->with(self::anything(), self::anything(), null)->willReturn(1450);
@@ -133,8 +141,9 @@ final class EventListServiceTest extends TestCase
             return $callback($item);
         });
 
-        $service = new EventListService($repo, $cache, $elastic, $this->cacheKeyConventionService());
-        $result = $service->getByUser($this->mockUser(), [
+        $cacheKeyConvention = $this->cacheKeyConventionService($user);
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class));
+        $result = $service->getByUser($user, [
             'title' => 'foo',
         ], 2, 20);
 
@@ -154,8 +163,25 @@ final class EventListServiceTest extends TestCase
         return $user;
     }
 
-    private function cacheKeyConventionService(): CacheKeyConventionService
+    private function cacheKeyConventionService(User $user): CacheKeyConventionService
     {
-        return new CacheKeyConventionService();
+        $cacheKeyConventionService = $this->createMock(CacheKeyConventionService::class);
+        $cacheKeyConventionService->expects(self::once())
+            ->method('buildPrivateEventKey')
+            ->with(
+                $user->getUsername(),
+                self::callback(static function (array $payload): bool {
+                    return isset($payload['accessContext'], $payload['userId'], $payload['filters'])
+                        && $payload['accessContext'] === 'user'
+                        && $payload['userId'] === 'user-id'
+                        && ($payload['filters']['title'] ?? null) === 'foo';
+                }),
+            )
+            ->willReturn('private_event_key');
+
+        $cacheKeyConventionService->expects(self::never())->method('tagPrivateEvents');
+        $cacheKeyConventionService->expects(self::never())->method('tagPublicEventsByApplication');
+
+        return $cacheKeyConventionService;
     }
 }


### PR DESCRIPTION
### Motivation

- Les tests de `EventListService` devaient suivre la nouvelle signature du service qui attend désormais un `CacheKeyConventionService` et un `LoggerInterface` en plus des dépendances existantes.
- Il fallait vérifier explicitement la génération de la clé cache privée et éviter les assertions incorrectes autour des tags lorsque le cache n’est pas tag-aware.

### Description

- Mise à jour de `tests/Unit/Calendar/Application/Service/EventListServiceTest.php` pour injecter un mock de `CacheKeyConventionService` et un mock de `LoggerInterface` lors de la construction de `EventListService`.
- Ajout de la méthode helper `cacheKeyConventionService(User $user)` qui mocke `buildPrivateEventKey(...)` et retourne une clé contrôlée (`private_event_key`).
- Ajout d’expectations explicites pour s’assurer que `tagPrivateEvents` et `tagPublicEventsByApplication` ne sont pas appelées dans ces scénarios avec `CacheInterface`.
- Adaptation des appels de tests pour passer l’objet `User` mocké au lieu de recréer l’utilisateur inline.

### Testing

- `php -l tests/Unit/Calendar/Application/Service/EventListServiceTest.php` a réussi et n’a trouvé aucune erreur de syntaxe.
- Tentative d’exécution de la suite via `vendor/bin/phpunit tests/Unit/Calendar/Application/Service/EventListServiceTest.php` a échoué car le binaire `phpunit` n’est pas présent dans l’environnement (idem pour `php bin/phpunit`).
- Recherche des autres instanciations de `EventListService` dans `tests/Unit/Calendar` avec `rg "new EventListService\(|EventListService::class"` a confirmé qu’il n’y avait pas d’autres tests à adapter dans ce module.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fb91a49c8326b3782a90f2a651b9)