### PR TITLE
feat(quiz): ensure immediate cache consistency after question creation

### DIFF
--- a/src/Quiz/Application/MessageHandler/CreateQuizQuestionCommandHandler.php
+++ b/src/Quiz/Application/MessageHandler/CreateQuizQuestionCommandHandler.php
@@ -10,6 +10,7 @@ use App\Configuration\Infrastructure\Repository\ConfigurationRepository;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Infrastructure\Repository\ApplicationRepository;
 use App\Quiz\Application\Message\CreateQuizQuestionCommand;
+use App\Quiz\Application\Service\QuizCacheService;
 use App\Quiz\Domain\Entity\Quiz;
 use App\Quiz\Domain\Entity\QuizAnswer;
 use App\Quiz\Domain\Entity\QuizQuestion;
@@ -29,6 +30,7 @@ final readonly class CreateQuizQuestionCommandHandler
         private QuizQuestionRepository $questionRepository,
         private ApplicationRepository $applicationRepository,
         private ConfigurationRepository $configurationRepository,
+        private QuizCacheService $quizCacheService,
     ) {
     }
 
@@ -85,5 +87,6 @@ final readonly class CreateQuizQuestionCommandHandler
         }
 
         $this->questionRepository->save($question);
+        $this->quizCacheService->invalidateByApplicationSlug($command->applicationSlug);
     }
 }

