### PR TITLE
Scope CRM task list cache invalidation by application

### DIFF
--- a/src/Crm/Application/Service/TaskListService.php
+++ b/src/Crm/Application/Service/TaskListService.php
@@ -49,10 +49,10 @@ readonly class TaskListService
         ]));
 
         /** @var array<string,mixed> $result */
-        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit, $crm): array {
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $filters, $page, $limit, $crm): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
-                $item->tag($this->cacheKeyConventionService->crmTaskListTag());
+                $item->tag($this->cacheKeyConventionService->crmTaskListTag($applicationSlug));
             }
 
             $esIds = $this->searchIdsFromElastic($filters);

--- a/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
@@ -125,7 +125,7 @@ final readonly class CreateTaskController
 
         $this->entityManager->persist($task);
         $this->entityManager->flush();
-        $this->messageBus->dispatch(new EntityCreated('crm_task', $task->getId()));
+        $this->messageBus->dispatch(new EntityCreated('crm_task', $task->getId(), context: ['applicationSlug' => $applicationSlug]));
 
         return new JsonResponse([
             'id' => $task->getId(),

--- a/src/Crm/Transport/Controller/Api/V1/Task/DeleteTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/DeleteTaskController.php
@@ -45,7 +45,7 @@ final readonly class DeleteTaskController
 
         $this->entityManager->remove($task);
         $this->entityManager->flush();
-        $this->messageBus->dispatch(new EntityDeleted('crm_task', $id));
+        $this->messageBus->dispatch(new EntityDeleted('crm_task', $id, context: ['applicationSlug' => $applicationSlug]));
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
@@ -106,7 +106,7 @@ final readonly class CreateTaskRequestController
 
         $this->entityManager->persist($taskRequest);
         $this->entityManager->flush();
-        $this->messageBus->dispatch(new EntityCreated('crm_task_request', $taskRequest->getId()));
+        $this->messageBus->dispatch(new EntityCreated('crm_task_request', $taskRequest->getId(), context: ['applicationSlug' => $applicationSlug]));
 
         return new JsonResponse([
             'id' => $taskRequest->getId(),

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/DeleteTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/DeleteTaskRequestController.php
@@ -45,7 +45,7 @@ final readonly class DeleteTaskRequestController
 
         $this->entityManager->remove($taskRequest);
         $this->entityManager->flush();
-        $this->messageBus->dispatch(new EntityDeleted('crm_task_request', $id));
+        $this->messageBus->dispatch(new EntityDeleted('crm_task_request', $id, context: ['applicationSlug' => $applicationSlug]));
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }

--- a/src/General/Application/MessageHandler/EntityProjectionHandler.php
+++ b/src/General/Application/MessageHandler/EntityProjectionHandler.php
@@ -100,7 +100,7 @@ final readonly class EntityProjectionHandler
             || $message->entityType === self::CRM_TASK_REQUEST
             || $message->entityType === self::CRM_SPRINT
         ) {
-            $this->projectCrmSupportEntities();
+            $this->projectCrmSupportEntities($message);
 
             return;
         }
@@ -229,9 +229,13 @@ final readonly class EntityProjectionHandler
 
     private function projectCrmTask(EntityMutationMessage $message): void
     {
+        $applicationSlug = (string)($message->context['applicationSlug'] ?? '');
+
         if ($message instanceof EntityDeleted) {
             $this->elasticsearchService->delete(CrmTaskProjection::INDEX_NAME, $message->entityId);
-            $this->cacheInvalidationService->invalidateCrmTaskListCaches();
+            if ($applicationSlug !== '') {
+                $this->cacheInvalidationService->invalidateCrmTaskListCaches($applicationSlug);
+            }
 
             return;
         }
@@ -250,7 +254,10 @@ final readonly class EntityProjectionHandler
             'updatedAt' => $task->getUpdatedAt()?->format(DATE_ATOM),
         ]);
 
-        $this->cacheInvalidationService->invalidateCrmTaskListCaches();
+        $applicationSlug = $task->getProject()?->getCompany()?->getCrm()?->getApplication()?->getSlug() ?? $applicationSlug;
+        if ($applicationSlug !== '') {
+            $this->cacheInvalidationService->invalidateCrmTaskListCaches($applicationSlug);
+        }
     }
 
     private function projectSchoolExam(EntityMutationMessage $message): void
@@ -285,9 +292,12 @@ final readonly class EntityProjectionHandler
         $this->cacheInvalidationService->invalidateShopProductListCaches();
     }
 
-    private function projectCrmSupportEntities(): void
+    private function projectCrmSupportEntities(EntityMutationMessage $message): void
     {
-        $this->cacheInvalidationService->invalidateCrmTaskListCaches();
+        $applicationSlug = (string)($message->context['applicationSlug'] ?? '');
+        if ($applicationSlug !== '') {
+            $this->cacheInvalidationService->invalidateCrmTaskListCaches($applicationSlug);
+        }
     }
 
     private function projectSchoolSupportEntities(): void

--- a/src/General/Application/Service/CacheInvalidationService.php
+++ b/src/General/Application/Service/CacheInvalidationService.php
@@ -51,15 +51,22 @@ class CacheInvalidationService
         ]));
     }
 
