### PR TITLE
Add metric for Calendar Elasticsearch fallback reasons

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -93,6 +93,9 @@ services:
             $password: '%env(ELASTICSEARCH_PASSWORD)%'
         #lazy: true
 
+    App\General\Domain\Service\Interfaces\MetricsCounterInterface:
+        class: App\General\Infrastructure\Service\NullMetricsCounter
+
     app.serializer.normalizer.object.external_message:
         class: Symfony\Component\Serializer\Normalizer\ObjectNormalizer
         autoconfigure: false

--- a/docs/technical-notes/calendar-elastic-fallback-metrics.md
+++ b/docs/technical-notes/calendar-elastic-fallback-metrics.md
@@ -1,0 +1,20 @@
+# Note technique — métrique de fallback Elasticsearch (Calendar)
+
+## Contexte
+
+Le service `EventListService` bascule sur les filtres repository SQL quand la recherche Elasticsearch n'est pas exploitable.
+
+## Métrique exposée
+
+- **Nom**: `calendar.elastic_fallback.count`
+- **Type**: compteur (counter), incrémenté de `1` par fallback
+
+## Tags / labels
+
+- **`reason`** (obligatoire)
+  - `exception`: une exception est levée pendant l'appel Elasticsearch
+  - `too_many_hits`: Elasticsearch retourne plus de `1000` résultats, ce qui déclenche la stratégie de fallback SQL
+
+## Comportement
+
+La métrique est incrémentée à chaque fallback, avant de poursuivre avec les filtres repository.

--- a/src/Calendar/Application/Service/EventListService.php
+++ b/src/Calendar/Application/Service/EventListService.php
@@ -8,6 +8,7 @@ use App\Calendar\Domain\Entity\Event;
 use App\Calendar\Domain\Repository\Interfaces\EventRepositoryInterface;
 use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\General\Domain\Service\Interfaces\MetricsCounterInterface;
 use App\User\Domain\Entity\User;
 use JsonException;
 use Psr\Cache\InvalidArgumentException;
@@ -23,6 +24,7 @@ use function array_map;
 final readonly class EventListService
 {
     private const int ELASTIC_IDS_LIMIT = 1000;
+    private const string ELASTIC_FALLBACK_COUNT_METRIC = "calendar.elastic_fallback.count";
 
     public function __construct(
         private EventRepositoryInterface $eventRepository,
@@ -30,6 +32,7 @@ final readonly class EventListService
         private ElasticsearchServiceInterface $elasticsearchService,
         private CacheKeyConventionService $cacheKeyConventionService,
         private LoggerInterface $logger,
+        private MetricsCounterInterface $metricsCounter,
     ) {
     }
 
@@ -219,6 +222,8 @@ final readonly class EventListService
 
             $totalHits = $this->extractTotalHits($response);
             if ($totalHits !== null && $totalHits > self::ELASTIC_IDS_LIMIT) {
+                $this->incrementElasticFallbackCounter('too_many_hits');
+
                 return null;
             }
 
@@ -231,6 +236,8 @@ final readonly class EventListService
 
             return array_values(array_unique($ids));
         } catch (Throwable $exception) {
+            $this->incrementElasticFallbackCounter('exception');
+
             $this->logger->warning('Unable to search event ids from Elasticsearch, fallback to repository filters.', [
                 'filterTypes' => array_values(array_keys(array_filter($filters, static fn (string $value): bool => $value !== ''))),
                 'exceptionClass' => $exception::class,
@@ -240,6 +247,13 @@ final readonly class EventListService
 
             return null;
         }
+    }
+
+    private function incrementElasticFallbackCounter(string $reason): void
+    {
+        $this->metricsCounter->increment(self::ELASTIC_FALLBACK_COUNT_METRIC, [
+            'reason' => $reason,
+        ]);
     }
 
     /**

--- a/src/General/Domain/Service/Interfaces/MetricsCounterInterface.php
+++ b/src/General/Domain/Service/Interfaces/MetricsCounterInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Domain\Service\Interfaces;
+
+interface MetricsCounterInterface
+{
+    /**
+     * @param array<string, string> $labels
+     */
+    public function increment(string $name, array $labels = [], int $value = 1): void;
+}
+

--- a/src/General/Infrastructure/Service/NullMetricsCounter.php
+++ b/src/General/Infrastructure/Service/NullMetricsCounter.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Infrastructure\Service;
+
+use App\General\Domain\Service\Interfaces\MetricsCounterInterface;
+
+final readonly class NullMetricsCounter implements MetricsCounterInterface
+{
+    public function increment(string $name, array $labels = [], int $value = 1): void
+    {
+    }
+}

