### PR TITLE
Add unique-constraint recovery tests for CreateBlogPostReactionCommandHandler

### DIFF
--- a/tests/Unit/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandlerTest.php
+++ b/tests/Unit/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandlerTest.php
@@ -14,9 +14,14 @@ use App\Blog\Domain\Enum\BlogReactionType;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
 use App\Blog\Infrastructure\Repository\BlogReactionRepository;
 use App\General\Application\Service\CacheInvalidationService;
+use App\Platform\Domain\Entity\Application;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManager;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 
 final class CreateBlogPostReactionCommandHandlerTest extends TestCase
 {
@@ -42,7 +47,9 @@ final class CreateBlogPostReactionCommandHandlerTest extends TestCase
         $notificationService->expects(self::once())
             ->method('notifyPostReactionCreated')
             ->with($post, $user, BlogReactionType::HEART->value);
-        $cacheInvalidationService->expects(self::once())->method('invalidateBlogCaches');
+        $cacheInvalidationService->expects(self::once())
+            ->method('invalidateBlogCaches')
+            ->with('app-slug', ['actor-id', 'post-author-id']);
 
         $handler = new CreateBlogPostReactionCommandHandler(
             $reactionRepository,
@@ -52,7 +59,7 @@ final class CreateBlogPostReactionCommandHandlerTest extends TestCase
             $cacheInvalidationService,
         );
 
-        $reactionId = $handler(new CreateBlogPostReactionCommand('op', 'actor', 'post', BlogReactionType::HEART));
+        $reactionId = $handler(new CreateBlogPostReactionCommand('op', 'actor-id', 'post', BlogReactionType::HEART));
 
         self::assertNotSame('', $reactionId);
     }
@@ -81,7 +88,9 @@ final class CreateBlogPostReactionCommandHandlerTest extends TestCase
             ->method('save')
             ->with($existingReaction);
         $notificationService->expects(self::never())->method('notifyPostReactionCreated');
-        $cacheInvalidationService->expects(self::once())->method('invalidateBlogCaches');
+        $cacheInvalidationService->expects(self::once())
+            ->method('invalidateBlogCaches')
+            ->with('app-slug', ['actor-id', 'post-author-id']);
 
         $handler = new CreateBlogPostReactionCommandHandler(
             $reactionRepository,
@@ -91,10 +100,119 @@ final class CreateBlogPostReactionCommandHandlerTest extends TestCase
             $cacheInvalidationService,
         );
 
-        $reactionId = $handler(new CreateBlogPostReactionCommand('op', 'actor', 'post', BlogReactionType::LAUGH));
+        $reactionId = $handler(new CreateBlogPostReactionCommand('op', 'actor-id', 'post', BlogReactionType::LAUGH));
 
         self::assertSame(BlogReactionType::LAUGH, $existingReaction->getType());
         self::assertSame($existingReaction->getId(), $reactionId);
