### PR TITLE
Align archived filtering for user conversation list/count and add integration test

### DIFF
--- a/src/Chat/Infrastructure/Repository/ConversationRepository.php
+++ b/src/Chat/Infrastructure/Repository/ConversationRepository.php
@@ -47,26 +47,14 @@ class ConversationRepository extends BaseRepository implements ConversationRepos
     {
         $offset = max(0, ($page - 1) * $limit);
 
-        $qb = $this->createQueryBuilder('conversation')
-            ->addSelect('chat')
-            ->innerJoin('conversation.chat', 'chat')
+        $qb = $this->applyListFilters($this->getConversationListQueryBuilder(), $filters, $esIds)
             ->innerJoin('conversation.participants', 'participant');
 
-        if (($filters['message'] ?? '') !== '') {
-            $qb->innerJoin('conversation.messages', 'messages')
-                ->andWhere('LOWER(messages.content) LIKE LOWER(:message)')
-                ->setParameter('message', '%' . $filters['message'] . '%');
-        }
-
-        if ($esIds !== null) {
-            $qb->andWhere('conversation.id IN (:esIds)')
-                ->setParameter('esIds', $esIds);
-        }
-
         return $qb
-            ->andWhere('IDENTITY(participant.user) = :userId')
-            ->setParameter('userId', $user->getId(), UuidBinaryOrderedTimeType::NAME)
-            ->orderBy('conversation.createdAt', 'DESC')
+            ->andWhere('participant.user = :user')
+            ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->orderBy('conversation.lastMessageAt', 'DESC')
+            ->addOrderBy('conversation.createdAt', 'DESC')
             ->setFirstResult($offset)
             ->setMaxResults($limit)
             ->getQuery()

--- a/tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php
+++ b/tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 
 namespace App\Tests\Application\Chat\Transport\Controller\Api\V1\Conversation;
 
+use App\Chat\Domain\Entity\ChatMessage;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
 use App\General\Domain\Utils\JSON;
 use App\Recruit\Infrastructure\DataFixtures\ORM\LoadRecruitChatCalendarScenarioData;
 use App\Tests\TestCase\WebTestCase;
+use App\User\Domain\Entity\User;
 use App\User\Infrastructure\DataFixtures\ORM\LoadUserData;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
@@ -63,6 +69,104 @@ final class UserConversationControllerTest extends WebTestCase
 
         $client->request('POST', $this->baseUrl . '/chats/' . $chatId . '/conversations', [], [], [], JSON::encode([]));
         self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+    }
+
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('GET conversations excludes archived conversations from items and pagination total, including with page/limit')]
+    public function testListExcludesArchivedConversationFromItemsAndTotal(): void
+    {
+        $this->createActiveAndArchivedConversationsForJohnRoot();
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', $this->baseUrl . '/conversations?message=archived-filter-token');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $content = $client->getResponse()->getContent();
+        self::assertNotFalse($content);
+        $payload = JSON::decode($content, true);
+
+        self::assertCount(1, $payload['items']);
+        self::assertSame(1, $payload['pagination']['totalItems']);
+
+        $client->request('GET', $this->baseUrl . '/conversations?message=archived-filter-token&page=2&limit=1');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $pagedContent = $client->getResponse()->getContent();
+        self::assertNotFalse($pagedContent);
+        $pagedPayload = JSON::decode($pagedContent, true);
+
+        self::assertCount(0, $pagedPayload['items']);
+        self::assertSame(1, $pagedPayload['pagination']['totalItems']);
+    }
+
+    private function createActiveAndArchivedConversationsForJohnRoot(): void
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        /** @var Conversation|null $seedConversation */
+        $seedConversation = $entityManager->getRepository(Conversation::class)->find(
+            LoadRecruitChatCalendarScenarioData::getUuidByKey('conversation-john-root-scenario')
+        );
+
+        self::assertInstanceOf(Conversation::class, $seedConversation);
+
+        $chat = $seedConversation->getChat();
+        $johnRoot = $this->getUserReference($entityManager, 'john-root');
+        $johnAdmin = $this->getUserReference($entityManager, 'john-admin');
+
+        $activeConversation = (new Conversation())
+            ->setChat($chat);
+
+        $archivedConversation = (new Conversation())
+            ->setChat($chat)
+            ->setArchivedAt(new DateTimeImmutable('now'));
+
+        $this->addParticipant($activeConversation, $johnRoot, $johnAdmin);
+        $this->addParticipant($archivedConversation, $johnRoot, $johnAdmin);
+
+        $this->addMessage($activeConversation, $johnRoot, 'archived-filter-token active');
+        $this->addMessage($archivedConversation, $johnRoot, 'archived-filter-token archived');
+
+        $entityManager->persist($activeConversation);
+        $entityManager->persist($archivedConversation);
+        $entityManager->flush();
+    }
+
+    private function addParticipant(Conversation $conversation, User ...$users): void
+    {
+        foreach ($users as $user) {
+            $participant = (new ConversationParticipant())
+                ->setConversation($conversation)
+                ->setUser($user);
+
+            $conversation->addParticipant($participant);
+        }
+    }
+
+    private function addMessage(Conversation $conversation, User $sender, string $content): void
+    {
+        $message = (new ChatMessage())
+            ->setConversation($conversation)
+            ->setSender($sender)
+            ->setContent($content);
+
+        $conversation->addMessage($message);
+        $conversation->setLastMessageAt(new DateTimeImmutable('now'));
+    }
+
+    private function getUserReference(EntityManagerInterface $entityManager, string $key): User
+    {
+        $user = $entityManager->getRepository(User::class)->find(
+            LoadUserData::getUuidByKey($key)
+        );
+
+        self::assertNotNull($user);
+
+        return $user;
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Garantir que les méthodes `findByUser()` et `countByUser()` appliquent exactement la même contrainte métier d’archivage (`conversation.archivedAt IS NULL`) pour éviter des écarts entre `items` et `pagination.totalItems`.
- Stabiliser le comportement de pagination en harmonisant l’ordre des listes avec le reste des requêtes (`lastMessageAt DESC`, puis `createdAt DESC`).

### Description

- Réécriture de `ConversationRepository::findByUser()` pour réutiliser `applyListFilters($this->getConversationListQueryBuilder(), $filters, $esIds)` ce qui applique déjà `conversation.archivedAt IS NULL`.
- Alimentation de la jointure des participants avec `participant.user = :user` et harmonisation du tri à `conversation.lastMessageAt DESC` puis `conversation.createdAt DESC` dans `findByUser()`.
- Ajout d’un test d’intégration `testListExcludesArchivedConversationFromItemsAndTotal()` dans `tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php` qui crée une conversation active et une conversation archivée portant le même token de filtre, puis vérifie que `items` et `pagination.totalItems` ne comptent que l’active et que `pagination.totalItems` reste stable avec `page/limit`.
- Fichiers modifiés : `src/Chat/Infrastructure/Repository/ConversationRepository.php` et `tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php`.

### Testing

- Exécution de vérifications de syntaxe avec `php -l src/Chat/Infrastructure/Repository/ConversationRepository.php` qui a réussi.
- Vérification de syntaxe avec `php -l tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php` qui a réussi.
- Tentative d’exécution du test ciblé via `vendor/bin/phpunit` dans cet environnement, mais l’exécutable `vendor/bin/phpunit` est indisponible, donc les tests PHPUnit d’intégration n’ont pas pu être lancés ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ac7a5900832683df8fac1a4e4b7d)