### PR TITLE
Scope school create controllers by application slug

### DIFF
--- a/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\School\Transport\Controller\Api\V1\Exam;
 
+use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Application\Service\CreateExamService;
 use App\School\Domain\Enum\ExamStatus;
 use App\School\Domain\Enum\ExamType;
 use App\School\Domain\Enum\Term;
 use App\School\Transport\Controller\Api\V1\Input\CreateExamInput;
 use App\School\Transport\Controller\Api\V1\Input\SchoolInputValidator;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,6 +26,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateExamController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private CreateExamService $createExamService,
         private SchoolInputValidator $inputValidator,
     ) {
@@ -51,9 +54,10 @@ final readonly class CreateExamController
     )]
     #[Route('/v1/school/applications/{applicationSlug}/exams', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, Request $request): JsonResponse
+    public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {
-        $request->attributes->set('applicationSlug', $applicationSlug);
+        $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
         $payload = $request->toArray();
 
         $input = new CreateExamInput();

--- a/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\School\Transport\Controller\Api\V1\Grade;
 
+use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Application\Service\CreateGradeService;
 use App\School\Transport\Controller\Api\V1\Input\CreateGradeInput;
 use App\School\Transport\Controller\Api\V1\Input\SchoolInputValidator;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,6 +23,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateGradeController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private CreateGradeService $createGradeService,
         private SchoolInputValidator $inputValidator,
     ) {
@@ -28,9 +31,10 @@ final readonly class CreateGradeController
 
     #[Route('/v1/school/applications/{applicationSlug}/grades', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, Request $request): JsonResponse
+    public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {
-        $request->attributes->set('applicationSlug', $applicationSlug);
+        $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
         $payload = $request->toArray();
 
         $input = new CreateGradeInput();

--- a/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\School\Transport\Controller\Api\V1\Student;
 
 use App\School\Application\Service\CreateStudentService;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Transport\Controller\Api\V1\Input\CreateStudentInput;
 use App\School\Transport\Controller\Api\V1\Input\SchoolInputValidator;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,6 +23,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateStudentController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private CreateStudentService $createStudentService,
         private SchoolInputValidator $inputValidator,
     ) {
@@ -28,9 +31,10 @@ final readonly class CreateStudentController
 
     #[Route('/v1/school/applications/{applicationSlug}/students', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, Request $request): JsonResponse
+    public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {
-        $request->attributes->set('applicationSlug', $applicationSlug);
+        $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
         $payload = $request->toArray();
 
         $input = new CreateStudentInput();

--- a/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\School\Transport\Controller\Api\V1\Teacher;
 
+use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Application\Service\CreateTeacherService;
 use App\School\Transport\Controller\Api\V1\Input\CreateTeacherInput;
 use App\School\Transport\Controller\Api\V1\Input\SchoolInputValidator;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,6 +23,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateTeacherController
 {
     public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
         private CreateTeacherService $createTeacherService,
         private SchoolInputValidator $inputValidator,
     ) {
@@ -28,9 +31,10 @@ final readonly class CreateTeacherController
 
     #[Route('/v1/school/applications/{applicationSlug}/teachers', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, Request $request): JsonResponse
+    public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {
-        $request->attributes->set('applicationSlug', $applicationSlug);
+        $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+
         $payload = $request->toArray();
 
         $input = new CreateTeacherInput();

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
@@ -78,6 +78,68 @@ final class SchoolApplicationScopedRoutesTest extends WebTestCase
             'name' => 'Classe Forbidden',
         ]));
         self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $ownerClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/students', [], [], [], JSON::encode([
+            'name' => 'Eleve Scoped Create',
+            'classId' => $classId,
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/students', [], [], [], JSON::encode([
+            'name' => 'Eleve Forbidden',
+            'classId' => $classId,
+        ]));
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $ownerClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/teachers', [], [], [], JSON::encode([
+            'name' => 'Prof Scoped Create',
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $ownerClient->getResponse()->getStatusCode());
+        $teacherId = JSON::decode((string)$ownerClient->getResponse()->getContent(), true)['id'];
+
+        $forbiddenClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/teachers', [], [], [], JSON::encode([
+            'name' => 'Prof Forbidden',
+        ]));
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $ownerClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams', [], [], [], JSON::encode([
+            'title' => 'Examen Scoped Create',
+            'classId' => $classId,
+            'teacherId' => $teacherId,
+            'type' => 'QUIZ',
+            'status' => 'DRAFT',
+            'term' => 'TERM_1',
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $ownerClient->getResponse()->getStatusCode());
+        $examId = JSON::decode((string)$ownerClient->getResponse()->getContent(), true)['id'];
+
+        $forbiddenClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams', [], [], [], JSON::encode([
+            'title' => 'Examen Forbidden',
+            'classId' => $classId,
+            'teacherId' => $teacherId,
+            'type' => 'QUIZ',
+            'status' => 'DRAFT',
+            'term' => 'TERM_1',
+        ]));
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/students');
+        $studentsResponseData = JSON::decode((string)$ownerClient->getResponse()->getContent(), true);
+        $studentId = $studentsResponseData['items'][0]['id'];
+
+        $ownerClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/grades', [], [], [], JSON::encode([
+            'score' => 15.5,
+            'studentId' => $studentId,
+            'examId' => $examId,
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $ownerClient->getResponse()->getStatusCode());
+
+        $forbiddenClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/grades', [], [], [], JSON::encode([
+            'score' => 12.0,
+            'studentId' => $studentId,
+            'examId' => $examId,
+        ]));
+        self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
     }
 
     #[TestDox('School scoped list endpoints only return data for the current school application.')]


### PR DESCRIPTION
### Motivation
- Ensure create endpoints for school-scoped resources validate and enforce the current application scope before performing business logic to prevent cross-application writes.
- Align create controllers with existing list/detail/delete controllers that already resolve application-scoped schools via `SchoolApplicationScopeResolver`.
- Add coverage for owner vs foreign-owner access on create endpoints to prevent regressions in access control.

### Description
- Injected `SchoolApplicationScopeResolver` into the `Create*Controller` classes for `Student`, `Teacher`, `Exam` and `Grade` and added `use App\User\Domain\Entity\User;` where needed.
- Updated each `__invoke` signature to accept `?User $loggedInUser` and added a call to `resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser)` before request payload parsing and business logic.
- Kept the scoped route paths as `/v1/school/applications/{applicationSlug}/...` and did not add or remove routes.
- Extended `tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php` to include owner vs foreign-owner POST assertions for `students`, `teachers`, `exams`, and `grades` create endpoints.

### Testing
- Ran PHP linting with `php -l` on the modified controllers and the updated test file and observed no syntax errors.
- Attempted to run the PHPUnit test with `./vendor/bin/phpunit tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php` but the environment lacks `vendor/bin/phpunit`, so full test execution could not be completed here.
- Verified repository changes locally via file diffs and ensured the new call to `resolveOrCreateSchoolByApplicationSlug` is present in each create controller and that the test additions compile.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4aca00cc4832699b9c1c592b1d7af)