--- a/src/Quiz/Application/Service/QuizCacheService.php
+++ b/src/Quiz/Application/Service/QuizCacheService.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Quiz\Application\Service;
+
+use App\Quiz\Domain\Enum\QuizCategory;
+use App\Quiz\Domain\Enum\QuizLevel;
+use Symfony\Contracts\Cache\CacheInterface;
+
+use function array_merge;
+use function array_values;
+use function sprintf;
+
+final readonly class QuizCacheService
+{
+    public function __construct(
+        private CacheInterface $cache,
+    ) {
+    }
+
+    public function buildQuizReadKey(string $applicationSlug, ?string $level, ?string $category, bool $includeCorrection): string
+    {
+        return sprintf(
+            'quiz_%s_%s_%s_%s',
+            $applicationSlug,
+            (string)$level,
+            (string)$category,
+            $includeCorrection ? 'with_correction' : 'public',
+        );
+    }
+
+    public function buildQuizStatsKey(string $applicationSlug): string
+    {
+        return sprintf('quiz_stats_%s', $applicationSlug);
+    }
+
+    public function invalidateByApplicationSlug(string $applicationSlug): void
+    {
+        foreach ($this->buildKeysToInvalidate($applicationSlug) as $cacheKey) {
+            $this->cache->delete($cacheKey);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildKeysToInvalidate(string $applicationSlug): array
+    {
+        $levels = array_merge([''], array_values(array_map(static fn (QuizLevel $level): string => $level->value, QuizLevel::cases())));
+        $categories = array_merge([''], array_values(array_map(static fn (QuizCategory $category): string => $category->value, QuizCategory::cases())));
+
+        $keys = [
+            $this->buildQuizStatsKey($applicationSlug),
+        ];
+
+        foreach ($levels as $level) {
+            foreach ($categories as $category) {
+                $keys[] = $this->buildQuizReadKey($applicationSlug, $level, $category, false);
+                $keys[] = $this->buildQuizReadKey($applicationSlug, $level, $category, true);
+            }
+        }
+
+        return $keys;
+    }
+}
+

--- a/src/Quiz/Application/Service/QuizReadService.php
+++ b/src/Quiz/Application/Service/QuizReadService.php
@@ -16,7 +16,6 @@ use Symfony\Contracts\Cache\ItemInterface;
 
 use function is_string;
 use function round;
-use function sprintf;
 
 final readonly class QuizReadService
 {
@@ -27,6 +26,7 @@ final readonly class QuizReadService
         private QuizRepository $quizRepository,
         private QuizQuestionRepository $quizQuestionRepository,
         private CacheInterface $cache,
+        private QuizCacheService $quizCacheService,
     ) {
     }
 
@@ -47,13 +47,7 @@ final readonly class QuizReadService
         bool $includeCorrection,
     ): array
     {
-        $cacheKey = sprintf(
-            'quiz_%s_%s_%s_%s',
-            $slug,
-            (string)$level,
-            (string)$category,
-            $includeCorrection ? 'with_correction' : 'public',
-        );
+        $cacheKey = $this->quizCacheService->buildQuizReadKey($slug, $level, $category, $includeCorrection);
 
         return $this->cache->get($cacheKey, function (ItemInterface $item) use ($slug, $level, $category, $includeCorrection): array {
             $item->expiresAfter(self::QUIZ_CACHE_TTL);
@@ -112,7 +106,7 @@ final readonly class QuizReadService
 
     public function getStatsByApplicationSlug(string $slug): array
     {
-        $cacheKey = sprintf('quiz_stats_%s', $slug);
+        $cacheKey = $this->quizCacheService->buildQuizStatsKey($slug);
 
         return $this->cache->get($cacheKey, function (ItemInterface $item) use ($slug): array {
             $item->expiresAfter(self::QUIZ_STATS_CACHE_TTL);

--- a/tests/Application/Quiz/Transport/Controller/Api/V1/QuizCacheInvalidationTest.php
+++ b/tests/Application/Quiz/Transport/Controller/Api/V1/QuizCacheInvalidationTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Quiz\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Quiz\Application\Message\CreateQuizQuestionCommand;
+use App\Quiz\Application\MessageHandler\CreateQuizQuestionCommandHandler;
+use App\Quiz\Domain\Entity\Quiz;
+use App\Tests\TestCase\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+final class QuizCacheInvalidationTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/quiz/applications';
+
+    #[TestDox('Creating a question invalidates quiz read and quiz stats caches for the application.')]
+    public function testCreateQuestionInvalidatesQuizAndStatsCache(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $quiz = $this->getPublishedQuizOwnedByRoot($entityManager);
+
+        $readerClient = $this->getTestClient('john-user', 'password-user');
+        $readerClient->request('GET', $this->baseUrl . '/' . $quiz->getApplication()->getSlug());
+        $initialQuizPayload = JSON::decode((string)$readerClient->getResponse()->getContent(), true);
+        self::assertSame(Response::HTTP_OK, $readerClient->getResponse()->getStatusCode());
+
+        $readerClient->request('GET', $this->baseUrl . '/' . $quiz->getApplication()->getSlug() . '/stats');
+        $initialStatsPayload = JSON::decode((string)$readerClient->getResponse()->getContent(), true);
+        self::assertSame(Response::HTTP_OK, $readerClient->getResponse()->getStatusCode());
+
+        /** @var InMemoryTransport $transport */
+        $transport = static::getContainer()->get('messenger.transport.async_priority_high');
+        $transport->reset();
+
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+        $ownerClient->request('POST', $this->baseUrl . '/' . $quiz->getApplication()->getSlug() . '/questions', content: JSON::encode([
+            'title' => 'Cache invalidation question',
+            'level' => 'easy',
+            'category' => 'general',
+            'points' => 2,
+            'answers' => [
+                ['label' => 'Right answer', 'correct' => true],
+                ['label' => 'Wrong answer', 'correct' => false],
+            ],
+        ]));
+
+        self::assertSame(Response::HTTP_ACCEPTED, $ownerClient->getResponse()->getStatusCode());
+
+        $envelopes = $transport->getSent();
+        self::assertCount(1, $envelopes);
+
+        $command = $envelopes[0]->getMessage();
+        self::assertInstanceOf(CreateQuizQuestionCommand::class, $command);
+
+        /** @var CreateQuizQuestionCommandHandler $handler */
+        $handler = static::getContainer()->get(CreateQuizQuestionCommandHandler::class);
+        $handler($command);
+
+        $readerClient->request('GET', $this->baseUrl . '/' . $quiz->getApplication()->getSlug());
+        $updatedQuizPayload = JSON::decode((string)$readerClient->getResponse()->getContent(), true);
+        self::assertSame(Response::HTTP_OK, $readerClient->getResponse()->getStatusCode());
+
+        $readerClient->request('GET', $this->baseUrl . '/' . $quiz->getApplication()->getSlug() . '/stats');
+        $updatedStatsPayload = JSON::decode((string)$readerClient->getResponse()->getContent(), true);
+        self::assertSame(Response::HTTP_OK, $readerClient->getResponse()->getStatusCode());
+
+        self::assertCount(count($initialQuizPayload['questions']) + 1, $updatedQuizPayload['questions']);
+        self::assertSame('Cache invalidation question', $updatedQuizPayload['questions'][count($updatedQuizPayload['questions']) - 1]['title']);
+
+        self::assertSame((int)$initialStatsPayload['questionCount'] + 1, (int)$updatedStatsPayload['questionCount']);
+        self::assertSame((int)$initialStatsPayload['answerCount'] + 2, (int)$updatedStatsPayload['answerCount']);
+    }
+
+    private function getPublishedQuizOwnedByRoot(EntityManagerInterface $entityManager): Quiz
+    {
+        $quiz = $entityManager->getRepository(Quiz::class)
+            ->createQueryBuilder('quiz')
+            ->innerJoin('quiz.application', 'application')->addSelect('application')
+            ->innerJoin('quiz.owner', 'owner')
+            ->andWhere('owner.username = :username')
+            ->andWhere('quiz.isPublished = true')
+            ->setParameter('username', 'john-root')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        self::assertInstanceOf(Quiz::class, $quiz);
+
+        return $quiz;
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure immediate cache consistency for the Quiz module after writing new questions by centralizing cache key management and enabling application-scoped invalidation while preserving the existing TTL behavior.

### Description
- Add `QuizCacheService` in `src/Quiz/Application/Service/` to centralize construction of `quiz_*` and `quiz_stats_*` keys and provide `invalidateByApplicationSlug()` to delete all read keys for an application.
- Update `QuizReadService` to use `QuizCacheService` for cache key construction while keeping the existing TTLs (`QUIZ_CACHE_TTL` and `QUIZ_STATS_CACHE_TTL`).
- Update `CreateQuizQuestionCommandHandler` to call `invalidateByApplicationSlug($command->applicationSlug)` immediately after persisting the new question so reads are consistent post-write.
- Add an integration test `tests/Application/Quiz/Transport/Controller/Api/V1/QuizCacheInvalidationTest.php` that warms quiz/stats caches, enqueues and handles the create-question command, then re-reads quiz and stats to assert the refreshed data.

### Testing
- Ran syntax checks with `php -l` on `src/Quiz/Application/Service/QuizCacheService.php`, `src/Quiz/Application/Service/QuizReadService.php`, `src/Quiz/Application/MessageHandler/CreateQuizQuestionCommandHandler.php` and `tests/Application/Quiz/Transport/Controller/Api/V1/QuizCacheInvalidationTest.php`, all of which reported no syntax errors.
- Added the integration test file at `tests/Application/Quiz/Transport/Controller/Api/V1/QuizCacheInvalidationTest.php` and validated it by invoking it in the test runner, but executing `php bin/phpunit` failed in this environment due to missing `bin/phpunit`.
- Attempting `vendor/bin/phpunit` also failed in this environment because vendor binaries/dependencies are not available, so the integration test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ada3d40483269408316a2abf3d2f)