### PR TITLE
Déprécation des routes legacy /v1/shop/products et migration vers applicationSlug

### DIFF
--- a/docs/application-slug-route-migration.md
+++ b/docs/application-slug-route-migration.md
@@ -19,3 +19,18 @@ Pour conserver la compatibilité avec les clients existants:
 
 ## Recommandation technique
 Quand le slug n'est pas dérivable automatiquement, retourner `400` avec un message explicite pour forcer la migration client.
+
+## Note de migration API – Shop Products
+
+### Shop products (`/v1/shop/products`)
+- Les routes legacy `GET /v1/shop/products` et `POST /v1/shop/products` sont **dépréciées**.
+- Les consommateurs externes doivent migrer vers les routes canoniques :
+  - `GET /v1/shop/applications/{applicationSlug}/products`
+  - `POST /v1/shop/applications/{applicationSlug}/products`
+  - `GET|PATCH|DELETE /v1/shop/applications/{applicationSlug}/products/{id}`
+- Pendant la fenêtre de migration, les routes legacy restent accessibles mais répondent avec les en-têtes HTTP:
+  - `Deprecation: true`
+  - `Sunset: Wed, 31 Dec 2026 23:59:59 GMT`
+  - `Warning: 299 - "Deprecated endpoint: use /v1/shop/applications/{applicationSlug}/products instead."`
+
+Action attendue côté clients: renseigner explicitement `applicationSlug` dans les chemins d'URL et retirer l'usage de `/v1/shop/products`.

--- a/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php
@@ -45,6 +45,7 @@ final readonly class CreateApplicationProductController
      * @throws ExceptionInterface
      */
     #[Route('/v1/shop/applications/{applicationSlug}/products', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Create product by application scope')]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {

--- a/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/ListApplicationProductsController.php
+++ b/src/Shop/Transport/Controller/Api/V1/ApplicationProduct/ListApplicationProductsController.php
@@ -32,6 +32,7 @@ final readonly class ListApplicationProductsController
      * @throws InvalidArgumentException
      */
     #[Route('/v1/shop/applications/{applicationSlug}/products', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'List products by application scope')]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {

--- a/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
@@ -32,6 +32,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class CreateProductController
 {
+    private const LEGACY_ROUTE_WARNING = 'Deprecated endpoint: use /v1/shop/applications/{applicationSlug}/products instead.';
+
     public function __construct(
         private ProductHydratorService $productHydratorService,
         private ProductInputValidator $productInputValidator,
@@ -48,6 +50,11 @@ final readonly class CreateProductController
      * @throws ExceptionInterface
      */
     #[Route('/v1/shop/products', methods: [Request::METHOD_POST])]
+    #[OA\Post(
+        deprecated: true,
+        summary: 'Legacy create product endpoint',
+        description: 'Deprecated: migrate to /v1/shop/applications/{applicationSlug}/products.',
+    )]
     public function __invoke(Request $request): JsonResponse
     {
         try {
@@ -80,9 +87,14 @@ final readonly class CreateProductController
         $this->entityManager->flush();
         $this->messageBus->dispatch(new EntityCreated('shop_product', $product->getId()));
 
-        return new JsonResponse([
+        $response = new JsonResponse([
             'id' => $product->getId(),
         ], JsonResponse::HTTP_CREATED);
+        $response->headers->set('Deprecation', 'true');
+        $response->headers->set('Sunset', 'Wed, 31 Dec 2026 23:59:59 GMT');
+        $response->headers->set('Warning', sprintf('299 - "%s"', self::LEGACY_ROUTE_WARNING));
+
+        return $response;
     }
 
     /**

--- a/src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php
@@ -20,6 +20,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class ListProductsController
 {
+    private const LEGACY_ROUTE_WARNING = 'Deprecated endpoint: use /v1/shop/applications/{applicationSlug}/products instead.';
+
     public function __construct(
         private ProductListService $productListService
     ) {
@@ -30,8 +32,18 @@ final readonly class ListProductsController
      * @throws InvalidArgumentException
      */
     #[Route('/v1/shop/products', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        deprecated: true,
+        summary: 'Legacy list products endpoint',
+        description: 'Deprecated: migrate to /v1/shop/applications/{applicationSlug}/products.',
+    )]
     public function __invoke(Request $request): JsonResponse
     {
-        return new JsonResponse($this->productListService->getList($request));
+        $response = new JsonResponse($this->productListService->getList($request));
+        $response->headers->set('Deprecation', 'true');
+        $response->headers->set('Sunset', 'Wed, 31 Dec 2026 23:59:59 GMT');
+        $response->headers->set('Warning', sprintf('299 - "%s"', self::LEGACY_ROUTE_WARNING));
+
+        return $response;
     }
 }

