### PR TITLE
Uniformiser les réponses des endpoints de mutation de message sur `operationId`

### DIFF
--- a/src/Chat/Transport/Controller/Api/V1/Message/DeleteMessageController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/DeleteMessageController.php
@@ -19,7 +19,7 @@ use Throwable;
 
 #[AsController]
 #[OA\Tag(name: 'Chat Conversation')]
-#[OA\Delete(path: '/v1/chat/private/messages/{messageId}', operationId: 'chat_message_delete', summary: 'Supprimer son message', tags: ['Chat Message'], parameters: [new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], responses: [new OA\Response(response: 202, description: 'Commande acceptée'), new OA\Response(response: 404, description: 'Message introuvable')])]
+#[OA\Delete(path: '/v1/chat/private/messages/{messageId}', operationId: 'chat_message_delete', summary: 'Supprimer son message', tags: ['Chat Message'], parameters: [new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000'))], responses: [new OA\Response(response: 202, description: 'Commande acceptée', content: new OA\JsonContent(example: ['operationId' => 'op_123'])), new OA\Response(response: 404, description: 'Message introuvable')])]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 readonly class DeleteMessageController
 {
@@ -44,7 +44,6 @@ readonly class DeleteMessageController
 
         return new JsonResponse([
             'operationId' => $operationId,
-            'id' => $messageId,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Message/MarkConversationAsReadController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/MarkConversationAsReadController.php
@@ -28,7 +28,9 @@ use Throwable;
         new OA\Parameter(name: 'conversationId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
     ],
     responses: [
-        new OA\Response(response: 202, description: 'Commande acceptée'),
+        new OA\Response(response: 202, description: 'Commande acceptée', content: new OA\JsonContent(example: [
+            'operationId' => 'op_123',
+        ])),
         new OA\Response(response: 404, description: 'Conversation introuvable'),
     ]
 )]
@@ -56,7 +58,6 @@ readonly class MarkConversationAsReadController
 
         return new JsonResponse([
             'operationId' => $operationId,
-            'conversationId' => $conversationId,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }

--- a/src/Chat/Transport/Controller/Api/V1/Message/PatchMessageController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Message/PatchMessageController.php
@@ -41,7 +41,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
         new OA\Parameter(name: 'messageId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000')),
     ],
     responses: [
-        new OA\Response(response: 202, description: 'Commande acceptée'),
+        new OA\Response(response: 202, description: 'Commande acceptée', content: new OA\JsonContent(example: [
+            'operationId' => 'op_123',
+        ])),
         new OA\Response(response: 404, description: 'Message introuvable'),
     ]
 )]
@@ -71,7 +73,6 @@ readonly class PatchMessageController
 
         return new JsonResponse([
             'operationId' => $operationId,
-            'id' => $messageId,
         ], JsonResponse::HTTP_ACCEPTED);
     }
 }

--- a/tests/Application/Chat/Transport/Controller/Api/V1/Message/UserMessageControllerTest.php
+++ b/tests/Application/Chat/Transport/Controller/Api/V1/Message/UserMessageControllerTest.php
@@ -46,8 +46,8 @@ final class UserMessageControllerTest extends WebTestCase
         self::assertNotFalse($createContent);
         $createPayload = JSON::decode($createContent, true);
         self::assertIsArray($createPayload);
-        self::assertArrayHasKey('operationId', $createPayload);
-        self::assertArrayNotHasKey('id', $createPayload);
+        self::assertSame(['operationId'], array_keys($createPayload));
+        self::assertIsString($createPayload['operationId']);
 
         $client->request('POST', $this->baseUrl . '/conversations/' . $conversationId . '/messages', [], [], [], JSON::encode([
             'content' => '',
@@ -63,8 +63,8 @@ final class UserMessageControllerTest extends WebTestCase
         self::assertNotFalse($patchContent);
         $patchPayload = JSON::decode($patchContent, true);
         self::assertIsArray($patchPayload);
-        self::assertArrayHasKey('operationId', $patchPayload);
-        self::assertArrayHasKey('id', $patchPayload);
+        self::assertSame(['operationId'], array_keys($patchPayload));
+        self::assertIsString($patchPayload['operationId']);
 
         $client->request('PATCH', $this->baseUrl . '/messages/' . $messageId, [], [], [], JSON::encode([
             'read' => 'yes',
@@ -73,6 +73,12 @@ final class UserMessageControllerTest extends WebTestCase
 
         $client->request('POST', $this->baseUrl . '/conversations/' . $conversationId . '/messages/read');
         self::assertSame(Response::HTTP_ACCEPTED, $client->getResponse()->getStatusCode());
+        $markReadContent = $client->getResponse()->getContent();
+        self::assertNotFalse($markReadContent);
+        $markReadPayload = JSON::decode($markReadContent, true);
+        self::assertIsArray($markReadPayload);
+        self::assertSame(['operationId'], array_keys($markReadPayload));
+        self::assertIsString($markReadPayload['operationId']);
 
         $unauthorizedClient = $this->getTestClient('john-user', 'password-user');
         $directConversationId = LoadRecruitChatCalendarScenarioData::getUuidByKey('conversation-direct-john-root-john-admin');
@@ -85,7 +91,7 @@ final class UserMessageControllerTest extends WebTestCase
         self::assertNotFalse($deleteContent);
         $deletePayload = JSON::decode($deleteContent, true);
         self::assertIsArray($deletePayload);
-        self::assertArrayHasKey('operationId', $deletePayload);
-        self::assertArrayHasKey('id', $deletePayload);
+        self::assertSame(['operationId'], array_keys($deletePayload));
+        self::assertIsString($deletePayload['operationId']);
     }
 }


### PR DESCRIPTION
### Motivation
- Garantir un contrat de réponse cohérent entre les endpoints de création, modification, suppression et marquage comme lu en utilisant un format centré sur `operationId`.
- Aligner la documentation OpenAPI et les tests applicatifs sur ce format unique pour éviter des divergences entre implémentation et spec.

### Description
- Les contrôleurs `PatchMessageController` et `DeleteMessageController` renvoient désormais uniquement `{ "operationId": "..." }` dans le body de réponse HTTP `202` pour harmoniser le contrat avec `CreateMessageController`.
- `MarkConversationAsReadController` supprime le champ additionnel (`conversationId`) du body de réponse et ajoute un exemple OpenAPI renvoyant uniquement `operationId` pour cohérence.
- Les annotations OpenAPI (`responses`) des endpoints `PATCH`, `DELETE` et `POST .../read` ont été mises à jour pour documenter un `JsonContent` d'exemple contenant uniquement `operationId`.
- Le test applicatif `tests/Application/Chat/Transport/Controller/Api/V1/Message/UserMessageControllerTest.php` a été modifié pour assert la même structure JSON (`['operationId']` comme clés et `operationId` de type string) sur les endpoints `create`, `patch`, `delete` et `mark-as-read`.

### Testing
- `php -l` a été exécuté avec succès sur `src/Chat/Transport/Controller/Api/V1/Message/MarkConversationAsReadController.php`, `src/Chat/Transport/Controller/Api/V1/Message/PatchMessageController.php`, `src/Chat/Transport/Controller/Api/V1/Message/DeleteMessageController.php` et sur le fichier de test modifié, et n’a reporté aucune erreur de syntaxe.
- L’exécution de la suite PHPUnit ciblée a été tentée mais n’a pas pu être lancée dans cet environnement car le binaire `./vendor/bin/phpunit` est absent, donc les tests automatisés n’ont pas été exécutés ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b4fcfe5c8326af919a4854d85ab6)