### PR TITLE
test(calendar): ajouter un garde-fou de requêtes SQL sur la liste d'événements

### DIFF
--- a/tests/Application/Calendar/Transport/Controller/Api/V1/Event/EventListingQueryCountTest.php
+++ b/tests/Application/Calendar/Transport/Controller/Api/V1/Event/EventListingQueryCountTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Calendar\Transport\Controller\Api\V1\Event;
+
+use App\Calendar\Domain\Entity\Calendar;
+use App\Calendar\Domain\Entity\Event;
+use App\Calendar\Domain\Enum\EventVisibility;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\Platform;
+use App\Platform\Domain\Enum\PlatformStatus;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\Response;
+
+use function count;
+use function is_array;
+use function method_exists;
+use function sprintf;
+
+final class EventListingQueryCountTest extends WebTestCase
+{
+    #[TestDox('Event list SQL count stays bounded when listing many more application events (anti-N+1 guard).')]
+    public function testApplicationEventListingQueryCountStaysBoundedAsItemsIncrease(): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $smallDataset = $this->createApplicationCalendarWithEvents($entityManager, 'small', 5);
+        $largeDataset = $this->createApplicationCalendarWithEvents($entityManager, 'large', 30);
+
+        $client = static::createClient(['debug' => true], $this->getJsonHeaders());
+
+        $smallQueryCount = $this->countSqlQueriesForListingRequest($client, $smallDataset['slug']);
+        $largeQueryCount = $this->countSqlQueriesForListingRequest($client, $largeDataset['slug']);
+
+        // Seuil métier : la page liste doit rester pilotée par un nombre fixe de requêtes
+        // (ex: lecture des items + pagination), et ne jamais évoluer linéairement avec le volume d'items.
+        self::assertLessThanOrEqual(
+            $smallQueryCount + 2,
+            $largeQueryCount,
+            sprintf('Expected bounded SQL growth for event listing: small=%d, large=%d', $smallQueryCount, $largeQueryCount),
+        );
+        self::assertLessThanOrEqual(
+            12,
+            $largeQueryCount,
+            sprintf('Expected absolute SQL ceiling for calendar event listing, got %d queries', $largeQueryCount),
+        );
+    }
+
+    private function countSqlQueriesForListingRequest(KernelBrowser $client, string $applicationSlug): int
+    {
+        $client->enableProfiler();
+        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/applications/' . $applicationSlug . '/events?limit=100');
+
+        $response = $client->getResponse();
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $profile = $client->getProfile();
+        self::assertNotFalse($profile, 'Symfony profiler profile should be available in this test.');
+
+        $dbCollector = $profile->getCollector('db');
+
+        if (method_exists($dbCollector, 'getQueryCount')) {
+            return (int)$dbCollector->getQueryCount();
+        }
+
+        $queries = $dbCollector->getQueries();
+
+        if (!is_array($queries)) {
+            self::fail('Doctrine profiler collector did not expose SQL queries as an array.');
+        }
+
+        $defaultConnectionQueries = $queries['default'] ?? $queries;
+        self::assertIsArray($defaultConnectionQueries);
+
+        return count($defaultConnectionQueries);
+    }
+
+    /**
+     * @return array{slug: string}
+     */
+    private function createApplicationCalendarWithEvents(
+        EntityManagerInterface $entityManager,
+        string $suffix,
+        int $eventCount,
+    ): array {
+        $owner = $entityManager->getRepository(User::class)->findOneBy([
+            'username' => 'john-root',
+        ]);
+        self::assertInstanceOf(User::class, $owner);
+
+        $platform = $entityManager->getRepository(Platform::class)->findOneBy([]);
+        self::assertInstanceOf(Platform::class, $platform);
+
+        $application = (new Application())
+            ->setTitle(sprintf('Calendar SQL Guard %s', $suffix))
+            ->setDescription('Integration test application for SQL query count guard.')
+            ->setStatus(PlatformStatus::ACTIVE)
+            ->setPrivate(false)
+            ->setUser($owner)
+            ->setPlatform($platform)
+            ->ensureGeneratedPhoto()
+            ->ensureGeneratedSlug();
+
+        $calendar = (new Calendar())
+            ->setTitle(sprintf('Calendar %s', $suffix))
+            ->setApplication($application)
+            ->setUser($owner);
+
+        $entityManager->persist($application);
+        $entityManager->persist($calendar);
+
+        $baseDate = new DateTimeImmutable('2031-01-01 08:00:00');
+
+        for ($index = 0; $index < $eventCount; ++$index) {
+            $startAt = $baseDate->modify(sprintf('+%d day', $index));
+            self::assertInstanceOf(DateTimeImmutable::class, $startAt);
+
+            $event = (new Event())
+                ->setTitle(sprintf('SQL guard event %s #%d', $suffix, $index + 1))
+                ->setDescription('Event used by integration test to guard query count scaling.')
+                ->setStartAt($startAt)
+                ->setEndAt($startAt->modify('+1 hour'))
+                ->setVisibility(EventVisibility::PUBLIC)
+                ->setCalendar($calendar)
+                ->setUser($owner);
+
+            $entityManager->persist($event);
+        }
+
+        $entityManager->flush();
+
+        return [
+            'slug' => $application->getSlug(),
+        ];
+    }
+}


### PR DESCRIPTION
### Motivation
- Prévenir les régressions de type N+1 sur l'endpoint de listing d'événements en mesurant le nombre de requêtes SQL lors de l'affichage d'un volume croissant d'items.
- Documenter le seuil métier attendu (croissance bornée) directement dans le test pour faciliter la maintenance et la détection précoce de régressions.

### Description
- Ajout du test d'intégration `EventListingQueryCountTest` sous `tests/Application/Calendar/Transport/Controller/Api/V1/Event/` qui crée deux jeux de données (5 vs 30 événements) et appelle l'endpoint `GET /api/v1/calendar/applications/{slug}/events`.
- Le test active le profiler Symfony via `KernelBrowser::enableProfiler()`, récupère le collecteur `db` et mesure le nombre de requêtes SQL en utilisant `getQueryCount()` quand disponible ou en comptant les entrées retournées par `getQueries()`.
- Assertions métier : un seuil relatif `large <= small + 2` et un plafond absolu `large <= 12` pour garantir que le nombre de requêtes reste borné quand le nombre d'items augmente.
- Le test inclut un commentaire expliquant la raison métier du seuil (garde-fou anti N+1 : la page doit être pilotée par un coût quasi fixe lié à la lecture/pagination, pas par le nombre d'items).

### Testing
- Linter PHP exécuté avec `php -l tests/Application/Calendar/Transport/Controller/Api/V1/Event/EventListingQueryCountTest.php` et passé avec succès.
- Exécution de la suite `phpunit` non possible dans cet environnement car `./vendor/bin/phpunit` est absent, donc le test n'a pas été exécuté ici (échec d'exécution, pas d'échec du test lui-même).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b27520708326a1cd63a48d54b0c1)