--- a/tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php
+++ b/tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php
@@ -16,7 +16,7 @@ final class ShopMutationControllerTest extends WebTestCase
 
         $client->request(
             Request::METHOD_POST,
-            self::API_URL_PREFIX . '/v1/shop/products',
+            self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/products',
             [],
             [],
             $this->getJsonHeaders(),
@@ -28,10 +28,12 @@ final class ShopMutationControllerTest extends WebTestCase
 
         self::assertResponseStatusCodeSame(201);
 
-        /** @var array{id: string} $payload */
+        /** @var array{id: string, shopId: string, applicationSlug: string} $payload */
         $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
         self::assertArrayHasKey('id', $payload);
         self::assertNotSame('', $payload['id']);
+        self::assertSame('shop-ops-center', $payload['applicationSlug']);
+        self::assertNotSame('', $payload['shopId']);
 
         /** @var ProductRepository $productRepository */
         $productRepository = static::getContainer()->get(ProductRepository::class);
@@ -77,6 +79,30 @@ final class ShopMutationControllerTest extends WebTestCase
         self::assertSame($products[0]->getId(), $payload['id']);
     }
 
+
+    public function testLegacyCreateProductRouteReturnsDeprecationHeaders(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/products',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'name' => 'Legacy Messenger Product',
+                'price' => 45.67,
+                'applicationSlug' => 'shop-ops-center',
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(201);
+        self::assertSame('true', $client->getResponse()->headers->get('Deprecation'));
+        self::assertSame('Wed, 31 Dec 2026 23:59:59 GMT', $client->getResponse()->headers->get('Sunset'));
+        self::assertNotFalse(strpos((string)$client->getResponse()->headers->get('Warning'), 'Deprecated endpoint'));
+    }
+
     public function testDeleteProductDispatchesCommandAndRemovesEntity(): void
     {
         /** @var ProductRepository $productRepository */
@@ -89,7 +115,7 @@ final class ShopMutationControllerTest extends WebTestCase
         $client = $this->getTestClient('john-user', 'password-user');
         $client->request(
             Request::METHOD_DELETE,
-            self::API_URL_PREFIX . '/v1/shop/products/' . $product->getId(),
+            self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/products/' . $product->getId(),
             [],
             [],
             $this->getJsonHeaders(),


### PR DESCRIPTION
### Motivation
- Clarifier la stratégie de routage V1 en promouvant les routes scoppées par `applicationSlug` tout en conservant temporairement la compatibilité avec les routes legacy.
- Informer les consommateurs externes de la dépréciation et fournir une fenêtre de migration explicite via en-têtes HTTP et documentation.
- Mettre à jour les contrôleurs, les tests d'intégration et la documentation OpenAPI/Nelmio pour refléter la stratégie retenue.

### Description
- Les endpoints legacy `GET /v1/shop/products` et `POST /v1/shop/products` sont marqués `deprecated` dans les attributs OpenAPI et renvoient désormais les en-têtes HTTP `Deprecation: true`, `Sunset: Wed, 31 Dec 2026 23:59:59 GMT` et `Warning: 299 - "Deprecated endpoint: use /v1/shop/applications/{applicationSlug}/products instead."` via une constante `LEGACY_ROUTE_WARNING` (modifications dans `src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php` et `CreateProductController.php`).
- Les routes canoniques scoppées par `applicationSlug` ont reçu des annotations OpenAPI additionnelles (`#[OA\Get]` / `#[OA\Post]`) pour améliorer la doc (modifications dans `src/Shop/Transport/Controller/Api/V1/ApplicationProduct/ListApplicationProductsController.php` et `CreateApplicationProductController.php`).
- Les tests d’intégration `tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php` ont été mis à jour pour utiliser les chemins canoniques pour création/suppression, et un test a été ajouté pour vérifier que la route legacy de création renvoie bien les en-têtes de dépréciation.
- Ajout d’une note de migration API détaillée pour les consommateurs externes expliquant les routes legacy concernées, les routes cibles et les en-têtes de dépréciation (`docs/application-slug-route-migration.md`).

### Testing
- Exécution de vérifications de syntaxe PHP avec `php -l` sur les fichiers modifiés : toutes les vérifications sont passées avec succès.
- Tentative d’exécution ciblée de PHPUnit (`./bin/phpunit` et `vendor/bin/phpunit`) : échec car le binaire PHPUnit n’est pas disponible dans cet environnement (tests unitaires/integration non exécutés ici).
- Les modifications ont été contrôlées localement pour cohérence de signature et d’annotations OpenAPI et les fichiers modifiés sont prêts pour exécution des suites CI/CD susceptibles d’exécuter PHPUnit dans l’environnement de build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b298be30832687a206e6135a199f)