### PR TITLE
test: validate cross-application reference isolation on scoped school POST routes

### DIFF
--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Application\School\Transport\Controller\Api\V1;
 use App\General\Domain\Utils\JSON;
 use App\Tests\TestCase\WebTestCase;
 use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Component\HttpFoundation\Response;
 
 final class SchoolApplicationScopedRoutesTest extends WebTestCase
@@ -228,5 +229,63 @@ final class SchoolApplicationScopedRoutesTest extends WebTestCase
         }
 
         self::assertStringContainsString('Forbidden application scope access.', (string)$forbiddenClient->getResponse()->getContent());
+    }
+
+    #[TestDox('School scoped POST endpoints reject references coming from another school application.')]
+    public function testScopedPostRoutesRejectForeignApplicationReferencesWithNotFound(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $campusClassId = $this->firstResourceId($client, '/v1/school/applications/school-campus-core/classes');
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-course-flow/students', [], [], [], JSON::encode([
+            'name' => 'Eleve cross app',
+            'classId' => $campusClassId,
+        ]));
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        self::assertSame('classId not found', $this->responsePayload($client)['message']);
+
+        $courseTeacherId = $this->firstResourceId($client, '/v1/school/applications/school-course-flow/teachers');
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-course-flow/exams', [], [], [], JSON::encode([
+            'title' => 'Examen cross app',
+            'classId' => $campusClassId,
+            'teacherId' => $courseTeacherId,
+            'type' => 'QUIZ',
+            'status' => 'DRAFT',
+            'term' => 'TERM_1',
+        ]));
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        self::assertSame('classId not found', $this->responsePayload($client)['message']);
+
+        $campusStudentId = $this->firstResourceId($client, '/v1/school/applications/school-campus-core/students');
+        $campusExamId = $this->firstResourceId($client, '/v1/school/applications/school-campus-core/exams');
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-course-flow/grades', [], [], [], JSON::encode([
+            'score' => 16.0,
+            'studentId' => $campusStudentId,
+            'examId' => $campusExamId,
+        ]));
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        self::assertSame('studentId not found', $this->responsePayload($client)['message']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function responsePayload(KernelBrowser $client): array
+    {
+        return JSON::decode((string)$client->getResponse()->getContent(), true);
+    }
+
+    private function firstResourceId(KernelBrowser $client, string $path): string
+    {
+        $client->request('GET', self::API_URL_PREFIX . $path);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        /** @var array{items: array<int, array{id: string}>} $payload */
+        $payload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        return $payload['items'][0]['id'];
     }
 }


### PR DESCRIPTION
### Motivation

- Garantir que les endpoints POST scoped d’une application scolaire rejettent les références appartenant à une autre application en retournant des `404` stables et des messages lisibles (`classId not found`, `studentId not found`).

### Description

- Ajout de la méthode de test `testScopedPostRoutesRejectForeignApplicationReferencesWithNotFound()` dans `tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php` pour lire un `classId` depuis `school-campus-core` et poster des ressources sur `school-course-flow` en vérifiant les `404` et messages attendus.
- Réplication du pattern pour les ressources `students`, `exams` et `grades` (vérification de `classId not found` et `studentId not found`).
- Ajout des helpers locaux `firstResourceId()` et `responsePayload()` et import de `KernelBrowser` pour factoriser la récupération d’identifiants et la lecture des payloads JSON.

### Testing

- Tentative d’exécution du test via `./vendor/bin/phpunit tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php` qui a échoué parce que `./vendor/bin/phpunit` est absent dans cet environnement (dépendances non installées).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b509a5bc83268438a274c726c4d4)