### PR TITLE
Centralize REST method traits and fix user retrieval in Chat conversation controller

### DIFF
--- a/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/UserConversationListController.php
@@ -12,8 +12,10 @@ use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
@@ -36,7 +38,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 readonly class UserConversationListController
 {
     public function __construct(
-        private ConversationListService $conversationListService
+        private ConversationListService $conversationListService,
+        private Security $security,
     ) {
     }
 
@@ -45,8 +48,13 @@ readonly class UserConversationListController
      * @throws InvalidArgumentException
      */
     #[Route(path: '/v1/chat/private/conversations', methods: [Request::METHOD_GET])]
-    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    public function __invoke(Request $request): JsonResponse
     {
+        $loggedInUser = $this->security->getUser();
+        if (!$loggedInUser instanceof User) {
+            throw new AccessDeniedHttpException('User not authenticated.');
+        }
+
         $page = max(1, $request->query->getInt('page', 1));
         $limit = max(1, min(100, $request->query->getInt('limit', 20)));
         $filters = [

--- a/src/General/Transport/Rest/Controller.php
+++ b/src/General/Transport/Rest/Controller.php
@@ -9,6 +9,14 @@ use App\General\Application\Rest\Interfaces\RestSmallResourceInterface;
 use App\General\Transport\Rest\Interfaces\ControllerInterface;
 use App\General\Transport\Rest\Interfaces\ResponseHandlerInterface;
 use App\General\Transport\Rest\Traits\Actions\RestActionBase;
+use App\General\Transport\Rest\Traits\Methods\CountMethod;
+use App\General\Transport\Rest\Traits\Methods\CreateMethod;
+use App\General\Transport\Rest\Traits\Methods\DeleteMethod;
+use App\General\Transport\Rest\Traits\Methods\FindMethod;
+use App\General\Transport\Rest\Traits\Methods\FindOneMethod;
+use App\General\Transport\Rest\Traits\Methods\IdsMethod;
+use App\General\Transport\Rest\Traits\Methods\PatchMethod;
+use App\General\Transport\Rest\Traits\Methods\UpdateMethod;
 use App\General\Transport\Rest\Traits\RestMethodHelper;
 use Override;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,6 +32,14 @@ abstract class Controller implements ControllerInterface
 {
     use RestActionBase;
     use RestMethodHelper;
+    use CountMethod;
+    use CreateMethod;
+    use DeleteMethod;
+    use FindMethod;
+    use FindOneMethod;
+    use IdsMethod;
+    use PatchMethod;
+    use UpdateMethod;
 
     public const string ACTION_COUNT = 'countAction';
     public const string ACTION_CREATE = 'createAction';

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyCountController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyCountController.php
@@ -13,12 +13,15 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\CountMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class CompanyCountController extends Controller
 {
+    use CountMethod;
+
     public function __construct(
         CompanyResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyCreateController.php
@@ -20,12 +20,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 use function count;
+use App\General\Transport\Rest\Traits\Methods\CreateMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class CompanyCreateController extends Controller
 {
+    use CreateMethod;
+
     public function __construct(
         CompanyResource $resource,
         private readonly AutoMapperInterface $autoMapper,

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyDeleteController.php
@@ -14,12 +14,15 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\DeleteMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class CompanyDeleteController extends Controller
 {
+    use DeleteMethod;
+
     public function __construct(
         CompanyResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyIdsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyIdsController.php
@@ -13,12 +13,15 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\IdsMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class CompanyIdsController extends Controller
 {
+    use IdsMethod;
+
     public function __construct(
         CompanyResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Company/CompanyPatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Company/CompanyPatchController.php
@@ -21,12 +21,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 use function count;
+use App\General\Transport\Rest\Traits\Methods\PatchMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class CompanyPatchController extends Controller
 {
+    use PatchMethod;
+
     public function __construct(
         CompanyResource $resource,
         private readonly AutoMapperInterface $autoMapper,

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCountController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCountController.php
@@ -13,12 +13,15 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\CountMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class JobCountController extends Controller
 {
+    use CountMethod;
+
     public function __construct(
         JobResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateController.php
@@ -21,12 +21,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 use function count;
+use App\General\Transport\Rest\Traits\Methods\CreateMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class JobCreateController extends Controller
 {
+    use CreateMethod;
+
     public function __construct(
         JobResource $resource,
         private readonly AutoMapperInterface $autoMapper,

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteController.php
@@ -14,12 +14,15 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\DeleteMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class JobDeleteController extends Controller
 {
+    use DeleteMethod;
+
     public function __construct(
         JobResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobIdsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobIdsController.php
@@ -13,12 +13,15 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\IdsMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class JobIdsController extends Controller
 {
+    use IdsMethod;
+
     public function __construct(
         JobResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchController.php
@@ -22,12 +22,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 use function count;
+use App\General\Transport\Rest\Traits\Methods\PatchMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class JobPatchController extends Controller
 {
+    use PatchMethod;
+
     public function __construct(
         JobResource $resource,
         private readonly AutoMapperInterface $autoMapper,

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryCountController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryCountController.php
@@ -13,12 +13,15 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\CountMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class SalaryCountController extends Controller
 {
+    use CountMethod;
+
     public function __construct(
         SalaryResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryCreateController.php
@@ -20,12 +20,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 use function count;
+use App\General\Transport\Rest\Traits\Methods\CreateMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class SalaryCreateController extends Controller
 {
+    use CreateMethod;
+
     public function __construct(
         SalaryResource $resource,
         private readonly AutoMapperInterface $autoMapper,

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryDeleteController.php
@@ -14,12 +14,15 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\DeleteMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class SalaryDeleteController extends Controller
 {
+    use DeleteMethod;
+
     public function __construct(
         SalaryResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryIdsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryIdsController.php
@@ -13,12 +13,15 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\IdsMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class SalaryIdsController extends Controller
 {
+    use IdsMethod;
+
     public function __construct(
         SalaryResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryPatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Salary/SalaryPatchController.php
@@ -21,12 +21,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 use function count;
+use App\General\Transport\Rest\Traits\Methods\PatchMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class SalaryPatchController extends Controller
 {
+    use PatchMethod;
+
     public function __construct(
         SalaryResource $resource,
         private readonly AutoMapperInterface $autoMapper,

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagCountController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagCountController.php
@@ -13,12 +13,15 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\CountMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class TagCountController extends Controller
 {
+    use CountMethod;
+
     public function __construct(
         TagResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagCreateController.php
@@ -20,12 +20,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 use function count;
+use App\General\Transport\Rest\Traits\Methods\CreateMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class TagCreateController extends Controller
 {
+    use CreateMethod;
+
     public function __construct(
         TagResource $resource,
         private readonly AutoMapperInterface $autoMapper,

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagDeleteController.php
@@ -14,12 +14,15 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Routing\Requirement\Requirement;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\DeleteMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class TagDeleteController extends Controller
 {
+    use DeleteMethod;
+
     public function __construct(
         TagResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagIdsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagIdsController.php
@@ -13,12 +13,15 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use App\General\Transport\Rest\Traits\Methods\IdsMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class TagIdsController extends Controller
 {
+    use IdsMethod;
+
     public function __construct(
         TagResource $resource,
     ) {

--- a/src/Recruit/Transport/Controller/Api/V1/Tag/TagPatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Tag/TagPatchController.php
@@ -21,12 +21,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 use function count;
+use App\General\Transport\Rest\Traits\Methods\PatchMethod;
 
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Recruit Management')]
 class TagPatchController extends Controller
 {
+    use PatchMethod;
+
     public function __construct(
         TagResource $resource,
         private readonly AutoMapperInterface $autoMapper,


### PR DESCRIPTION
### Motivation
- Reduce duplication by centralizing common REST method implementations into reusable traits and expose them via the base `Controller` class. 
- Make controllers for Recruit resources (`Company`, `Job`, `Salary`, `Tag`) leaner by reusing the centralized method traits. 
- Fix the Chat conversation listing controller to retrieve the logged-in user via the `Security` service and explicitly deny access when no authenticated `User` is available.

### Description
- Added imports of REST method traits into `App\General\Transport\Rest\Controller` and enabled the traits (`CountMethod`, `CreateMethod`, `DeleteMethod`, `FindMethod`, `FindOneMethod`, `IdsMethod`, `PatchMethod`, `UpdateMethod`) on the base controller, and kept existing helper traits and action/method constants. 
- Updated many Recruit API controllers (`Company*`, `Job*`, `Salary*`, `Tag*`) to `use` the appropriate method trait (`CountMethod`, `CreateMethod`, `DeleteMethod`, `IdsMethod`, `PatchMethod`) and call the delegated methods such as `countMethod`, `createMethod`, `deleteMethod`, `idsMethod`, and `patchMethod`. 
- Modified `UserConversationListController` to inject `Security` instead of expecting a `User` argument on `__invoke`, check that the returned user is an instance of `User`, and throw an `AccessDeniedHttpException` when not authenticated; updated imports accordingly.

### Testing
- Ran the test suite with `phpunit` and the unit/integration tests completed successfully. 
- Ran static analysis with `phpstan` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b470a06fe88326b2f15c5633f6fedd)