--- a/tests/Unit/Calendar/Application/Service/EventListServiceTest.php
+++ b/tests/Unit/Calendar/Application/Service/EventListServiceTest.php
@@ -8,6 +8,7 @@ use App\Calendar\Application\Service\EventListService;
 use App\Calendar\Domain\Repository\Interfaces\EventRepositoryInterface;
 use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\General\Domain\Service\Interfaces\MetricsCounterInterface;
 use App\User\Domain\Entity\User;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -38,7 +39,7 @@ final class EventListServiceTest extends TestCase
             ]);
 
         $cacheKeyConvention = $this->cacheKeyConventionService($user);
-        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class));
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class), $this->createMock(MetricsCounterInterface::class));
         $result = $service->getByUser($user, [
             'title' => 'foo',
         ], 1, 20);
@@ -75,7 +76,7 @@ final class EventListServiceTest extends TestCase
         });
 
         $cacheKeyConvention = $this->cacheKeyConventionService($user);
-        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class));
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class), $this->createMock(MetricsCounterInterface::class));
         $result = $service->getByUser($user, [
             'title' => 'foo',
         ], 1, 20);
@@ -101,8 +102,13 @@ final class EventListServiceTest extends TestCase
             return $callback($item);
         });
 
+        $metricsCounter = $this->createMock(MetricsCounterInterface::class);
+        $metricsCounter->expects(self::once())
+            ->method('increment')
+            ->with('calendar.elastic_fallback.count', ['reason' => 'exception'], 1);
+
         $cacheKeyConvention = $this->cacheKeyConventionService($user);
-        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class));
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class), $metricsCounter);
         $result = $service->getByUser($user, [
             'title' => 'foo',
         ], 1, 20);
@@ -142,8 +148,13 @@ final class EventListServiceTest extends TestCase
             return $callback($item);
         });
 
+        $metricsCounter = $this->createMock(MetricsCounterInterface::class);
+        $metricsCounter->expects(self::once())
+            ->method('increment')
+            ->with('calendar.elastic_fallback.count', ['reason' => 'too_many_hits'], 1);
+
         $cacheKeyConvention = $this->cacheKeyConventionService($user);
-        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class));
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class), $metricsCounter);
         $result = $service->getByUser($user, [
             'title' => 'foo',
         ], 2, 20);
@@ -185,7 +196,7 @@ final class EventListServiceTest extends TestCase
         $cacheKeyConvention->expects(self::once())->method('tagPrivateEvents')->with('user-id')->willReturn('private_events_user-id');
         $cacheKeyConvention->expects(self::never())->method('tagPublicEventsByApplication');
 
-        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class));
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class), $this->createMock(MetricsCounterInterface::class));
         $service->getByUser($user, ['title' => 'foo'], 1, 20);
     }
 
@@ -218,7 +229,7 @@ final class EventListServiceTest extends TestCase
         $cacheKeyConvention->expects(self::never())->method('tagPrivateEvents');
         $cacheKeyConvention->expects(self::once())->method('tagPublicEventsByApplication')->with('app-bro-world')->willReturn('public_events_app-bro-world');
 
-        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class));
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class), $this->createMock(MetricsCounterInterface::class));
         $service->getByApplicationSlug('app-bro-world', ['title' => 'foo'], 1, 20);
     }
 
@@ -252,7 +263,7 @@ final class EventListServiceTest extends TestCase
         $cacheKeyConvention->expects(self::never())->method('tagPrivateEvents');
         $cacheKeyConvention->expects(self::never())->method('tagPublicEventsByApplication');
 
-        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class));
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class), $this->createMock(MetricsCounterInterface::class));
         $service->getByUser($user, ['title' => 'foo'], 1, 20);
     }
 


### PR DESCRIPTION
### Motivation

- Provide observable counts when `EventListService` falls back from Elasticsearch to DB so we can monitor and alert on degraded search behavior.

### Description

- Add a `MetricsCounterInterface` contract and a default `NullMetricsCounter` implementation to allow pluggable metrics backends without breaking existing setups (`src/General/Domain/Service/Interfaces/MetricsCounterInterface.php`, `src/General/Infrastructure/Service/NullMetricsCounter.php`).
- Wire the `MetricsCounterInterface` into DI (`config/services.yaml`) with the null implementation as default.
- Instrument `EventListService` to increment the counter `calendar.elastic_fallback.count` using a `reason` label; increment on `exception` (Elasticsearch throws) and `too_many_hits` (total hits > 1000) via `incrementElasticFallbackCounter` helper (`src/Calendar/Application/Service/EventListService.php`).
- Update unit tests to inject a mock `MetricsCounterInterface` and assert increments for both fallback scenarios, and add a technical note documenting metric name and `reason` values (`docs/technical-notes/calendar-elastic-fallback-metrics.md`).

### Testing

- `php -l` syntax checks on modified files passed: `src/Calendar/Application/Service/EventListService.php`, `src/General/Domain/Service/Interfaces/MetricsCounterInterface.php`, and `src/General/Infrastructure/Service/NullMetricsCounter.php`.
- Unit tests were updated to assert metric calls, but running `phpunit` in this environment failed because the `phpunit` binary is not available; tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b4f3a0ac83269ec728656e46bd9b)