### PR TITLE
Enforce school-scoped relations in create services (students, exams, grades)

### DIFF
--- a/src/School/Application/Service/CreateExamService.php
+++ b/src/School/Application/Service/CreateExamService.php
@@ -7,6 +7,7 @@ namespace App\School\Application\Service;
 use App\General\Application\Message\EntityCreated;
 use App\School\Application\Exception\SchoolRelationException;
 use App\School\Domain\Entity\Exam;
+use App\School\Domain\Entity\School;
 use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Teacher;
 use App\School\Domain\Enum\ExamStatus;
@@ -28,6 +29,7 @@ final readonly class CreateExamService
     }
 
     public function create(
+        School $school,
         string $title,
         ?string $classId,
         ?string $teacherId,
@@ -44,12 +46,24 @@ final readonly class CreateExamService
         }
 
         $class = $this->classRepository->find($classId);
-        if (!$class instanceof SchoolClass) {
+        if (!$class instanceof SchoolClass || $class->getSchool()?->getId() !== $school->getId()) {
             throw SchoolRelationException::notFound('classId');
         }
 
         $teacher = $this->teacherRepository->find($teacherId);
         if (!$teacher instanceof Teacher) {
+            throw SchoolRelationException::notFound('teacherId');
+        }
+
+        $teacherBelongsToSchool = false;
+        foreach ($teacher->getClasses() as $teacherClass) {
+            if ($teacherClass->getSchool()?->getId() === $school->getId()) {
+                $teacherBelongsToSchool = true;
+                break;
+            }
+        }
+
+        if (!$teacherBelongsToSchool) {
             throw SchoolRelationException::notFound('teacherId');
         }
 

--- a/src/School/Application/Service/CreateGradeService.php
+++ b/src/School/Application/Service/CreateGradeService.php
@@ -8,6 +8,7 @@ use App\General\Application\Message\EntityCreated;
 use App\School\Application\Exception\SchoolRelationException;
 use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\Grade;
+use App\School\Domain\Entity\School;
 use App\School\Domain\Entity\Student;
 use App\School\Infrastructure\Repository\ExamRepository;
 use App\School\Infrastructure\Repository\StudentRepository;
@@ -24,7 +25,7 @@ final readonly class CreateGradeService
     ) {
     }
 
-    public function create(float $score, ?string $studentId, ?string $examId): Grade
+    public function create(School $school, float $score, ?string $studentId, ?string $examId): Grade
     {
         if (!is_string($studentId)) {
             throw SchoolRelationException::unprocessable('studentId is required');
@@ -35,12 +36,12 @@ final readonly class CreateGradeService
         }
 
         $student = $this->studentRepository->find($studentId);
-        if (!$student instanceof Student) {
+        if (!$student instanceof Student || $student->getSchoolClass()?->getSchool()?->getId() !== $school->getId()) {
             throw SchoolRelationException::notFound('studentId');
         }
 
         $exam = $this->examRepository->find($examId);
-        if (!$exam instanceof Exam) {
+        if (!$exam instanceof Exam || $exam->getSchoolClass()?->getSchool()?->getId() !== $school->getId()) {
             throw SchoolRelationException::notFound('examId');
         }
 

--- a/src/School/Application/Service/CreateStudentService.php
+++ b/src/School/Application/Service/CreateStudentService.php
@@ -6,6 +6,7 @@ namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityCreated;
 use App\School\Application\Exception\SchoolRelationException;
+use App\School\Domain\Entity\School;
 use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Student;
 use App\School\Infrastructure\Repository\SchoolClassRepository;
@@ -21,14 +22,14 @@ final readonly class CreateStudentService
     ) {
     }
 
-    public function create(string $name, ?string $classId): Student
+    public function create(School $school, string $name, ?string $classId): Student
     {
         if (!is_string($classId)) {
             throw SchoolRelationException::unprocessable('classId is required');
         }
 
         $class = $this->classRepository->find($classId);
-        if (!$class instanceof SchoolClass) {
+        if (!$class instanceof SchoolClass || $class->getSchool()?->getId() !== $school->getId()) {
             throw SchoolRelationException::notFound('classId');
         }
 

--- a/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
@@ -56,7 +56,7 @@ final readonly class CreateExamController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {
-        $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
 
         $payload = $request->toArray();
 
@@ -74,6 +74,7 @@ final readonly class CreateExamController
         }
 
         $exam = $this->createExamService->create(
+            $school,
             $input->title,
             $input->classId,
             $input->teacherId,

--- a/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
@@ -33,7 +33,7 @@ final readonly class CreateGradeController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {
-        $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
 
         $payload = $request->toArray();
 
@@ -47,7 +47,7 @@ final readonly class CreateGradeController
             return $validationResponse;
         }
 
-        $grade = $this->createGradeService->create($input->score, $input->studentId, $input->examId);
+        $grade = $this->createGradeService->create($school, $input->score, $input->studentId, $input->examId);
 
         return new JsonResponse([
             'id' => $grade->getId(),

--- a/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
@@ -33,7 +33,7 @@ final readonly class CreateStudentController
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {
-        $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
 
         $payload = $request->toArray();
 
@@ -46,7 +46,7 @@ final readonly class CreateStudentController
             return $validationResponse;
         }
 
-        $student = $this->createStudentService->create($input->name, $input->classId);
+        $student = $this->createStudentService->create($school, $input->name, $input->classId);
 
         return new JsonResponse([
             'id' => $student->getId(),


### PR DESCRIPTION
### Motivation
- Prevent cross-school relations by ensuring IDs resolved during creation belong to the currently resolved `School` scope.
- Surface a clear `SchoolRelationException::notFound('<reference>')` when a linked resource is not part of the target school.
- Keep existing business validations intact (for example teacher assigned to class and student/exam same class).

### Description
- Updated `CreateStudentService::create`, `CreateExamService::create`, and `CreateGradeService::create` signatures to accept `School $school` as the first argument and added school ownership checks for resolved entities.
- In `CreateStudentService` the resolved `classId` is now validated to belong to the provided `School`, otherwise `SchoolRelationException::notFound('classId')` is thrown.
- In `CreateExamService` the resolved `classId` is validated against the `School` and `teacherId` is validated to be attached to at least one class in the same `School` (and still must be assigned to the target class), otherwise `SchoolRelationException::notFound('teacherId')` or `::unprocessable(...)` is thrown as appropriate.
- In `CreateGradeService` both `studentId` and `examId` are validated to belong to the provided `School`, while preserving the existing validation that the `student` and `exam` belong to the same class.
- Adapted `CreateStudentController`, `CreateExamController`, and `CreateGradeController` to resolve the `School` via `SchoolApplicationScopeResolver::resolveOrCreateSchoolByApplicationSlug(...)` and pass the resolved `School` into the service calls.

### Testing
- Ran `php -l` syntax checks on the modified service and controller files (`CreateStudentService`, `CreateExamService`, `CreateGradeService`, `CreateStudentController`, `CreateExamController`, `CreateGradeController`) and all files passed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4af603294832690e6c84f46c4e088)