### PR TITLE
CRM: harmonize V1 API error responses using CrmApiErrorResponseFactory

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/Company/DeleteCompanyController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/DeleteCompanyController.php
@@ -7,6 +7,7 @@ namespace App\Crm\Transport\Controller\Api\V1\Company;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Company;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityDeleted;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -26,6 +27,7 @@ final readonly class DeleteCompanyController
     public function __construct(
         private CompanyRepository $companyRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -38,7 +40,7 @@ final readonly class DeleteCompanyController
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $company = $this->companyRepository->findOneScopedById($id, $crm->getId());
         if (!$company instanceof Company) {
-            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+            return $this->errorResponseFactory->notFoundReference('companyId');
         }
 
         $this->entityManager->remove($company);

--- a/src/Crm/Transport/Controller/Api/V1/Project/DeleteProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/DeleteProjectController.php
@@ -7,6 +7,7 @@ namespace App\Crm\Transport\Controller\Api\V1\Project;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityDeleted;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -27,6 +28,7 @@ final readonly class DeleteProjectController
     public function __construct(
         private ProjectRepository $projectRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -42,7 +44,7 @@ final readonly class DeleteProjectController
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $project = $this->projectRepository->findOneScopedById($id, $crm->getId());
         if (!$project instanceof Project) {
-            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+            return $this->errorResponseFactory->notFoundReference('projectId');
         }
 
         $this->entityManager->remove($project);

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/DeleteSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/DeleteSprintController.php
@@ -7,6 +7,7 @@ namespace App\Crm\Transport\Controller\Api\V1\Sprint;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Sprint;
 use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityDeleted;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -26,6 +27,7 @@ final readonly class DeleteSprintController
     public function __construct(
         private SprintRepository $sprintRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -38,7 +40,7 @@ final readonly class DeleteSprintController
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $sprint = $this->sprintRepository->findOneScopedById($id, $crm->getId());
         if (!$sprint instanceof Sprint) {
-            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+            return $this->errorResponseFactory->notFoundReference('sprintId');
         }
 
         $this->entityManager->remove($sprint);

--- a/src/Crm/Transport/Controller/Api/V1/Task/DeleteTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/DeleteTaskController.php
@@ -7,6 +7,7 @@ namespace App\Crm\Transport\Controller\Api\V1\Task;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityDeleted;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -26,6 +27,7 @@ final readonly class DeleteTaskController
     public function __construct(
         private TaskRepository $taskRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -38,7 +40,7 @@ final readonly class DeleteTaskController
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $task = $this->taskRepository->findOneScopedById($id, $crm->getId());
         if (!$task instanceof Task) {
-            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+            return $this->errorResponseFactory->notFoundReference('taskId');
         }
 
         $this->entityManager->remove($task);

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/DeleteTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/DeleteTaskRequestController.php
@@ -7,6 +7,7 @@ namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Crm\Infrastructure\Repository\TaskRequestRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityDeleted;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
@@ -26,6 +27,7 @@ final readonly class DeleteTaskRequestController
     public function __construct(
         private TaskRequestRepository $taskRequestRepository,
         private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -38,7 +40,7 @@ final readonly class DeleteTaskRequestController
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
         $taskRequest = $this->taskRequestRepository->findOneScopedById($id, $crm->getId());
         if (!$taskRequest instanceof TaskRequest) {
-            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+            return $this->errorResponseFactory->notFoundReference('taskRequestId');
         }
 
         $this->entityManager->remove($taskRequest);

--- a/tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php
@@ -36,6 +36,9 @@ final class CrmControllerTest extends WebTestCase
         );
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
     }
 
     #[TestDox('CreateSprintController rejects projectId from another CRM application scope.')]
@@ -54,6 +57,9 @@ final class CrmControllerTest extends WebTestCase
         );
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
     }
 
     #[TestDox('CreateTaskController rejects projectId from another CRM application scope.')]
@@ -72,6 +78,9 @@ final class CrmControllerTest extends WebTestCase
         );
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
     }
 
     #[TestDox('CreateTaskController rejects sprintId from another CRM application scope.')]
