### PR TITLE
Scope school exam cache keys and tags by application slug

### DIFF
--- a/src/General/Application/MessageHandler/EntityProjectionHandler.php
+++ b/src/General/Application/MessageHandler/EntityProjectionHandler.php
@@ -257,7 +257,7 @@ final readonly class EntityProjectionHandler
     {
         if ($message instanceof EntityDeleted) {
             $this->elasticsearchService->delete(SchoolExamProjection::INDEX_NAME, $message->entityId);
-            $this->cacheInvalidationService->invalidateSchoolExamListCaches();
+            $this->cacheInvalidationService->invalidateSchoolExamListCaches(isset($message->context['applicationSlug']) ? (string)$message->context['applicationSlug'] : null);
 
             return;
         }
@@ -276,7 +276,8 @@ final readonly class EntityProjectionHandler
             'updatedAt' => $exam->getUpdatedAt()?->format(DATE_ATOM),
         ]);
 
-        $this->cacheInvalidationService->invalidateSchoolExamListCaches();
+        $applicationSlug = $exam->getSchoolClass()?->getSchool()?->getApplication()?->getSlug();
+        $this->cacheInvalidationService->invalidateSchoolExamListCaches($applicationSlug);
     }
 
     private function projectShopCatalog(): void
@@ -291,6 +292,6 @@ final readonly class EntityProjectionHandler
 
     private function projectSchoolSupportEntities(): void
     {
-        $this->cacheInvalidationService->invalidateSchoolExamListCaches();
+        $this->cacheInvalidationService->invalidateSchoolExamListCaches(null);
     }
 }

--- a/src/General/Application/Service/CacheInvalidationService.php
+++ b/src/General/Application/Service/CacheInvalidationService.php
@@ -63,16 +63,22 @@ class CacheInvalidationService
         ]));
     }
 
-    public function invalidateSchoolExamListCaches(): void
+    public function invalidateSchoolExamListCaches(?string $applicationSlug = null): void
     {
         if ($this->cache instanceof TagAwareCacheInterface) {
-            $this->cache->invalidateTags([$this->cacheKeyConventionService->schoolExamListTag()]);
+            if ($applicationSlug !== null && $applicationSlug !== '') {
+                $this->cache->invalidateTags([$this->cacheKeyConventionService->schoolExamListTagByApplication($applicationSlug)]);
+            } else {
+                $this->cache->invalidateTags([$this->cacheKeyConventionService->schoolExamListTag()]);
+            }
         }
 
-        $this->cache->delete($this->cacheKeyConventionService->buildSchoolExamListKey(1, 20, [
-            'q' => '',
-            'title' => '',
-        ]));
+        if ($applicationSlug !== null && $applicationSlug !== '') {
+            $this->cache->delete($this->cacheKeyConventionService->buildSchoolExamListKey($applicationSlug, 1, 20, [
+                'q' => '',
+                'title' => '',
+            ]));
+        }
     }
 
     public function invalidateRecruitJobListCaches(string $applicationSlug): void

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -162,9 +162,10 @@ class CacheKeyConventionService
     /**
      * @param array<string, mixed> $filters
      */
-    public function buildSchoolExamListKey(int $page, int $limit, array $filters): string
+    public function buildSchoolExamListKey(string $applicationSlug, int $page, int $limit, array $filters): string
     {
         return 'school_exam_list_' . md5((string)json_encode([
+            'applicationSlug' => $applicationSlug,
             'page' => $page,
             'limit' => $limit,
             'filters' => $filters,
@@ -287,6 +288,11 @@ class CacheKeyConventionService
     public function schoolExamListTag(): string
     {
         return 'cache_school_exam_list';
+    }
+
+    public function schoolExamListTagByApplication(string $applicationSlug): string
+    {
+        return 'cache_school_exam_list_' . $this->sanitizeSegment($applicationSlug);
     }
 
     public function schoolClassListByApplicationTag(string $applicationSlug): string

--- a/src/School/Application/Service/CreateExamService.php
+++ b/src/School/Application/Service/CreateExamService.php
@@ -67,7 +67,10 @@ final readonly class CreateExamService
 
         $this->entityManager->persist($exam);
         $this->entityManager->flush();
-        $this->messageBus->dispatch(new EntityCreated('school_exam', $exam->getId()));
+        $applicationSlug = $class->getSchool()?->getApplication()?->getSlug();
+        $this->messageBus->dispatch(new EntityCreated('school_exam', $exam->getId(), context: [
+            'applicationSlug' => $applicationSlug,
+        ]));
 
         return $exam;
     }

--- a/src/School/Application/Service/DeleteExamService.php
+++ b/src/School/Application/Service/DeleteExamService.php
@@ -28,9 +28,13 @@ final readonly class DeleteExamService
             return false;
         }
 
+        $applicationSlug = $exam->getSchoolClass()?->getSchool()?->getApplication()?->getSlug();
+
         $this->entityManager->remove($exam);
         $this->entityManager->flush();
-        $this->messageBus->dispatch(new EntityDeleted('school_exam', $id));
+        $this->messageBus->dispatch(new EntityDeleted('school_exam', $id, context: [
+            'applicationSlug' => $applicationSlug,
+        ]));
 
         return true;
     }

--- a/src/School/Application/Service/ExamListService.php
+++ b/src/School/Application/Service/ExamListService.php
@@ -39,13 +39,17 @@ readonly class ExamListService
             'q' => trim((string)$request->query->get('q', '')),
             'title' => trim((string)$request->query->get('title', '')),
         ];
