### PR TITLE
Renforce l'intégrité des réactions blog et la gestion des doublons

### DIFF
--- a/migrations/Version20260313130000.php
+++ b/migrations/Version20260313130000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260313130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Strengthen blog reaction integrity with unique and target constraints.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE UNIQUE INDEX uniq_blog_reaction_author_comment ON blog_reaction (author_id, comment_id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_blog_reaction_author_post ON blog_reaction (author_id, post_id)');
+        $this->addSql('ALTER TABLE blog_reaction ADD CONSTRAINT chk_blog_reaction_exactly_one_target CHECK ((comment_id IS NOT NULL AND post_id IS NULL) OR (comment_id IS NULL AND post_id IS NOT NULL))');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE blog_reaction DROP CHECK chk_blog_reaction_exactly_one_target');
+        $this->addSql('DROP INDEX uniq_blog_reaction_author_comment ON blog_reaction');
+        $this->addSql('DROP INDEX uniq_blog_reaction_author_post ON blog_reaction');
+    }
+}

--- a/src/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandler.php
@@ -13,6 +13,7 @@ use App\Blog\Infrastructure\Repository\BlogReactionRepository;
 use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -59,7 +60,31 @@ final readonly class CreateBlogPostReactionCommandHandler
             ->setAuthor($user)
             ->setType($command->type);
 
-        $this->reactionRepository->save($reaction);
+        try {
+            $this->reactionRepository->save($reaction);
+        } catch (UniqueConstraintViolationException) {
+            $this->reactionRepository->getEntityManager()->clear();
+
+            $post = $this->postRepository->find($command->postId);
+            $user = $this->userRepository->find($command->actorUserId);
+
+            if (!$post instanceof BlogPost || !$user instanceof User) {
+                throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found.');
+            }
+
+            $existingReaction = $this->reactionRepository->findOneByPostAndAuthor($post, $user);
+
+            if (!$existingReaction instanceof BlogReaction) {
+                throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Unable to create blog reaction.');
+            }
+
+            $existingReaction->setType($command->type);
+            $this->reactionRepository->save($existingReaction);
+
+            $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
+
+            return $existingReaction->getId();
+        }
 
         $this->blogNotificationService->notifyPostReactionCreated($post, $user, $command->type->value);
         $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $affectedUserIds);

--- a/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
@@ -13,6 +13,7 @@ use App\Blog\Infrastructure\Repository\BlogReactionRepository;
 use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -61,7 +62,31 @@ final readonly class CreateBlogReactionCommandHandler
             ->setAuthor($user)
             ->setType($command->type);
 
-        $this->reactionRepository->save($reaction);
+        try {
+            $this->reactionRepository->save($reaction);
+        } catch (UniqueConstraintViolationException) {
+            $this->reactionRepository->getEntityManager()->clear();
+
+            $comment = $this->commentRepository->find($command->commentId);
+            $user = $this->userRepository->find($command->actorUserId);
+
+            if (!$comment instanceof BlogComment || !$user instanceof User) {
+                throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found.');
+            }
+
+            $existingReaction = $this->reactionRepository->findOneByCommentAndAuthor($comment, $user);
+
+            if (!$existingReaction instanceof BlogReaction) {
+                throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Unable to create blog reaction.');
+            }
+
+            $existingReaction->setType($command->type);
+            $this->reactionRepository->save($existingReaction);
+
+            $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
+
+            return $existingReaction->getId();
+        }
 
         $this->blogNotificationService->notifyReactionCreated($comment, $user, $command->type->value);
         $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $affectedUserIds);

--- a/src/Blog/Domain/Entity/BlogReaction.php
+++ b/src/Blog/Domain/Entity/BlogReaction.php
@@ -9,13 +9,21 @@ use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
 use App\User\Domain\Entity\User;
+use DomainException;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
 
 #[ORM\Entity]
-#[ORM\Table(name: 'blog_reaction')]
+#[ORM\Table(
+    name: 'blog_reaction',
+    uniqueConstraints: [
+        new ORM\UniqueConstraint(name: 'uniq_blog_reaction_author_comment', columns: ['author_id', 'comment_id']),
+        new ORM\UniqueConstraint(name: 'uniq_blog_reaction_author_post', columns: ['author_id', 'post_id']),
+    ],
+)]
+#[ORM\HasLifecycleCallbacks]
 class BlogReaction implements EntityInterface
 {
     use Timestampable;
@@ -56,6 +64,7 @@ class BlogReaction implements EntityInterface
     {
         $this->comment = $comment;
         $this->post = null;
+        $this->assertSingleTarget();
 
         return $this;
     }
@@ -71,6 +80,7 @@ class BlogReaction implements EntityInterface
     {
         $this->post = $post;
         $this->comment = null;
+        $this->assertSingleTarget();
 
         return $this;
     }
@@ -93,5 +103,19 @@ class BlogReaction implements EntityInterface
         $this->type = $type;
 
         return $this;
+    }
+
+    #[ORM\PrePersist]
+    #[ORM\PreUpdate]
+    public function validateTargetIntegrity(): void
+    {
+        $this->assertSingleTarget();
+    }
+
+    private function assertSingleTarget(): void
+    {
+        if (($this->comment === null) === ($this->post === null)) {
+            throw new DomainException('A blog reaction must target either a comment or a post.');
+        }
     }
 }

