### PR TITLE
feat(recruit): add private interview scheduling endpoints and validations

### DIFF
--- a/migrations/Version20260314130000.php
+++ b/migrations/Version20260314130000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260314130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add recruit interviews entity and table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("CREATE TABLE recruit_interview (id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', application_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', scheduled_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', duration_minutes INT NOT NULL, mode VARCHAR(25) NOT NULL, location_or_url VARCHAR(255) NOT NULL, interviewer_ids JSON NOT NULL, status VARCHAR(25) NOT NULL DEFAULT 'planned', notes LONGTEXT DEFAULT NULL, created_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', updated_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', INDEX idx_recruit_interview_application_scheduled_at (application_id, scheduled_at), INDEX IDX_B44E3A4A57698A6A (application_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+        $this->addSql('ALTER TABLE recruit_interview ADD CONSTRAINT FK_B44E3A4A57698A6A FOREIGN KEY (application_id) REFERENCES recruit_application (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE recruit_interview DROP FOREIGN KEY FK_B44E3A4A57698A6A');
+        $this->addSql('DROP TABLE recruit_interview');
+    }
+}

--- a/src/Recruit/Application/Service/InterviewService.php
+++ b/src/Recruit/Application/Service/InterviewService.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Interview;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Recruit\Domain\Enum\InterviewMode;
+use App\Recruit\Domain\Enum\InterviewStatus;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Infrastructure\Repository\InterviewRepository;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function in_array;
+use function is_array;
+use function is_int;
+use function is_string;
+use function mb_strlen;
+use function strtolower;
+use function trim;
+
+readonly class InterviewService
+{
+    private const int MIN_DURATION_MINUTES = 15;
+    private const int MAX_DURATION_MINUTES = 240;
+
+    public function __construct(
+        private ApplicationRepository $applicationRepository,
+        private InterviewRepository $interviewRepository,
+    ) {
+    }
+
+    /** @param array<string,mixed> $payload */
+    public function create(string $applicationId, array $payload, User $loggedInUser): Interview
+    {
+        $application = $this->getOwnedApplication($applicationId, $loggedInUser);
+        $this->assertApplicationAllowsInterview($application);
+
+        $interview = (new Interview())
+            ->setApplication($application)
+            ->setScheduledAt($this->extractScheduledAt($payload))
+            ->setDurationMinutes($this->extractDuration($payload))
+            ->setMode($this->extractMode($payload))
+            ->setLocationOrUrl($this->extractLocationOrUrl($payload))
+            ->setInterviewerIds($this->extractInterviewerIds($payload))
+            ->setStatus($this->extractStatus($payload, false))
+            ->setNotes($this->extractNotes($payload));
+
+        $this->interviewRepository->save($interview);
+
+        return $interview;
+    }
+
+    /** @param array<string,mixed> $payload */
+    public function update(string $interviewId, array $payload, User $loggedInUser): Interview
+    {
+        $interview = $this->interviewRepository->find($interviewId);
+        if (!$interview instanceof Interview) {
+            throw new NotFoundHttpException('Interview not found.');
+        }
+
+        $application = $interview->getApplication();
+        $this->assertApplicationOwnership($application, $loggedInUser);
+        $this->assertApplicationAllowsInterview($application);
+
+        if (isset($payload['scheduledAt'])) {
+            $interview->setScheduledAt($this->extractScheduledAt($payload));
+        }
+
+        if (isset($payload['durationMinutes'])) {
+            $interview->setDurationMinutes($this->extractDuration($payload));
+        }
+
+        if (isset($payload['mode'])) {
+            $interview->setMode($this->extractMode($payload));
+        }
+
+        if (isset($payload['locationOrUrl'])) {
+            $interview->setLocationOrUrl($this->extractLocationOrUrl($payload));
+        }
+
+        if (isset($payload['interviewerIds'])) {
+            $interview->setInterviewerIds($this->extractInterviewerIds($payload));
+        }
+
+        if (isset($payload['status'])) {
+            $interview->setStatus($this->extractStatus($payload, true));
+        }
+
+        if (isset($payload['notes'])) {
+            $interview->setNotes($this->extractNotes($payload));
+        }
+
+        $this->interviewRepository->save($interview);
+
+        return $interview;
+    }
+
+    public function delete(string $interviewId, User $loggedInUser): void
+    {
+        $interview = $this->interviewRepository->find($interviewId);
+        if (!$interview instanceof Interview) {
+            throw new NotFoundHttpException('Interview not found.');
+        }
+
+        $this->assertApplicationOwnership($interview->getApplication(), $loggedInUser);
+
+        $this->interviewRepository->remove($interview);
+    }
+
+    /** @return array<int, Interview> */
+    public function listByApplication(string $applicationId, User $loggedInUser): array
+    {
+        $application = $this->getOwnedApplication($applicationId, $loggedInUser);
+
+        return $this->interviewRepository->findByApplicationOrdered($application);
+    }
+
+    private function getOwnedApplication(string $applicationId, User $loggedInUser): Application
+    {
+        $application = $this->applicationRepository->find($applicationId);
+        if (!$application instanceof Application) {
+            throw new NotFoundHttpException('Application not found.');
+        }
+
+        $this->assertApplicationOwnership($application, $loggedInUser);
+
+        return $application;
+    }
+
+    private function assertApplicationOwnership(Application $application, User $loggedInUser): void
+    {
+        if ($application->getJob()->getOwner()?->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You are not allowed to manage interviews for this application.');
+        }
+    }
+
+    private function assertApplicationAllowsInterview(Application $application): void
+    {
+        if (in_array($application->getStatus(), [ApplicationStatus::REJECTED, ApplicationStatus::HIRED], true)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Cannot schedule or update interviews for applications with status REJECTED or HIRED.');
+        }
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function extractScheduledAt(array $payload): DateTimeImmutable
+    {
+        if (!is_string($payload['scheduledAt'] ?? null)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "scheduledAt" must be a valid datetime string.');
+        }
+
+        try {
+            $scheduledAt = new DateTimeImmutable($payload['scheduledAt']);
+        } catch (\Throwable) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "scheduledAt" must be a valid datetime string.');
+        }
+
+        if ($scheduledAt <= new DateTimeImmutable()) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "scheduledAt" must be in the future.');
+        }
+
+        return $scheduledAt;
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function extractDuration(array $payload): int
+    {
+        if (!is_int($payload['durationMinutes'] ?? null)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "durationMinutes" must be an integer.');
+        }
+
+        $duration = $payload['durationMinutes'];
+        if ($duration < self::MIN_DURATION_MINUTES || $duration > self::MAX_DURATION_MINUTES) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "durationMinutes" must be between 15 and 240.');
+        }
+
+        return $duration;
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function extractMode(array $payload): InterviewMode
+    {
+        if (!is_string($payload['mode'] ?? null)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "mode" must be one of: visio, on-site.');
+        }
+
+        $mode = InterviewMode::tryFrom($payload['mode']);
+        if ($mode === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "mode" must be one of: visio, on-site.');
+        }
+
+        return $mode;
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function extractLocationOrUrl(array $payload): string
+    {
+        if (!is_string($payload['locationOrUrl'] ?? null) || trim($payload['locationOrUrl']) === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "locationOrUrl" must be a non-empty string.');
+        }
+
+        return trim($payload['locationOrUrl']);
+    }
+
+    /** @param array<string,mixed> $payload @return array<int,string> */
+    private function extractInterviewerIds(array $payload): array
+    {
+        if (!is_array($payload['interviewerIds'] ?? null)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "interviewerIds" must be an array of user IDs.');
+        }
+
+        $interviewerIds = array_values(array_filter(array_map(static fn (mixed $value): ?string => is_string($value) && trim($value) !== '' ? trim($value) : null, $payload['interviewerIds'])));
+
+        return $interviewerIds;
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function extractStatus(array $payload, bool $allowDoneAndCanceled): InterviewStatus
+    {
+        if (!is_string($payload['status'] ?? null)) {
+            return InterviewStatus::PLANNED;
+        }
+
+        $status = InterviewStatus::tryFrom(strtolower($payload['status']));
+        if ($status === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" must be one of: planned, done, canceled.');
+        }
+
+        if (!$allowDoneAndCanceled && $status !== InterviewStatus::PLANNED) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "status" can only be "planned" when creating an interview.');
+        }
+
+        return $status;
+    }
+
+    /** @param array<string,mixed> $payload */
+    private function extractNotes(array $payload): ?string
+    {
+        if (!isset($payload['notes'])) {
+            return null;
+        }
+
+        if (!is_string($payload['notes'])) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "notes" must be a string or null.');
+        }
+
+        $notes = trim($payload['notes']);
+
+        if ($notes === '') {
+            return null;
+        }
+
+        if (mb_strlen($notes) > 5000) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "notes" is too long.');
+        }
+
+        return $notes;
+    }
+}

