### PR TITLE
Add shop API input DTOs and unified validation handling

### DIFF
--- a/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php
@@ -8,7 +8,11 @@ use App\General\Application\Message\EntityCreated;
 use App\Shop\Application\Service\ProductHydratorService;
 use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Product;
+use App\Shop\Transport\Controller\Api\V1\Input\Product\CreateProductInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Product\ProductInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
 use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,6 +30,7 @@ final readonly class CreateApplicationProductController
     public function __construct(
         private ShopApplicationResolverService $shopApplicationResolverService,
         private ProductHydratorService $productHydratorService,
+        private ProductInputValidator $productInputValidator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -37,7 +42,18 @@ final readonly class CreateApplicationProductController
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
         $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
-        $payload = (array)json_decode((string)$request->getContent(), true);
+
+        try {
+            $payload = (array) json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
+
+        $input = CreateProductInput::fromArray($payload);
+        $validationResponse = $this->productInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
 
         $product = $this->productHydratorService->hydrateProduct((new Product())->setShop($shop), $payload);
 

--- a/src/Shop/Transport/Controller/Api/V1/Category/CreateCategoryController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Category/CreateCategoryController.php
@@ -8,7 +8,11 @@ use App\General\Application\Message\EntityCreated;
 use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Application\Service\SlugBuilderService;
 use App\Shop\Domain\Entity\Category;
+use App\Shop\Transport\Controller\Api\V1\Input\Category\CategoryInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Category\CreateCategoryInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
 use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,6 +30,7 @@ final readonly class CreateCategoryController
     public function __construct(
         private ShopApplicationResolverService $shopApplicationResolverService,
         private SlugBuilderService $slugBuilderService,
+        private CategoryInputValidator $categoryInputValidator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -37,12 +42,24 @@ final readonly class CreateCategoryController
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
         $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
-        $payload = (array)json_decode((string)$request->getContent(), true);
+
+        try {
+            $payload = (array) json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
+
+        $input = CreateCategoryInput::fromArray($payload);
+        $validationResponse = $this->categoryInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
         $category = (new Category())
             ->setShop($shop)
-            ->setName((string)($payload['name'] ?? ''))
-            ->setSlug($this->slugBuilderService->buildSlug((string)($payload['slug'] ?? $payload['name'] ?? '')))
-            ->setDescription(($payload['description'] ?? null) !== null ? (string)$payload['description'] : null);
+            ->setName($input->name)
+            ->setSlug($this->slugBuilderService->buildSlug((string) ($input->slug ?? $input->name)))
+            ->setDescription($input->description);
 
         $this->entityManager->persist($category);
         $this->entityManager->flush();

--- a/src/Shop/Transport/Controller/Api/V1/Checkout/CheckoutController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Checkout/CheckoutController.php
@@ -7,7 +7,11 @@ namespace App\Shop\Transport\Controller\Api\V1\Checkout;
 use App\Shop\Application\Message\CheckoutCommand;
 use App\Shop\Application\Service\MoneyFormatter;
 use App\Shop\Domain\Entity\Order;
+use App\Shop\Transport\Controller\Api\V1\Input\Checkout\CheckoutInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Checkout\CheckoutInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
 use App\User\Domain\Entity\User;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -27,6 +31,7 @@ final readonly class CheckoutController
 {
     public function __construct(
         private Security $security,
+        private CheckoutInputValidator $checkoutInputValidator,
         private MessageBusInterface $messageBus,
     ) {
     }
@@ -41,27 +46,27 @@ final readonly class CheckoutController
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');
         }
 
-        $payload = (array)json_decode((string)$request->getContent(), true);
+        try {
+            $payload = (array) json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
 
-        $billingAddress = trim((string)($payload['billingAddress'] ?? ''));
-        $shippingAddress = trim((string)($payload['shippingAddress'] ?? ''));
-        $email = trim((string)($payload['email'] ?? ''));
-        $phone = trim((string)($payload['phone'] ?? ''));
-        $shippingMethod = trim((string)($payload['shippingMethod'] ?? ''));
-
-        if ($billingAddress === '' || $shippingAddress === '' || $email === '' || $phone === '' || $shippingMethod === '') {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Missing required checkout payload.');
+        $input = CheckoutInput::fromArray($payload);
+        $validationResponse = $this->checkoutInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
         }
 
         $envelope = $this->messageBus->dispatch(new CheckoutCommand(
             operationId: $request->headers->get('x-request-id', uniqid('checkout-', true)),
             shopId: $shopId,
             userId: $user->getId(),
-            billingAddress: $billingAddress,
-            shippingAddress: $shippingAddress,
-            email: $email,
-            phone: $phone,
-            shippingMethod: $shippingMethod,
+            billingAddress: $input->billingAddress,
+            shippingAddress: $input->shippingAddress,
+            email: $input->email,
+            phone: $input->phone,
+            shippingMethod: $input->shippingMethod,
         ));
 
         /** @var HandledStamp|null $handled */

--- a/src/Shop/Transport/Controller/Api/V1/Input/Category/CategoryInputValidator.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Category/CategoryInputValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Category;
+
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final readonly class CategoryInputValidator
+{
+    public function __construct(private ValidatorInterface $validator)
+    {
+    }
+
+    public function validate(CreateCategoryInput $input): ?JsonResponse
+    {
+        $violations = $this->validator->validate($input);
+        if ($violations->count() === 0) {
+            return null;
+        }
+
+        return ValidationResponseFactory::fromViolations($violations);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Category/CreateCategoryInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Category/CreateCategoryInput.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Category;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateCategoryInput
+{
+    #[Assert\NotBlank(message: 'name is required.')]
+    public string $name = '';
+
+    public ?string $slug = null;
+    public ?string $description = null;
+
+    /** @param array<string, mixed> $payload */
+    public static function fromArray(array $payload): self
+    {
+        $input = new self();
+        $input->name = trim((string) ($payload['name'] ?? ''));
+        $input->slug = is_string($payload['slug'] ?? null) ? trim((string) $payload['slug']) : null;
+        $input->description = ($payload['description'] ?? null) !== null ? (string) $payload['description'] : null;
+
+        return $input;
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Checkout/CheckoutInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Checkout/CheckoutInput.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Checkout;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CheckoutInput
+{
+    #[Assert\NotBlank(message: 'billingAddress is required.')]
+    public string $billingAddress = '';
+
+    #[Assert\NotBlank(message: 'shippingAddress is required.')]
+    public string $shippingAddress = '';
+
+    #[Assert\NotBlank(message: 'email is required.')]
+    #[Assert\Email(message: 'email must be valid.')]
+    public string $email = '';
+
+    #[Assert\NotBlank(message: 'phone is required.')]
+    public string $phone = '';
+
+    #[Assert\NotBlank(message: 'shippingMethod is required.')]
+    public string $shippingMethod = '';
+
+    /** @param array<string, mixed> $payload */
+    public static function fromArray(array $payload): self
+    {
+        $input = new self();
+        $input->billingAddress = trim((string) ($payload['billingAddress'] ?? ''));
+        $input->shippingAddress = trim((string) ($payload['shippingAddress'] ?? ''));
+        $input->email = trim((string) ($payload['email'] ?? ''));
+        $input->phone = trim((string) ($payload['phone'] ?? ''));
+        $input->shippingMethod = trim((string) ($payload['shippingMethod'] ?? ''));
+
+        return $input;
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Checkout/CheckoutInputValidator.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Checkout/CheckoutInputValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Checkout;
+
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final readonly class CheckoutInputValidator
+{
+    public function __construct(private ValidatorInterface $validator)
+    {
+    }
+
+    public function validate(CheckoutInput $input): ?JsonResponse
+    {
+        $violations = $this->validator->validate($input);
+        if ($violations->count() === 0) {
+            return null;
+        }
+
+        return ValidationResponseFactory::fromViolations($violations);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Payment/ConfirmPaymentInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Payment/ConfirmPaymentInput.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Payment;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class ConfirmPaymentInput
+{
+    #[Assert\NotBlank(message: 'providerReference is required.')]
+    public string $providerReference = '';
+
+    /** @param array<string, mixed> $payload */
+    public static function fromArray(array $payload): self
+    {
+        $input = new self();
+        $input->providerReference = trim((string) ($payload['providerReference'] ?? ''));
+
+        return $input;
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Payment/PaymentInputValidator.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Payment/PaymentInputValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Payment;
+
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final readonly class PaymentInputValidator
+{
+    public function __construct(private ValidatorInterface $validator)
+    {
+    }
+
+    public function validate(ConfirmPaymentInput $input): ?JsonResponse
+    {
+        $violations = $this->validator->validate($input);
+        if ($violations->count() === 0) {
+            return null;
+        }
+
+        return ValidationResponseFactory::fromViolations($violations);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Product/CreateProductInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Product/CreateProductInput.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Product;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateProductInput
+{
+    #[Assert\NotBlank(message: 'name is required.')]
+    public string $name = '';
+
+    #[Assert\NotBlank(message: 'sku is required.')]
+    #[Assert\Regex(pattern: '/^[A-Z0-9][A-Z0-9_-]*$/', message: 'sku format is invalid.')]
+    public string $sku = '';
+
+    #[Assert\GreaterThan(value: 0, message: 'price must be greater than 0.')]
+    public float $price = 0;
+
+    #[Assert\GreaterThanOrEqual(value: 0, message: 'stock must be greater than or equal to 0.')]
+    public int $stock = 0;
+
+    public ?string $description = null;
+    public ?string $currencyCode = null;
+    public ?string $categoryId = null;
+
+    /** @var array<int, string> */
+    public array $tagIds = [];
+
+    public bool $isFeatured = false;
+    public ?string $status = null;
+    public ?string $shopId = null;
+    public ?string $applicationSlug = null;
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $input = new self();
+        $input->name = trim((string) ($payload['name'] ?? ''));
+        $input->sku = strtoupper(trim((string) ($payload['sku'] ?? '')));
+        $input->price = (float) ($payload['price'] ?? 0);
+        $input->stock = (int) ($payload['stock'] ?? 0);
+        $input->description = ($payload['description'] ?? null) !== null ? (string) $payload['description'] : null;
+        $input->currencyCode = is_string($payload['currencyCode'] ?? null) ? trim((string) $payload['currencyCode']) : null;
+        $input->categoryId = is_string($payload['categoryId'] ?? null) ? trim((string) $payload['categoryId']) : null;
+        $input->tagIds = array_values(array_filter((array) ($payload['tagIds'] ?? []), static fn (mixed $id): bool => is_string($id)));
+        $input->isFeatured = (bool) ($payload['isFeatured'] ?? false);
+        $input->status = is_string($payload['status'] ?? null) ? (string) $payload['status'] : null;
+        $input->shopId = is_string($payload['shopId'] ?? null) ? trim((string) $payload['shopId']) : null;
+        $input->applicationSlug = is_string($payload['applicationSlug'] ?? null) ? trim((string) $payload['applicationSlug']) : null;
+
+        return $input;
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Product/PatchProductInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Product/PatchProductInput.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Product;
+
+final class PatchProductInput
+{
+    public ?string $name = null;
+    public ?string $sku = null;
+    public ?float $price = null;
+    public ?int $stock = null;
+    public ?string $description = null;
+    public ?string $currencyCode = null;
+    public ?string $categoryId = null;
+
+    /** @var array<int, string>|null */
+    public ?array $tagIds = null;
+
+    public ?bool $isFeatured = null;
+    public ?string $status = null;
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $input = new self();
+        $input->name = array_key_exists('name', $payload) ? trim((string) $payload['name']) : null;
+        $input->sku = array_key_exists('sku', $payload) ? strtoupper(trim((string) $payload['sku'])) : null;
+        $input->price = array_key_exists('price', $payload) ? (float) $payload['price'] : null;
+        $input->stock = array_key_exists('stock', $payload) ? (int) $payload['stock'] : null;
+        $input->description = array_key_exists('description', $payload) ? (($payload['description'] ?? null) !== null ? (string) $payload['description'] : null) : null;
+        $input->currencyCode = array_key_exists('currencyCode', $payload) ? (($payload['currencyCode'] ?? null) !== null ? (string) $payload['currencyCode'] : null) : null;
+        $input->categoryId = array_key_exists('categoryId', $payload) ? (($payload['categoryId'] ?? null) !== null ? (string) $payload['categoryId'] : null) : null;
+        if (array_key_exists('tagIds', $payload)) {
+            $input->tagIds = array_values(array_filter((array) $payload['tagIds'], static fn (mixed $id): bool => is_string($id)));
+        }
+        $input->isFeatured = array_key_exists('isFeatured', $payload) ? (bool) $payload['isFeatured'] : null;
+        $input->status = array_key_exists('status', $payload) ? (($payload['status'] ?? null) !== null ? (string) $payload['status'] : null) : null;
+
+        return $input;
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Product/ProductInputValidator.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Product/ProductInputValidator.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Product;
+
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final readonly class ProductInputValidator
+{
+    public function __construct(private ValidatorInterface $validator)
+    {
+    }
+
+    public function validate(CreateProductInput|PatchProductInput $input): ?JsonResponse
+    {
+        if ($input instanceof CreateProductInput) {
+            $violations = $this->validator->validate($input);
+            if ($violations->count() > 0) {
+                return ValidationResponseFactory::fromViolations($violations);
+            }
+
+            return null;
+        }
+
+        $errors = [];
+        if ($input->name !== null && $input->name === '') {
+            $errors[] = ['field' => 'name', 'message' => 'name cannot be blank.', 'code' => 'NAME_REQUIRED'];
+        }
+        if ($input->sku !== null && ($input->sku === '' || preg_match('/^[A-Z0-9][A-Z0-9_-]*$/', $input->sku) !== 1)) {
+            $errors[] = ['field' => 'sku', 'message' => 'sku format is invalid.', 'code' => 'SKU_INVALID'];
+        }
+        if ($input->price !== null && $input->price <= 0) {
+            $errors[] = ['field' => 'price', 'message' => 'price must be greater than 0.', 'code' => 'PRICE_INVALID'];
+        }
+        if ($input->stock !== null && $input->stock < 0) {
+            $errors[] = ['field' => 'stock', 'message' => 'stock must be greater than or equal to 0.', 'code' => 'STOCK_INVALID'];
+        }
+
+        if ($errors === []) {
+            return null;
+        }
+
+        return new JsonResponse([
+            'message' => 'Validation failed.',
+            'errors' => $errors,
+        ], JsonResponse::HTTP_UNPROCESSABLE_ENTITY);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Support/ValidationResponseFactory.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Support/ValidationResponseFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Support;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Validator\ConstraintViolationInterface;
+
+use function array_map;
+use function iterator_to_array;
+
+final class ValidationResponseFactory
+{
+    public static function invalidJson(string $message = 'Invalid JSON payload.'): JsonResponse
+    {
+        return new JsonResponse([
+            'message' => 'Validation failed.',
+            'errors' => [[
+                'field' => 'payload',
+                'message' => $message,
+                'code' => 'INVALID_JSON',
+            ]],
+        ], JsonResponse::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @param iterable<ConstraintViolationInterface> $violations
+     */
+    public static function fromViolations(iterable $violations): JsonResponse
+    {
+        return new JsonResponse([
+            'message' => 'Validation failed.',
+            'errors' => array_map(
+                static fn (ConstraintViolationInterface $violation): array => [
+                    'field' => $violation->getPropertyPath(),
+                    'message' => $violation->getMessage(),
+                    'code' => $violation->getCode(),
+                ],
+                iterator_to_array($violations),
+            ),
+        ], JsonResponse::HTTP_UNPROCESSABLE_ENTITY);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Tag/CreateTagInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Tag/CreateTagInput.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Tag;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateTagInput
+{
+    #[Assert\NotBlank(message: 'label is required.')]
+    public string $label = '';
+
+    public ?string $type = null;
+
+    /** @param array<string, mixed> $payload */
+    public static function fromArray(array $payload): self
+    {
+        $input = new self();
+        $input->label = trim((string) ($payload['label'] ?? ''));
+        $input->type = is_string($payload['type'] ?? null) ? trim((string) $payload['type']) : null;
+
+        return $input;
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Tag/TagInputValidator.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Tag/TagInputValidator.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Tag;
+
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final readonly class TagInputValidator
+{
+    public function __construct(private ValidatorInterface $validator)
+    {
+    }
+
+    public function validate(CreateTagInput $input): ?JsonResponse
+    {
+        $violations = $this->validator->validate($input);
+        if ($violations->count() === 0) {
+            return null;
+        }
+
+        return ValidationResponseFactory::fromViolations($violations);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Payment/ConfirmPaymentController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/ConfirmPaymentController.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Shop\Transport\Controller\Api\V1\Payment;
 
 use App\Shop\Application\Service\PaymentService;
+use App\Shop\Transport\Controller\Api\V1\Input\Payment\ConfirmPaymentInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Payment\PaymentInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -21,6 +24,7 @@ final readonly class ConfirmPaymentController
 {
     public function __construct(
         private PaymentService $paymentService,
+        private PaymentInputValidator $paymentInputValidator,
     ) {
     }
 
@@ -34,14 +38,20 @@ final readonly class ConfirmPaymentController
     public function __invoke(string $applicationSlug, string $orderId, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
-        $payload = (array)json_decode((string)$request->getContent(), true);
-        $providerReference = trim((string)($payload['providerReference'] ?? ''));
 
-        if ($providerReference === '') {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'providerReference is required.');
+        try {
+            $payload = (array) json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
         }
 
-        $transaction = $this->paymentService->confirmPayment($applicationSlug, $orderId, $providerReference, $payload);
+        $input = ConfirmPaymentInput::fromArray($payload);
+        $validationResponse = $this->paymentInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $transaction = $this->paymentService->confirmPayment($applicationSlug, $orderId, $input->providerReference, $payload);
 
         return new JsonResponse([
             'id' => $transaction->getId(),

--- a/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
@@ -6,9 +6,15 @@ namespace App\Shop\Transport\Controller\Api\V1\Product;
 
 use App\General\Application\Message\EntityCreated;
 use App\Shop\Application\Service\ProductHydratorService;
+use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Product;
+use App\Shop\Domain\Entity\Shop;
 use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Shop\Transport\Controller\Api\V1\Input\Product\CreateProductInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Product\ProductInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
 use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,6 +31,8 @@ final readonly class CreateProductController
 {
     public function __construct(
         private ProductHydratorService $productHydratorService,
+        private ProductInputValidator $productInputValidator,
+        private ShopApplicationResolverService $shopApplicationResolverService,
         private ShopRepository $shopRepository,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
@@ -34,12 +42,31 @@ final readonly class CreateProductController
     #[Route('/v1/shop/products', methods: [Request::METHOD_POST])]
     public function __invoke(Request $request): JsonResponse
     {
-        $payload = (array) json_decode((string) $request->getContent(), true);
-        $product = $this->productHydratorService->hydrateProduct(new Product(), $payload);
-
-        if (is_string($payload['shopId'] ?? null)) {
-            $product->setShop($this->shopRepository->find($payload['shopId']));
+        try {
+            $payload = (array) json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
         }
+
+        $input = CreateProductInput::fromArray($payload);
+        $validationResponse = $this->productInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $shop = $this->resolveShop($input);
+        if (!$shop instanceof Shop) {
+            return new JsonResponse([
+                'message' => 'Validation failed.',
+                'errors' => [[
+                    'field' => 'shopId',
+                    'message' => 'shopId is required when applicationSlug is missing.',
+                    'code' => 'SHOP_SCOPE_REQUIRED',
+                ]],
+            ], JsonResponse::HTTP_UNPROCESSABLE_ENTITY);
+        }
+
+        $product = $this->productHydratorService->hydrateProduct((new Product())->setShop($shop), $payload);
 
         $this->entityManager->persist($product);
         $this->entityManager->flush();
@@ -48,5 +75,20 @@ final readonly class CreateProductController
         return new JsonResponse([
             'id' => $product->getId(),
         ], JsonResponse::HTTP_CREATED);
+    }
+
+    private function resolveShop(CreateProductInput $input): ?Shop
+    {
+        if ($input->applicationSlug !== null && $input->applicationSlug !== '') {
+            return $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($input->applicationSlug);
+        }
+
+        if ($input->shopId !== null && $input->shopId !== '') {
+            $shop = $this->shopRepository->find($input->shopId);
+
+            return $shop instanceof Shop ? $shop : null;
+        }
+
+        return null;
     }
 }

--- a/src/Shop/Transport/Controller/Api/V1/Product/PatchProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/PatchProductController.php
@@ -10,7 +10,11 @@ use App\Shop\Application\Service\ProductListService;
 use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Product;
 use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Shop\Transport\Controller\Api\V1\Input\Product\PatchProductInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Product\ProductInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
 use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,6 +33,7 @@ final readonly class PatchProductController
         private ShopApplicationResolverService $shopApplicationResolverService,
         private ProductRepository $productRepository,
         private ProductHydratorService $productHydratorService,
+        private ProductInputValidator $productInputValidator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -45,7 +50,18 @@ final readonly class PatchProductController
             return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
         }
 
-        $payload = (array)json_decode((string)$request->getContent(), true);
+        try {
+            $payload = (array) json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
+
+        $input = PatchProductInput::fromArray($payload);
+        $validationResponse = $this->productInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
         $this->productHydratorService->hydrateProduct($product, $payload, true);
 
         $this->entityManager->flush();

--- a/src/Shop/Transport/Controller/Api/V1/Tag/CreateTagController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Tag/CreateTagController.php
@@ -8,7 +8,11 @@ use App\General\Application\Message\EntityCreated;
 use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Tag;
 use App\Shop\Domain\Enum\TagType;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use App\Shop\Transport\Controller\Api\V1\Input\Tag\CreateTagInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Tag\TagInputValidator;
 use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,6 +29,7 @@ final readonly class CreateTagController
 {
     public function __construct(
         private ShopApplicationResolverService $shopApplicationResolverService,
+        private TagInputValidator $tagInputValidator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -37,10 +42,21 @@ final readonly class CreateTagController
         $request->attributes->set('applicationSlug', $applicationSlug);
         $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
 
-        $payload = (array)json_decode((string)$request->getContent(), true);
+        try {
+            $payload = (array) json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
+
+        $input = CreateTagInput::fromArray($payload);
+        $validationResponse = $this->tagInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
         $tag = (new Tag())
-            ->setLabel((string)($payload['label'] ?? ''))
-            ->setType(TagType::tryFrom((string)($payload['type'] ?? '')) ?? TagType::MARKETING);
+            ->setLabel($input->label)
+            ->setType(TagType::tryFrom((string) ($input->type ?? '')) ?? TagType::MARKETING);
 
         $this->entityManager->persist($tag);
         $this->entityManager->flush();


### PR DESCRIPTION
### Motivation
- Introduce explicit input DTOs and validation to centralize and standardize request payload handling for shop-related endpoints and to enforce business rules early in the request lifecycle.
- Prevent orphaned resources by requiring or resolving a `shop` scope (prefer `applicationSlug`, fallback to explicit `shopId`) before creating products.
- Normalize validation error responses to a single JSON structure so clients receive consistent errors across controllers.

### Description
- Added input DTOs and validators for products (`CreateProductInput`, `PatchProductInput`, `ProductInputValidator`), categories (`CreateCategoryInput`, `CategoryInputValidator`), tags (`CreateTagInput`, `TagInputValidator`), checkout (`CheckoutInput`, `CheckoutInputValidator`) and payment confirmation (`ConfirmPaymentInput`, `PaymentInputValidator`).
- Added `ValidationResponseFactory` to produce a uniform `{"message":"Validation failed.","errors":[...]}` JSON shape and to handle invalid JSON payloads (`INVALID_JSON`).
- Updated Shop API V1 controllers (`Product`, `ApplicationProduct`, `Category`, `Tag`, `Checkout`, `Payment/ConfirmPayment`) to parse JSON safely (using `JSON_THROW_ON_ERROR`), validate input before hydration/persistence, and return the unified validation response on errors.
- Enforced product business rules at validation time: required `name`, non-empty and format-checked `sku`, `price > 0`, and `stock >= 0`, and prevented product creation when no shop scope can be resolved.

### Testing
- Ran a PHP syntax check over changed files with `for f in $(git status --short | awk '{print $2}'); do if [ -f "$f" ]; then php -l "$f" || exit 1; fi; done` which completed successfully.
- Ran `find src/Shop/Transport/Controller/Api/V1/Input -type f -name '*.php' -print0 | xargs -0 -n1 php -l` to lint all new input files which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3fbced08c832688a66b5fee89a0d5)