### PR TITLE
Enforce published-only access for quiz read and submit endpoints

### DIFF
--- a/src/Quiz/Application/Service/QuizReadService.php
+++ b/src/Quiz/Application/Service/QuizReadService.php
@@ -9,6 +9,8 @@ use App\Quiz\Domain\Enum\QuizCategory;
 use App\Quiz\Domain\Enum\QuizLevel;
 use App\Quiz\Infrastructure\Repository\QuizQuestionRepository;
 use App\Quiz\Infrastructure\Repository\QuizRepository;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 
@@ -59,6 +61,10 @@ final readonly class QuizReadService
 
             if (!$quiz instanceof Quiz) {
                 return [];
+            }
+
+            if (!$quiz->isPublished()) {
+                throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Quiz not found for this application.');
             }
 
             $questions = $this->quizQuestionRepository->findByFilters(

--- a/src/Quiz/Application/Service/QuizSubmissionService.php
+++ b/src/Quiz/Application/Service/QuizSubmissionService.php
@@ -33,11 +33,7 @@ final readonly class QuizSubmissionService
      */
     public function submitByApplicationSlug(string $applicationSlug, array $payload): array
     {
-        $quiz = $this->quizRepository->createQueryBuilder('q')
-            ->leftJoin('q.application', 'application')->addSelect('application')
-            ->andWhere('application.slug = :slug')->setParameter('slug', $applicationSlug)
-            ->getQuery()
-            ->getOneOrNullResult();
+        $quiz = $this->quizRepository->findPublishedByApplicationSlugWithConfiguration($applicationSlug);
 
         if (!$quiz instanceof Quiz) {
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Quiz not found for this application.');

--- a/src/Quiz/Infrastructure/Repository/QuizRepository.php
+++ b/src/Quiz/Infrastructure/Repository/QuizRepository.php
@@ -39,4 +39,17 @@ class QuizRepository extends BaseRepository
 
         return $result instanceof Quiz ? $result : null;
     }
+
+    public function findPublishedByApplicationSlugWithConfiguration(string $slug): ?Quiz
+    {
+        $result = $this->createQueryBuilder('quiz')
+            ->leftJoin('quiz.application', 'application')
+            ->leftJoin('quiz.configuration', 'configuration')->addSelect('configuration')
+            ->andWhere('application.slug = :slug')->setParameter('slug', $slug)
+            ->andWhere('quiz.isPublished = true')
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $result instanceof Quiz ? $result : null;
+    }
 }

--- a/tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php
+++ b/tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php
@@ -95,6 +95,41 @@ final class SubmitQuizByApplicationControllerTest extends WebTestCase
         }
     }
 
+
+    #[TestDox('GET quiz by application returns 404 for an unpublished quiz.')]
+    public function testGetQuizByApplicationReturnsNotFoundWhenQuizIsNotPublished(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $quiz = $this->getAnyPublishedQuiz($entityManager);
+        $quiz->setPublished(false);
+        $entityManager->flush();
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request('GET', $this->baseUrl . '/' . $quiz->getApplication()->getSlug());
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+    }
+
+    #[TestDox('Submitting a quiz returns 404 when the quiz is not published.')]
+    public function testSubmitQuizReturnsNotFoundWhenQuizIsNotPublished(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $quiz = $this->getAnyPublishedQuiz($entityManager);
+        $quiz->setPublished(false);
+        $entityManager->flush();
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request(
+            'POST',
+            $this->baseUrl . '/' . $quiz->getApplication()->getSlug() . '/submit',
+            content: JSON::encode([
+                'answers' => [],
+            ])
+        );
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+    }
+
     #[TestDox('Submitting invalid quiz payload returns 422.')]
     public function testSubmitQuizWithInvalidPayloadReturnsValidationError(): void
     {


### PR DESCRIPTION
### Motivation
- Ensure unpublished quizzes are not visible or submittable through public read and submit endpoints by enforcing a business-level published check.
- Centralize the published constraint in the repository to avoid duplicated query logic.
- Add controller-level tests to validate the product rule that unpublished quizzes should return `404` on GET and POST submit.

### Description
- Added an explicit `isPublished()` guard in `QuizReadService::getQuizProjectionByApplicationSlug()` that throws a `404` `HttpException` when a quiz exists but is not published.
- Introduced `QuizRepository::findPublishedByApplicationSlugWithConfiguration()` to fetch only published quizzes with their configuration.
- Updated `QuizSubmissionService::submitByApplicationSlug()` to use the new repository method so submissions against unpublished quizzes immediately return `404`.
- Extended `tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php` with two tests that assert GET and POST return `404` when the quiz is unpublished.

### Testing
- Ran syntax checks with `php -l` on changed files which succeeded for `src/Quiz/Application/Service/QuizReadService.php`, `src/Quiz/Application/Service/QuizSubmissionService.php`, `src/Quiz/Infrastructure/Repository/QuizRepository.php` and the modified test file.
- Attempted to run the specific PHPUnit test but the test runner was not available in the environment (`./vendor/bin/phpunit` and `bin/phpunit` were not found), so full test execution could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4abc4c900832697a0fef2bb0ca2cd)