### PR TITLE
test(chat): add regression coverage for deleted message filtering in conversation lists

### DIFF
--- a/tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php
+++ b/tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php
@@ -102,6 +102,69 @@ final class UserConversationControllerTest extends WebTestCase
         self::assertSame(1, $pagedPayload['pagination']['totalItems']);
     }
 
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('GET private conversations message filter ignores deleted messages for user listing')]
+    public function testListByUserMessageFilterIgnoresDeletedMessages(): void
+    {
+        $this->createConversationWithDeletedKeywordMessage('deleted-only-filter-token-user');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', $this->baseUrl . '/conversations?message=deleted-only-filter-token-user');
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $content = $client->getResponse()->getContent();
+        self::assertNotFalse($content);
+        $payload = JSON::decode($content, true);
+
+        self::assertCount(0, $payload['items']);
+        self::assertSame(0, $payload['pagination']['totalItems']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('GET application chat conversations message filter ignores deleted messages for chat listing')]
+    public function testListByChatIdMessageFilterIgnoresDeletedMessages(): void
+    {
+        $chatId = $this->createConversationWithDeletedKeywordMessage('deleted-only-filter-token-chat');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/chat/crm-pipeline-pro/chats/' . $chatId . '/conversations?message=deleted-only-filter-token-chat');
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $content = $client->getResponse()->getContent();
+        self::assertNotFalse($content);
+        $payload = JSON::decode($content, true);
+
+        self::assertCount(0, $payload['items']);
+        self::assertSame(0, $payload['pagination']['totalItems']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('GET application private chat conversations message filter ignores deleted messages for chat and user listing')]
+    public function testListByChatIdAndUserMessageFilterIgnoresDeletedMessages(): void
+    {
+        $chatId = $this->createConversationWithDeletedKeywordMessage('deleted-only-filter-token-chat-user');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/chat/crm-pipeline-pro/private/chats/' . $chatId . '/conversations?message=deleted-only-filter-token-chat-user');
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $content = $client->getResponse()->getContent();
+        self::assertNotFalse($content);
+        $payload = JSON::decode($content, true);
+
+        self::assertCount(0, $payload['items']);
+        self::assertSame(0, $payload['pagination']['totalItems']);
+    }
+
     private function createActiveAndArchivedConversationsForJohnRoot(): void
     {
         /** @var EntityManagerInterface $entityManager */
@@ -156,6 +219,48 @@ final class UserConversationControllerTest extends WebTestCase
 
         $conversation->addMessage($message);
         $conversation->setLastMessageAt(new DateTimeImmutable('now'));
+    }
+
+    private function createConversationWithDeletedKeywordMessage(string $keyword): string
+    {
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        /** @var Conversation|null $seedConversation */
+        $seedConversation = $entityManager->getRepository(Conversation::class)->find(
+            LoadRecruitChatCalendarScenarioData::getUuidByKey('conversation-john-root-scenario')
+        );
+
+        self::assertInstanceOf(Conversation::class, $seedConversation);
+
+        $chat = $seedConversation->getChat();
+        $johnRoot = $this->getUserReference($entityManager, 'john-root');
+        $johnAdmin = $this->getUserReference($entityManager, 'john-admin');
+
+        $conversation = (new Conversation())
+            ->setChat($chat);
+
+        $this->addParticipant($conversation, $johnRoot, $johnAdmin);
+
+        $deletedMessage = (new ChatMessage())
+            ->setConversation($conversation)
+            ->setSender($johnRoot)
+            ->setContent('contains ' . $keyword)
+            ->setDeletedAt(new DateTimeImmutable('now'));
+
+        $visibleMessage = (new ChatMessage())
+            ->setConversation($conversation)
+            ->setSender($johnAdmin)
+            ->setContent('message without keyword');
+
+        $conversation->addMessage($deletedMessage);
+        $conversation->addMessage($visibleMessage);
+        $conversation->setLastMessageAt($visibleMessage->getCreatedAt());
+
+        $entityManager->persist($conversation);
+        $entityManager->flush();
+
+        return $chat->getId();
     }
 
     private function getUserReference(EntityManagerInterface $entityManager, string $key): User


### PR DESCRIPTION
### Motivation
- Garantir que le filtre `message` n’expose pas une conversation lorsqu’un message correspondant est marqué comme supprimé, et appliquer cette règle à tous les chemins de listing (`findByUser`, `findByChatId`, `findByChatIdAndUser`).

### Description
- Vérification que `ConversationRepository::applyListFilters` utilise bien `filterMessage.deletedAt IS NULL` dans la condition `EXISTS` pour le filtre `message` (aucun changement de production nécessaire). 
- Ajout de tests de non-régression dans `tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php` couvrant les trois chemins de listing (`/v1/chat/private/conversations`, `/v1/chat/{applicationSlug}/chats/{chatId}/conversations` et `/v1/chat/{applicationSlug}/private/chats/{chatId}/conversations`).
- Introduction d’un helper de fixture `createConversationWithDeletedKeywordMessage` qui crée la situation demandée (message A contenant le mot-clé et `deletedAt` non-null, message B visible sans mot-clé) et vérifie que la conversation n’est pas renvoyée par les filtres.

### Testing
- Exécution de la vérification de syntaxe PHP avec `php -l tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php` qui a réussi. 
- Tentative d’exécution de `./vendor/bin/phpunit tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php` qui n’a pas pu être lancée car le binaire PHPUnit n’est pas présent dans cet environnement. 
- Inspection manuelle du repository a confirmé la présence de la condition `filterMessage.deletedAt IS NULL` dans `src/Chat/Infrastructure/Repository/ConversationRepository.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4af5427c483268ca68ee68e09ad2a)