### PR TITLE
Add tests for blog reaction unique-constraint recovery flow

### DIFF
--- a/tests/Unit/Blog/Application/MessageHandler/CreateBlogReactionCommandHandlerTest.php
+++ b/tests/Unit/Blog/Application/MessageHandler/CreateBlogReactionCommandHandlerTest.php
@@ -18,7 +18,11 @@ use App\General\Application\Service\CacheInvalidationService;
 use App\Platform\Domain\Entity\Application;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 final class CreateBlogReactionCommandHandlerTest extends TestCase
 {
@@ -57,6 +61,116 @@ final class CreateBlogReactionCommandHandlerTest extends TestCase
         );
 
         $handler(new CreateBlogReactionCommand('op', 'actor-id', 'comment', BlogReactionType::HEART));
+    }
+
+    public function testInvokeRecoversFromUniqueConstraintAndUpdatesExistingReaction(): void
+    {
+        $reactionRepository = $this->createMock(BlogReactionRepository::class);
+        $commentRepository = $this->createMock(BlogCommentRepository::class);
+        $userRepository = $this->createMock(UserRepository::class);
+        $notificationService = $this->createMock(BlogNotificationService::class);
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+        $entityManager = $this->createMock(EntityManager::class);
+
+        [$comment, $user] = $this->createCommentAndUser();
+        $existingReaction = (new BlogReaction())
+            ->setComment($comment)
+            ->setAuthor($user)
+            ->setType(BlogReactionType::LIKE);
+
+        $commentRepository->method('find')->willReturn($comment);
+        $userRepository->method('find')->willReturn($user);
+        $reactionRepository->expects(self::exactly(2))
+            ->method('findOneByCommentAndAuthor')
+            ->with($comment, $user)
+            ->willReturnOnConsecutiveCalls(null, $existingReaction);
+        $saveCalls = 0;
+        $reactionRepository->expects(self::exactly(2))
+            ->method('save')
+            ->with(self::callback(static fn (BlogReaction $reaction): bool => $reaction instanceof BlogReaction))
+            ->willReturnCallback(function () use (&$saveCalls, $reactionRepository): BlogReactionRepository {
+                ++$saveCalls;
+
+                if ($saveCalls === 1) {
+                    throw $this->createUniqueConstraintViolationException();
+                }
+
+                return $reactionRepository;
+            });
+        $reactionRepository->expects(self::once())
+            ->method('getEntityManager')
+            ->willReturn($entityManager);
+        $entityManager->expects(self::once())->method('clear');
+        $notificationService->expects(self::never())->method('notifyReactionCreated');
+        $cacheInvalidationService->expects(self::once())
+            ->method('invalidateBlogCaches')
+            ->with('app-slug', ['actor-id', 'comment-author-id', 'post-author-id', 'parent-author-id']);
+
+        $handler = new CreateBlogReactionCommandHandler(
+            $reactionRepository,
+            $commentRepository,
+            $userRepository,
+            $notificationService,
+            $cacheInvalidationService,
+        );
+
+        $reactionId = $handler(new CreateBlogReactionCommand('op', 'actor-id', 'comment', BlogReactionType::HEART));
+
+        self::assertSame(BlogReactionType::HEART, $existingReaction->getType());
+        self::assertSame($existingReaction->getId(), $reactionId);
+    }
+
+    public function testInvokeThrowsConflictWhenRecoveryCannotFindExistingReaction(): void
+    {
+        $reactionRepository = $this->createMock(BlogReactionRepository::class);
+        $commentRepository = $this->createMock(BlogCommentRepository::class);
+        $userRepository = $this->createMock(UserRepository::class);
+        $notificationService = $this->createMock(BlogNotificationService::class);
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+        $entityManager = $this->createMock(EntityManager::class);
+
+        [$comment, $user] = $this->createCommentAndUser();
+
+        $commentRepository->method('find')->willReturn($comment);
+        $userRepository->method('find')->willReturn($user);
+        $reactionRepository->expects(self::exactly(2))
+            ->method('findOneByCommentAndAuthor')
+            ->with($comment, $user)
+            ->willReturn(null);
+        $reactionRepository->expects(self::once())
+            ->method('save')
+            ->willThrowException($this->createUniqueConstraintViolationException());
+        $reactionRepository->expects(self::once())
+            ->method('getEntityManager')
+            ->willReturn($entityManager);
+        $entityManager->expects(self::once())->method('clear');
+        $notificationService->expects(self::never())->method('notifyReactionCreated');
+        $cacheInvalidationService->expects(self::never())->method('invalidateBlogCaches');
+
+        $handler = new CreateBlogReactionCommandHandler(
+            $reactionRepository,
+            $commentRepository,
+            $userRepository,
+            $notificationService,
+            $cacheInvalidationService,
+        );
+
+        try {
+            $handler(new CreateBlogReactionCommand('op', 'actor-id', 'comment', BlogReactionType::HEART));
+            self::fail('Expected conflict exception to be thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(JsonResponse::HTTP_CONFLICT, $exception->getStatusCode());
+            self::assertSame('Unable to create blog reaction.', $exception->getMessage());
+        }
+    }
+
+
+    private function createUniqueConstraintViolationException(): UniqueConstraintViolationException
+    {
+        /** @var UniqueConstraintViolationException $exception */
+        $exception = (new \ReflectionClass(UniqueConstraintViolationException::class))->newInstanceWithoutConstructor();
+
+        return $exception;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Cover the recovery flow in `CreateBlogReactionCommandHandler` when `BlogReactionRepository::save()` raises `UniqueConstraintViolationException` to ensure the handler clears the `EntityManager`, reloads resources, and updates an existing reaction.
- Add a failing-case test that ensures a `409 Conflict` is raised when recovery cannot find an existing reaction.

### Description
- Added `testInvokeRecoversFromUniqueConstraintAndUpdatesExistingReaction` which simulates `save()` throwing a `UniqueConstraintViolationException` on first attempt, expects `getEntityManager()->clear()`, reloads comment/user, finds the existing `BlogReaction`, updates its type and calls `invalidateBlogCaches` with the affected users.
- Added `testInvokeThrowsConflictWhenRecoveryCannotFindExistingReaction` which simulates `save()` throwing and no existing reaction being found after recovery and asserts a `HttpException` with status `409` and message `Unable to create blog reaction.`
- Introduced a test helper `createUniqueConstraintViolationException()` to produce a `UniqueConstraintViolationException` instance for mocking, and used an `EntityManager` mock to assert `clear()` is called.

### Testing
- Ran PHP syntax check with `php -l tests/Unit/Blog/Application/MessageHandler/CreateBlogReactionCommandHandlerTest.php` which succeeded.
- Attempted to run the PHPUnit file with `./vendor/bin/phpunit tests/Unit/Blog/Application/MessageHandler/CreateBlogReactionCommandHandlerTest.php` but the PHPUnit binary is not available in this environment so the full unit test run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4af3ccb588326aa8e72352be25ab5)