--- a/src/Recruit/Domain/Entity/Application.php
+++ b/src/Recruit/Domain/Entity/Application.php
@@ -8,6 +8,8 @@ use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
 use App\Recruit\Domain\Enum\ApplicationStatus;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
@@ -40,9 +42,14 @@ class Application implements EntityInterface
     ])]
     private ApplicationStatus $status = ApplicationStatus::WAITING;
 
+    /** @var Collection<int, Interview>|ArrayCollection<int, Interview> */
+    #[ORM\OneToMany(targetEntity: Interview::class, mappedBy: 'application', cascade: ['remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $interviews;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
+        $this->interviews = new ArrayCollection();
     }
 
     #[Override]
@@ -83,5 +90,13 @@ class Application implements EntityInterface
         $this->status = $status instanceof ApplicationStatus ? $status : ApplicationStatus::from($status);
 
         return $this;
+    }
+
+    /**
+     * @return Collection<int, Interview>|ArrayCollection<int, Interview>
+     */
+    public function getInterviews(): Collection|ArrayCollection
+    {
+        return $this->interviews;
     }
 }

--- a/src/Recruit/Domain/Entity/Interview.php
+++ b/src/Recruit/Domain/Entity/Interview.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Recruit\Domain\Enum\InterviewMode;
+use App\Recruit\Domain\Enum\InterviewStatus;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+use function array_values;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_interview')]
+#[ORM\Index(name: 'idx_recruit_interview_application_scheduled_at', columns: ['application_id', 'scheduled_at'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Interview implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Application::class, inversedBy: 'interviews')]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Application $application;
+
+    #[ORM\Column(name: 'scheduled_at', type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $scheduledAt;
+
+    #[ORM\Column(name: 'duration_minutes', type: Types::INTEGER)]
+    private int $durationMinutes;
+
+    #[ORM\Column(name: 'mode', type: Types::STRING, length: 25, enumType: InterviewMode::class)]
+    private InterviewMode $mode;
+
+    #[ORM\Column(name: 'location_or_url', type: Types::STRING, length: 255)]
+    private string $locationOrUrl;
+
+    /** @var array<int, string> */
+    #[ORM\Column(name: 'interviewer_ids', type: Types::JSON)]
+    private array $interviewerIds = [];
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 25, enumType: InterviewStatus::class, options: ['default' => 'planned'])]
+    private InterviewStatus $status = InterviewStatus::PLANNED;
+
+    #[ORM\Column(name: 'notes', type: Types::TEXT, nullable: true)]
+    private ?string $notes = null;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getApplication(): Application
+    {
+        return $this->application;
+    }
+
+    public function setApplication(Application $application): self
+    {
+        $this->application = $application;
+
+        return $this;
+    }
+
+    public function getScheduledAt(): \DateTimeImmutable
+    {
+        return $this->scheduledAt;
+    }
+
+    public function setScheduledAt(\DateTimeImmutable $scheduledAt): self
+    {
+        $this->scheduledAt = $scheduledAt;
+
+        return $this;
+    }
+
+    public function getDurationMinutes(): int
+    {
+        return $this->durationMinutes;
+    }
+
+    public function setDurationMinutes(int $durationMinutes): self
+    {
+        $this->durationMinutes = $durationMinutes;
+
+        return $this;
+    }
+
+    public function getMode(): InterviewMode
+    {
+        return $this->mode;
+    }
+
+    public function setMode(InterviewMode|string $mode): self
+    {
+        $this->mode = $mode instanceof InterviewMode ? $mode : InterviewMode::from($mode);
+
+        return $this;
+    }
+
+    public function getLocationOrUrl(): string
+    {
+        return $this->locationOrUrl;
+    }
+
+    public function setLocationOrUrl(string $locationOrUrl): self
+    {
+        $this->locationOrUrl = $locationOrUrl;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getInterviewerIds(): array
+    {
+        return $this->interviewerIds;
+    }
+
+    /**
+     * @param array<int, string> $interviewerIds
+     */
+    public function setInterviewerIds(array $interviewerIds): self
+    {
+        $this->interviewerIds = array_values($interviewerIds);
+
+        return $this;
+    }
+
+    public function getStatus(): InterviewStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(InterviewStatus|string $status): self
+    {
+        $this->status = $status instanceof InterviewStatus ? $status : InterviewStatus::from($status);
+
+        return $this;
+    }
+
+    public function getNotes(): ?string
+    {
+        return $this->notes;
+    }
+
+    public function setNotes(?string $notes): self
+    {
+        $this->notes = $notes;
+
+        return $this;
+    }
+}

