### PR TITLE
docs(calendar): add non-régression checklist in Calendar README

### DIFF
--- a/src/Calendar/README.md
+++ b/src/Calendar/README.md
@@ -30,3 +30,13 @@ These routes are reserved to personal resources only (events not linked to an ap
 - `PATCH /v1/calendar/applications/{applicationSlug}/events/{eventId}`
 - `DELETE /v1/calendar/applications/{applicationSlug}/events/{eventId}`
 - `POST /v1/calendar/applications/{applicationSlug}/events/{eventId}/cancel`
+
+## Non-régression
+
+Checklist pré-merge (PR) :
+
+- [ ] PATCH partiel `startAt` / `endAt` validé.
+- [ ] Pagination + filtres texte vérifiés (avec Elastic et sans Elastic).
+- [ ] Invalidation par tags de cache contrôlée (privé et public).
+- [ ] Cohérence OpenAPI confirmée pour les endpoints de mutation.
+- [ ] Cas `404` / `422` couverts pour routes `private` et `application`.


### PR DESCRIPTION
### Motivation
- Ajouter une checklist pré-merge dans `src/Calendar/README.md` pour standardiser les contrôles non-régression liés aux endpoints du module calendar.

### Description
- Ajout d’une section `Non-régression` dans `src/Calendar/README.md` contenant une liste à cocher concise couvrant `startAt`/`endAt` (PATCH partiel), pagination + filtres texte (avec/sans Elastic), invalidation cache privé/public, cohérence OpenAPI des mutations, et cas `404`/`422` pour routes `private` et `application`.

### Testing
- Changement purement documentaire; aucun test automatisé d’exécution requis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b4f5e77c8326bdaea04b07c9a19a)