### PR TITLE
feat(school): unify School API error contract and OpenAPI error statuses

### DIFF
--- a/src/General/Transport/EventSubscriber/ExceptionSubscriber.php
+++ b/src/General/Transport/EventSubscriber/ExceptionSubscriber.php
@@ -7,6 +7,7 @@ namespace App\General\Transport\EventSubscriber;
 use App\General\Application\Exception\Interfaces\ClientErrorInterface;
 use App\General\Domain\Exception\Interfaces\TranslatableExceptionInterface;
 use App\General\Domain\Utils\JSON;
+use App\School\Application\Exception\SchoolClientExceptionInterface;
 use App\User\Application\Security\UserTypeIdentification;
 use Doctrine\DBAL\Exception;
 use Doctrine\ORM\Exception\ORMException;
@@ -27,6 +28,7 @@ use function array_intersect;
 use function array_key_exists;
 use function class_implements;
 use function in_array;
+use function str_starts_with;
 use function spl_object_hash;
 
 /**
@@ -84,7 +86,7 @@ class ExceptionSubscriber implements EventSubscriberInterface
         $response = new Response();
         $response->headers->set('Content-Type', 'application/json');
         $response->setStatusCode($this->getStatusCode($exception));
-        $response->setContent(JSON::encode($this->getErrorMessage($exception, $response)));
+        $response->setContent(JSON::encode($this->getErrorMessage($exception, $response, $event)));
         // Send the modified response object to the event
         $event->setResponse($response);
     }
@@ -102,8 +104,12 @@ class ExceptionSubscriber implements EventSubscriberInterface
      *
      * @return array<string, mixed>
      */
-    private function getErrorMessage(Throwable $exception, Response $response): array
+    private function getErrorMessage(Throwable $exception, Response $response, ExceptionEvent $event): array
     {
+        if ($this->isSchoolRequest($event)) {
+            return $this->getSchoolErrorMessage($exception, $response);
+        }
+
         $message = $exception instanceof TranslatableExceptionInterface
             ? $this->translator->trans($exception->getMessage(), $exception->getParameters(), $exception->getDomain())
             : $this->getExceptionMessage($exception);
@@ -129,6 +135,36 @@ class ExceptionSubscriber implements EventSubscriberInterface
         }
 
         return $error;
