### PR TITLE
Harden application creation: validate recruit scope and prevent duplicate active applications

### DIFF
--- a/src/Recruit/Infrastructure/Repository/ApplicationRepository.php
+++ b/src/Recruit/Infrastructure/Repository/ApplicationRepository.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Recruit\Infrastructure\Repository;
 
 use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Applicant;
 use App\Recruit\Domain\Entity\Application as Entity;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Enum\ApplicationStatus;
 use App\Recruit\Domain\Repository\Interfaces\ApplicationRepositoryInterface;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
@@ -25,5 +28,25 @@ class ApplicationRepository extends BaseRepository implements ApplicationReposit
     public function __construct(
         protected ManagerRegistry $managerRegistry
     ) {
+    }
+
+    public function findActiveByApplicantAndJob(Applicant $applicant, Job $job): ?Entity
+    {
+        return $this->createQueryBuilder('application')
+            ->where('application.applicant = :applicant')
+            ->andWhere('application.job = :job')
+            ->andWhere('application.status IN (:statuses)')
+            ->setParameter('applicant', $applicant)
+            ->setParameter('job', $job)
+            ->setParameter('statuses', [
+                ApplicationStatus::WAITING,
+                ApplicationStatus::IN_PROGRESS,
+                ApplicationStatus::DISCUSSION,
+                ApplicationStatus::INVITE_TO_INTERVIEW,
+                ApplicationStatus::INTERVIEW,
+            ])
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\Application;
 
+use App\Recruit\Application\Service\RecruitResolverService;
 use App\Recruit\Domain\Entity\Application;
 use App\Recruit\Domain\Enum\ApplicationStatus;
 use App\Recruit\Infrastructure\Repository\ApplicantRepository;
@@ -29,6 +30,7 @@ class ApplicationCreateController
         private readonly ApplicationRepository $applicationRepository,
         private readonly ApplicantRepository $applicantRepository,
         private readonly JobRepository $jobRepository,
+        private readonly RecruitResolverService $recruitResolverService,
     ) {
     }
 
@@ -78,6 +80,16 @@ class ApplicationCreateController
         $job = $this->jobRepository->find($jobId);
         if ($job === null) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "jobId".');
