### PR TITLE
Rendre obligatoires les relations parentes CRM et ajouter migration de remédiation

### DIFF
--- a/docs/sql/crm_required_relations_remediation.sql
+++ b/docs/sql/crm_required_relations_remediation.sql
@@ -1,0 +1,35 @@
+-- Prévisualisation et remédiation contrôlée avant migration de contraintes NOT NULL CRM.
+-- Cette stratégie applique une suppression contrôlée des enregistrements orphelins.
+
+START TRANSACTION;
+
+-- 1) Mesurer les impacts avant suppression.
+SELECT 'crm_company_without_crm' AS anomaly, COUNT(*) AS total FROM crm_company WHERE crm_id IS NULL
+UNION ALL
+SELECT 'crm_project_without_company', COUNT(*) FROM crm_project WHERE company_id IS NULL
+UNION ALL
+SELECT 'crm_sprint_without_project', COUNT(*) FROM crm_sprint WHERE project_id IS NULL
+UNION ALL
+SELECT 'crm_task_without_project', COUNT(*) FROM crm_task WHERE project_id IS NULL
+UNION ALL
+SELECT 'crm_task_request_without_task', COUNT(*) FROM crm_task_request WHERE task_id IS NULL;
+
+-- 2) Suppression contrôlée du plus bas niveau vers le plus haut niveau.
+DELETE FROM crm_task_request WHERE task_id IS NULL;
+DELETE FROM crm_task WHERE project_id IS NULL;
+DELETE FROM crm_sprint WHERE project_id IS NULL;
+DELETE FROM crm_project WHERE company_id IS NULL;
+DELETE FROM crm_company WHERE crm_id IS NULL;
+
+-- 3) Vérification post-remédiation.
+SELECT 'crm_company_without_crm' AS anomaly, COUNT(*) AS total FROM crm_company WHERE crm_id IS NULL
+UNION ALL
+SELECT 'crm_project_without_company', COUNT(*) FROM crm_project WHERE company_id IS NULL
+UNION ALL
+SELECT 'crm_sprint_without_project', COUNT(*) FROM crm_sprint WHERE project_id IS NULL
+UNION ALL
+SELECT 'crm_task_without_project', COUNT(*) FROM crm_task WHERE project_id IS NULL
+UNION ALL
+SELECT 'crm_task_request_without_task', COUNT(*) FROM crm_task_request WHERE task_id IS NULL;
+
+COMMIT;

--- a/migrations/Version20260313140000.php
+++ b/migrations/Version20260313140000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260313140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Make CRM core parent relations mandatory and clean orphan rows before enforcing NOT NULL constraints.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DELETE FROM crm_task_request WHERE task_id IS NULL');
+        $this->addSql('DELETE FROM crm_task WHERE project_id IS NULL');
+        $this->addSql('DELETE FROM crm_sprint WHERE project_id IS NULL');
+        $this->addSql('DELETE FROM crm_project WHERE company_id IS NULL');
+        $this->addSql('DELETE FROM crm_company WHERE crm_id IS NULL');
+
+        $this->addSql("ALTER TABLE crm_company CHANGE crm_id crm_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql("ALTER TABLE crm_project CHANGE company_id company_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql("ALTER TABLE crm_sprint CHANGE project_id project_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql("ALTER TABLE crm_task CHANGE project_id project_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql("ALTER TABLE crm_task_request CHANGE task_id task_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE crm_task_request CHANGE task_id task_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql("ALTER TABLE crm_task CHANGE project_id project_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql("ALTER TABLE crm_sprint CHANGE project_id project_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql("ALTER TABLE crm_project CHANGE company_id company_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql("ALTER TABLE crm_company CHANGE crm_id crm_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+    }
+}

--- a/src/Crm/Domain/Entity/Company.php
+++ b/src/Crm/Domain/Entity/Company.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'crm_company')]
@@ -28,7 +29,8 @@ class Company implements EntityInterface
     private UuidInterface $id;
 
     #[ORM\ManyToOne(targetEntity: Crm::class, inversedBy: 'companies')]
-    #[ORM\JoinColumn(name: 'crm_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(name: 'crm_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull]
     private ?Crm $crm = null;
 
     #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]

--- a/src/Crm/Domain/Entity/Project.php
+++ b/src/Crm/Domain/Entity/Project.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'crm_project')]
@@ -30,7 +31,8 @@ class Project implements EntityInterface
     private UuidInterface $id;
 
     #[ORM\ManyToOne(targetEntity: Company::class, inversedBy: 'projects')]
-    #[ORM\JoinColumn(name: 'company_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(name: 'company_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull]
     private ?Company $company = null;
 
     #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]

--- a/src/Crm/Domain/Entity/Sprint.php
+++ b/src/Crm/Domain/Entity/Sprint.php
@@ -16,6 +16,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 use Throwable;
 
 #[ORM\Entity]