-    public function invalidateCrmTaskListCaches(): void
+    public function invalidateCrmTaskListCaches(?string $applicationSlug = null): void
     {
+        if ($applicationSlug === null || $applicationSlug === '') {
+            return;
+        }
+
         if ($this->cache instanceof TagAwareCacheInterface) {
-            $this->cache->invalidateTags([$this->cacheKeyConventionService->crmTaskListTag()]);
+            $this->cache->invalidateTags([$this->cacheKeyConventionService->crmTaskListTag($applicationSlug)]);
         }
 
         $this->cache->delete($this->cacheKeyConventionService->buildCrmTaskListKey(1, 20, [
             'q' => '',
             'title' => '',
+            'status' => '',
+            'priority' => '',
+            'applicationSlug' => $applicationSlug,
         ]));
     }
 

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -290,9 +290,9 @@ class CacheKeyConventionService
         return 'cache_shop_product_list_' . $this->sanitizeSegment($applicationSlug);
     }
 
-    public function crmTaskListTag(): string
+    public function crmTaskListTag(string $applicationSlug): string
     {
-        return 'cache_crm_task_list';
+        return 'cache_crm_task_list_' . $this->sanitizeSegment($applicationSlug);
     }
 
     public function crmCompanyListByApplicationTag(string $applicationSlug): string

--- a/tests/Unit/General/Application/Service/CacheInvalidationServiceTest.php
+++ b/tests/Unit/General/Application/Service/CacheInvalidationServiceTest.php
@@ -42,4 +42,20 @@ final class CacheInvalidationServiceTest extends TestCase
 
         $service->invalidateSchoolExamListCaches('school-campus-core');
     }
+
+    public function testInvalidateCrmTaskListCachesByApplicationUsesScopedTag(): void
+    {
+        $cache = $this->createMock(TagAwareCacheInterface::class);
+        $cache->expects(self::once())
+            ->method('invalidateTags')
+            ->with(['cache_crm_task_list_crm-app-core']);
+        $cache->expects(self::once())
+            ->method('delete')
+            ->with(self::stringStartsWith('crm_task_list_'));
+
+        $service = new CacheInvalidationService($cache, new CacheKeyConventionService());
+
+        $service->invalidateCrmTaskListCaches('crm-app-core');
+    }
+
 }

--- a/tests/Unit/General/Application/Service/CacheKeyConventionServiceTest.php
+++ b/tests/Unit/General/Application/Service/CacheKeyConventionServiceTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\General\Application\Service;
+
+use App\General\Application\Service\CacheKeyConventionService;
+use PHPUnit\Framework\TestCase;
+
+final class CacheKeyConventionServiceTest extends TestCase
+{
+    public function testCrmTaskListTagIsScopedByApplicationSlug(): void
+    {
+        $service = new CacheKeyConventionService();
+
+        $tagA = $service->crmTaskListTag('crm-app-alpha');
+        $tagB = $service->crmTaskListTag('crm-app-beta');
+
+        self::assertNotSame($tagA, $tagB);
+        self::assertSame('cache_crm_task_list_crm-app-alpha', $tagA);
+        self::assertSame('cache_crm_task_list_crm-app-beta', $tagB);
+    }
+}


### PR DESCRIPTION
### Motivation

- Éviter le chevauchement de tags/cache entre plusieurs applications CRM en scoppant le tag des listes de tasks par `applicationSlug` plutôt que d'utiliser un tag global.
- Rendre cohérente la stratégie de tagging/invalidation avec celle utilisée pour d'autres listes applicatives (ex: `CompanyApplicationListService`).
- Permettre des invalidations fines lors de la création/suppression de `crm_task` et `crm_task_request` pour ne rafraîchir que le cache de l'application concernée.

### Description

- La convention de tags a été modifiée en rendant `crmTaskListTag` acceptant un paramètre `string $applicationSlug` et en produisant `cache_crm_task_list_{application}` via `CacheKeyConventionService`.
- `TaskListService` tague désormais les entrées cache avec le tag applicatif en appelant `crmTaskListTag($applicationSlug)` lors de la création de l`Item` cache.
- `CacheInvalidationService::invalidateCrmTaskListCaches` accepte maintenant `?string $applicationSlug = null`, invalide le tag scoppé via `crmTaskListTag($applicationSlug)` et supprime la clé construite incluant `applicationSlug` et autres filtres.
- Les événements `EntityCreated`/`EntityDeleted` pour `crm_task` et `crm_task_request` incluent désormais `context: ['applicationSlug' => $applicationSlug]`, et `EntityProjectionHandler` en extrait ce `applicationSlug` pour déclencher l'invalidation ciblée.
- Ajout de tests unitaires : `tests/Unit/General/Application/Service/CacheKeyConventionServiceTest.php` vérifiant que deux slugs produisent des tags distincts, et extension de `CacheInvalidationServiceTest` pour couvrir l'invalidation scoppée.

### Testing

- Lint PHP : exécuté via `php -l` sur les fichiers modifiés (`TaskListService`, `CacheKeyConventionService`, `CacheInvalidationService`, `EntityProjectionHandler`, contrôleurs CRM et nouveaux tests) et aucun problème de syntaxe détecté.
- Tests unitaires ajoutés : `CacheKeyConventionServiceTest` et un cas additionnel dans `CacheInvalidationServiceTest` (créés dans `tests/Unit/General/Application/Service`).
- Tentative d'exécution des tests via `vendor/bin/phpunit ...` impossible dans l'environnement d'exécution (exécutable `vendor/bin/phpunit` absent), donc les nouveaux tests n'ont pas été lancés ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b542033c8326be35f6b85103fe48)