+        }
+
+        $recruit = $this->recruitResolverService->resolveByApplicationSlug($applicationSlug);
+        if ($job->getRecruit()?->getId() !== $recruit->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'The given job does not belong to this application.');
+        }
+
+        $existingApplication = $this->applicationRepository->findActiveByApplicantAndJob($applicant, $job);
+        if ($existingApplication instanceof Application) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'An active application already exists for this applicant and job.');
         }
 
         $application = (new Application())

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateControllerTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Application;
+
+use App\General\Domain\Utils\JSON;
+use App\Platform\Domain\Entity\Application as PlatformApplication;
+use App\Recruit\Domain\Entity\Applicant;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Entity\Recruit;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class ApplicationCreateControllerTest extends WebTestCase
+{
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that POST /v1/recruit/applications/{applicationSlug}/applications rejects a job from another application.')]
+    public function testThatCreateRejectsJobApplicationSlugMismatch(): void
+    {
+        $rootContext = $this->getApplicantAndApplicationSlugForUsername('john-root');
+        $foreignJobId = $this->getAnyJobIdForUsername('john-user');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('POST', self::API_URL_PREFIX . '/v1/recruit/applications/' . $rootContext['applicationSlug'] . '/applications', content: JSON::encode([
+            'applicantId' => $rootContext['applicantId'],
+            'jobId' => $foreignJobId,
+        ]));
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that POST /v1/recruit/applications/{applicationSlug}/applications rejects duplicate active applications for same applicant and job.')]
+    public function testThatCreateRejectsDuplicateActiveApplication(): void
+    {
+        [$applicationSlug, $applicantId, $jobId] = $this->createDedicatedContextForUsername('john-root');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $payload = JSON::encode([
+            'applicantId' => $applicantId,
+            'jobId' => $jobId,
+        ]);
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/recruit/applications/' . $applicationSlug . '/applications', content: $payload);
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/recruit/applications/' . $applicationSlug . '/applications', content: $payload);
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @return array{applicationSlug: string, applicantId: string}
+     */
+    private function getApplicantAndApplicationSlugForUsername(string $username): array
+    {
+        self::bootKernel();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $user = $entityManager->getRepository(User::class)->findOneBy([
+            'username' => $username,
+        ]);
+        self::assertInstanceOf(User::class, $user);
+
+        $application = $entityManager->getRepository(PlatformApplication::class)->findOneBy([
+            'user' => $user,
+            'title' => 'Recruit Lite App',
+        ]);
+        self::assertInstanceOf(PlatformApplication::class, $application);
+
+        $applicant = $entityManager->getRepository(Applicant::class)->findOneBy([
+            'user' => $user,
+        ]);
+        self::assertInstanceOf(Applicant::class, $applicant);
+
+        return [
+            'applicationSlug' => $application->getSlug(),
+            'applicantId' => $applicant->getId(),
+        ];
+    }
+
+    private function getAnyJobIdForUsername(string $username): string
+    {
+        self::bootKernel();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $user = $entityManager->getRepository(User::class)->findOneBy([
+            'username' => $username,
+        ]);
+        self::assertInstanceOf(User::class, $user);
+
+        $application = $entityManager->getRepository(PlatformApplication::class)->findOneBy([
+            'user' => $user,
+            'title' => 'Recruit Lite App',
+        ]);
+        self::assertInstanceOf(PlatformApplication::class, $application);
+
+        $recruit = $entityManager->getRepository(Recruit::class)->findOneBy([
+            'application' => $application,
+        ]);
+        self::assertInstanceOf(Recruit::class, $recruit);
+
+        $job = $entityManager->getRepository(Job::class)->findOneBy([
+            'recruit' => $recruit,
+        ]);
+        self::assertInstanceOf(Job::class, $job);
+
+        return $job->getId();
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: string}
+     */
+    private function createDedicatedContextForUsername(string $username): array
+    {
+        self::bootKernel();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $user = $entityManager->getRepository(User::class)->findOneBy([
+            'username' => $username,
+        ]);
+        self::assertInstanceOf(User::class, $user);
+
+        $application = $entityManager->getRepository(PlatformApplication::class)->findOneBy([
+            'user' => $user,
+            'title' => 'Recruit Lite App',
+        ]);
+        self::assertInstanceOf(PlatformApplication::class, $application);
+
+        $recruit = $entityManager->getRepository(Recruit::class)->findOneBy([
+            'application' => $application,
+        ]);
+        self::assertInstanceOf(Recruit::class, $recruit);
+
+        $applicant = $entityManager->getRepository(Applicant::class)->findOneBy([
+            'user' => $user,
+        ]);
+        self::assertInstanceOf(Applicant::class, $applicant);
+
+        $job = (new Job())
+            ->setRecruit($recruit)
+            ->setOwner($user)
+            ->setTitle('Application create controller dedicated job')
+            ->ensureGeneratedSlug();
+
+        $entityManager->persist($job);
+        $entityManager->flush();
+
+        return [$application->getSlug(), $applicant->getId(), $job->getId()];
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure applications are created only within the correct application scope by resolving the `Recruit` from `applicationSlug` and comparing it to the target `Job` to prevent cross-app submissions.
- Prevent users from creating duplicate active applications for the same `applicant`/`job` pair at the controller level before persistence.
- Provide a repository-level helper to encapsulate the active-application lookup and make the controller logic explicit and testable.

### Description
- The `ApplicationCreateController` now injects and uses `RecruitResolverService` to resolve the `Recruit` from the `applicationSlug` and rejects requests where `job->getRecruit()` does not match the resolved `Recruit` with a 403 via `HttpException`.
- A functional uniqueness check is performed before saving by calling a new repository method `ApplicationRepository::findActiveByApplicantAndJob($applicant, $job)` and returning 400 if an active application already exists.
- `ApplicationRepository` was extended with `findActiveByApplicantAndJob()` which filters by active statuses (`WAITING`, `IN_PROGRESS`, `DISCUSSION`, `INVITE_TO_INTERVIEW`, `INTERVIEW`) and returns an existing `Application` or `null`.
- Added controller integration tests in `tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateControllerTest.php` that cover the `applicationSlug`/`job` mismatch (expects 403) and duplicate active application scenario (first POST 201, second POST 400). No DB schema migration was added because the `Application` entity already contains a DB-level unique constraint on `(applicant_id, job_id)`.

### Testing
- Ran PHP syntax checks with `php -l` on the modified files and they succeeded for `src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php`, `src/Recruit/Infrastructure/Repository/ApplicationRepository.php`, and the new test file.
- Attempted to run PHPUnit in this environment but the PHPUnit binary is not available, so the new integration tests were added but not executed here (`./vendor/bin/phpunit` / `./bin/phpunit` / `./tools/01_phpunit/vendor/bin/phpunit` unavailable).
- Verified no syntax errors and ensured the new code compiles at PHP parse time.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fbbe3bac8326a294a785bd7c1074)