@@ -31,7 +32,8 @@ class Sprint implements EntityInterface
     private UuidInterface $id;
 
     #[ORM\ManyToOne(targetEntity: Project::class, inversedBy: 'sprints')]
-    #[ORM\JoinColumn(name: 'project_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(name: 'project_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull]
     private ?Project $project = null;
 
     #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]

--- a/src/Crm/Domain/Entity/Task.php
+++ b/src/Crm/Domain/Entity/Task.php
@@ -18,6 +18,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 use Throwable;
 
 #[ORM\Entity]
@@ -33,7 +34,8 @@ class Task implements EntityInterface
     private UuidInterface $id;
 
     #[ORM\ManyToOne(targetEntity: Project::class, inversedBy: 'tasks')]
-    #[ORM\JoinColumn(name: 'project_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(name: 'project_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull]
     private ?Project $project = null;
 
     #[ORM\ManyToOne(targetEntity: Sprint::class, inversedBy: 'tasks')]

--- a/src/Crm/Domain/Entity/TaskRequest.php
+++ b/src/Crm/Domain/Entity/TaskRequest.php
@@ -17,6 +17,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'crm_task_request')]
@@ -31,7 +32,8 @@ class TaskRequest implements EntityInterface
     private UuidInterface $id;
 
     #[ORM\ManyToOne(targetEntity: Task::class, inversedBy: 'taskRequests')]
-    #[ORM\JoinColumn(name: 'task_id', referencedColumnName: 'id', nullable: true, onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(name: 'task_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull]
     private ?Task $task = null;
 
     #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]

--- a/src/Crm/Transport/Request/CreateProjectRequest.php
+++ b/src/Crm/Transport/Request/CreateProjectRequest.php
@@ -28,6 +28,8 @@ final class CreateProjectRequest
     #[Assert\DateTime]
     public ?string $dueAt = null;
 
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
     #[Assert\Uuid]
     public ?string $companyId = null;
 

--- a/src/Crm/Transport/Request/CreateSprintRequest.php
+++ b/src/Crm/Transport/Request/CreateSprintRequest.php
@@ -25,6 +25,8 @@ final class CreateSprintRequest
     #[Assert\DateTime]
     public ?string $endDate = null;
 
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
     #[Assert\Uuid]
     public ?string $projectId = null;
 

--- a/src/Crm/Transport/Request/CreateTaskRequest.php
+++ b/src/Crm/Transport/Request/CreateTaskRequest.php
@@ -29,6 +29,8 @@ final class CreateTaskRequest
     #[Assert\Type(type: 'numeric')]
     public null|int|float|string $estimatedHours = null;
 
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
     #[Assert\Uuid]
     public ?string $projectId = null;
 

--- a/src/Crm/Transport/Request/CreateTaskRequestEntryRequest.php
+++ b/src/Crm/Transport/Request/CreateTaskRequestEntryRequest.php
@@ -22,6 +22,8 @@ final class CreateTaskRequestEntryRequest
     #[Assert\DateTime]
     public ?string $resolvedAt = null;
 
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
     #[Assert\Uuid]
     public ?string $taskId = null;
 


### PR DESCRIPTION
### Motivation
- Faire respecter les règles produit sur l’intégrité référentielle pour les entités CRM en rendant obligatoires les relations parent (ex: `Company.crm`, `Project.company`, `Sprint.project`, `Task.project`, `TaskRequest.task`).
- Empêcher la création d’objets orphelins depuis l’API en alignant la validation applicative sur les contraintes DB.

### Description
- Les `JoinColumn` ont été passés en `nullable: false` pour `crm_company.crm_id`, `crm_project.company_id`, `crm_sprint.project_id`, `crm_task.project_id` et `crm_task_request.task_id`, et les propriétés d’entité reçoivent `#[Assert\NotNull]` correspondants (fichiers sous `src/Crm/Domain/Entity`).
- Les DTO/requests de création ont été durcis pour exiger les références parentales en ajoutant `#[Assert\NotBlank]`/`#[Assert\NotNull]` sur `companyId`, `projectId` et `taskId` (fichiers sous `src/Crm/Transport/Request`).
- Ajout d’une migration Doctrine `migrations/Version20260313140000.php` qui supprime d’abord les enregistrements orphelins dans l’ordre contrôlé (leaf → parent) puis applique `NOT NULL` sur les colonnes FK ciblées, et inclut un `down()` qui restaure la nullabilité.
- Ajout d’un script SQL de remédiation `docs/sql/crm_required_relations_remediation.sql` proposant des requêtes de pré-vérification, suppression contrôlée et vérification post-remédiation pour exécution en runbook ops.

### Testing
- J’ai exécuté la vérification de syntaxe PHP `php -l` sur tous les fichiers modifiés (entités, requests, migration) et toutes les vérifications se sont terminées sans erreur.
- La validation de schéma via `php bin/console doctrine:schema:validate --skip-sync` n’a pas pu être exécutée avec succès en CI local car les dépendances ne sont pas installées dans cet environnement et `composer install` est requis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4012d8e2883268c29b07e969a2d76)