--- a/tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php
+++ b/tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php
@@ -6,6 +6,8 @@ namespace App\Tests\Application\Blog\Transport\Controller\Api\V1;
 
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Enum\BlogVisibility;
+use App\Blog\Infrastructure\Repository\BlogCommentRepository;
+use App\Blog\Infrastructure\Repository\BlogReactionRepository;
 use App\Tests\TestCase\WebTestCase;
 use App\User\Infrastructure\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -204,6 +206,64 @@ final class BlogControllerTest extends WebTestCase
 
         self::assertCount(1, $johnUserReactionTypes);
         self::assertSame('laugh', $johnUserReactionTypes[0]);
+    }
+
+    public function testCreateReactionDoubleSubmissionKeepsSingleDatabaseRow(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request(Request::METHOD_GET, self::API_URL_PREFIX . '/v1/blog/shop-ops-center/feed');
+        self::assertResponseStatusCodeSame(200);
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $targetCommentId = self::findFirstCommentId($payload);
+        self::assertNotNull($targetCommentId);
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/private/blog/comments/' . $targetCommentId . '/reactions',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'type' => 'heart',
+            ], JSON_THROW_ON_ERROR),
+        );
+        self::assertResponseStatusCodeSame(202);
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/private/blog/comments/' . $targetCommentId . '/reactions',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'type' => 'laugh',
+            ], JSON_THROW_ON_ERROR),
+        );
+        self::assertResponseStatusCodeSame(202);
+
+        /** @var UserRepository $userRepository */
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $johnUser = $userRepository->findOneBy([
+            'username' => 'john-user',
+        ]);
+        self::assertNotNull($johnUser);
+
+        /** @var BlogCommentRepository $commentRepository */
+        $commentRepository = static::getContainer()->get(BlogCommentRepository::class);
+        $comment = $commentRepository->find($targetCommentId);
+        self::assertNotNull($comment);
+
+        /** @var BlogReactionRepository $reactionRepository */
+        $reactionRepository = static::getContainer()->get(BlogReactionRepository::class);
+        $reactions = $reactionRepository->findBy([
+            'comment' => $comment,
+            'author' => $johnUser,
+        ]);
+
+        self::assertCount(1, $reactions);
     }
 
 


### PR DESCRIPTION
### Motivation
- Empêcher des réactions en doublon d’un même auteur sur une même cible et garantir qu’une réaction cible exactement un commentaire ou un post.
- Gérer proprement les courses concurrentes / double-soumission lors de la création de réactions pour éviter les erreurs d’unicité et maintenir un état cohérent.

### Description
- Ajout de contraintes d’unicité Doctrine sur l’entité `BlogReaction` via `#[ORM\Table(... uniqueConstraints ...)]` pour (`author_id`, `comment_id`) et (`author_id`, `post_id`) et ajout d’un `#[ORM\HasLifecycleCallbacks]` avec validation `PrePersist/PreUpdate` (méthode `assertSingleTarget`) pour garantir une cible unique applicative dans `src/Blog/Domain/Entity/BlogReaction.php`.
- Ajout d’une migration `migrations/Version20260313130000.php` qui crée les deux index uniques et ajoute une check constraint SQL `chk_blog_reaction_exactly_one_target` pour garantir au niveau base que la réaction vise soit un commentaire soit un post.
- Durcissement des handlers `CreateBlogReactionCommandHandler` et `CreateBlogPostReactionCommandHandler` pour attraper `UniqueConstraintViolationException`, faire `EntityManager::clear()`, re-fetch des entités et effectuer un `update` sur la réaction existante (upsert soft) afin de résoudre les races de création.
- Ajout d’un test fonctionnel `testCreateReactionDoubleSubmissionKeepsSingleDatabaseRow` dans `tests/Application/Blog/Transport/Controller/Api/V1/BlogControllerTest.php` qui simule deux POST consécutifs et vérifie qu’une seule ligne existe en base pour le couple (commentaire, auteur).

### Testing
- Vérification de la syntaxe PHP des fichiers modifiés avec `php -l` (tous les fichiers modifiés n’ont pas d’erreur de syntaxe). ✅
- Tentative d’exécution de tests PHPUnit ciblés échouée car `vendor/bin/phpunit` est absent dans cet environnement de build, donc les tests fonctionnels n’ont pas pu être lancés ici. ⚠️
- Les changements ont été commités localement et incluent la nouvelle migration `migrations/Version20260313130000.php` prête à être exécutée en CI / en environnement avec les binaires de test disponibles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fb8d92e483268d1415eeb424f101)