+    }
+
+    /**
+     * @return array{message: string, code: string, details: array<int, array<string, mixed>>}
+     */
+    private function getSchoolErrorMessage(Throwable $exception, Response $response): array
+    {
+        $statusCode = $response->getStatusCode();
+
+        $defaultErrorCode = match ($statusCode) {
+            Response::HTTP_FORBIDDEN => 'SCHOOL_FORBIDDEN',
+            Response::HTTP_NOT_FOUND => 'SCHOOL_NOT_FOUND',
+            Response::HTTP_UNPROCESSABLE_ENTITY => 'SCHOOL_UNPROCESSABLE',
+            default => 'SCHOOL_ERROR',
+        };
+
+        return [
+            'message' => $this->getExceptionMessage($exception),
+            'code' => $exception instanceof SchoolClientExceptionInterface
+                ? $exception->getErrorCode()
+                : $defaultErrorCode,
+            'details' => $exception instanceof SchoolClientExceptionInterface
+                ? $exception->getDetails()
+                : [],
+        ];
+    }
+
+    private function isSchoolRequest(ExceptionEvent $event): bool
+    {
+        return str_starts_with($event->getRequest()->getPathInfo(), '/v1/school');
     }
 
     /**

--- a/src/School/Application/Exception/SchoolClientExceptionInterface.php
+++ b/src/School/Application/Exception/SchoolClientExceptionInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Exception;
+
+use App\General\Application\Exception\Interfaces\ClientErrorInterface;
+
+interface SchoolClientExceptionInterface extends ClientErrorInterface
+{
+    public function getErrorCode(): string;
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getDetails(): array;
+}
+

--- a/src/School/Application/Exception/SchoolRelationException.php
+++ b/src/School/Application/Exception/SchoolRelationException.php
@@ -7,27 +7,39 @@ namespace App\School\Application\Exception;
 use App\General\Application\Exception\Interfaces\ClientErrorInterface;
 use RuntimeException;
 
-final class SchoolRelationException extends RuntimeException implements ClientErrorInterface
+final class SchoolRelationException extends RuntimeException implements ClientErrorInterface, SchoolClientExceptionInterface
 {
     public function __construct(
         string $message,
         private readonly int $statusCode,
+        private readonly string $errorCode,
+        private readonly array $details = [],
     ) {
         parent::__construct($message, $statusCode);
     }
 
     public static function notFound(string $reference): self
     {
-        return new self($reference . ' not found', 404);
+        return new self($reference . ' not found', 404, 'SCHOOL_RELATION_NOT_FOUND');
     }
 
     public static function unprocessable(string $message): self
     {
-        return new self($message, 422);
+        return new self($message, 422, 'SCHOOL_RELATION_UNPROCESSABLE');
     }
 
     public function getStatusCode(): int
     {
         return $this->statusCode;
+    }
+
+    public function getErrorCode(): string
+    {
+        return $this->errorCode;
+    }
+
+    public function getDetails(): array
+    {
+        return $this->details;
     }
 }

--- a/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
@@ -31,6 +31,9 @@ final readonly class CreateClassByApplicationController
 
     #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]
+    #[OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]
+    #[OA\Response(response: 422, description: 'Validation failed', content: new OA\JsonContent(ref: '#/components/schemas/SchoolValidationError'))]
     public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);

--- a/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
@@ -49,7 +49,9 @@ final readonly class CreateExamController
         )),
         responses: [
             new OA\Response(response: 201, description: 'Examen créé'),
-            new OA\Response(response: 422, description: 'Validation failed'),
+            new OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError')),
+            new OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError')),
+            new OA\Response(response: 422, description: 'Validation failed', content: new OA\JsonContent(ref: '#/components/schemas/SchoolValidationError')),
         ],
     )]
     #[Route('/v1/school/applications/{applicationSlug}/exams', methods: [Request::METHOD_POST])]

--- a/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
@@ -31,6 +31,9 @@ final readonly class CreateGradeController
 
     #[Route('/v1/school/applications/{applicationSlug}/grades', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]
+    #[OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]
+    #[OA\Response(response: 422, description: 'Validation failed', content: new OA\JsonContent(ref: '#/components/schemas/SchoolValidationError'))]
     public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);

--- a/src/School/Transport/Controller/Api/V1/Input/SchoolInputValidator.php
+++ b/src/School/Transport/Controller/Api/V1/Input/SchoolInputValidator.php
@@ -27,7 +27,8 @@ final readonly class SchoolInputValidator
 
         return new JsonResponse([
             'message' => 'Validation failed.',
-            'violations' => array_map(
+            'code' => 'SCHOOL_VALIDATION_FAILED',
+            'details' => array_map(
                 static fn (ConstraintViolationInterface $violation): array => [
                     'propertyPath' => $violation->getPropertyPath(),
                     'message' => $violation->getMessage(),

--- a/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
@@ -31,6 +31,9 @@ final readonly class CreateStudentController
 
     #[Route('/v1/school/applications/{applicationSlug}/students', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]
+    #[OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]
+    #[OA\Response(response: 422, description: 'Validation failed', content: new OA\JsonContent(ref: '#/components/schemas/SchoolValidationError'))]
     public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);

--- a/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
@@ -31,6 +31,9 @@ final readonly class CreateTeacherController
 
     #[Route('/v1/school/applications/{applicationSlug}/teachers', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]
+    #[OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]
+    #[OA\Response(response: 422, description: 'Validation failed', content: new OA\JsonContent(ref: '#/components/schemas/SchoolValidationError'))]
     public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {
         $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);

--- a/src/School/Transport/OpenApi/SchoolErrorSchemas.php
+++ b/src/School/Transport/OpenApi/SchoolErrorSchemas.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\OpenApi;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'SchoolError',
+    required: ['message', 'code', 'details'],
+    properties: [
+        new OA\Property(property: 'message', type: 'string', example: 'Forbidden application scope access.'),
+        new OA\Property(property: 'code', type: 'string', example: 'SCHOOL_FORBIDDEN'),
+        new OA\Property(property: 'details', type: 'array', items: new OA\Items(type: 'object')),
+    ],
+    type: 'object'
+)]
+#[OA\Schema(
+    schema: 'SchoolValidationError',
+    required: ['message', 'code', 'details'],
+    properties: [
+        new OA\Property(property: 'message', type: 'string', example: 'Validation failed.'),
+        new OA\Property(property: 'code', type: 'string', example: 'SCHOOL_VALIDATION_FAILED'),
+        new OA\Property(
+            property: 'details',
+            type: 'array',
+            items: new OA\Items(
+                type: 'object',
+                properties: [
+                    new OA\Property(property: 'propertyPath', type: 'string', example: 'classId'),
+                    new OA\Property(property: 'message', type: 'string', example: 'This value should not be blank.'),
+                    new OA\Property(property: 'code', type: 'string', nullable: true),
+                ],
+            ),
+        ),
+    ],
+    type: 'object'
+)]
+final class SchoolErrorSchemas
+{
+}

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
@@ -34,7 +34,10 @@ final class SchoolApplicationScopedRoutesTest extends WebTestCase
 
         $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/teachers');
         self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
-        self::assertStringContainsString('Forbidden application scope access.', (string)$forbiddenClient->getResponse()->getContent());
+        $forbiddenPayload = JSON::decode((string)$forbiddenClient->getResponse()->getContent(), true);
+        self::assertSame('Forbidden application scope access.', $forbiddenPayload['message']);
+        self::assertSame('SCHOOL_FORBIDDEN', $forbiddenPayload['code']);
+        self::assertSame([], $forbiddenPayload['details']);
 
         $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams');
         self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
@@ -225,6 +228,10 @@ final class SchoolApplicationScopedRoutesTest extends WebTestCase
         foreach ($forbiddenPayloads as $endpoint => $payload) {
             $forbiddenClient->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/' . $endpoint, [], [], [], JSON::encode($payload));
             self::assertSame(Response::HTTP_FORBIDDEN, $forbiddenClient->getResponse()->getStatusCode());
+
+            $forbiddenPayload = JSON::decode((string)$forbiddenClient->getResponse()->getContent(), true);
+            self::assertSame('SCHOOL_FORBIDDEN', $forbiddenPayload['code']);
+            self::assertSame([], $forbiddenPayload['details']);
         }
 
         self::assertStringContainsString('Forbidden application scope access.', (string)$forbiddenClient->getResponse()->getContent());

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolCreateReferenceValidationTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolCreateReferenceValidationTest.php
@@ -24,14 +24,20 @@ final class SchoolCreateReferenceValidationTest extends WebTestCase
             'schoolId' => self::UNKNOWN_UUID,
         ]));
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
-        self::assertSame('schoolId not found', $this->responsePayload($client)['message']);
+        $payload = $this->responsePayload($client);
+        self::assertSame('schoolId not found', $payload['message']);
+        self::assertSame('SCHOOL_RELATION_NOT_FOUND', $payload['code']);
+        self::assertSame([], $payload['details']);
 
         $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/students', [], [], [], JSON::encode([
             'name' => 'Eleve API',
             'classId' => self::UNKNOWN_UUID,
         ]));
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
-        self::assertSame('classId not found', $this->responsePayload($client)['message']);
+        $payload = $this->responsePayload($client);
+        self::assertSame('classId not found', $payload['message']);
+        self::assertSame('SCHOOL_RELATION_NOT_FOUND', $payload['code']);
+        self::assertSame([], $payload['details']);
 
         $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams', [], [], [], JSON::encode([
             'title' => 'Examen API',
@@ -42,7 +48,10 @@ final class SchoolCreateReferenceValidationTest extends WebTestCase
             'term' => 'term_1',
         ]));
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
-        self::assertSame('classId not found', $this->responsePayload($client)['message']);
+        $payload = $this->responsePayload($client);
+        self::assertSame('classId not found', $payload['message']);
+        self::assertSame('SCHOOL_RELATION_NOT_FOUND', $payload['code']);
+        self::assertSame([], $payload['details']);
 
         $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/grades', [], [], [], JSON::encode([
             'score' => 12,
@@ -50,7 +59,10 @@ final class SchoolCreateReferenceValidationTest extends WebTestCase
             'examId' => self::UNKNOWN_UUID,
         ]));
         self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
-        self::assertSame('studentId not found', $this->responsePayload($client)['message']);
+        $payload = $this->responsePayload($client);
+        self::assertSame('studentId not found', $payload['message']);
+        self::assertSame('SCHOOL_RELATION_NOT_FOUND', $payload['code']);
+        self::assertSame([], $payload['details']);
     }
 
     #[TestDox('School create endpoints reject cross-scope relations with stable 422 messages.')]
@@ -70,7 +82,10 @@ final class SchoolCreateReferenceValidationTest extends WebTestCase
             'term' => 'term_1',
         ]));
         self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
-        self::assertSame('teacherId is not assigned to classId', $this->responsePayload($client)['message']);
+        $payload = $this->responsePayload($client);
+        self::assertSame('teacherId is not assigned to classId', $payload['message']);
+        self::assertSame('SCHOOL_RELATION_UNPROCESSABLE', $payload['code']);
+        self::assertSame([], $payload['details']);
 
         $campusStudentId = $this->firstResourceId($client, '/v1/school/applications/school-campus-core/students');
         $courseExamId = $this->firstResourceId($client, '/v1/school/applications/school-course-flow/exams');
@@ -81,7 +96,10 @@ final class SchoolCreateReferenceValidationTest extends WebTestCase
             'examId' => $courseExamId,
         ]));
         self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
-        self::assertSame('studentId and examId must belong to the same class', $this->responsePayload($client)['message']);
+        $payload = $this->responsePayload($client);
+        self::assertSame('studentId and examId must belong to the same class', $payload['message']);
+        self::assertSame('SCHOOL_RELATION_UNPROCESSABLE', $payload['code']);
+        self::assertSame([], $payload['details']);
     }
 
     /**

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php
@@ -20,6 +20,9 @@ final class SchoolCrudValidationPaginationTest extends WebTestCase
             'name' => '',
         ]));
         self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+        $classValidationPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+        self::assertSame('SCHOOL_VALIDATION_FAILED', $classValidationPayload['code']);
+        self::assertNotEmpty($classValidationPayload['details']);
 
         $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes', [], [], [], JSON::encode([
             'name' => 'Classe API Test',
@@ -57,6 +60,9 @@ final class SchoolCrudValidationPaginationTest extends WebTestCase
             'term' => 'invalid',
         ]));
         self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+        $examValidationPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+        self::assertSame('SCHOOL_VALIDATION_FAILED', $examValidationPayload['code']);
+        self::assertNotEmpty($examValidationPayload['details']);
 
         $client->request('POST', self::API_URL_PREFIX . '/v1/school/exams', [], [], [], JSON::encode([
             'title' => 'Exam CRUD API Test',


### PR DESCRIPTION
### Motivation

- Ensure all School API errors share a single, predictable payload shape (`message`, `code`, `details`) so clients can reliably parse 403/404/422 responses. 
- Surface stable error codes from domain exceptions (e.g. relation checks) so integration tests and consumers can assert exact failure reasons. 
- Align input validation responses and OpenAPI documentation with the new contract for consistency across controllers.

### Description

- Added a School-specific client exception contract `SchoolClientExceptionInterface` and updated `SchoolRelationException` to expose a stable `errorCode` and `details` payload. 
- Updated the global `ExceptionSubscriber` to detect `/v1/school` requests and return errors in the `message`/`code`/`details` shape (with sensible defaults for 403/404/422). 
- Aligned `SchoolInputValidator` to return the same contract for validation failures (`code: SCHOOL_VALIDATION_FAILED`, `details: [...]`). 
- Added OpenAPI component schemas (`SchoolError`, `SchoolValidationError`) and annotated school create endpoints with 403/404/422 responses referencing those schemas. 
- Updated School API tests to assert the new error structure and expected error codes for 403/404/422 scenarios.

### Testing

- `php -l` (syntax check) was run against all modified PHP files and reported no syntax errors. 
- Attempted to run the School API PHPUnit tests, but `./vendor/bin/phpunit` is not available in this environment so full test execution could not be performed. 
- Changes were committed (commit shown in rollout) and the modified files are ready for CI to run the full test suite and OpenAPI generation checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b50deea48326adb82f67bb8ee2de)