### PR TITLE
docs: ajouter checklist GO/NO-GO unifiée et section risques/rollback

### DIFF
--- a/docs/blog-reaction-migration-runbook.md
+++ b/docs/blog-reaction-migration-runbook.md
@@ -7,6 +7,40 @@ Valider et exploiter la migration `migrations/Version20260313130000.php` qui ajo
 - l'index unique `(author_id, post_id)`;
 - la contrainte CHECK `chk_blog_reaction_exactly_one_target`.
 
+## 0) Checklist GO/NO-GO (unique)
+
+> Cette checklist est **obligatoire** et doit être remplie dans un unique ticket de release (ou document d'exploitation) avant toute mise en production.
+
+| Domaine | Vérification | Statut | Preuve/lien | Validateur |
+| --- | --- | --- | --- | --- |
+| DB | `docs/sql/blog_reaction_integrity_audit.sql` exécuté, anomalies à `0` | ⬜ |  |  |
+| Tests | Tests applicatifs de non-régression exécutés et verts | ⬜ |  |  |
+| Cache | Invalidation/échauffement cache validés selon stratégie env | ⬜ |  |  |
+| Visibilité | Dashboards/logs consultables (erreurs SQL, taux d'échec) | ⬜ |  |  |
+| Monitoring | Alertes opérationnelles actives (DB + app) pour J+0/J+1 | ⬜ |  |  |
+| Runbook | Procédure de remédiation + rollback relue et accessible | ⬜ |  |  |
+
+### Validation obligatoire avant GO
+
+Le passage en GO est autorisé uniquement si les trois validations suivantes sont explicitement enregistrées:
+
+- **Dev**: conformité technique de la migration, scripts et impacts applicatifs.
+- **QA**: couverture des scénarios de test et non-régression.
+- **Ops**: monitoring, capacité de rollback, fenêtre d'exploitation.
+
+Sans validation **Dev + QA + Ops**, la décision doit rester **NO-GO**.
+
+### Journal de décision GO/NO-GO
+
+Tracer la décision dans le ticket/document unique avec le format minimal suivant:
+
+```text
+Décision: GO | NO-GO
+Date de validation: YYYY-MM-DD HH:MM TZ
+Validations: Dev=<nom> ; QA=<nom> ; Ops=<nom>
+Commentaires: <risques / réserves éventuelles>
+```
+
 ## 1) Vérifier l'état de migration en dev / staging / prod
 
 > Pré-requis: exécuter ces commandes depuis le conteneur/app avec dépendances PHP installées.
@@ -92,6 +126,23 @@ SELECT id, comment_id, post_id, author_id, type, created_at, updated_at
 FROM blog_reaction_remediation_20260313_backup
 WHERE remediated_at >= '<timestamp_de_la_fenetre_incident>';
 ```
+
+## 4.1) Risques connus + stratégie de rollback
+
+### Risques connus
+
+- **Conflits de contraintes**: échecs en écriture si des doublons historiques subsistent (`duplicate key`).
+- **Conflits métier**: rejet d'insert/update si `comment_id` et `post_id` sont simultanément NULL ou non-NULL (CHECK).
+- **Perte de données ciblée**: la remédiation peut supprimer des lignes incohérentes (sauvegardées dans la table backup).
+- **Bruit opérationnel**: hausse temporaire d'erreurs applicatives côté endpoints de réaction pendant la fenêtre de déploiement.
+
+### Stratégie de rollback
+
+1. Confirmer l'incident via logs + audit SQL.
+2. Exécuter le rollback Doctrine (section 4).
+3. Si remédiation effectuée, évaluer la restauration depuis `blog_reaction_remediation_20260313_backup`.
+4. Rejouer l'audit SQL pour confirmer le retour à un état stable.
+5. Consigner la décision finale (**GO** de reprise ou **NO-GO** prolongé) avec date/heure et validateurs Dev/QA/Ops.
 
 ## 5) Procédure d'exploitation post-déploiement
 


### PR DESCRIPTION
### Motivation
- Renforcer la gouvernance de mise en production pour la migration `Version20260313130000` en centralisant les vérifications opérationnelles nécessaires avant GO.
- Forcer une validation croisée par les équipes Dev, QA et Ops pour réduire le risque d'incident lié aux index/contraintes et à la qualité des données.
- Fournir une traçabilité minimale de la décision GO/NO-GO et une procédure claire de retour arrière en cas d'incident.

### Description
- Ajout d'une section "Checklist GO/NO-GO (unique)" dans `docs/blog-reaction-migration-runbook.md` couvrant DB, tests, cache, visibilité, monitoring et runbook avec colonne statut/preuve/validateur.
- Imposition d'une validation explicite "Dev + QA + Ops" comme prérequis pour autoriser le passage en GO.
- Ajout d'un format standardisé pour tracer la décision GO/NO-GO et la date/heure de validation dans le ticket/document unique.
- Ajout d'une section "Risques connus + stratégie de rollback" listant les risques opérationnels majeurs et les étapes de retour arrière recommandées.

### Testing
- Exécution de `git diff --check` qui a renvoyé sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b4e801ac8326a9a47989a459b849)