### PR TITLE
Validate and normalize quiz answers (single-choice) and add submission/validation tests

### DIFF
--- a/src/Quiz/Application/MessageHandler/CreateQuizQuestionCommandHandler.php
+++ b/src/Quiz/Application/MessageHandler/CreateQuizQuestionCommandHandler.php
@@ -22,6 +22,12 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+use function count;
+use function is_array;
+use function is_string;
+use function preg_replace;
+use function trim;
+
 #[AsMessageHandler]
 final readonly class CreateQuizQuestionCommandHandler
 {
@@ -56,6 +62,40 @@ final readonly class CreateQuizQuestionCommandHandler
             throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'At least two answers are required.');
         }
 
+        $normalizedAnswers = [];
+        $correctAnswersCount = 0;
+
+        foreach (array_values($command->answers) as $index => $answerItem) {
+            if (!is_array($answerItem)) {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Each answer must be an object with "label" and "correct" fields.');
+            }
+
+            $label = is_string($answerItem['label'] ?? null) ? $answerItem['label'] : '';
+            $normalizedLabel = trim((string)preg_replace('/\s+/', ' ', $label));
+            if ($normalizedLabel == '') {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Answer labels must be non-empty.');
+            }
+
+            $isCorrect = ($answerItem['correct'] ?? false) === true;
+            if ($isCorrect) {
+                ++$correctAnswersCount;
+            }
+
+            $normalizedAnswers[] = [
+                'label' => $normalizedLabel,
+                'correct' => $isCorrect,
+                'position' => $index + 1,
+            ];
+        }
+
+        if ($correctAnswersCount < 1) {
+            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'At least one answer must be marked as correct.');
+        }
+
+        if ($correctAnswersCount > 1) {
+            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Single-choice quizzes require exactly one correct answer per question.');
+        }
+
         $question = (new QuizQuestion())
             ->setQuiz($quiz)
             ->setTitle($command->title)
@@ -65,12 +105,12 @@ final readonly class CreateQuizQuestionCommandHandler
             ->setExplanation($command->explanation)
             ->setPosition($this->questionRepository->nextPositionForQuiz($quiz));
 
