### PR TITLE
Enforce checkout application scope and add scoped HTTP integration tests

### DIFF
--- a/src/Shop/Application/Message/CheckoutCommand.php
+++ b/src/Shop/Application/Message/CheckoutCommand.php
@@ -10,6 +10,7 @@ final readonly class CheckoutCommand implements MessageHighInterface
 {
     public function __construct(
         public string $operationId,
+        public string $applicationSlug,
         public string $shopId,
         public string $userId,
         public string $billingAddress,

--- a/src/Shop/Application/Service/CheckoutService.php
+++ b/src/Shop/Application/Service/CheckoutService.php
@@ -47,6 +47,10 @@ final readonly class CheckoutService
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Shop not found.');
         }
 
+        if ($shop->getApplication()?->getSlug() !== $command->applicationSlug) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Shop does not belong to the requested application scope.');
+        }
+
         $user = $this->userRepository->find($command->userId);
         if ($user === null) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');

--- a/src/Shop/Transport/Controller/Api/V1/Checkout/CheckoutController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Checkout/CheckoutController.php
@@ -60,6 +60,7 @@ final readonly class CheckoutController
 
         $envelope = $this->messageBus->dispatch(new CheckoutCommand(
             operationId: $request->headers->get('x-request-id', uniqid('checkout-', true)),
+            applicationSlug: $applicationSlug,
             shopId: $shopId,
             userId: $user->getId(),
             billingAddress: $input->billingAddress,

--- a/tests/Application/Shop/Transport/Controller/Api/V1/CheckoutControllerTest.php
+++ b/tests/Application/Shop/Transport/Controller/Api/V1/CheckoutControllerTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Shop\Transport\Controller\Api\V1;
+
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Tests\TestCase\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class CheckoutControllerTest extends WebTestCase
+{
+    public function testCheckoutReturnsCreatedOrAcceptedWhenScopeIsValid(): void
+    {
+        /** @var ShopRepository $shopRepository */
+        $shopRepository = static::getContainer()->get(ShopRepository::class);
+        $shop = $shopRepository->findOneByApplicationSlug('shop-ops-center');
+        self::assertNotNull($shop);
+
+        /** @var ProductRepository $productRepository */
+        $productRepository = static::getContainer()->get(ProductRepository::class);
+        $product = $productRepository->findBy(['shop' => $shop], ['createdAt' => 'ASC'])[0] ?? null;
+        self::assertNotNull($product);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/carts/' . $shop->getId() . '/items',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'productId' => $product->getId(),
+                'quantity' => 1,
+            ], JSON_THROW_ON_ERROR)
+        );
+        self::assertResponseStatusCodeSame(201);
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/checkout/' . $shop->getId(),
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode($this->validCheckoutPayload(), JSON_THROW_ON_ERROR)
+        );
+
+        self::assertContains($client->getResponse()->getStatusCode(), [201, 202]);
+    }
+
+    public function testCheckoutReturnsForbiddenWhenShopBelongsToAnotherApplicationScope(): void
+    {
+        /** @var ShopRepository $shopRepository */
+        $shopRepository = static::getContainer()->get(ShopRepository::class);
+        $foreignShop = $shopRepository->findOneByApplicationSlug('shop-catalog-lab');
+        self::assertNotNull($foreignShop);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/checkout/' . $foreignShop->getId(),
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode($this->validCheckoutPayload(), JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(403);
+
+        /** @var array{message?: string} $payload */
+        $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('Shop does not belong to the requested application scope.', $payload['message'] ?? null);
+    }
+
+    public function testCheckoutReturnsNotFoundWhenShopDoesNotExist(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/checkout/11111111-1111-1111-1111-111111111111',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode($this->validCheckoutPayload(), JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(404);
+
+        /** @var array{message?: string} $payload */
+        $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('Shop not found.', $payload['message'] ?? null);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function validCheckoutPayload(): array
+    {
+        return [
+            'billingAddress' => '10 Main street',
+            'shippingAddress' => '20 Main street',
+            'email' => 'john@doe.test',
+            'phone' => '123456',
+            'shippingMethod' => 'express',
+        ];
+    }
+}

--- a/tests/Unit/Shop/Application/MessageHandler/CheckoutCommandHandlerTest.php
+++ b/tests/Unit/Shop/Application/MessageHandler/CheckoutCommandHandlerTest.php
@@ -17,7 +17,7 @@ final class CheckoutCommandHandlerTest extends TestCase
 {
     public function testInvokeExecutesCheckoutInTransaction(): void
     {
-        $command = new CheckoutCommand('op', 'shop-id', 'user-id', 'a', 'b', 'c@d.test', '123', 'pickup');
+        $command = new CheckoutCommand('op', 'shop-ops-center', 'shop-id', 'user-id', 'a', 'b', 'c@d.test', '123', 'pickup');
         $order = new Order();
 
         $connection = $this->createMock(Connection::class);

--- a/tests/Unit/Shop/Application/MessageHandler/CheckoutServiceTest.php
+++ b/tests/Unit/Shop/Application/MessageHandler/CheckoutServiceTest.php
@@ -149,6 +149,7 @@ final class CheckoutServiceTest extends TestCase
     {
         return new CheckoutCommand(
             operationId: 'op',
+            applicationSlug: 'shop-ops-center',
             shopId: $shop->getId(),
             userId: $user->getId(),
             billingAddress: '10 Main street',


### PR DESCRIPTION
### Motivation

- Ensure checkout operations are executed only within the requested application scope to prevent cross-application access. 
- Provide a stable, explicit API error when a `shopId` is valid but belongs to another application so clients can rely on the message. 
- Add HTTP integration coverage for success, cross-scope forbidden, and missing-shop cases and adapt unit tests to the new command signature.

### Description

- Add `applicationSlug` to the `CheckoutCommand` DTO and pass it from the `CheckoutController` when dispatching the command (`src/Shop/Application/Message/CheckoutCommand.php`, `src/Shop/Transport/Controller/Api/V1/Checkout/CheckoutController.php`).
- Keep and enforce the scope guard in `CheckoutService` by checking `CheckoutCommand::applicationSlug` against `Shop->getApplication()->getSlug()` and throw `403` with the stable message `Shop does not belong to the requested application scope.` for mismatches (`src/Shop/Application/Service/CheckoutService.php`).
- Add HTTP integration tests that cover: a valid checkout in the correct scope (accept `201` or `202` depending on bus mode), a cross-scope checkout returning `403` with the stable message, and a checkout for a non-existent shop returning `404` (`tests/Application/Shop/Transport/Controller/Api/V1/CheckoutControllerTest.php`).
- Update unit tests that construct `CheckoutCommand` to the new constructor signature (`tests/Unit/Shop/Application/MessageHandler/CheckoutCommandHandlerTest.php`, `tests/Unit/Shop/Application/MessageHandler/CheckoutServiceTest.php`).

### Testing

- Ran syntax checks with `php -l` on the modified and new PHP files and they all passed with no syntax errors. 
- Created and linted the new HTTP integration test file `tests/Application/Shop/Transport/Controller/Api/V1/CheckoutControllerTest.php` and updated unit tests to match the new `CheckoutCommand` shape. 
- Attempted to run PHPUnit via `vendor/bin/phpunit` and `bin/phpunit` but the PHPUnit binary is not available in this environment, so automated PHPUnit test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ad4b145c8326a32c93b569d3c8ea)