### PR TITLE
refactor(chat): use ConversationParticipant lastReadMessageAt for read status

### DIFF
--- a/src/Chat/Application/MessageHandler/MarkConversationMessagesAsReadCommandHandler.php
+++ b/src/Chat/Application/MessageHandler/MarkConversationMessagesAsReadCommandHandler.php
@@ -7,7 +7,6 @@ namespace App\Chat\Application\MessageHandler;
 use App\Chat\Application\Message\MarkConversationMessagesAsReadCommand;
 use App\Chat\Domain\Entity\Conversation;
 use App\Chat\Domain\Entity\ConversationParticipant;
-use App\Chat\Infrastructure\Repository\ChatMessageRepository;
 use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
 use App\Chat\Infrastructure\Repository\ConversationRepository;
 use App\General\Application\Service\CacheInvalidationService;
@@ -21,7 +20,6 @@ final readonly class MarkConversationMessagesAsReadCommandHandler
     public function __construct(
         private ConversationRepository $conversationRepository,
         private ConversationParticipantRepository $participantRepository,
-        private ChatMessageRepository $messageRepository,
         private CacheInvalidationService $cacheInvalidationService,
     ) {
     }
@@ -30,13 +28,9 @@ final readonly class MarkConversationMessagesAsReadCommandHandler
     {
         [$conversation, $participant] = $this->findParticipantConversation($command->conversationId, $command->actorUserId);
 
-        $updated = $this->messageRepository->markConversationMessagesAsRead($conversation->getId(), $command->actorUserId);
         $participant->setLastReadMessageAt(new \DateTimeImmutable());
         $this->participantRepository->save($participant);
-
-        if ($updated > 0) {
-            $this->cacheInvalidationService->invalidateConversationCaches($conversation->getChat()->getId(), $command->actorUserId);
-        }
+        $this->cacheInvalidationService->invalidateConversationCaches($conversation->getChat()->getId(), $command->actorUserId);
     }
 
     /**

--- a/src/Chat/Infrastructure/Repository/ChatMessageRepository.php
+++ b/src/Chat/Infrastructure/Repository/ChatMessageRepository.php
@@ -23,23 +23,4 @@ class ChatMessageRepository extends BaseRepository
         protected ManagerRegistry $managerRegistry
     ) {
     }
-
-    public function markConversationMessagesAsRead(string $conversationId, string $actorUserId): int
-    {
-        return $this->getEntityManager()->createQueryBuilder()
-            ->update(Entity::class, 'm')
-            ->set('m.read', ':read')
-            ->set('m.readAt', ':readAt')
-            ->where('m.conversation = :conversationId')
-            ->andWhere('m.sender != :actorUserId')
-            ->andWhere('m.deletedAt IS NULL')
-            ->andWhere('m.read = :unread')
-            ->setParameter('read', true)
-            ->setParameter('unread', false)
-            ->setParameter('readAt', new \DateTimeImmutable())
-            ->setParameter('conversationId', $conversationId)
-            ->setParameter('actorUserId', $actorUserId)
-            ->getQuery()
-            ->execute();
-    }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Message/ListConversationMessagesController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/ListConversationMessagesController.php
@@ -41,11 +41,21 @@ class ListConversationMessagesController
     public function __invoke(string $conversationId, User $loggedInUser): JsonResponse
     {
         $conversation = $this->chatAccessResolverService->resolveParticipantConversation($conversationId, $loggedInUser);
+        $lastReadMessageAt = null;
+        foreach ($conversation->getParticipants() as $participant) {
+            if ($participant->getUser()->getId() === $loggedInUser->getId()) {
+                $lastReadMessageAt = $participant->getLastReadMessageAt();
+                break;
+            }
+        }
 
         $items = [];
         foreach ($conversation->getMessages()->toArray() as $message) {
             $sender = $message->getSender();
             $senderId = $sender->getId();
+
+            $isOwner = $senderId === $loggedInUser->getId();
+            $isRead = $isOwner || ($lastReadMessageAt !== null && $message->getCreatedAt() !== null && $message->getCreatedAt() <= $lastReadMessageAt);
 
             $items[] = [
                 'id' => $message->getId(),
@@ -55,11 +65,11 @@ class ListConversationMessagesController
                     'firstName' => $sender->getFirstName(),
                     'lastName' => $sender->getLastName(),
                     'photo' => $sender->getPhoto(),
-                    'owner' => $senderId === $loggedInUser->getId(),
+                    'owner' => $isOwner,
                 ],
                 'attachments' => $message->getAttachments(),
-                'read' => $message->isRead(),
-                'readAt' => $message->getReadAt()?->format(DATE_ATOM),
+                'read' => $isRead,
+                'readAt' => $isRead && !$isOwner ? $lastReadMessageAt?->format(DATE_ATOM) : null,
                 'createdAt' => $message->getCreatedAt()?->format(DATE_ATOM),
             ];
         }

--- a/tests/Unit/Chat/Application/MessageHandler/MessageHandlersTest.php
+++ b/tests/Unit/Chat/Application/MessageHandler/MessageHandlersTest.php
@@ -96,11 +96,10 @@ final class MessageHandlersTest extends TestCase
         self::assertNull($message->getReadAt());
     }
 
-    public function testMarkConversationMessagesAsReadInvalidatesCacheOnlyWhenMessagesWereUpdated(): void
+    public function testMarkConversationMessagesAsReadUpdatesParticipantReadPointerAndInvalidatesCache(): void
     {
         $conversationRepo = $this->createMock(ConversationRepository::class);
         $participantRepo = $this->createMock(ConversationParticipantRepository::class);
-        $messageRepo = $this->createMock(ChatMessageRepository::class);
         $cache = $this->createMock(CacheInvalidationService::class);
 
         $actor = $this->makeUser('20000000-0000-1000-8000-000000000006');
@@ -111,13 +110,9 @@ final class MessageHandlersTest extends TestCase
         $participantRepo->method('findOneBy')->willReturn($participant);
         $participantRepo->expects(self::exactly(2))->method('save');
 
-        $messageRepo->expects(self::exactly(2))->method('markConversationMessagesAsRead')
-            ->with($conversation->getId(), $actor->getId())
-            ->willReturnOnConsecutiveCalls(0, 2);
+        $cache->expects(self::exactly(2))->method('invalidateConversationCaches')->with($conversation->getChat()->getId(), $actor->getId());
 
-        $cache->expects(self::once())->method('invalidateConversationCaches')->with($conversation->getChat()->getId(), $actor->getId());
-
-        $handler = new MarkConversationMessagesAsReadCommandHandler($conversationRepo, $participantRepo, $messageRepo, $cache);
+        $handler = new MarkConversationMessagesAsReadCommandHandler($conversationRepo, $participantRepo, $cache);
 
         $handler(new MarkConversationMessagesAsReadCommand('op-1', $actor->getId(), $conversation->getId()));
         $firstReadAt = $participant->getLastReadMessageAt();

--- a/tests/Unit/Chat/Application/Service/ConversationListServiceTest.php
+++ b/tests/Unit/Chat/Application/Service/ConversationListServiceTest.php
@@ -113,17 +113,24 @@ final class ConversationListServiceTest extends TestCase
         $sender->method('getLastName')->willReturn('User');
         $sender->method('getPhoto')->willReturn(null);
 
+        $readMessage = $this->createMock(ChatMessage::class);
+        $readMessage->method('getId')->willReturn('message-read-id');
+        $readMessage->method('getContent')->willReturn('older message');
+        $readMessage->method('getSender')->willReturn($sender);
+        $readMessage->method('getDeletedAt')->willReturn(null);
+        $readMessage->method('getCreatedAt')->willReturn(new \DateTimeImmutable('2024-01-01T10:00:00+00:00'));
+
         $message = $this->createMock(ChatMessage::class);
         $message->method('getId')->willReturn('message-id');
         $message->method('getContent')->willReturn(str_repeat('hello', 80));
         $message->method('getSender')->willReturn($sender);
         $message->method('getDeletedAt')->willReturn(null);
-        $message->method('getCreatedAt')->willReturn(new \DateTimeImmutable('2024-01-01T10:00:00+00:00'));
+        $message->method('getCreatedAt')->willReturn(new \DateTimeImmutable('2024-01-01T12:00:00+00:00'));
 
         $participant = $this->createMock(ConversationParticipant::class);
         $participant->method('getUser')->willReturn($connectedUser);
         $participant->method('getId')->willReturn('participant-id');
-        $participant->method('getLastReadMessageAt')->willReturn(null);
+        $participant->method('getLastReadMessageAt')->willReturn(new \DateTimeImmutable('2024-01-01T11:00:00+00:00'));
 
         $conversation = $this->createMock(Conversation::class);
         $conversation->method('getId')->willReturn('conversation-id');
@@ -131,7 +138,7 @@ final class ConversationListServiceTest extends TestCase
         $conversation->method('getType')->willReturn(ConversationType::DIRECT);
         $conversation->method('getTitle')->willReturn('Conversation');
         $conversation->method('getParticipants')->willReturn(new ArrayCollection([$participant]));
-        $conversation->method('getMessages')->willReturn(new ArrayCollection([$message]));
+        $conversation->method('getMessages')->willReturn(new ArrayCollection([$readMessage, $message]));
         $conversation->method('getLastMessageAt')->willReturn(null);
         $conversation->method('getArchivedAt')->willReturn(null);
         $conversation->method('getCreatedAt')->willReturn(new \DateTimeImmutable('2024-01-01T00:00:00+00:00'));
@@ -163,7 +170,8 @@ final class ConversationListServiceTest extends TestCase
         self::assertSame('message-id', $result['items'][0]['lastMessage']['id']);
         self::assertSame(280, mb_strlen($result['items'][0]['lastMessage']['content']));
         self::assertSame('sender-id', $result['items'][0]['lastMessage']['sender']['id']);
-        self::assertSame('2024-01-01T10:00:00+00:00', $result['items'][0]['lastMessage']['createdAt']);
+        self::assertSame('2024-01-01T12:00:00+00:00', $result['items'][0]['lastMessage']['createdAt']);
+        self::assertSame(1, $result['items'][0]['unreadMessagesCount']);
     }
 
     private function mockUser(): User


### PR DESCRIPTION
### Motivation
- Centralize the conversation "read" status on the participant level by using `ConversationParticipant.lastReadMessageAt` as the source of truth instead of per-message `ChatMessage.read/readAt` values.
- Simplify handlers and projections so read state is always computed for the current participant and avoid global message updates that do not reflect per-user read pointers.

### Description
- Changed `MarkConversationMessagesAsReadCommandHandler` to update only the participant pointer via `ConversationParticipant::setLastReadMessageAt()` and always invalidate the conversation cache for the actor instead of updating message rows. (`src/Chat/Application/MessageHandler/MarkConversationMessagesAsReadCommandHandler.php`)
- Removed the repository method that performed a bulk update of message `read/readAt` (`markConversationMessagesAsRead`) from `ChatMessageRepository` since it is no longer used. (`src/Chat/Infrastructure/Repository/ChatMessageRepository.php`)
- Updated the messages listing projection to compute `read` and `readAt` for the connected user from that participant pointer (`lastReadMessageAt`) and to keep message `owner` logic consistent. (`src/Chat/Transport/Controller/Api/V1/Message/ListConversationMessagesController.php`)
- Updated unit tests to reflect the participant-centric read semantics by adapting `MessageHandlersTest` and `ConversationListServiceTest` expectations. (`tests/Unit/Chat/Application/MessageHandler/MessageHandlersTest.php`, `tests/Unit/Chat/Application/Service/ConversationListServiceTest.php`)

### Testing
- Ran PHP syntax checks (`php -l`) on modified files and they succeeded without syntax errors. 
- Attempted to run PHPUnit but the test binary/dependencies are not available in this environment so unit test execution could not be performed (`vendor/bin/phpunit` / `bin/phpunit` missing). 
- Updated unit tests locally in the branch to reflect the new behavior but their execution was not possible here due to missing test runner dependencies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fb9c15d8832699bd1e697a2a6be0)