-        foreach (array_values($command->answers) as $index => $answerItem) {
+        foreach ($normalizedAnswers as $answerItem) {
             $answer = (new QuizAnswer())
                 ->setQuestion($question)
-                ->setLabel((string)($answerItem['label'] ?? ''))
-                ->setCorrect((bool)($answerItem['correct'] ?? false))
-                ->setPosition($index + 1);
+                ->setLabel($answerItem['label'])
+                ->setCorrect($answerItem['correct'])
+                ->setPosition($answerItem['position']);
             $this->questionRepository->getEntityManager()->persist($answer);
         }
 

--- a/tests/Application/Quiz/Transport/Controller/Api/V1/QuizCacheInvalidationTest.php
+++ b/tests/Application/Quiz/Transport/Controller/Api/V1/QuizCacheInvalidationTest.php
@@ -9,6 +9,7 @@ use App\Quiz\Application\Message\CreateQuizQuestionCommand;
 use App\Quiz\Application\MessageHandler\CreateQuizQuestionCommandHandler;
 use App\Quiz\Domain\Entity\Quiz;
 use App\Tests\TestCase\WebTestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\HttpFoundation\Response;
@@ -74,6 +75,120 @@ final class QuizCacheInvalidationTest extends WebTestCase
 
         self::assertSame((int)$initialStatsPayload['questionCount'] + 1, (int)$updatedStatsPayload['questionCount']);
         self::assertSame((int)$initialStatsPayload['answerCount'] + 2, (int)$updatedStatsPayload['answerCount']);
+    }
+
+    #[TestDox('Creating a question requires at least one correct answer.')]
+    public function testCreateQuestionValidationRequiresAtLeastOneCorrectAnswer(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $quiz = $this->getPublishedQuizOwnedByRoot($entityManager);
+
+        /** @var InMemoryTransport $transport */
+        $transport = static::getContainer()->get('messenger.transport.async_priority_high');
+        $transport->reset();
+
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+        $ownerClient->request('POST', $this->baseUrl . '/' . $quiz->getApplication()->getSlug() . '/questions', content: JSON::encode([
+            'title' => 'Invalid question no correct answer',
+            'level' => 'easy',
+            'category' => 'general',
+            'points' => 2,
+            'answers' => [
+                ['label' => 'Wrong A', 'correct' => false],
+                ['label' => 'Wrong B', 'correct' => false],
+            ],
+        ]));
+
+        self::assertSame(Response::HTTP_ACCEPTED, $ownerClient->getResponse()->getStatusCode());
+
+        $envelopes = $transport->getSent();
+        self::assertCount(1, $envelopes);
+        $command = $envelopes[0]->getMessage();
+        self::assertInstanceOf(CreateQuizQuestionCommand::class, $command);
+
+        /** @var CreateQuizQuestionCommandHandler $handler */
+        $handler = static::getContainer()->get(CreateQuizQuestionCommandHandler::class);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->expectExceptionMessage('At least one answer must be marked as correct.');
+        $handler($command);
+    }
+
+    #[TestDox('Creating a question rejects multi-choice answers for single-choice quizzes.')]
+    public function testCreateQuestionValidationRejectsMultipleCorrectAnswers(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $quiz = $this->getPublishedQuizOwnedByRoot($entityManager);
+
+        /** @var InMemoryTransport $transport */
+        $transport = static::getContainer()->get('messenger.transport.async_priority_high');
+        $transport->reset();
+
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+        $ownerClient->request('POST', $this->baseUrl . '/' . $quiz->getApplication()->getSlug() . '/questions', content: JSON::encode([
+            'title' => 'Invalid question multi-correct',
+            'level' => 'easy',
+            'category' => 'general',
+            'points' => 2,
+            'answers' => [
+                ['label' => 'Right A', 'correct' => true],
+                ['label' => 'Right B', 'correct' => true],
+            ],
+        ]));
+
+        self::assertSame(Response::HTTP_ACCEPTED, $ownerClient->getResponse()->getStatusCode());
+
+        $envelopes = $transport->getSent();
+        self::assertCount(1, $envelopes);
+        $command = $envelopes[0]->getMessage();
+        self::assertInstanceOf(CreateQuizQuestionCommand::class, $command);
+
+        /** @var CreateQuizQuestionCommandHandler $handler */
+        $handler = static::getContainer()->get(CreateQuizQuestionCommandHandler::class);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->expectExceptionMessage('Single-choice quizzes require exactly one correct answer per question.');
+        $handler($command);
+    }
+
+    #[TestDox('Creating a question rejects empty answer labels.')]
+    public function testCreateQuestionValidationRejectsEmptyLabels(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $quiz = $this->getPublishedQuizOwnedByRoot($entityManager);
+
+        /** @var InMemoryTransport $transport */
+        $transport = static::getContainer()->get('messenger.transport.async_priority_high');
+        $transport->reset();
+
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+        $ownerClient->request('POST', $this->baseUrl . '/' . $quiz->getApplication()->getSlug() . '/questions', content: JSON::encode([
+            'title' => 'Invalid question empty label',
+            'level' => 'easy',
+            'category' => 'general',
+            'points' => 2,
+            'answers' => [
+                ['label' => '    ', 'correct' => true],
+                ['label' => 'Wrong', 'correct' => false],
+            ],
+        ]));
+
+        self::assertSame(Response::HTTP_ACCEPTED, $ownerClient->getResponse()->getStatusCode());
+
+        $envelopes = $transport->getSent();
+        self::assertCount(1, $envelopes);
+        $command = $envelopes[0]->getMessage();
+        self::assertInstanceOf(CreateQuizQuestionCommand::class, $command);
+
+        /** @var CreateQuizQuestionCommandHandler $handler */
+        $handler = static::getContainer()->get(CreateQuizQuestionCommandHandler::class);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $this->expectExceptionMessage('Answer labels must be non-empty.');
+        $handler($command);
     }
 
     private function getPublishedQuizOwnedByRoot(EntityManagerInterface $entityManager): Quiz

--- a/tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php
+++ b/tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php
@@ -67,6 +67,87 @@ final class SubmitQuizByApplicationControllerTest extends WebTestCase
         self::assertSame(count($questions), (int)$responseData['correctAnswers']);
     }
 
