### PR TITLE
feat(recruit): add canonical application status pipeline and transition history

### DIFF
--- a/migrations/Version20260314100000.php
+++ b/migrations/Version20260314100000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260314100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Introduce canonical recruit application status pipeline and persist status transition history.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("UPDATE recruit_application SET status = 'SCREENING' WHERE status IN ('IN_PROGRESS', 'DISCUSSION')");
+        $this->addSql("UPDATE recruit_application SET status = 'INTERVIEW_PLANNED' WHERE status = 'INVITE_TO_INTERVIEW'");
+        $this->addSql("UPDATE recruit_application SET status = 'INTERVIEW_DONE' WHERE status = 'INTERVIEW'");
+        $this->addSql("UPDATE recruit_application SET status = 'HIRED' WHERE status = 'ACCEPTED'");
+
+        $this->addSql("CREATE TABLE recruit_application_status_history (id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', application_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', author_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', from_status VARCHAR(25) NOT NULL, to_status VARCHAR(25) NOT NULL, comment LONGTEXT DEFAULT NULL, created_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', updated_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', INDEX idx_recruit_application_status_history_application_created_at (application_id, created_at), INDEX IDX_RECRUIT_APPLICATION_STATUS_HISTORY_APPLICATION_ID (application_id), INDEX IDX_RECRUIT_APPLICATION_STATUS_HISTORY_AUTHOR_ID (author_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+        $this->addSql('ALTER TABLE recruit_application_status_history ADD CONSTRAINT FK_RECRUIT_APPLICATION_STATUS_HISTORY_APPLICATION_ID FOREIGN KEY (application_id) REFERENCES recruit_application (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_application_status_history ADD CONSTRAINT FK_RECRUIT_APPLICATION_STATUS_HISTORY_AUTHOR_ID FOREIGN KEY (author_id) REFERENCES user (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE recruit_application_status_history DROP FOREIGN KEY FK_RECRUIT_APPLICATION_STATUS_HISTORY_APPLICATION_ID');
+        $this->addSql('ALTER TABLE recruit_application_status_history DROP FOREIGN KEY FK_RECRUIT_APPLICATION_STATUS_HISTORY_AUTHOR_ID');
+        $this->addSql('DROP TABLE recruit_application_status_history');
+
+        $this->addSql("UPDATE recruit_application SET status = 'IN_PROGRESS' WHERE status = 'SCREENING'");
+        $this->addSql("UPDATE recruit_application SET status = 'INVITE_TO_INTERVIEW' WHERE status = 'INTERVIEW_PLANNED'");
+        $this->addSql("UPDATE recruit_application SET status = 'INTERVIEW' WHERE status = 'INTERVIEW_DONE'");
+        $this->addSql("UPDATE recruit_application SET status = 'ACCEPTED' WHERE status = 'HIRED'");
+    }
+}

--- a/src/Recruit/Application/Service/ApplicationStatusTransitionService.php
+++ b/src/Recruit/Application/Service/ApplicationStatusTransitionService.php
@@ -5,12 +5,17 @@ declare(strict_types=1);
 namespace App\Recruit\Application\Service;
 
 use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\ApplicationStatusHistory;
 use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Recruit\Infrastructure\Repository\ApplicationStatusHistoryRepository;
+use App\User\Domain\Entity\User;
 use DomainException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 use function array_key_exists;
+use function array_map;
+use function implode;
 use function in_array;
 use function is_string;
 use function strtoupper;