+    }
+
+    public function testInvokeRecoversFromUniqueConstraintAndUpdatesExistingReaction(): void
+    {
+        $reactionRepository = $this->createMock(BlogReactionRepository::class);
+        $postRepository = $this->createMock(BlogPostRepository::class);
+        $userRepository = $this->createMock(UserRepository::class);
+        $notificationService = $this->createMock(BlogNotificationService::class);
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+        $entityManager = $this->createMock(EntityManager::class);
+
+        [$post, $user] = $this->createPostAndUser();
+        $existingReaction = (new BlogReaction())
+            ->setPost($post)
+            ->setAuthor($user)
+            ->setType(BlogReactionType::LIKE);
+
+        $postRepository->method('find')->willReturn($post);
+        $userRepository->method('find')->willReturn($user);
+        $reactionRepository->expects(self::exactly(2))
+            ->method('findOneByPostAndAuthor')
+            ->with($post, $user)
+            ->willReturnOnConsecutiveCalls(null, $existingReaction);
+        $saveCalls = 0;
+        $reactionRepository->expects(self::exactly(2))
+            ->method('save')
+            ->with(self::callback(static fn (BlogReaction $reaction): bool => $reaction instanceof BlogReaction))
+            ->willReturnCallback(function () use (&$saveCalls, $reactionRepository): BlogReactionRepository {
+                ++$saveCalls;
+
+                if ($saveCalls === 1) {
+                    throw $this->createUniqueConstraintViolationException();
+                }
+
+                return $reactionRepository;
+            });
+        $reactionRepository->expects(self::once())
+            ->method('getEntityManager')
+            ->willReturn($entityManager);
+        $entityManager->expects(self::once())->method('clear');
+        $notificationService->expects(self::never())->method('notifyPostReactionCreated');
+        $cacheInvalidationService->expects(self::once())
+            ->method('invalidateBlogCaches')
+            ->with('app-slug', ['actor-id', 'post-author-id']);
+
+        $handler = new CreateBlogPostReactionCommandHandler(
+            $reactionRepository,
+            $postRepository,
+            $userRepository,
+            $notificationService,
+            $cacheInvalidationService,
+        );
+
+        $reactionId = $handler(new CreateBlogPostReactionCommand('op', 'actor-id', 'post', BlogReactionType::HEART));
+
+        self::assertSame(BlogReactionType::HEART, $existingReaction->getType());
+        self::assertSame($existingReaction->getId(), $reactionId);
+    }
+
+    public function testInvokeThrowsConflictWhenRecoveryCannotFindExistingReaction(): void
+    {
+        $reactionRepository = $this->createMock(BlogReactionRepository::class);
+        $postRepository = $this->createMock(BlogPostRepository::class);
+        $userRepository = $this->createMock(UserRepository::class);
+        $notificationService = $this->createMock(BlogNotificationService::class);
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+        $entityManager = $this->createMock(EntityManager::class);
+
+        [$post, $user] = $this->createPostAndUser();
+
+        $postRepository->method('find')->willReturn($post);
+        $userRepository->method('find')->willReturn($user);
+        $reactionRepository->expects(self::exactly(2))
+            ->method('findOneByPostAndAuthor')
+            ->with($post, $user)
+            ->willReturn(null);
+        $reactionRepository->expects(self::once())
+            ->method('save')
+            ->willThrowException($this->createUniqueConstraintViolationException());
+        $reactionRepository->expects(self::once())
+            ->method('getEntityManager')
+            ->willReturn($entityManager);
+        $entityManager->expects(self::once())->method('clear');
+        $notificationService->expects(self::never())->method('notifyPostReactionCreated');
+        $cacheInvalidationService->expects(self::never())->method('invalidateBlogCaches');
+
+        $handler = new CreateBlogPostReactionCommandHandler(
+            $reactionRepository,
+            $postRepository,
+            $userRepository,
+            $notificationService,
+            $cacheInvalidationService,
+        );
+
+        try {
+            $handler(new CreateBlogPostReactionCommand('op', 'actor-id', 'post', BlogReactionType::HEART));
+            self::fail('Expected conflict exception to be thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(JsonResponse::HTTP_CONFLICT, $exception->getStatusCode());
+            self::assertSame('Unable to create blog reaction.', $exception->getMessage());
+        }
+    }
+
+    private function createUniqueConstraintViolationException(): UniqueConstraintViolationException
+    {
+        /** @var UniqueConstraintViolationException $exception */
+        $exception = (new \ReflectionClass(UniqueConstraintViolationException::class))->newInstanceWithoutConstructor();
+
+        return $exception;
     }
 
     /**
@@ -102,11 +220,18 @@ final class CreateBlogPostReactionCommandHandlerTest extends TestCase
      */
     private function createPostAndUser(): array
     {
+        $application = $this->createMock(Application::class);
+        $application->method('getSlug')->willReturn('app-slug');
+
         $blog = $this->createMock(Blog::class);
-        $blog->method('getApplication')->willReturn(null);
+        $blog->method('getApplication')->willReturn($application);
+
+        $postAuthor = $this->createMock(User::class);
+        $postAuthor->method('getId')->willReturn('post-author-id');
 
         $post = $this->createMock(BlogPost::class);
         $post->method('getBlog')->willReturn($blog);
+        $post->method('getAuthor')->willReturn($postAuthor);
 
         $user = $this->createMock(User::class);
 


### PR DESCRIPTION
### Motivation
- Ensure the post reaction handler correctly recovers from a `UniqueConstraintViolationException` raised during the initial `save()` and follows the reload → find existing → update → return id flow.
- Verify the handler returns an HTTP 409 when recovery cannot find the reaction after clearing and reloading.
- Assert cache invalidation is called with the expected application slug and list of affected user ids.

### Description
- Extended `tests/Unit/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandlerTest.php` with imports for `UniqueConstraintViolationException`, `EntityManager`, `JsonResponse`, and `HttpException` to support new scenarios.
- Added a test `testInvokeRecoversFromUniqueConstraintAndUpdatesExistingReaction` that simulates an initial `save()` throwing a unique constraint exception and validates the `clear`, refetch, update, and returned id behavior while ensuring cache invalidation arguments include `app-slug` and `['actor-id','post-author-id']`.
- Added a test `testInvokeThrowsConflictWhenRecoveryCannotFindExistingReaction` that asserts an HTTP 409 (`JsonResponse::HTTP_CONFLICT`) and the message `Unable to create blog reaction.` when recovery still cannot locate the reaction.
- Updated the `createPostAndUser()` helper to supply an `Application` slug and `post` author id so cache invalidation expectations can be asserted precisely.

### Testing
- Ran a syntax check with `php -l tests/Unit/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandlerTest.php`, which succeeded with no syntax errors.
- Attempted to run the test suite with `./vendor/bin/phpunit` and `php bin/phpunit`, but the PHPUnit runner is not available in this environment so tests could not be executed.
- The modified test file is `tests/Unit/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandlerTest.php` and was verified to be syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b26d514c8326bf2d4bf7125eb528)