### PR TITLE
Add forbidden POST scope coverage for school scoped routes

### DIFF
--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
@@ -164,4 +164,69 @@ final class SchoolApplicationScopedRoutesTest extends WebTestCase
             self::assertEmpty(array_intersect($campusIds, $courseIds), sprintf('Resource %s leaked entities across schools.', $resource));
         }
     }
+
+    #[TestDox('School scoped POST endpoints deny forbidden user on students, teachers, exams and grades resources.')]
+    public function testScopedPostRoutesAreForbiddenForForeignUser(): void
+    {
+        $ownerClient = $this->getTestClient('john-root', 'password-root');
+        $forbiddenClient = $this->getTestClient('john-user', 'password-user');
+
+        $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes');
+        self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+        $classId = JSON::decode((string)$ownerClient->getResponse()->getContent(), true)['items'][0]['id'];
+
+        $ownerClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/teachers', [], [], [], JSON::encode([
+            'name' => 'Prof Forbidden Scope Setup',
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $ownerClient->getResponse()->getStatusCode());
+        $teacherId = JSON::decode((string)$ownerClient->getResponse()->getContent(), true)['id'];
+
+        $ownerClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/students', [], [], [], JSON::encode([
+            'name' => 'Eleve Forbidden Scope Setup',
+            'classId' => $classId,
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $ownerClient->getResponse()->getStatusCode());
+        $studentId = JSON::decode((string)$ownerClient->getResponse()->getContent(), true)['id'];
+
+        $ownerClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams', [], [], [], JSON::encode([
+            'title' => 'Examen Forbidden Scope Setup',
+            'classId' => $classId,
+            'teacherId' => $teacherId,
+            'type' => 'QUIZ',
+            'status' => 'DRAFT',
+            'term' => 'TERM_1',
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $ownerClient->getResponse()->getStatusCode());
+        $examId = JSON::decode((string)$ownerClient->getResponse()->getContent(), true)['id'];
+
+        $forbiddenPayloads = [
+            'students' => [
+                'name' => 'Eleve Forbidden Scoped Post',
+                'classId' => $classId,
+            ],
+            'teachers' => [
+                'name' => 'Prof Forbidden Scoped Post',
+            ],
+            'exams' => [
+                'title' => 'Examen Forbidden Scoped Post',
+                'classId' => $classId,
+                'teacherId' => $teacherId,
+                'type' => 'QUIZ',
+                'status' => 'DRAFT',
+                'term' => 'TERM_1',
+            ],
+            'grades' => [
+                'score' => 11.5,
+                'studentId' => $studentId,
+                'examId' => $examId,
+            ],
+        ];
+
+        foreach ($forbiddenPayloads as $endpoint => $payload) {
+            $forbiddenClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/' . $endpoint, [], [], [], JSON::encode($payload));
+            self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+        }
+
+        self::assertStringContainsString('Forbidden application scope access.', (string)$forbiddenClient->getResponse()->getContent());
+    }
 }


### PR DESCRIPTION
### Motivation
- Ensure POST endpoints under the `school-campus-core` application enforce application-scoped access control and deny requests from a foreign user.
- Verify that the API returns `HTTP_FORBIDDEN` and includes a scope error message when a forbidden client attempts to create scoped resources.

### Description
- Add a new test `testScopedPostRoutesAreForbiddenForForeignUser` to `tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php` that exercises owner vs forbidden user scenarios.
- The test creates required dependencies as the owner (`class`, `teacher`, `student`, `exam`), then attempts `POST` requests as the forbidden client to `students`, `teachers`, `exams`, and `grades` under `/v1/school/applications/school-campus-core/*`.
- Each forbidden `POST` is asserted to return `Response::HTTP_FORBIDDEN` and the response content is checked for the message `Forbidden application scope access.`

### Testing
- Ran a PHP syntax check with `php -l tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php` which succeeded.
- Attempted to run `./vendor/bin/phpunit` for the file but the `phpunit` binary is not available in this environment, so full test execution could not be performed.
- The new test file passes static syntax validation and is ready to run in CI or a local environment with project dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b284daa483268c8bfa4d074d69a9)