@@ -19,10 +24,11 @@ readonly class ApplicationStatusTransitionService
 {
     public function __construct(
         private ApplicationDiscussionBootstrapService $applicationDiscussionBootstrapService,
+        private ApplicationStatusHistoryRepository $applicationStatusHistoryRepository,
     ) {
     }
 
-    public function applyStatusTransition(Application $application, mixed $status): void
+    public function applyStatusTransition(Application $application, mixed $status, User $author, ?string $comment = null): void
     {
         if (!is_string($status)) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" must be provided as a string.');
@@ -30,15 +36,28 @@ readonly class ApplicationStatusTransitionService
 
         $newStatus = ApplicationStatus::tryFrom(strtoupper($status));
         if ($newStatus === null) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" must be one of: WAITING, IN_PROGRESS, DISCUSSION, INVITE_TO_INTERVIEW, INTERVIEW, ACCEPTED, REJECTED.');
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" must be one of: WAITING, SCREENING, INTERVIEW_PLANNED, INTERVIEW_DONE, OFFER_SENT, HIRED, REJECTED.');
         }
 
         $currentStatus = $application->getStatus();
-        if ($newStatus !== $currentStatus && !$this->isAllowedTransition($currentStatus, $newStatus)) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Status transition is not allowed for this application.');
+
+        if ($newStatus === $currentStatus) {
+            return;
         }
 
-        if ($newStatus === ApplicationStatus::DISCUSSION && $currentStatus !== ApplicationStatus::DISCUSSION) {
+        if (!$this->isAllowedTransition($currentStatus, $newStatus)) {
+            $allowedStatuses = $this->getAllowedTransitions($currentStatus);
+            $allowedStatusesAsString = $allowedStatuses === []
+                ? 'none'
+                : implode(', ', array_map(static fn (ApplicationStatus $applicationStatus): string => $applicationStatus->value, $allowedStatuses));
+
+            throw new HttpException(
+                JsonResponse::HTTP_BAD_REQUEST,
+                'Cannot transition application status from ' . $currentStatus->value . ' to ' . $newStatus->value . '. Allowed next statuses: ' . $allowedStatusesAsString . '.',
+            );
+        }
+
+        if ($newStatus === ApplicationStatus::SCREENING && $currentStatus !== ApplicationStatus::SCREENING) {
             try {
                 $this->applicationDiscussionBootstrapService->bootstrap($application);
             } catch (DomainException $exception) {
@@ -47,24 +66,41 @@ readonly class ApplicationStatusTransitionService
         }
 
         $application->setStatus($newStatus);
+
+        $history = (new ApplicationStatusHistory())
+            ->setApplication($application)
+            ->setAuthor($author)
+            ->setFromStatus($currentStatus)
+            ->setToStatus($newStatus)
+            ->setComment($comment);
+
+        $this->applicationStatusHistoryRepository->save($history, false);
     }
 
     private function isAllowedTransition(ApplicationStatus $from, ApplicationStatus $to): bool
     {
+        return in_array($to, $this->getAllowedTransitions($from), true);
+    }
+
+    /**
+     * @return array<int, ApplicationStatus>
+     */
+    private function getAllowedTransitions(ApplicationStatus $from): array
+    {
         $allowedTransitions = [
-            ApplicationStatus::WAITING->value => [ApplicationStatus::IN_PROGRESS->value, ApplicationStatus::REJECTED->value],
-            ApplicationStatus::IN_PROGRESS->value => [ApplicationStatus::DISCUSSION->value, ApplicationStatus::INVITE_TO_INTERVIEW->value, ApplicationStatus::REJECTED->value],
-            ApplicationStatus::DISCUSSION->value => [ApplicationStatus::INVITE_TO_INTERVIEW->value, ApplicationStatus::REJECTED->value],
-            ApplicationStatus::INVITE_TO_INTERVIEW->value => [ApplicationStatus::INTERVIEW->value, ApplicationStatus::REJECTED->value],
-            ApplicationStatus::INTERVIEW->value => [ApplicationStatus::ACCEPTED->value, ApplicationStatus::REJECTED->value],
-            ApplicationStatus::ACCEPTED->value => [],
+            ApplicationStatus::WAITING->value => [ApplicationStatus::SCREENING, ApplicationStatus::REJECTED],
+            ApplicationStatus::SCREENING->value => [ApplicationStatus::INTERVIEW_PLANNED, ApplicationStatus::REJECTED],
+            ApplicationStatus::INTERVIEW_PLANNED->value => [ApplicationStatus::INTERVIEW_DONE, ApplicationStatus::REJECTED],
+            ApplicationStatus::INTERVIEW_DONE->value => [ApplicationStatus::OFFER_SENT, ApplicationStatus::REJECTED],
+            ApplicationStatus::OFFER_SENT->value => [ApplicationStatus::HIRED, ApplicationStatus::REJECTED],
+            ApplicationStatus::HIRED->value => [],
             ApplicationStatus::REJECTED->value => [],
         ];
 
         if (!array_key_exists($from->value, $allowedTransitions)) {
-            return false;
+            return [];
         }
 
-        return in_array($to->value, $allowedTransitions[$from->value], true);
+        return $allowedTransitions[$from->value];
     }
 }

--- a/src/Recruit/Domain/Entity/ApplicationStatusHistory.php
+++ b/src/Recruit/Domain/Entity/ApplicationStatusHistory.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\User\Domain\Entity\User;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_application_status_history')]
+#[ORM\Index(name: 'idx_recruit_application_status_history_application_created_at', columns: ['application_id', 'created_at'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class ApplicationStatusHistory implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Application::class)]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Application $application;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'author_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $author;
+
+    #[ORM\Column(name: 'from_status', type: Types::STRING, length: 25, enumType: ApplicationStatus::class)]
+    private ApplicationStatus $fromStatus;
+
+    #[ORM\Column(name: 'to_status', type: Types::STRING, length: 25, enumType: ApplicationStatus::class)]
+    private ApplicationStatus $toStatus;
+
+    #[ORM\Column(name: 'comment', type: Types::TEXT, nullable: true)]
+    private ?string $comment = null;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getApplication(): Application
+    {
+        return $this->application;
+    }
+
+    public function setApplication(Application $application): self
+    {
+        $this->application = $application;
+
+        return $this;
+    }
+
+    public function getAuthor(): User
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(User $author): self
+    {
+        $this->author = $author;
+
+        return $this;
+    }
+
+    public function getFromStatus(): ApplicationStatus
+    {
+        return $this->fromStatus;
+    }
+
+    public function setFromStatus(ApplicationStatus $fromStatus): self
+    {
+        $this->fromStatus = $fromStatus;
+
+        return $this;
+    }
+
+    public function getToStatus(): ApplicationStatus
+    {
+        return $this->toStatus;
+    }
+
+    public function setToStatus(ApplicationStatus $toStatus): self
+    {
+        $this->toStatus = $toStatus;
+
+        return $this;
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    public function setComment(?string $comment): self
+    {
+        $this->comment = $comment;
+
+        return $this;
+    }
+}

--- a/src/Recruit/Domain/Enum/ApplicationStatus.php
+++ b/src/Recruit/Domain/Enum/ApplicationStatus.php
@@ -7,10 +7,10 @@ namespace App\Recruit\Domain\Enum;
 enum ApplicationStatus: string
 {
     case WAITING = 'WAITING';
-    case IN_PROGRESS = 'IN_PROGRESS';
-    case DISCUSSION = 'DISCUSSION';
-    case INVITE_TO_INTERVIEW = 'INVITE_TO_INTERVIEW';
-    case INTERVIEW = 'INTERVIEW';
-    case ACCEPTED = 'ACCEPTED';
+    case SCREENING = 'SCREENING';
+    case INTERVIEW_PLANNED = 'INTERVIEW_PLANNED';
+    case INTERVIEW_DONE = 'INTERVIEW_DONE';
+    case OFFER_SENT = 'OFFER_SENT';
+    case HIRED = 'HIRED';
     case REJECTED = 'REJECTED';
 }

--- a/src/Recruit/Domain/Repository/Interfaces/ApplicationStatusHistoryRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/ApplicationStatusHistoryRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface ApplicationStatusHistoryRepositoryInterface
+{
+}

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitApplicationData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitApplicationData.php
@@ -75,15 +75,15 @@ final class LoadRecruitApplicationData extends Fixture implements OrderedFixture
         $this->createApplication(
             applicant: $johnUserApplicant,
             job: $jobIncomingForRoot,
-            reference: 'Recruit-Application-john-user-incoming-root-in-progress',
-            status: ApplicationStatus::IN_PROGRESS
+            reference: 'Recruit-Application-john-user-incoming-root-screening',
+            status: ApplicationStatus::SCREENING
         );
 
         $this->createApplication(
             applicant: $johnApiApplicant,
             job: $jobIncomingForRoot,
-            reference: 'Recruit-Application-john-api-incoming-root-interview',
-            status: ApplicationStatus::INTERVIEW
+            reference: 'Recruit-Application-john-api-incoming-root-interview-done',
+            status: ApplicationStatus::INTERVIEW_DONE
         );
 
         $this->createApplication(
@@ -96,22 +96,22 @@ final class LoadRecruitApplicationData extends Fixture implements OrderedFixture
         $this->createApplication(
             applicant: $johnAdminApplicant,
             job: $jobOwnedByOtherUser,
-            reference: 'Recruit-Application-john-admin-on-other-owner-discussion',
-            status: ApplicationStatus::DISCUSSION
+            reference: 'Recruit-Application-john-admin-on-other-owner-screening',
+            status: ApplicationStatus::SCREENING
         );
 
         $this->createApplication(
             applicant: $johnUserApplicant,
             job: $jobOwnedByOtherUser,
-            reference: 'Recruit-Application-john-user-on-other-owner-invite-to-interview',
-            status: ApplicationStatus::INVITE_TO_INTERVIEW
+            reference: 'Recruit-Application-john-user-on-other-owner-interview-planned-done',
+            status: ApplicationStatus::INTERVIEW_PLANNED
         );
 
         $this->createApplication(
             applicant: $johnApiApplicant,
             job: $jobOwnedByOtherUser,
-            reference: 'Recruit-Application-john-api-on-other-owner-accepted',
-            status: ApplicationStatus::ACCEPTED
+            reference: 'Recruit-Application-john-api-on-other-owner-hired',
+            status: ApplicationStatus::HIRED
         );
 
         $this->createApplication(

--- a/src/Recruit/Infrastructure/Repository/ApplicationRepository.php
+++ b/src/Recruit/Infrastructure/Repository/ApplicationRepository.php
@@ -40,10 +40,10 @@ class ApplicationRepository extends BaseRepository implements ApplicationReposit
             ->setParameter('job', $job)
             ->setParameter('statuses', [
                 ApplicationStatus::WAITING,
-                ApplicationStatus::IN_PROGRESS,
-                ApplicationStatus::DISCUSSION,
-                ApplicationStatus::INVITE_TO_INTERVIEW,
-                ApplicationStatus::INTERVIEW,
+                ApplicationStatus::SCREENING,
+                ApplicationStatus::INTERVIEW_PLANNED,
+                ApplicationStatus::INTERVIEW_DONE,
+                ApplicationStatus::OFFER_SENT,
             ])
             ->setMaxResults(1)
             ->getQuery()

--- a/src/Recruit/Infrastructure/Repository/ApplicationStatusHistoryRepository.php
+++ b/src/Recruit/Infrastructure/Repository/ApplicationStatusHistoryRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\ApplicationStatusHistory as Entity;
+use App\Recruit\Domain\Repository\Interfaces\ApplicationStatusHistoryRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class ApplicationStatusHistoryRepository extends BaseRepository implements ApplicationStatusHistoryRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusHistoryListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusHistoryListController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Application;
+
+use App\Recruit\Domain\Entity\ApplicationStatusHistory;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Infrastructure\Repository\ApplicationStatusHistoryRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Application')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class ApplicationStatusHistoryListController
+{
+    public function __construct(
+        private ApplicationRepository $applicationRepository,
+        private ApplicationStatusHistoryRepository $applicationStatusHistoryRepository,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/applications/{applicationSlug}/private/applications/{applicationId}/status-history', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Get(summary: 'Retourne l\'historique des transitions de statut d\'une candidature.')]
+    public function __invoke(string $applicationSlug, string $applicationId, User $loggedInUser): JsonResponse
+    {
+        $application = $this->applicationRepository->find($applicationId);
+
+        if ($application === null) {
+            throw new NotFoundHttpException('Application not found.');
+        }
+
+        $ownerId = $application->getJob()->getOwner()?->getId();
+        if ($ownerId === null || $ownerId !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You are not allowed to view the status history for this application.');
+        }
+
+        $historyEntries = $this->applicationStatusHistoryRepository->findBy([
+            'application' => $application,
+        ], [
+            'createdAt' => 'ASC',
+        ]);
+
+        return new JsonResponse(array_map(
+            static fn (ApplicationStatusHistory $history): array => [
+                'id' => $history->getId(),
+                'fromStatus' => $history->getFromStatus()->value,
+                'toStatus' => $history->getToStatus()->value,
+                'authorId' => $history->getAuthor()->getId(),
+                'comment' => $history->getComment(),
+                'createdAt' => $history->getCreatedAt()?->format(DATE_ATOM),
+            ],
+            $historyEntries,
+        ));
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
@@ -19,6 +19,8 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
+use function is_string;
+
 #[AsController]
 #[OA\Tag(name: 'Recruit Application')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
@@ -43,7 +45,8 @@ readonly class ApplicationStatusUpdateController
             content: new OA\JsonContent(
                 required: ['status'],
                 properties: [
-                    new OA\Property(property: 'status', type: 'string', enum: ['WAITING', 'IN_PROGRESS', 'DISCUSSION', 'INVITE_TO_INTERVIEW', 'INTERVIEW', 'ACCEPTED', 'REJECTED']),
+                    new OA\Property(property: 'status', type: 'string', enum: ['WAITING', 'SCREENING', 'INTERVIEW_PLANNED', 'INTERVIEW_DONE', 'OFFER_SENT', 'HIRED', 'REJECTED']),
+                    new OA\Property(property: 'comment', type: 'string', nullable: true),
                 ],
             ),
         ),
@@ -68,7 +71,8 @@ readonly class ApplicationStatusUpdateController
 
         /** @var array<string, mixed> $payload */
         $payload = $request->toArray();
-        $this->applicationStatusTransitionService->applyStatusTransition($application, $payload['status'] ?? null);
+        $comment = is_string($payload['comment'] ?? null) ? $payload['comment'] : null;
+        $this->applicationStatusTransitionService->applyStatusTransition($application, $payload['status'] ?? null, $loggedInUser, $comment);
 
         $this->applicationRepository->save($application);
 

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateControllerTest.php
@@ -23,14 +23,14 @@ class ApplicationStatusUpdateControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that transition to DISCUSSION creates conversation and participants for owner and applicant.')]
-    public function testThatTransitionToDiscussionCreatesConversation(): void
+    #[TestDox('Test that transition to SCREENING creates conversation and participants for owner and applicant.')]
+    public function testThatTransitionToScreeningCreatesConversation(): void
     {
-        [$recruitApplication, $platformApplication] = $this->prepareApplicationForDiscussionTransition();
+        [$recruitApplication, $platformApplication] = $this->prepareApplicationForScreeningTransition();
 
         $client = $this->getTestClient('john-root', 'password-root');
         $client->request('PATCH', self::API_URL_PREFIX . '/v1/recruit/applications/recruit-talent-core/private/applications/' . $recruitApplication->getId() . '/status', content: JSON::encode([
-            'status' => ApplicationStatus::DISCUSSION->value,
+            'status' => ApplicationStatus::SCREENING->value,
         ]));
 
         $response = $client->getResponse();
@@ -63,21 +63,21 @@ class ApplicationStatusUpdateControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that repeated transition to DISCUSSION is idempotent and does not duplicate conversation or participants.')]
-    public function testThatSecondTransitionToDiscussionDoesNotDuplicateConversation(): void
+    #[TestDox('Test that repeated transition to SCREENING is idempotent and does not duplicate conversation or participants.')]
+    public function testThatSecondTransitionToScreeningDoesNotDuplicateConversation(): void
     {
-        [$recruitApplication, $platformApplication] = $this->prepareApplicationForDiscussionTransition();
+        [$recruitApplication, $platformApplication] = $this->prepareApplicationForScreeningTransition();
 
         $client = $this->getTestClient('john-root', 'password-root');
         $url = self::API_URL_PREFIX . '/v1/recruit/applications/recruit-talent-core/private/applications/' . $recruitApplication->getId() . '/status';
 
         $client->request('PATCH', $url, content: JSON::encode([
-            'status' => ApplicationStatus::DISCUSSION->value,
+            'status' => ApplicationStatus::SCREENING->value,
         ]));
         self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
 
         $client->request('PATCH', $url, content: JSON::encode([
-            'status' => ApplicationStatus::DISCUSSION->value,
+            'status' => ApplicationStatus::SCREENING->value,
         ]));
         self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
 
@@ -102,9 +102,43 @@ class ApplicationStatusUpdateControllerTest extends WebTestCase
     }
 
     /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that GET status-history returns status transitions with author and comment.')]
+    public function testThatStatusHistoryEndpointReturnsTransitionEvents(): void
+    {
+        [$recruitApplication] = $this->prepareApplicationForScreeningTransition();
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $baseUrl = self::API_URL_PREFIX . '/v1/recruit/applications/recruit-talent-core/private/applications/' . $recruitApplication->getId();
+
+        $client->request('PATCH', $baseUrl . '/status', content: JSON::encode([
+            'status' => ApplicationStatus::SCREENING->value,
+            'comment' => 'Premier tri RH',
+        ]));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request('GET', $baseUrl . '/status-history');
+        $response = $client->getResponse();
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        /** @var array<int, array<string, mixed>> $payload */
+        $payload = JSON::decode($response->getContent() ?: '[]');
+
+        self::assertNotEmpty($payload);
+        $lastEvent = $payload[array_key_last($payload)];
+
+        self::assertSame(ApplicationStatus::WAITING->value, $lastEvent['fromStatus']);
+        self::assertSame(ApplicationStatus::SCREENING->value, $lastEvent['toStatus']);
+        self::assertSame('Premier tri RH', $lastEvent['comment']);
+        self::assertNotEmpty($lastEvent['authorId']);
+        self::assertNotEmpty($lastEvent['createdAt']);
+    }
+
+    /**
      * @return array{0: RecruitApplication, 1: PlatformApplication}
      */
-    private function prepareApplicationForDiscussionTransition(): array
+    private function prepareApplicationForScreeningTransition(): array
     {
         self::bootKernel();
         /** @var EntityManagerInterface $entityManager */
@@ -116,7 +150,7 @@ class ApplicationStatusUpdateControllerTest extends WebTestCase
         self::assertInstanceOf(User::class, $owner);
 
         $recruitApplication = $entityManager->getRepository(RecruitApplication::class)->findOneBy([
-            'status' => ApplicationStatus::IN_PROGRESS,
+            'status' => ApplicationStatus::WAITING,
         ]);
         self::assertInstanceOf(RecruitApplication::class, $recruitApplication);
         self::assertSame($owner->getId(), $recruitApplication->getJob()->getOwner()?->getId());
@@ -153,7 +187,7 @@ class ApplicationStatusUpdateControllerTest extends WebTestCase
             $entityManager->flush();
         }
 
-        $recruitApplication->setStatus(ApplicationStatus::IN_PROGRESS);
+        $recruitApplication->setStatus(ApplicationStatus::WAITING);
         $entityManager->flush();
 
         return [$recruitApplication, $platformApplication];

--- a/tests/Unit/Recruit/Application/Service/ApplicationStatusTransitionServiceTest.php
+++ b/tests/Unit/Recruit/Application/Service/ApplicationStatusTransitionServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Recruit\Application\Service;
+
+use App\Recruit\Application\Service\ApplicationDiscussionBootstrapService;
+use App\Recruit\Application\Service\ApplicationStatusTransitionService;
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\ApplicationStatusHistory;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Recruit\Infrastructure\Repository\ApplicationStatusHistoryRepository;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ApplicationStatusTransitionServiceTest extends TestCase
+{
+    public function testApplyStatusTransitionAllowsValidTransitionAndPersistsHistory(): void
+    {
+        $application = (new Application())->setStatus(ApplicationStatus::WAITING);
+        $author = $this->createMock(User::class);
+
+        $bootstrapService = $this->createMock(ApplicationDiscussionBootstrapService::class);
+        $bootstrapService->expects(self::once())
+            ->method('bootstrap')
+            ->with($application);
+
+        $historyRepository = $this->createMock(ApplicationStatusHistoryRepository::class);
+        $historyRepository->expects(self::once())
+            ->method('save')
+            ->with(
+                self::callback(static function (mixed $history) use ($application, $author): bool {
+                    if (!$history instanceof ApplicationStatusHistory) {
+                        return false;
+                    }
+
+                    return $history->getApplication() === $application
+                        && $history->getAuthor() === $author
+                        && $history->getFromStatus() === ApplicationStatus::WAITING
+                        && $history->getToStatus() === ApplicationStatus::SCREENING
+                        && $history->getComment() === 'Commentaire RH';
+                }),
+                false,
+            );
+
+        $service = new ApplicationStatusTransitionService($bootstrapService, $historyRepository);
+
+        $service->applyStatusTransition($application, ApplicationStatus::SCREENING->value, $author, 'Commentaire RH');
+
+        self::assertSame(ApplicationStatus::SCREENING, $application->getStatus());
+    }
+
+    public function testApplyStatusTransitionThrowsWhenTransitionIsNotAllowed(): void
+    {
+        $application = (new Application())->setStatus(ApplicationStatus::WAITING);
+        $author = $this->createMock(User::class);
+
+        $bootstrapService = $this->createMock(ApplicationDiscussionBootstrapService::class);
+        $historyRepository = $this->createMock(ApplicationStatusHistoryRepository::class);
+        $historyRepository->expects(self::never())->method('save');
+
+        $service = new ApplicationStatusTransitionService($bootstrapService, $historyRepository);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Cannot transition application status from WAITING to HIRED. Allowed next statuses: SCREENING, REJECTED.');
+
+        $service->applyStatusTransition($application, ApplicationStatus::HIRED->value, $author);
+    }
+
+    public function testApplyStatusTransitionThrowsWhenStatusIsInvalid(): void
+    {
+        $application = (new Application())->setStatus(ApplicationStatus::WAITING);
+        $author = $this->createMock(User::class);
+
+        $bootstrapService = $this->createMock(ApplicationDiscussionBootstrapService::class);
+        $historyRepository = $this->createMock(ApplicationStatusHistoryRepository::class);
+
+        $service = new ApplicationStatusTransitionService($bootstrapService, $historyRepository);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Field "status" must be one of: WAITING, SCREENING, INTERVIEW_PLANNED, INTERVIEW_DONE, OFFER_SENT, HIRED, REJECTED.');
+
+        $service->applyStatusTransition($application, 'UNKNOWN', $author);
+    }
+}


### PR DESCRIPTION
### Motivation
- Standardiser le pipeline métier des candidatures pour refléter un flux canonique (`WAITING` → `SCREENING` → `INTERVIEW_PLANNED` → `INTERVIEW_DONE` → `OFFER_SENT` → `HIRED`/`REJECTED`).
- Empêcher les transitions invalides et fournir des erreurs explicites indiquant les statuts suivants autorisés pour améliorer l'expérience opérateur et la traçabilité.
- Conserver un journal d'événements de transition (auteur, commentaire, date) et l'exposer via l'API privée pour audit et suivi opérationnel.

### Description
- Défini l'enum canonical dans `src/Recruit/Domain/Enum/ApplicationStatus.php` avec les valeurs `WAITING`, `SCREENING`, `INTERVIEW_PLANNED`, `INTERVIEW_DONE`, `OFFER_SENT`, `HIRED`, `REJECTED`.
- Mis à jour `ApplicationStatusTransitionService` (`applyStatusTransition`) pour valider et appliquer les transitions autorisées, retourner des erreurs détaillées listant les statuts suivants autorisés, déclencher le bootstrap de discussion au premier passage en `SCREENING`, et persister un événement d'historique (`ApplicationStatusHistory`) avec auteur et commentaire.
- Ajouté l'entité `ApplicationStatusHistory` et son repository (`ApplicationStatusHistoryRepository` + interface) pour stocker `fromStatus`, `toStatus`, `author`, `createdAt` et `comment`, ainsi que le controller `ApplicationStatusHistoryListController` exposant `GET /v1/recruit/applications/{applicationSlug}/private/applications/{applicationId}/status-history` avec contrôle d'accès propriétaire.
- Alignement des fixtures et des filtres de repository (`findActiveByApplicantAndJob`) sur les nouveaux statuts et ajout d'une migration `migrations/Version20260314100000.php` qui mappe les anciens statuts vers les nouveaux et crée la table `recruit_application_status_history` avec les clés étrangères.
- Mise à jour de l'endpoint de mise à jour de statut pour accepter un champ optionnel `comment` et transmettre l'auteur connecté au service de transition.
- Ajout de tests : tests unitaires pour `ApplicationStatusTransitionService` (validations, erreurs explicites, persistance d'historique) et tests d'intégration API pour les transitions (idempotence, bootstrap de conversation) et la consultation de l'historique.

### Testing
- Exécution des vérifications de syntaxe PHP (`php -l`) sur tous les fichiers modifiés/nouveaux réussie pour les fichiers suivants et les autres changements associés. 
- Tentative d'exécution des suites PHPUnit dans cet environnement échouée car `./vendor/bin/phpunit` n'est pas disponible, donc les nouveaux tests unitaires et d'intégration ajoutés n'ont pas été exécutés ici (tests présents : `tests/Unit/Recruit/Application/Service/ApplicationStatusTransitionServiceTest.php` et `tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateControllerTest.php`).
- Validation locale minimale : `git diff ... | xargs php -l` et `php -l` sur les nouveaux fichiers ont été lancés et n'ont signalé aucune erreur de syntaxe.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4af7be1948326a6a520f5f3533dbd)