@@ -93,6 +102,9 @@ final class CrmControllerTest extends WebTestCase
         );
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
     }
 
     #[TestDox('CreateTaskRequestController rejects taskId from another CRM application scope.')]
@@ -111,6 +123,38 @@ final class CrmControllerTest extends WebTestCase
         );
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
+    }
+
+
+
+    #[TestDox('CreateTaskController returns 422 for sprint/project mismatch in same CRM scope.')]
+    public function testCreateTaskRejectsSprintProjectMismatch(): void
+    {
+        $companyId = $this->createCompany();
+        $projectId = $this->createProject($companyId);
+
+        $otherCompanyId = $this->createCompany();
+        $otherProjectId = $this->createProject($otherCompanyId);
+        $sprintId = $this->createSprint($otherProjectId);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/tasks', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode([
+                'title' => 'Task with mismatched sprint/project',
+                'projectId' => $projectId,
+                'sprintId' => $sprintId,
+            ])
+        );
+
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertSame('Provided "sprintId" does not belong to the provided "projectId".', $payload['message'] ?? null);
+        self::assertSame([], $payload['errors'] ?? null);
     }
 
     #[TestDox('Delete endpoints reject IDs from another CRM application scope.')]
@@ -126,6 +170,9 @@ final class CrmControllerTest extends WebTestCase
         );
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
     }
 
     /**
@@ -192,6 +239,26 @@ final class CrmControllerTest extends WebTestCase
             content: JSON::encode([
                 'name' => 'Cross Scope Company ' . uniqid('', true),
                 'contactEmail' => 'cross.scope.company@example.com',
+            ])
+        );
+
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode(), "Response:\n" . $client->getResponse());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string)$payload['id'];
+    }
+
+
+
+    private function createSprint(string $projectId): string
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/sprints', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode([
+                'name' => 'Cross Scope Sprint ' . uniqid('', true),
+                'projectId' => $projectId,
             ])
         );
 

--- a/tests/Application/Crm/Transport/Controller/Api/V1/CrmEndpointsSmokeTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/CrmEndpointsSmokeTest.php
@@ -41,6 +41,54 @@ final class CrmEndpointsSmokeTest extends WebTestCase
         $client->request('GET', sprintf('%s/v1/crm/applications/not-found-slug/%s', self::API_URL_PREFIX, $resource));
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
+    }
+
+    #[TestDox('POST create endpoints return 400 for invalid JSON payload.')]
+    #[DataProvider('createEndpointsProvider')]
+    public function testCreateEndpointsInvalidJson(string $resource): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/%s', self::API_URL_PREFIX, self::APPLICATION_SLUG, $resource),
+            server: ['CONTENT_TYPE' => 'application/json'],
+            content: '{"invalid":'
+        );
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertSame('Invalid JSON payload.', $payload['message'] ?? null);
+        self::assertSame([], $payload['errors'] ?? null);
+    }
+
+    #[TestDox('POST date-based endpoints return 400 for invalid date format.')]
+    #[DataProvider('invalidDateProvider')]
+    public function testCreateEndpointsInvalidDate(string $resource, string $titleOrNameField, string $dateField): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $payload = [$titleOrNameField => 'Invalid date payload'];
+        if ($resource === 'sprints') {
+            $companyId = $this->createCompany();
+            $payload['projectId'] = $this->createProject($companyId);
+        }
+
+        $payload[$dateField] = '2024-01-01';
+
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/%s', self::API_URL_PREFIX, self::APPLICATION_SLUG, $resource),
+            content: JSON::encode($payload)
+        );
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+        $decoded = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertSame(sprintf('Invalid date format for "%s".', $dateField), $decoded['message'] ?? null);
+        self::assertSame([], $decoded['errors'] ?? null);
     }
 
     #[TestDox('POST /companies returns 201 and then DELETE /companies/{id} returns 204.')]
@@ -89,6 +137,9 @@ final class CrmEndpointsSmokeTest extends WebTestCase
         );
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
     }
 
     #[TestDox('DELETE /projects/{id} returns 404 for unknown entity.')]
@@ -123,6 +174,9 @@ final class CrmEndpointsSmokeTest extends WebTestCase
         );
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
     }
 
     #[TestDox('DELETE /sprints/{id} returns 404 for unknown entity.')]
@@ -157,6 +211,9 @@ final class CrmEndpointsSmokeTest extends WebTestCase
         );
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
     }
 
     #[TestDox('DELETE /tasks/{id} returns 404 for unknown entity.')]
@@ -193,6 +250,9 @@ final class CrmEndpointsSmokeTest extends WebTestCase
         );
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
     }
 
     #[TestDox('DELETE /task-requests/{id} returns 404 for unknown entity.')]
@@ -223,6 +283,36 @@ final class CrmEndpointsSmokeTest extends WebTestCase
         $client->request('GET', self::API_URL_PREFIX . '/v1/crm/applications/not-found-slug/dashboard');
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
+    }
+
+    /**
+     * @return array<int, array{string}>
+     */
+    public static function createEndpointsProvider(): array
+    {
+        return [
+            ['companies'],
+            ['projects'],
+            ['sprints'],
+            ['tasks'],
+            ['task-requests'],
+        ];
+    }
+
+    /**
+     * @return array<int, array{string,string,string}>
+     */
+    public static function invalidDateProvider(): array
+    {
+        return [
+            ['projects', 'name', 'startedAt'],
+            ['sprints', 'name', 'startDate'],
+            ['tasks', 'title', 'dueAt'],
+            ['task-requests', 'title', 'resolvedAt'],
+        ];
     }
 
     /**
@@ -343,6 +433,9 @@ final class CrmEndpointsSmokeTest extends WebTestCase
         $client->request('DELETE', sprintf('%s/v1/crm/applications/%s/%s/%s', self::API_URL_PREFIX, self::APPLICATION_SLUG, $resource, self::UNKNOWN_UUID));
 
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertArrayHasKey('message', $payload);
+        self::assertSame([], $payload['errors'] ?? null);
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Uniformiser la sortie d'erreur des contrôleurs API CRM v1 pour garantir un schéma d'erreur commun `{message, errors}` et des codes HTTP cohérents.
- Forcer l'utilisation d'une fabrique dédiée pour couvrir les cas courants : JSON invalide / date invalide / référence inconnue / violation de scope logique.

### Description

- Remplacé les `new JsonResponse(..., JsonResponse::HTTP_NOT_FOUND)` dans les contrôleurs DELETE sous `src/Crm/Transport/Controller/Api/V1/` par des appels à `CrmApiErrorResponseFactory::notFoundReference(...)` et injecté `CrmApiErrorResponseFactory` dans ces contrôleurs.
- Ajouté des assertions dans les tests d'intégration CRM pour vérifier le schéma d'erreur commun (`message`, `errors`) sur les cas 404 et delete cross-scope.
- Ajouté des tests couvrant les créations CRM pour valider que : `400` est retourné pour JSON invalide et pour format de date invalide sur les endpoints concernés, et `422` est retourné pour le mismatch logique `sprintId`/`projectId`.
- Ajouté un helper `createSprint` aux tests et amélioré quelques assertions existantes pour décoder et vérifier le payload JSON d'erreur.

### Testing

- Vérification de syntaxe PHP sur les fichiers modifiés avec `php -l` : toutes les cibles modifiées (`src/...` et `tests/...`) sont valides.
- Tentative d'exécution ciblée des tests PHPUnit échouée dans cet environnement car `./bin/phpunit` n'est pas disponible (commande non présente).
- Tous les fichiers modifiés ont été relus et les tests mis à jour pour attendre le schéma d'erreur uniforme; les assertions ajoutées valident les messages et le champ `errors` (tests non exécutés ici).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b2a280d48326bb11827a77ee7ed0)