--- a/src/Recruit/Domain/Enum/InterviewMode.php
+++ b/src/Recruit/Domain/Enum/InterviewMode.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Enum;
+
+enum InterviewMode: string
+{
+    case VISIO = 'visio';
+    case ON_SITE = 'on-site';
+}

--- a/src/Recruit/Domain/Enum/InterviewStatus.php
+++ b/src/Recruit/Domain/Enum/InterviewStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Enum;
+
+enum InterviewStatus: string
+{
+    case PLANNED = 'planned';
+    case DONE = 'done';
+    case CANCELED = 'canceled';
+}

--- a/src/Recruit/Domain/Repository/Interfaces/InterviewRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/InterviewRepositoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Interview;
+
+interface InterviewRepositoryInterface
+{
+    /**
+     * @return array<int, Interview>
+     */
+    public function findByApplicationOrdered(Application $application): array;
+}

--- a/src/Recruit/Infrastructure/Repository/InterviewRepository.php
+++ b/src/Recruit/Infrastructure/Repository/InterviewRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Interview as Entity;
+use App\Recruit\Domain\Repository\Interfaces\InterviewRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class InterviewRepository extends BaseRepository implements InterviewRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+
+    public function findByApplicationOrdered(Application $application): array
+    {
+        return $this->createQueryBuilder('interview')
+            ->where('interview.application = :application')
+            ->setParameter('application', $application)
+            ->orderBy('interview.scheduledAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewCreateController.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Interview;
+
+use App\Recruit\Application\Service\InterviewService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Interview')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class InterviewCreateController
+{
+    public function __construct(private InterviewService $interviewService)
+    {
+    }
+
+    #[Route(path: '/v1/recruit/private/applications/{applicationId}/interviews', methods: [Request::METHOD_POST])]
+    public function __invoke(string $applicationId, Request $request, User $loggedInUser): JsonResponse
+    {
+        /** @var array<string,mixed> $payload */
+        $payload = $request->toArray();
+        $interview = $this->interviewService->create($applicationId, $payload, $loggedInUser);
+
+        return new JsonResponse($this->normalize($interview), JsonResponse::HTTP_CREATED);
+    }
+
+    /** @return array<string,mixed> */
+    private function normalize(\App\Recruit\Domain\Entity\Interview $interview): array
+    {
+        return [
+            'id' => $interview->getId(),
+            'applicationId' => $interview->getApplication()->getId(),
+            'scheduledAt' => $interview->getScheduledAt()->format(DATE_ATOM),
+            'durationMinutes' => $interview->getDurationMinutes(),
+            'mode' => $interview->getMode()->value,
+            'locationOrUrl' => $interview->getLocationOrUrl(),
+            'interviewerIds' => $interview->getInterviewerIds(),
+            'status' => $interview->getStatus()->value,
+            'notes' => $interview->getNotes(),
+        ];
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewDeleteController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Interview;
+
+use App\Recruit\Application\Service\InterviewService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Interview')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class InterviewDeleteController
+{
+    public function __construct(private InterviewService $interviewService)
+    {
+    }
+
+    #[Route(path: '/v1/recruit/private/interviews/{interviewId}', methods: [Request::METHOD_DELETE])]
+    public function __invoke(string $interviewId, User $loggedInUser): JsonResponse
+    {
+        $this->interviewService->delete($interviewId, $loggedInUser);
+
+        return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewListController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Interview;
+
+use App\Recruit\Application\Service\InterviewService;
+use App\Recruit\Domain\Entity\Interview;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function array_map;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Interview')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class InterviewListController
+{
+    public function __construct(private InterviewService $interviewService)
+    {
+    }
+
+    #[Route(path: '/v1/recruit/private/applications/{applicationId}/interviews', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationId, User $loggedInUser): JsonResponse
+    {
+        $items = $this->interviewService->listByApplication($applicationId, $loggedInUser);
+
+        return new JsonResponse(array_map(static fn (Interview $interview): array => [
+            'id' => $interview->getId(),
+            'scheduledAt' => $interview->getScheduledAt()->format(DATE_ATOM),
+            'durationMinutes' => $interview->getDurationMinutes(),
+            'mode' => $interview->getMode()->value,
+            'locationOrUrl' => $interview->getLocationOrUrl(),
+            'interviewerIds' => $interview->getInterviewerIds(),
+            'status' => $interview->getStatus()->value,
+            'notes' => $interview->getNotes(),
+        ], $items));
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewPatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewPatchController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Interview;
+
+use App\Recruit\Application\Service\InterviewService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Interview')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class InterviewPatchController
+{
+    public function __construct(private InterviewService $interviewService)
+    {
+    }
+
+    #[Route(path: '/v1/recruit/private/interviews/{interviewId}', methods: [Request::METHOD_PATCH])]
+    public function __invoke(string $interviewId, Request $request, User $loggedInUser): JsonResponse
+    {
+        /** @var array<string,mixed> $payload */
+        $payload = $request->toArray();
+        $interview = $this->interviewService->update($interviewId, $payload, $loggedInUser);
+
+        return new JsonResponse([
+            'id' => $interview->getId(),
+            'status' => $interview->getStatus()->value,
+            'scheduledAt' => $interview->getScheduledAt()->format(DATE_ATOM),
+            'durationMinutes' => $interview->getDurationMinutes(),
+        ]);
+    }
+}

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Interview/PrivateInterviewControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Interview/PrivateInterviewControllerTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Interview;
+
+use App\General\Domain\Utils\JSON;
+use App\Platform\Domain\Entity\Application as PlatformApplication;
+use App\Recruit\Domain\Entity\Applicant;
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Interview;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Entity\Recruit;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class PrivateInterviewControllerTest extends WebTestCase
+{
+    /** @throws Throwable */
+    #[TestDox('POST /v1/recruit/private/applications/{applicationId}/interviews creates interview for owner.')]
+    public function testCreateInterview(): void
+    {
+        [$applicationId] = $this->createDedicatedApplicationContext('john-root');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('POST', self::API_URL_PREFIX . '/v1/recruit/private/applications/' . $applicationId . '/interviews', content: JSON::encode([
+            'scheduledAt' => (new DateTimeImmutable('+2 days'))->format(DATE_ATOM),
+            'durationMinutes' => 60,
+            'mode' => 'visio',
+            'locationOrUrl' => 'https://meet.example/room',
+            'interviewerIds' => ['u-1', 'u-2'],
+            'notes' => 'Premier entretien',
+        ]));
+
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+    }
+
+    /** @throws Throwable */
+    #[TestDox('POST /v1/recruit/private/applications/{applicationId}/interviews rejects REJECTED/HIRED applications.')]
+    public function testCreateInterviewRejectsClosedApplicationStatus(): void
+    {
+        [$applicationId] = $this->createDedicatedApplicationContext('john-root', ApplicationStatus::REJECTED);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('POST', self::API_URL_PREFIX . '/v1/recruit/private/applications/' . $applicationId . '/interviews', content: JSON::encode([
+            'scheduledAt' => (new DateTimeImmutable('+2 days'))->format(DATE_ATOM),
+            'durationMinutes' => 60,
+            'mode' => 'visio',
+            'locationOrUrl' => 'https://meet.example/room',
+            'interviewerIds' => [],
+        ]));
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+    }
+
+    /** @throws Throwable */
+    #[TestDox('PATCH /v1/recruit/private/interviews/{interviewId} updates interview.')]
+    public function testPatchInterview(): void
+    {
+        [$applicationId, $interviewId] = $this->createDedicatedInterview('john-root');
+        self::assertNotEmpty($applicationId);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('PATCH', self::API_URL_PREFIX . '/v1/recruit/private/interviews/' . $interviewId, content: JSON::encode([
+            'durationMinutes' => 90,
+            'status' => 'done',
+        ]));
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
+
+    /** @throws Throwable */
+    #[TestDox('GET /v1/recruit/private/applications/{applicationId}/interviews lists interviews.')]
+    public function testListInterviews(): void
+    {
+        [$applicationId] = $this->createDedicatedInterview('john-root');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/private/applications/' . $applicationId . '/interviews');
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $content = $client->getResponse()->getContent();
+        self::assertNotFalse($content);
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload);
+        self::assertNotEmpty($payload);
+    }
+
+    /** @throws Throwable */
+    #[TestDox('DELETE /v1/recruit/private/interviews/{interviewId} deletes interview.')]
+    public function testDeleteInterview(): void
+    {
+        [, $interviewId] = $this->createDedicatedInterview('john-root');
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('DELETE', self::API_URL_PREFIX . '/v1/recruit/private/interviews/' . $interviewId);
+
+        self::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @return array{0: string, 1?: string}
+     */
+    private function createDedicatedApplicationContext(string $username, ApplicationStatus $status = ApplicationStatus::WAITING): array
+    {
+        self::bootKernel();
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
+        self::assertInstanceOf(User::class, $user);
+
+        $platformApplication = $entityManager->getRepository(PlatformApplication::class)->findOneBy([
+            'user' => $user,
+            'title' => 'Recruit Lite App',
+        ]);
+        self::assertInstanceOf(PlatformApplication::class, $platformApplication);
+
+        $recruit = $entityManager->getRepository(Recruit::class)->findOneBy(['application' => $platformApplication]);
+        self::assertInstanceOf(Recruit::class, $recruit);
+
+        $job = (new Job())
+            ->setRecruit($recruit)
+            ->setOwner($user)
+            ->setTitle('Interview flow job')
+            ->ensureGeneratedSlug();
+        $entityManager->persist($job);
+
+        $applicant = $entityManager->getRepository(Applicant::class)->findOneBy(['user' => $user]);
+        self::assertInstanceOf(Applicant::class, $applicant);
+
+        $application = (new Application())
+            ->setApplicant($applicant)
+            ->setJob($job)
+            ->setStatus($status);
+
+        $entityManager->persist($application);
+        $entityManager->flush();
+
+        return [$application->getId()];
+    }
+
+    /** @return array{0: string, 1: string} */
+    private function createDedicatedInterview(string $username): array
+    {
+        [$applicationId] = $this->createDedicatedApplicationContext($username);
+
+        self::bootKernel();
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $application = $entityManager->getRepository(Application::class)->find($applicationId);
+        self::assertInstanceOf(Application::class, $application);
+
+        $interview = (new Interview())
+            ->setApplication($application)
+            ->setScheduledAt(new DateTimeImmutable('+1 day'))
+            ->setDurationMinutes(45)
+            ->setMode('visio')
+            ->setLocationOrUrl('https://meet.example/seed')
+            ->setInterviewerIds(['seed-user'])
+            ->setStatus('planned');
+
+        $entityManager->persist($interview);
+        $entityManager->flush();
+
+        return [$applicationId, $interview->getId()];
+    }
+}

--- a/tests/Unit/Recruit/Application/Service/InterviewServiceTest.php
+++ b/tests/Unit/Recruit/Application/Service/InterviewServiceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Recruit\Application\Service;
+
+use App\Recruit\Application\Service\InterviewService;
+use App\Recruit\Domain\Entity\Applicant;
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Interview;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Infrastructure\Repository\InterviewRepository;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class InterviewServiceTest extends TestCase
+{
+    public function testCreateRejectsClosedApplication(): void
+    {
+        $owner = $this->createMock(User::class);
+        $owner->method('getId')->willReturn('u1');
+
+        $application = $this->buildApplication($owner, ApplicationStatus::REJECTED);
+
+        $applicationRepository = $this->createMock(ApplicationRepository::class);
+        $applicationRepository->method('find')->willReturn($application);
+
+        $interviewRepository = $this->createMock(InterviewRepository::class);
+        $interviewRepository->expects(self::never())->method('save');
+
+        $service = new InterviewService($applicationRepository, $interviewRepository);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Cannot schedule or update interviews for applications with status REJECTED or HIRED.');
+
+        $service->create('app-id', [
+            'scheduledAt' => (new DateTimeImmutable('+1 day'))->format(DATE_ATOM),
+            'durationMinutes' => 45,
+            'mode' => 'visio',
+            'locationOrUrl' => 'https://meet',
+            'interviewerIds' => [],
+        ], $owner);
+    }
+
+    public function testCreateRejectsPastDate(): void
+    {
+        $owner = $this->createMock(User::class);
+        $owner->method('getId')->willReturn('u1');
+
+        $application = $this->buildApplication($owner, ApplicationStatus::WAITING);
+
+        $applicationRepository = $this->createMock(ApplicationRepository::class);
+        $applicationRepository->method('find')->willReturn($application);
+
+        $interviewRepository = $this->createMock(InterviewRepository::class);
+
+        $service = new InterviewService($applicationRepository, $interviewRepository);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Field "scheduledAt" must be in the future.');
+
+        $service->create('app-id', [
+            'scheduledAt' => (new DateTimeImmutable('-1 hour'))->format(DATE_ATOM),
+            'durationMinutes' => 45,
+            'mode' => 'visio',
+            'locationOrUrl' => 'https://meet',
+            'interviewerIds' => [],
+        ], $owner);
+    }
+
+    public function testCreateRejectsInvalidDuration(): void
+    {
+        $owner = $this->createMock(User::class);
+        $owner->method('getId')->willReturn('u1');
+
+        $application = $this->buildApplication($owner, ApplicationStatus::WAITING);
+
+        $applicationRepository = $this->createMock(ApplicationRepository::class);
+        $applicationRepository->method('find')->willReturn($application);
+
+        $interviewRepository = $this->createMock(InterviewRepository::class);
+
+        $service = new InterviewService($applicationRepository, $interviewRepository);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Field "durationMinutes" must be between 15 and 240.');
+
+        $service->create('app-id', [
+            'scheduledAt' => (new DateTimeImmutable('+1 day'))->format(DATE_ATOM),
+            'durationMinutes' => 5,
+            'mode' => 'visio',
+            'locationOrUrl' => 'https://meet',
+            'interviewerIds' => [],
+        ], $owner);
+    }
+
+    public function testCreatePersistsInterview(): void
+    {
+        $owner = $this->createMock(User::class);
+        $owner->method('getId')->willReturn('u1');
+
+        $application = $this->buildApplication($owner, ApplicationStatus::WAITING);
+
+        $applicationRepository = $this->createMock(ApplicationRepository::class);
+        $applicationRepository->method('find')->willReturn($application);
+
+        $interviewRepository = $this->createMock(InterviewRepository::class);
+        $interviewRepository->expects(self::once())->method('save')->with(self::isInstanceOf(Interview::class));
+
+        $service = new InterviewService($applicationRepository, $interviewRepository);
+
+        $interview = $service->create('app-id', [
+            'scheduledAt' => (new DateTimeImmutable('+1 day'))->format(DATE_ATOM),
+            'durationMinutes' => 30,
+            'mode' => 'on-site',
+            'locationOrUrl' => 'Paris HQ',
+            'interviewerIds' => ['u-2'],
+            'notes' => 'focus culture',
+        ], $owner);
+
+        self::assertSame(30, $interview->getDurationMinutes());
+        self::assertSame('on-site', $interview->getMode()->value);
+    }
+
+    private function buildApplication(User $owner, ApplicationStatus $status): Application
+    {
+        $job = (new Job())->setOwner($owner)->setTitle('X')->ensureGeneratedSlug();
+
+        return (new Application())
+            ->setApplicant(new Applicant())
+            ->setJob($job)
+            ->setStatus($status);
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduire la gestion des entretiens pour les candidatures afin d’autoriser la planification, modification, suppression et listing d’entretiens privés liés à une candidature.

### Description
- Ajout de l’entité `Interview` dans `src/Recruit/Domain/Entity` avec les champs `application`, `scheduledAt`, `durationMinutes`, `mode`, `locationOrUrl`, `interviewerIds`, `status` et `notes` et mapping Doctrine; création des enums `InterviewMode` et `InterviewStatus`.
- Liaison `OneToMany` entre `Application` et `Interview` et ajout d’un repository `InterviewRepositoryInterface` plus implémentation Doctrine `InterviewRepository` avec `findByApplicationOrdered`.
- Exposition des endpoints privés REST : `POST /v1/recruit/private/applications/{applicationId}/interviews`, `PATCH /v1/recruit/private/interviews/{interviewId}`, `DELETE /v1/recruit/private/interviews/{interviewId}`, `GET /v1/recruit/private/applications/{applicationId}/interviews` via de nouveaux controllers.
- Implémentation de la couche application `InterviewService` avec validations métier : interdiction si candidature en `REJECTED`/`HIRED`, `scheduledAt` obligatoire et futur, et `durationMinutes` limité entre `15` et `240`, plus normalisation et persistance.
- Ajout d’une migration SQL `migrations/Version20260314130000.php` pour créer la table `recruit_interview`.

### Testing
- Ajout de tests unitaires `tests/Unit/Recruit/Application/Service/InterviewServiceTest.php` couvrant validations et cas nominal, et tests d’intégration contrôleurs `tests/Application/Recruit/Transport/Controller/Api/V1/Interview/PrivateInterviewControllerTest.php` pour create/patch/list/delete flows.
- Exécuté des vérifications de syntaxe PHP (`php -l`) sur tous les fichiers modifiés et ajoutés, qui ont réussi sans erreurs.
- Tentative d’exécution de `phpunit` échouée dans cet environnement car le binaire n’est pas disponible (`./vendor/bin/phpunit: No such file or directory`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b291c48883269928e88bcb340480)