### PR TITLE
Hide quiz answer correction data from public GET endpoint

### DIFF
--- a/src/Quiz/Application/Service/QuizReadService.php
+++ b/src/Quiz/Application/Service/QuizReadService.php
@@ -30,9 +30,30 @@ final readonly class QuizReadService
 
     public function getByApplicationSlug(string $slug, ?string $level = null, ?string $category = null): array
     {
-        $cacheKey = sprintf('quiz_%s_%s_%s', $slug, (string)$level, (string)$category);
+        return $this->getQuizProjectionByApplicationSlug($slug, $level, $category, false);
+    }
 
-        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($slug, $level, $category): array {
+    public function getCorrectionByApplicationSlug(string $slug, ?string $level = null, ?string $category = null): array
+    {
+        return $this->getQuizProjectionByApplicationSlug($slug, $level, $category, true);
+    }
+
+    private function getQuizProjectionByApplicationSlug(
+        string $slug,
+        ?string $level,
+        ?string $category,
+        bool $includeCorrection,
+    ): array
+    {
+        $cacheKey = sprintf(
+            'quiz_%s_%s_%s_%s',
+            $slug,
+            (string)$level,
+            (string)$category,
+            $includeCorrection ? 'with_correction' : 'public',
+        );
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($slug, $level, $category, $includeCorrection): array {
             $item->expiresAfter(self::QUIZ_CACHE_TTL);
             $quiz = $this->quizRepository->findOneByApplicationSlugWithConfiguration($slug);
 
@@ -62,12 +83,22 @@ final readonly class QuizReadService
                     'position' => $q->getPosition(),
                     'points' => $q->getPoints(),
                     'explanation' => $q->getExplanation(),
-                    'answers' => array_map(static fn ($a): array => [
-                        'id' => $a->getId(),
-                        'label' => $a->getLabel(),
-                        'correct' => $a->isCorrect(),
-                        'position' => $a->getPosition(),
-                    ], $q->getAnswers()->toArray()),
+                    'answers' => array_map(
+                        static function ($a) use ($includeCorrection): array {
+                            $answer = [
+                                'id' => $a->getId(),
+                                'label' => $a->getLabel(),
+                                'position' => $a->getPosition(),
+                            ];
+
+                            if ($includeCorrection) {
+                                $answer['correct'] = $a->isCorrect();
+                            }
+
+                            return $answer;
+                        },
+                        $q->getAnswers()->toArray()
+                    ),
                 ], $questions),
             ];
         });

--- a/src/Quiz/Application/Service/QuizSubmissionService.php
+++ b/src/Quiz/Application/Service/QuizSubmissionService.php
@@ -47,7 +47,7 @@ final readonly class QuizSubmissionService
             throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "answers" must be an array.');
         }
 
-        $quizData = $this->quizReadService->getByApplicationSlug($applicationSlug);
+        $quizData = $this->quizReadService->getCorrectionByApplicationSlug($applicationSlug);
         if ($quizData === []) {
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Quiz not found for this application.');
         }

--- a/tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php
+++ b/tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php
@@ -67,6 +67,34 @@ final class SubmitQuizByApplicationControllerTest extends WebTestCase
         self::assertSame(count($questions), (int)$responseData['correctAnswers']);
     }
 
+    #[TestDox('GET quiz by application does not expose answers correction data.')]
+    public function testGetQuizByApplicationDoesNotExposeAnswerCorrection(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $quiz = $this->getAnyPublishedQuiz($entityManager);
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request('GET', $this->baseUrl . '/' . $quiz->getApplication()->getSlug());
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData['questions'] ?? null);
+
+        foreach ($responseData['questions'] as $question) {
+            self::assertIsArray($question['answers'] ?? null);
+
+            foreach ($question['answers'] as $answer) {
+                self::assertIsArray($answer);
+                self::assertArrayNotHasKey('correct', $answer);
+            }
+        }
+    }
+
     #[TestDox('Submitting invalid quiz payload returns 422.')]
     public function testSubmitQuizWithInvalidPayloadReturnsValidationError(): void
     {


### PR DESCRIPTION
### Motivation

- Prevent leaking answer correction metadata (`answers[].correct`) in the public `GET /v1/quiz/applications/{applicationSlug}` API while still allowing server-side scoring to use the correction data.

### Description

- Added `QuizReadService::getCorrectionByApplicationSlug` and centralized projection logic in `getQuizProjectionByApplicationSlug(..., bool $includeCorrection)` to produce public vs internal projections and vary the cache key accordingly.
- The public projection returned by `getByApplicationSlug` no longer includes the `correct` field in answer objects, while the internal projection (used for scoring) includes it.
- Updated `QuizSubmissionService::submitByApplicationSlug` to call `getCorrectionByApplicationSlug` so scoring uses server-only correction data.
- Added an integration assertion `testGetQuizByApplicationDoesNotExposeAnswerCorrection` in `tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php` to validate `GET` responses do not expose `answers[].correct`.

### Testing

- `php -l` syntax checks were run for `src/Quiz/Application/Service/QuizReadService.php`, `src/Quiz/Application/Service/QuizSubmissionService.php` and the modified test file and they all passed.
- Attempted to run `vendor/bin/phpunit` and `bin/phpunit` for the new/updated tests but the phpunit binary is not present in this environment so the test suite could not be executed here (failure due to missing binary).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4aa35bf808326b5e34482426c02b3)