### PR TITLE
Fix QuizReadService class structure and restore stats caching

### DIFF
--- a/src/Quiz/Application/Service/QuizReadService.php
+++ b/src/Quiz/Application/Service/QuizReadService.php
@@ -4,33 +4,33 @@ declare(strict_types=1);
 
 namespace App\Quiz\Application\Service;
 
+use App\Quiz\Domain\Entity\Quiz;
+use App\Quiz\Domain\Enum\QuizCategory;
+use App\Quiz\Domain\Enum\QuizLevel;
+use App\Quiz\Infrastructure\Repository\QuizQuestionRepository;
+use App\Quiz\Infrastructure\Repository\QuizRepository;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+use function is_string;
+use function round;
+use function sprintf;
+
+final readonly class QuizReadService
+{
+    private const QUIZ_CACHE_TTL = 120;
     private const QUIZ_STATS_CACHE_TTL = 120;
-        $cacheKey = sprintf('quiz_stats_%s', $slug);
-        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($slug): array {
-            $item->expiresAfter(self::QUIZ_STATS_CACHE_TTL);
-            $quiz = $this->quizRepository->findOneByApplicationSlugWithConfiguration($slug);
-            if ($quiz === null) {
-                return [];
-            }
 
-            $stats = $this->quizQuestionRepository->getQuizStats($quiz);
+    public function __construct(
+        private QuizRepository $quizRepository,
+        private QuizQuestionRepository $quizQuestionRepository,
+        private CacheInterface $cache,
+    ) {
+    }
 
-            return [
-                'questionCount' => $stats['questionCount'],
-                'answerCount' => $stats['answerCount'],
-                'averageAnswersPerQuestion' => $stats['questionCount'] > 0
-                    ? round($stats['answerCount'] / $stats['questionCount'], 2)
-                    : 0.0,
-                'totalPoints' => $stats['totalPoints'],
-            ];
-        });
-
-    /**
-     * @throws InvalidArgumentException
-     */
     public function getByApplicationSlug(string $slug, ?string $level = null, ?string $category = null): array
     {
-        $cacheKey = sprintf('quiz_%s_%s_%s', $slug, (string)$level, (string)$category);
+        $cacheKey = sprintf('quiz_%s_%s_%s', $slug, (string) $level, (string) $category);
 
         return $this->cache->get($cacheKey, function (ItemInterface $item) use ($slug, $level, $category): array {
             $item->expiresAfter(self::QUIZ_CACHE_TTL);
@@ -73,31 +73,27 @@ namespace App\Quiz\Application\Service;
         });
     }
 
-    /**
-     * @throws InvalidArgumentException
-     */
     public function getStatsByApplicationSlug(string $slug): array
     {
-        $quiz = $this->getByApplicationSlug($slug);
-        if ($quiz === []) {
-            return [];
-        }
+        $cacheKey = sprintf('quiz_stats_%s', $slug);
 
-        $questionCount = 0;
-        $answerCount = 0;
-        $totalPoints = 0;
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($slug): array {
+            $item->expiresAfter(self::QUIZ_STATS_CACHE_TTL);
+            $quiz = $this->quizRepository->findOneByApplicationSlugWithConfiguration($slug);
+            if ($quiz === null) {
+                return [];
+            }
 
-        foreach ($quiz['questions'] as $question) {
-            ++$questionCount;
-            $answerCount += count($question['answers']);
-            $totalPoints += (int)$question['points'];
-        }
+            $stats = $this->quizQuestionRepository->getQuizStats($quiz);
 
-        return [
-            'questionCount' => $questionCount,
-            'answerCount' => $answerCount,
-            'averageAnswersPerQuestion' => $questionCount > 0 ? round($answerCount / $questionCount, 2) : 0.0,
-            'totalPoints' => $totalPoints,
-        ];
+            return [
+                'questionCount' => $stats['questionCount'],
+                'answerCount' => $stats['answerCount'],
+                'averageAnswersPerQuestion' => $stats['questionCount'] > 0
+                    ? round($stats['answerCount'] / $stats['questionCount'], 2)
+                    : 0.0,
+                'totalPoints' => $stats['totalPoints'],
+            ];
+        });
     }
 }


### PR DESCRIPTION
### Motivation
- The original `QuizReadService` file contained top-level `private` code that caused a PHP parse error and broke application startup.
- Restoring a valid class structure and cache-backed stats logic is required to make quiz read and stats endpoints usable and efficient.

### Description
- Rewrote `QuizReadService` with proper `use` imports, a `final readonly class` declaration, cache TTL constants, and constructor injection for `QuizRepository`, `QuizQuestionRepository`, and `CacheInterface`.
- Restored `getByApplicationSlug()` to return a cached, normalized quiz payload with optional `level`/`category` filtering using `QuizLevel::fromString` and `QuizCategory::fromString`.
- Implemented `getStatsByApplicationSlug()` to use a dedicated cache key and obtain aggregated stats from `QuizQuestionRepository::getQuizStats()`, including computed `averageAnswersPerQuestion`.
- Added `use function` imports for `is_string`, `round`, and `sprintf` and standardized cache key formatting.

### Testing
- Ran a syntax check with `php -l src/Quiz/Application/Service/QuizReadService.php` which reported no syntax errors.
- Executed `composer prepare` which failed in this environment due to missing installed dependencies and not because of the updated file (`Dependencies are missing. Try running "composer install"`).
- Verified the updated service mirrors repository calls and caching patterns used elsewhere in the codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b403bfeb8883268ee339d44824f169)