### PR TITLE
Document 200/201 for chat reaction creation and add API test

### DIFF
--- a/src/Chat/Transport/Controller/Api/V1/Reaction/CreateReactionController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Reaction/CreateReactionController.php
@@ -24,11 +24,27 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
-#[OA\Post(path: '/v1/chat/private/messages/{messageId}/reactions', operationId: 'chat_reaction_create', summary: 'Créer une réaction', requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['reaction'], properties: [new OA\Property(property: 'reaction', type: 'string', enum: ChatReactionType::VALUES, example: 'like')], example: [
-    'reaction' => 'like',
-])), tags: ['Chat Message Reaction'], parameters: [new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], responses: [new OA\Response(response: 201, description: 'Réaction créée', content: new OA\JsonContent(example: [
-    'id' => '8f210e56-6550-4b61-b7f3-8994f5f6dc41',
-])), new OA\Response(response: 400, description: 'Payload invalide'), new OA\Response(response: 404, description: 'Message introuvable')])]
+#[OA\Post(
+    path: '/v1/chat/private/messages/{messageId}/reactions',
+    operationId: 'chat_reaction_create',
+    summary: 'Créer une réaction',
+    description: 'Retourne 201 lorsqu\'une nouvelle réaction est créée. Retourne 200 lorsque la même réaction existe déjà pour cet utilisateur et ce message.',
+    requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ['reaction'], properties: [new OA\Property(property: 'reaction', type: 'string', enum: ChatReactionType::VALUES, example: 'like')], example: [
+        'reaction' => 'like',
+    ])),
+    tags: ['Chat Message Reaction'],
+    parameters: [new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))],
+    responses: [
+        new OA\Response(response: 200, description: 'Réaction déjà existante', content: new OA\JsonContent(example: [
+            'id' => '3f2f9366-c280-4dd7-ad5f-c3ba7a87d4c2',
+        ])),
+        new OA\Response(response: 201, description: 'Nouvelle réaction créée', content: new OA\JsonContent(example: [
+            'id' => '8f210e56-6550-4b61-b7f3-8994f5f6dc41',
+        ])),
+        new OA\Response(response: 400, description: 'Payload invalide'),
+        new OA\Response(response: 404, description: 'Message introuvable'),
+    ]
+)]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 readonly class CreateReactionController
 {

--- a/tests/Application/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationControllerTest.php
+++ b/tests/Application/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationControllerTest.php
@@ -18,6 +18,38 @@ final class UserReactionMutationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
+    #[TestDox('Reaction create returns 201 on first identical POST and 200 on second')]
+    public function testCreateReactionReturnsCreatedThenOkOnDuplicatePost(): void
+    {
+        $messageId = LoadRecruitChatCalendarScenarioData::getUuidByKey('message-john-root-scenario-from-john-root');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('POST', $this->baseUrl . '/messages/' . $messageId . '/reactions', [], [], [], JSON::encode([
+            'reaction' => 'like',
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $firstContent = $client->getResponse()->getContent();
+        self::assertNotFalse($firstContent);
+        $firstPayload = JSON::decode($firstContent, true);
+        $firstReactionId = $firstPayload['id'] ?? null;
+        self::assertIsString($firstReactionId);
+
+        $client->request('POST', $this->baseUrl . '/messages/' . $messageId . '/reactions', [], [], [], JSON::encode([
+            'reaction' => 'like',
+        ]));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $secondContent = $client->getResponse()->getContent();
+        self::assertNotFalse($secondContent);
+        $secondPayload = JSON::decode($secondContent, true);
+        self::assertSame($firstReactionId, $secondPayload['id'] ?? null);
+    }
+
+    /**
+     * @throws Throwable
+     */
     #[TestDox('Reaction create/patch/delete nominal + validation + ownership authorization')]
     public function testReactionEndpoints(): void
     {


### PR DESCRIPTION
### Motivation

- Rendre explicite dans la documentation OpenAPI le comportement distinct du endpoint de création de réaction entre création nouvelle (201) et requête redondante (200). 
- Prévenir les confusions côté client en fournissant des exemples séparés pour les réponses `200` et `201` et en garantir le comportement via un test API.

### Description

- Mise à jour de l'attribut OpenAPI sur `POST /v1/chat/private/messages/{messageId}/reactions` pour ajouter une `description` claire et documenter à la fois la réponse `200` (réaction déjà existante) et la réponse `201` (nouvelle réaction créée) avec des exemples JSON distincts.
- Ajout d'un test API dans `UserReactionMutationControllerTest` qui vérifie explicitement qu'un premier `POST` retourne `201` et qu'un second `POST` identique retourne `200` en renvoyant le même `id` de réaction.

### Testing

- Exécution du linter PHP sur les fichiers modifiés via `php -l` qui a validé la syntaxe des fichiers modifiés.
- Tentative d'exécution du test via `./vendor/bin/phpunit tests/Application/Chat/Transport/Controller/Api/V1/Reaction/UserReactionMutationControllerTest.php` qui n'a pas pu être lancée car `vendor/bin/phpunit` est indisponible dans cet environnement.
- Aucun test PHPUnit automatisé n'a été exécuté ici en raison de l'environnement de CI local absent, la nouvelle suite est toutefois ajoutée et prête à être exécutée dans l'environnement de test habituel.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b27bc7a8832685c7a9fa2952bf70)