### PR TITLE
Refactor CRM response normalization across sprint/project/task endpoints

### DIFF
--- a/src/Crm/Application/Service/CrmApiNormalizer.php
+++ b/src/Crm/Application/Service/CrmApiNormalizer.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\User\Domain\Entity\User;
+use DateTimeInterface;
+
+final class CrmApiNormalizer
+{
+    /** @return array<string,mixed> */
+    public function normalizeTask(Task $task): array
+    {
+        $assignees = [];
+        foreach ($task->getAssignees() as $assignee) {
+            if (!$assignee instanceof User) {
+                continue;
+            }
+
+            $assignees[] = $this->normalizeAssignee($assignee);
+        }
+
+        $children = [];
+        foreach ($task->getTaskRequests() as $taskRequest) {
+            if (!$taskRequest instanceof TaskRequest) {
+                continue;
+            }
+
+            $children[] = $this->normalizeTaskRequest($taskRequest);
+        }
+
+        return [
+            'id' => $task->getId(),
+            'title' => $task->getTitle(),
+            'status' => $task->getStatus()->value,
+            'priority' => $task->getPriority()->value,
+            'projectId' => $task->getProject()?->getId(),
+            'projectName' => $task->getProject()?->getName(),
+            'sprintId' => $task->getSprint()?->getId(),
+            'sprintName' => $task->getSprint()?->getName(),
+            'dueAt' => $this->normalizeDate($task->getDueAt()),
+            'estimatedHours' => $task->getEstimatedHours(),
+            'updatedAt' => $this->normalizeDate($task->getUpdatedAt()),
+            'assignees' => $assignees,
+            'children' => $children,
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    public function normalizeTaskRequest(TaskRequest $taskRequest): array
+    {
+        $assignees = [];
+        foreach ($taskRequest->getAssignees() as $assignee) {
+            if (!$assignee instanceof User) {
+                continue;
+            }
+
+            $assignees[] = $this->normalizeAssignee($assignee);
+        }
+
+        return [
+            'id' => $taskRequest->getId(),
+            'taskId' => $taskRequest->getTask()?->getId(),
+            'title' => $taskRequest->getTitle(),
+            'status' => $taskRequest->getStatus()->value,
+            'requestedAt' => $this->normalizeDate($taskRequest->getRequestedAt()),
+            'resolvedAt' => $this->normalizeDate($taskRequest->getResolvedAt()),
+            'assignees' => $assignees,
+        ];
+    }
+
+    /** @param array<string,mixed> $item
+     * @return array<string,mixed>
+     */
+    public function normalizeSprintProjection(array $item): array
+    {
+        return [
+            'id' => (string)($item['id'] ?? ''),
+            'title' => (string)($item['name'] ?? ''),
+            'status' => (string)($item['status'] ?? ''),
+            'projectId' => $item['projectId'] ?? null,
+            'startDate' => $this->normalizeDateValue($item['startDate'] ?? null),
+            'endDate' => $this->normalizeDateValue($item['endDate'] ?? null),
+        ];
+    }
+
+    /** @param array<string,mixed> $item
+     * @return array<string,mixed>
+     */
+    public function normalizeProjectProjection(array $item): array
+    {
+        return [
+            'id' => (string)($item['id'] ?? ''),
+            'title' => (string)($item['name'] ?? ''),
+            'status' => (string)($item['status'] ?? ''),
+            'companyId' => $item['companyId'] ?? null,
+        ];
+    }
+
+    /** @param array<string,mixed> $item
+     * @return array<string,mixed>
+     */
+    public function normalizeTaskRequestProjection(array $item): array
+    {
+        return [
+            'id' => (string)($item['id'] ?? ''),
+            'taskId' => $item['taskId'] ?? null,
+            'title' => (string)($item['title'] ?? ''),
+            'status' => (string)($item['status'] ?? ''),
+            'requestedAt' => $this->normalizeDateValue($item['requestedAt'] ?? null),
+            'resolvedAt' => $this->normalizeDateValue($item['resolvedAt'] ?? null),
+            'assignees' => [],
+        ];
+    }
+
+    /** @return array<string,mixed> */
+    private function normalizeAssignee(User $user): array
+    {
+        return [
+            'id' => $user->getId(),
+            'username' => $user->getUsername(),
+            'firstName' => $user->getFirstName(),
+            'lastName' => $user->getLastName(),
+            'photo' => $user->getPhoto(),
+        ];
+    }
+
+    private function normalizeDate(?DateTimeInterface $date): ?string
+    {
+        return $date?->format(DATE_ATOM);
+    }
+
+    private function normalizeDateValue(mixed $value): ?string
+    {
+        if ($value instanceof DateTimeInterface) {
+            return $value->format(DATE_ATOM);
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Crm/Application/Service/TaskBoardService.php
+++ b/src/Crm/Application/Service/TaskBoardService.php
@@ -8,7 +8,6 @@ use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\User\Domain\Entity\User;
-use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 
 final readonly class TaskBoardService
@@ -16,6 +15,7 @@ final readonly class TaskBoardService
     public function __construct(
         private TaskRepository $taskRepository,
         private CrmApplicationScopeResolver $applicationScopeResolver,
+        private CrmApiNormalizer $crmApiNormalizer,
     ) {
     }
 
@@ -47,7 +47,7 @@ final readonly class TaskBoardService
                 $items[$sprintId] = [
                     'sprint' => [
                         'id' => $task->getSprint()?->getId(),
-                        'name' => $task->getSprint()?->getName(),
+                        'title' => $task->getSprint()?->getName(),
                         'status' => $task->getSprint()?->getStatus()->value,
                     ],
                     'tasks' => [],
@@ -110,43 +110,12 @@ final readonly class TaskBoardService
     /** @return array<string,mixed> */
     private function normalizeTask(Task $task): array
     {
-        return [
-            'id' => $task->getId(),
-            'title' => $task->getTitle(),
-            'status' => $task->getStatus()->value,
-            'priority' => $task->getPriority()->value,
-            'sprintId' => $task->getSprint()?->getId(),
-            'projectId' => $task->getProject()?->getId(),
-            'assignees' => array_map(static fn (User $user): array => [
-                'id' => $user->getId(),
-                'username' => $user->getUsername(),
-                'email' => $user->getEmail(),
-                'firstName' => $user->getFirstName(),
-                'lastName' => $user->getLastName(),
-                'photo' => $user->getPhoto(),
-            ], $task->getAssignees()->toArray()),
-            'children' => array_map(fn (TaskRequest $taskRequest): array => $this->normalizeTaskRequest($taskRequest), $task->getTaskRequests()->toArray()),
-        ];
+        return $this->crmApiNormalizer->normalizeTask($task);
     }
 
     /** @return array<string,mixed> */
     private function normalizeTaskRequest(TaskRequest $taskRequest): array
     {
-        return [
-            'id' => $taskRequest->getId(),
-            'taskId' => $taskRequest->getTask()?->getId(),
-            'title' => $taskRequest->getTitle(),
-            'status' => $taskRequest->getStatus()->value,
-            'requestedAt' => $taskRequest->getRequestedAt()->format(DATE_ATOM),
-            'resolvedAt' => $taskRequest->getResolvedAt()?->format(DATE_ATOM),
-            'assignees' => array_map(static fn (User $user): array => [
-                'id' => $user->getId(),
-                'username' => $user->getUsername(),
-                'email' => $user->getEmail(),
-                'firstName' => $user->getFirstName(),
-                'lastName' => $user->getLastName(),
-                'photo' => $user->getPhoto(),
-            ], $taskRequest->getAssignees()->toArray()),
-        ];
+        return $this->crmApiNormalizer->normalizeTaskRequest($taskRequest);
     }
 }

--- a/src/Crm/Application/Service/TaskListService.php
+++ b/src/Crm/Application/Service/TaskListService.php
@@ -8,7 +8,6 @@ use App\Crm\Application\Projection\CrmTaskProjection;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\General\Application\Service\CacheKeyConventionService;
-use App\User\Domain\Entity\User;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Symfony\Component\HttpFoundation\Request;
@@ -25,6 +24,7 @@ readonly class TaskListService
         private ElasticsearchServiceInterface $elasticsearchService,
         private CacheKeyConventionService $cacheKeyConventionService,
         private CrmApplicationScopeResolver $applicationScopeResolver,
+        private CrmApiNormalizer $crmApiNormalizer,
     ) {
     }
 
@@ -88,27 +88,7 @@ readonly class TaskListService
                 $qb->andWhere('task.id IN (:ids)')->setParameter('ids', $esIds);
             }
 
-            $items = array_map(static fn (Task $task): array => [
-                'id' => $task->getId(),
-                'title' => $task->getTitle(),
-                'projectId' => $task->getProject()?->getId(),
-                'projectName' => $task->getProject()?->getName(),
-                'sprintId' => $task->getSprint()?->getId(),
-                'sprintName' => $task->getSprint()?->getName(),
-                'status' => $task->getStatus()->value,
-                'priority' => $task->getPriority()->value,
-                'dueAt' => $task->getDueAt()?->format(DATE_ATOM),
-                'estimatedHours' => $task->getEstimatedHours(),
-                'updatedAt' => $task->getUpdatedAt()?->format(DATE_ATOM),
-                'assignees' => array_map(static fn (User $assignee): array => [
-                    'id' => $assignee->getId(),
-                    'username' => $assignee->getUsername(),
-                    'email' => $assignee->getEmail(),
-                    'firstName' => $assignee->getFirstName(),
-                    'lastName' => $assignee->getLastName(),
-                    'photo' => $assignee->getPhoto(),
-                ], $task->getAssignees()->toArray()),
-            ], $qb->getQuery()->getResult());
+            $items = array_map(fn (Task $task): array => $this->crmApiNormalizer->normalizeTask($task), $qb->getQuery()->getResult());
 
             $countQb = $this->taskRepository->createQueryBuilder('task')->select('COUNT(task.id)')
                 ->leftJoin('task.project', 'project')

--- a/src/Crm/Transport/Controller/Api/V1/Project/ListProjectsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/ListProjectsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Controller\Api\V1\Project;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmApiNormalizer;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -22,6 +23,7 @@ final readonly class ListProjectsController
     public function __construct(
         private ProjectRepository $projectRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiNormalizer $crmApiNormalizer,
     ) {
     }
 
@@ -37,7 +39,7 @@ final readonly class ListProjectsController
             'status' => trim((string)$request->query->get('status', '')),
         ];
 
-        $items = $this->projectRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $filters);
+        $items = array_map(fn (array $item): array => $this->crmApiNormalizer->normalizeProjectProjection($item), $this->projectRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $filters));
         $totalItems = $this->projectRepository->countScopedByCrm($crm->getId(), $filters);
 
         return new JsonResponse([

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/ListSprintsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/ListSprintsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Controller\Api\V1\Sprint;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmApiNormalizer;
 use App\Crm\Infrastructure\Repository\SprintRepository;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -22,6 +23,7 @@ final readonly class ListSprintsController
     public function __construct(
         private SprintRepository $sprintRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiNormalizer $crmApiNormalizer,
     ) {
     }
 
@@ -37,7 +39,7 @@ final readonly class ListSprintsController
             'status' => trim((string)$request->query->get('status', '')),
         ];
 
-        $items = $this->sprintRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $filters);
+        $items = array_map(fn (array $item): array => $this->crmApiNormalizer->normalizeSprintProjection($item), $this->sprintRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $filters));
         $totalItems = $this->sprintRepository->countScopedByCrm($crm->getId(), $filters);
 
         return new JsonResponse([

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmApiNormalizer;
 use App\Crm\Infrastructure\Repository\TaskRequestRepository;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -22,6 +23,7 @@ final readonly class ListTaskRequestsController
     public function __construct(
         private TaskRequestRepository $taskRequestRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiNormalizer $crmApiNormalizer,
     ) {
     }
 
@@ -37,7 +39,7 @@ final readonly class ListTaskRequestsController
             'status' => trim((string)$request->query->get('status', '')),
         ];
 
-        $items = $this->taskRequestRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $filters);
+        $items = array_map(fn (array $item): array => $this->crmApiNormalizer->normalizeTaskRequestProjection($item), $this->taskRequestRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $filters));
         $totalItems = $this->taskRequestRepository->countScopedByCrm($crm->getId(), $filters);
 
         return new JsonResponse([


### PR DESCRIPTION
### Motivation
- Avoid returning raw Doctrine `->toArray()` results from CRM endpoints and enforce explicit API payload shapes. 
- Centralize task / task-request normalization to remove duplication and make output fields consistent. 
- Ensure dates and enums are serialized consistently (ISO `DATE_ATOM` and enum `value`) across CRM list endpoints.

### Description
- Add a new service `App\Crm\Application\Service\CrmApiNormalizer` implementing `normalizeTask`, `normalizeTaskRequest` and projection normalizers for sprints/projects/task-requests with explicit shapes and minimal assignee info. 
- Update `TaskListService` to delegate task payload building to `CrmApiNormalizer` instead of constructing arrays inline. 
- Refactor `TaskBoardService` to use `CrmApiNormalizer` for `normalizeTask`/`normalizeTaskRequest` and harmonize sprint `title` field in board responses. 
- Update controllers `ListSprintsController`, `ListProjectsController` and `ListTaskRequestsController` to map repository projection rows through the corresponding normalizer methods before returning JSON.

### Testing
- Ran PHP syntax checks on modified files using `php -l` for `CrmApiNormalizer`, `TaskBoardService`, `TaskListService`, and the three updated controllers and all reported no syntax errors. 
- Verified with a code search that direct `->toArray()` usage was removed from the CRM application/transport layers by scanning `src/Crm/Application` and `src/Crm/Transport` directories.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3feae71e88326a92a19e8aa0d9ddf)