+    #[TestDox('A quiz submission is scored with single-choice rules per question.')]
+    public function testSubmitQuizAppliesSingleChoiceScoring(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $quiz = $this->getAnyPublishedQuiz($entityManager);
+        $questions = $entityManager->getRepository(QuizQuestion::class)->findBy([
+            'quiz' => $quiz,
+        ], [
+            'position' => 'ASC',
+        ]);
+
+        $answersPayload = [];
+        $expectedTotalPoints = 0;
+        $expectedEarnedPoints = 0;
+        $expectedCorrectAnswers = 0;
+        $hasForcedWrongAnswer = false;
+
+        foreach ($questions as $question) {
+            $expectedTotalPoints += $question->getPoints();
+
+            $correctAnswerId = null;
+            $wrongAnswerId = null;
+            foreach ($question->getAnswers() as $answer) {
+                if (!$answer instanceof QuizAnswer) {
+                    continue;
+                }
+
+                if ($answer->isCorrect() && $correctAnswerId === null) {
+                    $correctAnswerId = $answer->getId();
+                }
+
+                if (!$answer->isCorrect() && $wrongAnswerId === null) {
+                    $wrongAnswerId = $answer->getId();
+                }
+            }
+
+            self::assertNotNull($correctAnswerId);
+
+            $selectedAnswerId = $correctAnswerId;
+            if (!$hasForcedWrongAnswer && $wrongAnswerId !== null) {
+                $selectedAnswerId = $wrongAnswerId;
+                $hasForcedWrongAnswer = true;
+            } else {
+                $expectedEarnedPoints += $question->getPoints();
+                ++$expectedCorrectAnswers;
+            }
+
+            $answersPayload[] = [
+                'questionId' => $question->getId(),
+                'answerId' => $selectedAnswerId,
+            ];
+        }
+
+        self::assertTrue($hasForcedWrongAnswer, 'The selected quiz fixture must include at least one wrong answer option.');
+
+        $expectedScore = $expectedTotalPoints > 0
+            ? round(($expectedEarnedPoints / $expectedTotalPoints) * 100, 2)
+            : 0.0;
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request(
+            'POST',
+            $this->baseUrl . '/' . $quiz->getApplication()->getSlug() . '/submit',
+            content: JSON::encode([
+                'answers' => $answersPayload,
+            ])
+        );
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertSame($expectedScore, (float)$responseData['score']);
+        self::assertSame($expectedCorrectAnswers, (int)$responseData['correctAnswers']);
+        self::assertSame($expectedEarnedPoints, (int)$responseData['earnedPoints']);
+        self::assertSame($expectedTotalPoints, (int)$responseData['totalPoints']);
+    }
+
     #[TestDox('GET quiz by application does not expose answers correction data.')]
     public function testGetQuizByApplicationDoesNotExposeAnswerCorrection(): void
     {
@@ -94,7 +175,6 @@ final class SubmitQuizByApplicationControllerTest extends WebTestCase
             }
         }
     }
-
 
     #[TestDox('GET quiz by application returns 404 for an unpublished quiz.')]
     public function testGetQuizByApplicationReturnsNotFoundWhenQuizIsNotPublished(): void
@@ -143,6 +223,27 @@ final class SubmitQuizByApplicationControllerTest extends WebTestCase
             content: JSON::encode([
                 'answers' => [[
                     'questionId' => 12,
+                ]],
+            ])
+        );
+
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+    }
+
+    #[TestDox('Submitting quiz payload with non-string answer id returns 422.')]
+    public function testSubmitQuizWithNonStringAnswerIdReturnsValidationError(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $quiz = $this->getAnyPublishedQuiz($entityManager);
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request(
+            'POST',
+            $this->baseUrl . '/' . $quiz->getApplication()->getSlug() . '/submit',
+            content: JSON::encode([
+                'answers' => [[
+                    'questionId' => 'q_1',
+                    'answerId' => ['a_1'],
                 ]],
             ])
         );


### PR DESCRIPTION
### Motivation

- Garantir l'intégrité des questions créées en validant les réponses fournies (labels non vides, présence d'une bonne réponse) et adopter une stratégie claire pour le type de question (single-choice) car la soumission actuelle n'accepte qu'un seul `answerId` par question.
- Normaliser les labels d'answers (trim + réduction des espaces) pour éviter des contenus vides ou inconsistants persistés en base.
- Ajouter des tests pour couvrir les cas invalides de création de question et vérifier le scoring attendu côté soumission.

### Description

- Ajout de validations et normalisation dans `src/Quiz/Application/MessageHandler/CreateQuizQuestionCommandHandler.php` : vérification que chaque réponse est un objet, `label` non vide après normalisation, au moins une réponse marquée `correct = true`, et rejet si plus d'une réponse correcte (single-choice enforced), puis persistance des labels/positions normalisés.
- Adaptation de la boucle de persistance pour utiliser les réponses normalisées plutôt que le payload brut.
- Ajout de tests d'intégration/handler dans `tests/Application/Quiz/Transport/Controller/Api/V1/QuizCacheInvalidationTest.php` pour valider : aucune bonne réponse → 422, plusieurs bonnes réponses → 422, label vide → 422.
- Extension des tests de soumission dans `tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php` avec un test de scoring conforme à la règle single-choice et un test additionnel vérifiant que `answerId` non-string retourne 422.

### Testing

- Lint PHP : `php -l src/Quiz/Application/MessageHandler/CreateQuizQuestionCommandHandler.php`, `php -l tests/Application/Quiz/Transport/Controller/Api/V1/QuizCacheInvalidationTest.php` et `php -l tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php` ont tous réussi sans erreur de syntaxe.
- Tentative d'exécution PHPUnit via `php -d memory_limit=1G ./vendor/bin/phpunit ...` et `php bin/phpunit ...` a échoué car l'exécutable PHPUnit n'est pas disponible dans cet environnement (impossible d'ouvrir le fichier d'entrée). 
- Aucune suite PHPUnit complète n'a donc été exécutée ici; les nouveaux tests ont été ajoutés et sont prêts à être lancés dans l'environnement CI/dev disposant de PHPUnit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4afa6ef0883269a8bf5925ebfbf5d)