-        $cacheKey = $this->cacheKeyConventionService->buildSchoolExamListKey($page, $limit, [...$filters, "schoolId" => $schoolId]);
+        $applicationSlug = (string)$request->attributes->get('applicationSlug', 'default');
+        $cacheKey = $this->cacheKeyConventionService->buildSchoolExamListKey($applicationSlug, $page, $limit, [...$filters, "schoolId" => $schoolId]);
 
         /** @var array<string,mixed> $result */
-        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit, $schoolId): array {
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit, $schoolId, $applicationSlug): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
-                $item->tag($this->cacheKeyConventionService->schoolExamListTag());
+                $item->tag([
+                    $this->cacheKeyConventionService->schoolExamListTag(),
+                    $this->cacheKeyConventionService->schoolExamListTagByApplication($applicationSlug),
+                ]);
             }
 
             $esIds = $this->searchIdsFromElastic($filters);

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolListingCacheRegressionTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolListingCacheRegressionTest.php
@@ -32,6 +32,33 @@ final class SchoolListingCacheRegressionTest extends WebTestCase
         self::assertGreaterThanOrEqual(30, $firstPayload['pagination']['totalItems']);
     }
 
+
+    #[TestDox('Exam list cache is isolated per application slug.')]
+    public function testExamListCacheIsolationByApplicationSlug(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $campusEndpoint = self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams?page=1&limit=10&q=Examen';
+        $courseEndpoint = self::API_URL_PREFIX . '/v1/school/applications/school-course-flow/exams?page=1&limit=10&q=Examen';
+
+        $client->request('GET', $campusEndpoint);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $campusPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        $client->request('GET', $courseEndpoint);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $coursePayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        self::assertNotSame($campusPayload['items'], $coursePayload['items']);
+
+        $client->request('GET', $campusEndpoint);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $campusPayloadSecondCall = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        self::assertSame($campusPayload['items'], $campusPayloadSecondCall['items']);
+        self::assertSame($campusPayload['pagination'], $campusPayloadSecondCall['pagination']);
+    }
+
     #[TestDox('Class list by application remains stable across repeated calls with pagination/filters on larger fixture datasets (cache regression).')]
     public function testClassApplicationListCacheAndPaginationRegression(): void
     {

--- a/tests/Unit/General/Application/Service/CacheInvalidationServiceTest.php
+++ b/tests/Unit/General/Application/Service/CacheInvalidationServiceTest.php
@@ -27,4 +27,21 @@ final class CacheInvalidationServiceTest extends TestCase
 
         $service->invalidateBlogCaches('my-app', ['actor', 'author', 'actor', '', null]);
     }
+
+
+    public function testInvalidateSchoolExamCachesByApplicationUsesScopedTag(): void
+    {
+        $cache = $this->createMock(TagAwareCacheInterface::class);
+        $cache->expects(self::once())
+            ->method('invalidateTags')
+            ->with(['cache_school_exam_list_school-campus-core']);
+        $cache->expects(self::once())
+            ->method('delete')
+            ->with(self::stringStartsWith('school_exam_list_'));
+
+        $service = new CacheInvalidationService($cache, new CacheKeyConventionService());
+
+        $service->invalidateSchoolExamListCaches('school-campus-core');
+    }
+
 }


### PR DESCRIPTION
### Motivation

- Corriger une fuite de cache entre applications en isolant les payloads d’examens par `applicationSlug` pour éviter des collisions et des invalidations trop larges.

### Description

- Modifier la signature de `CacheKeyConventionService::buildSchoolExamListKey` pour accepter `applicationSlug` et l’inclure dans le hash, et ajouter `schoolExamListTagByApplication(string $applicationSlug)`.
- Adapter `ExamListService::getList` pour lire `applicationSlug` depuis les attributs de la requête et utiliser cette valeur pour construire la clé cache et tagger les éléments avec le tag global et le tag scoped par application (`schoolExamListTagByApplication`).
- Mettre à jour `CacheInvalidationService::invalidateSchoolExamListCaches` pour accepter un `?string $applicationSlug` et invalider le tag scoped / supprimer la clé scoped quand un slug est fourni.
- Propager `applicationSlug` dans les messages de mutation d’examens depuis `CreateExamService` et `DeleteExamService`, et utiliser ce contexte dans `EntityProjectionHandler` pour cibler l’invalidation du scope d’application.
- Ajouter une couverture de régression applicative `tests/Application/School/Transport/Controller/Api/V1/SchoolListingCacheRegressionTest.php::testExamListCacheIsolationByApplicationSlug` et un test unitaire `tests/Unit/General/Application/Service/CacheInvalidationServiceTest.php::testInvalidateSchoolExamCachesByApplicationUsesScopedTag`.

### Testing

- `php -l` a été exécuté sur tous les fichiers modifiés et aucun défaut de syntaxe n’a été détecté (fichiers vérifiés listés dans la PR).
- L’exécution de `phpunit` n’a pas pu être réalisée car `./vendor/bin/phpunit` n’est pas disponible dans cet environnement, donc les nouveaux tests n’ont pas été exécutés ici.
- Les nouveaux tests ont été ajoutés aux emplacements mentionnés pour être exécutés dans l’intégration CI locale ou pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fbb38f6c8326b2b47858d8068446)