### PR TITLE
feat(recruit): add Offer entity, workflow, audit and endpoints

### DIFF
--- a/migrations/Version20260314143000.php
+++ b/migrations/Version20260314143000.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260314143000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add recruit offers and offer audit tables.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("CREATE TABLE recruit_offer (id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', application_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', salary_proposed DOUBLE PRECISION NOT NULL, start_date DATE NOT NULL COMMENT '(DC2Type:date_immutable)', contract_type VARCHAR(25) NOT NULL, status VARCHAR(25) NOT NULL DEFAULT 'DRAFT', created_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', updated_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', INDEX idx_recruit_offer_application_created_at (application_id, created_at), INDEX IDX_DBC327B157698A6A (application_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+        $this->addSql('ALTER TABLE recruit_offer ADD CONSTRAINT FK_DBC327B157698A6A FOREIGN KEY (application_id) REFERENCES recruit_application (id) ON DELETE CASCADE');
+
+        $this->addSql("CREATE TABLE recruit_offer_status_history (id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', offer_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', author_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', action VARCHAR(50) NOT NULL, from_status VARCHAR(25) NOT NULL, to_status VARCHAR(25) NOT NULL, comment LONGTEXT DEFAULT NULL, created_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', updated_at DATETIME DEFAULT NULL COMMENT '(DC2Type:datetime_immutable)', INDEX idx_recruit_offer_status_history_offer_created_at (offer_id, created_at), INDEX IDX_FD25235953C674EE (offer_id), INDEX IDX_FD252359F675F31B (author_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+        $this->addSql('ALTER TABLE recruit_offer_status_history ADD CONSTRAINT FK_FD25235953C674EE FOREIGN KEY (offer_id) REFERENCES recruit_offer (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE recruit_offer_status_history ADD CONSTRAINT FK_FD252359F675F31B FOREIGN KEY (author_id) REFERENCES user (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE recruit_offer_status_history DROP FOREIGN KEY FK_FD25235953C674EE');
+        $this->addSql('ALTER TABLE recruit_offer_status_history DROP FOREIGN KEY FK_FD252359F675F31B');
+        $this->addSql('ALTER TABLE recruit_offer DROP FOREIGN KEY FK_DBC327B157698A6A');
+        $this->addSql('DROP TABLE recruit_offer_status_history');
+        $this->addSql('DROP TABLE recruit_offer');
+    }
+}

--- a/src/Recruit/Application/Service/OfferWorkflowService.php
+++ b/src/Recruit/Application/Service/OfferWorkflowService.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Offer;
+use App\Recruit\Domain\Entity\OfferStatusHistory;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Recruit\Domain\Enum\ContractType;
+use App\Recruit\Domain\Enum\OfferStatus;
+use App\Recruit\Infrastructure\Repository\ApplicationStatusHistoryRepository;
+use App\Recruit\Infrastructure\Repository\OfferRepository;
+use App\Recruit\Infrastructure\Repository\OfferStatusHistoryRepository;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use ValueError;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+use function is_numeric;
+use function is_string;
+use function mb_strlen;
+use function strtoupper;
+
+readonly class OfferWorkflowService
+{
+    public function __construct(
+        private OfferRepository $offerRepository,
+        private OfferStatusHistoryRepository $offerStatusHistoryRepository,
+        private ApplicationStatusHistoryRepository $applicationStatusHistoryRepository,
+    ) {
+    }
+
+    /** @param array<string,mixed> $payload */
+    public function create(Application $application, array $payload, User $author): Offer
+    {
+        if ($application->getStatus() === ApplicationStatus::HIRED || $application->getStatus() === ApplicationStatus::REJECTED) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Cannot create an offer for a closed application.');
+        }
+
+        $salary = $payload['salaryProposed'] ?? null;
+        if (!is_numeric($salary)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "salaryProposed" must be numeric.');
+        }
+
+        $startDate = $payload['startDate'] ?? null;
+        if (!is_string($startDate)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "startDate" must be a string with format Y-m-d.');
+        }
+
+        $parsedStartDate = DateTimeImmutable::createFromFormat('Y-m-d', $startDate);
+        if (!$parsedStartDate instanceof DateTimeImmutable) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "startDate" must use format Y-m-d.');
+        }
+
+        $contractType = $payload['contractType'] ?? null;
+        if (!is_string($contractType)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "contractType" must be a string.');
+        }
+
+        $comment = is_string($payload['comment'] ?? null) ? $payload['comment'] : null;
+
+        try {
+            $parsedContractType = ContractType::from($contractType);
+        } catch (ValueError) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "contractType" must be one of: CDI, CDD, Freelance, Internship.');
+        }
+
+        $offer = (new Offer())
+            ->setApplication($application)
+            ->setSalaryProposed((float) $salary)
+            ->setStartDate($parsedStartDate)
+            ->setContractType($parsedContractType)
+            ->setStatus(OfferStatus::DRAFT);
+
+        $this->offerRepository->save($offer, false);
+        $this->logOfferAction($offer, $author, 'created', OfferStatus::DRAFT, OfferStatus::DRAFT, $comment);
+
+        return $offer;
+    }
+
+    public function send(Offer $offer, User $author, ?string $comment = null): void
+    {
+        $this->transitionOffer($offer, $author, 'sent', OfferStatus::SENT, $comment);
+    }
+
+    public function accept(Offer $offer, User $author, ?string $comment = null): void
+    {
+        $this->transitionOffer($offer, $author, 'accepted', OfferStatus::ACCEPTED, $comment);
+
+        $application = $offer->getApplication();
+        $fromStatus = $application->getStatus();
+
+        if ($fromStatus !== ApplicationStatus::OFFER_SENT) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Application must be in OFFER_SENT status before accepting an offer.');
+        }
+
+        $application->setStatus(ApplicationStatus::HIRED);
+        $this->applicationStatusHistoryRepository->save((new \App\Recruit\Domain\Entity\ApplicationStatusHistory())
+            ->setApplication($application)
+            ->setAuthor($author)
+            ->setFromStatus($fromStatus)
+            ->setToStatus(ApplicationStatus::HIRED)
+            ->setComment($comment), false);
+    }
+
+    public function decline(Offer $offer, User $author, ?string $comment = null): void
+    {
+        $this->transitionOffer($offer, $author, 'declined', OfferStatus::DECLINED, $comment);
+
+        $application = $offer->getApplication();
+        $fromStatus = $application->getStatus();
+
+        if ($fromStatus !== ApplicationStatus::OFFER_SENT) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Application must be in OFFER_SENT status before declining an offer.');
+        }
+
+        $application->setStatus(ApplicationStatus::REJECTED);
+        $this->applicationStatusHistoryRepository->save((new \App\Recruit\Domain\Entity\ApplicationStatusHistory())
+            ->setApplication($application)
+            ->setAuthor($author)
+            ->setFromStatus($fromStatus)
+            ->setToStatus(ApplicationStatus::REJECTED)
+            ->setComment($comment), false);
+    }
+
+    public function withdraw(Offer $offer, User $author, ?string $comment = null): void
+    {
+        $this->transitionOffer($offer, $author, 'withdrawn', OfferStatus::WITHDRAWN, $comment);
+    }
+
+    private function transitionOffer(Offer $offer, User $author, string $action, OfferStatus $toStatus, ?string $comment): void
+    {
+        $fromStatus = $offer->getStatus();
+        if (!$this->isAllowedTransition($fromStatus, $toStatus)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Cannot transition offer status from ' . $fromStatus->value . ' to ' . $toStatus->value . '.');
+        }
+
+        $offer->setStatus($toStatus);
+        $this->logOfferAction($offer, $author, $action, $fromStatus, $toStatus, $comment);
+
+        if ($toStatus === OfferStatus::SENT) {
+            $offer->getApplication()->setStatus(ApplicationStatus::OFFER_SENT);
+        }
+    }
+
+    private function isAllowedTransition(OfferStatus $from, OfferStatus $to): bool
+    {
+        return match ($from) {
+            OfferStatus::DRAFT => $to === OfferStatus::SENT || $to === OfferStatus::WITHDRAWN,
+            OfferStatus::SENT => $to === OfferStatus::ACCEPTED || $to === OfferStatus::DECLINED || $to === OfferStatus::WITHDRAWN,
+            OfferStatus::ACCEPTED, OfferStatus::DECLINED, OfferStatus::WITHDRAWN => false,
+        };
+    }
+
+    private function logOfferAction(Offer $offer, User $author, string $action, OfferStatus $fromStatus, OfferStatus $toStatus, ?string $comment): void
+    {
+        $this->offerStatusHistoryRepository->save((new OfferStatusHistory())
+            ->setOffer($offer)
+            ->setAuthor($author)
+            ->setAction($this->sanitizeAction($action))
+            ->setFromStatus($fromStatus)
+            ->setToStatus($toStatus)
+            ->setComment($comment), false);
+    }
+
+    private function sanitizeAction(string $action): string
+    {
+        $action = strtoupper($action);
+
+        return mb_strlen($action) > 50 ? 'UPDATED' : $action;
+    }
+}

--- a/src/Recruit/Domain/Entity/Application.php
+++ b/src/Recruit/Domain/Entity/Application.php
@@ -46,10 +46,15 @@ class Application implements EntityInterface
     #[ORM\OneToMany(targetEntity: Interview::class, mappedBy: 'application', cascade: ['remove'], orphanRemoval: true)]
     private Collection|ArrayCollection $interviews;
 
+    /** @var Collection<int, Offer>|ArrayCollection<int, Offer> */
+    #[ORM\OneToMany(targetEntity: Offer::class, mappedBy: 'application', cascade: ['remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $offers;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
         $this->interviews = new ArrayCollection();
+        $this->offers = new ArrayCollection();
     }
 
     #[Override]
@@ -98,5 +103,13 @@ class Application implements EntityInterface
     public function getInterviews(): Collection|ArrayCollection
     {
         return $this->interviews;
+    }
+
+    /**
+     * @return Collection<int, Offer>|ArrayCollection<int, Offer>
+     */
+    public function getOffers(): Collection|ArrayCollection
+    {
+        return $this->offers;
     }
 }

--- a/src/Recruit/Domain/Entity/Offer.php
+++ b/src/Recruit/Domain/Entity/Offer.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Recruit\Domain\Enum\ContractType;
+use App\Recruit\Domain\Enum\OfferStatus;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_offer')]
+#[ORM\Index(name: 'idx_recruit_offer_application_created_at', columns: ['application_id', 'created_at'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Offer implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Application::class, inversedBy: 'offers')]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Application $application;
+
+    #[ORM\Column(name: 'salary_proposed', type: Types::FLOAT)]
+    private float $salaryProposed;
+
+    #[ORM\Column(name: 'start_date', type: Types::DATE_IMMUTABLE)]
+    private \DateTimeImmutable $startDate;
+
+    #[ORM\Column(name: 'contract_type', type: Types::STRING, length: 25, enumType: ContractType::class)]
+    private ContractType $contractType;
+
+    #[ORM\Column(name: 'status', type: Types::STRING, length: 25, enumType: OfferStatus::class, options: ['default' => 'DRAFT'])]
+    private OfferStatus $status = OfferStatus::DRAFT;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getApplication(): Application
+    {
+        return $this->application;
+    }
+
+    public function setApplication(Application $application): self
+    {
+        $this->application = $application;
+
+        return $this;
+    }
+
+    public function getSalaryProposed(): float
+    {
+        return $this->salaryProposed;
+    }
+
+    public function setSalaryProposed(float $salaryProposed): self
+    {
+        $this->salaryProposed = $salaryProposed;
+
+        return $this;
+    }
+
+    public function getStartDate(): \DateTimeImmutable
+    {
+        return $this->startDate;
+    }
+
+    public function setStartDate(\DateTimeImmutable $startDate): self
+    {
+        $this->startDate = $startDate;
+
+        return $this;
+    }
+
+    public function getContractType(): ContractType
+    {
+        return $this->contractType;
+    }
+
+    public function setContractType(ContractType|string $contractType): self
+    {
+        $this->contractType = $contractType instanceof ContractType ? $contractType : ContractType::from($contractType);
+
+        return $this;
+    }
+
+    public function getStatus(): OfferStatus
+    {
+        return $this->status;
+    }
+
+    public function setStatus(OfferStatus|string $status): self
+    {
+        $this->status = $status instanceof OfferStatus ? $status : OfferStatus::from($status);
+
+        return $this;
+    }
+}

--- a/src/Recruit/Domain/Entity/OfferStatusHistory.php
+++ b/src/Recruit/Domain/Entity/OfferStatusHistory.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\Recruit\Domain\Enum\OfferStatus;
+use App\User\Domain\Entity\User;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_offer_status_history')]
+#[ORM\Index(name: 'idx_recruit_offer_status_history_offer_created_at', columns: ['offer_id', 'created_at'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class OfferStatusHistory implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Offer::class)]
+    #[ORM\JoinColumn(name: 'offer_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private Offer $offer;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'author_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private User $author;
+
+    #[ORM\Column(name: 'action', type: Types::STRING, length: 50)]
+    private string $action;
+
+    #[ORM\Column(name: 'from_status', type: Types::STRING, length: 25, enumType: OfferStatus::class)]
+    private OfferStatus $fromStatus;
+
+    #[ORM\Column(name: 'to_status', type: Types::STRING, length: 25, enumType: OfferStatus::class)]
+    private OfferStatus $toStatus;
+
+    #[ORM\Column(name: 'comment', type: Types::TEXT, nullable: true)]
+    private ?string $comment = null;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getOffer(): Offer
+    {
+        return $this->offer;
+    }
+
+    public function setOffer(Offer $offer): self
+    {
+        $this->offer = $offer;
+
+        return $this;
+    }
+
+    public function getAuthor(): User
+    {
+        return $this->author;
+    }
+
+    public function setAuthor(User $author): self
+    {
+        $this->author = $author;
+
+        return $this;
+    }
+
+    public function getAction(): string
+    {
+        return $this->action;
+    }
+
+    public function setAction(string $action): self
+    {
+        $this->action = $action;
+
+        return $this;
+    }
+
+    public function getFromStatus(): OfferStatus
+    {
+        return $this->fromStatus;
+    }
+
+    public function setFromStatus(OfferStatus $fromStatus): self
+    {
+        $this->fromStatus = $fromStatus;
+
+        return $this;
+    }
+
+    public function getToStatus(): OfferStatus
+    {
+        return $this->toStatus;
+    }
+
+    public function setToStatus(OfferStatus $toStatus): self
+    {
+        $this->toStatus = $toStatus;
+
+        return $this;
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    public function setComment(?string $comment): self
+    {
+        $this->comment = $comment;
+
+        return $this;
+    }
+}

--- a/src/Recruit/Domain/Enum/OfferStatus.php
+++ b/src/Recruit/Domain/Enum/OfferStatus.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Enum;
+
+enum OfferStatus: string
+{
+    case DRAFT = 'DRAFT';
+    case SENT = 'SENT';
+    case ACCEPTED = 'ACCEPTED';
+    case DECLINED = 'DECLINED';
+    case WITHDRAWN = 'WITHDRAWN';
+}

--- a/src/Recruit/Domain/Repository/Interfaces/OfferRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/OfferRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface OfferRepositoryInterface
+{
+}

--- a/src/Recruit/Domain/Repository/Interfaces/OfferStatusHistoryRepositoryInterface.php
+++ b/src/Recruit/Domain/Repository/Interfaces/OfferStatusHistoryRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Domain\Repository\Interfaces;
+
+interface OfferStatusHistoryRepositoryInterface
+{
+}

--- a/src/Recruit/Infrastructure/Repository/OfferRepository.php
+++ b/src/Recruit/Infrastructure/Repository/OfferRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\Offer as Entity;
+use App\Recruit\Domain\Repository\Interfaces\OfferRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class OfferRepository extends BaseRepository implements OfferRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+}

--- a/src/Recruit/Infrastructure/Repository/OfferStatusHistoryRepository.php
+++ b/src/Recruit/Infrastructure/Repository/OfferStatusHistoryRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Recruit\Domain\Entity\OfferStatusHistory as Entity;
+use App\Recruit\Domain\Repository\Interfaces\OfferStatusHistoryRepositoryInterface;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class OfferStatusHistoryRepository extends BaseRepository implements OfferStatusHistoryRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Offer/OfferCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Offer/OfferCreateController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Offer;
+
+use App\Recruit\Application\Service\OfferWorkflowService;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Infrastructure\Repository\OfferRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_string;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Offer')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class OfferCreateController
+{
+    public function __construct(
+        private ApplicationRepository $applicationRepository,
+        private OfferRepository $offerRepository,
+        private OfferWorkflowService $offerWorkflowService,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/applications/{applicationSlug}/private/applications/{applicationId}/offers', methods: [Request::METHOD_POST])]
+    public function __invoke(string $applicationSlug, string $applicationId, Request $request, User $loggedInUser): JsonResponse
+    {
+        $request->attributes->set('applicationSlug', $applicationSlug);
+        $application = $this->applicationRepository->find($applicationId);
+
+        if ($application === null) {
+            throw new NotFoundHttpException('Application not found.');
+        }
+
+        if ($application->getJob()->getOwner()?->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You are not allowed to manage offers for this application.');
+        }
+
+        /** @var array<string,mixed> $payload */
+        $payload = $request->toArray();
+        $offer = $this->offerWorkflowService->create($application, $payload, $loggedInUser);
+        $this->offerRepository->save($offer);
+        $this->applicationRepository->save($application);
+
+        return new JsonResponse($this->normalize($offer), JsonResponse::HTTP_CREATED);
+    }
+
+    /** @return array<string,mixed> */
+    private function normalize(\App\Recruit\Domain\Entity\Offer $offer): array
+    {
+        return [
+            'id' => $offer->getId(),
+            'applicationId' => $offer->getApplication()->getId(),
+            'salaryProposed' => $offer->getSalaryProposed(),
+            'startDate' => $offer->getStartDate()->format('Y-m-d'),
+            'contractType' => $offer->getContractType()->value,
+            'status' => $offer->getStatus()->value,
+        ];
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Offer/OfferStatusUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Offer/OfferStatusUpdateController.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Offer;
+
+use App\Recruit\Application\Service\OfferWorkflowService;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Infrastructure\Repository\OfferRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_string;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Offer')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class OfferStatusUpdateController
+{
+    public function __construct(
+        private OfferRepository $offerRepository,
+        private ApplicationRepository $applicationRepository,
+        private OfferWorkflowService $offerWorkflowService,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/applications/{applicationSlug}/private/offers/{offerId}/send', methods: [Request::METHOD_POST])]
+    public function send(string $applicationSlug, string $offerId, Request $request, User $loggedInUser): JsonResponse
+    {
+        return $this->apply($applicationSlug, $offerId, $request, $loggedInUser, 'send');
+    }
+
+    #[Route(path: '/v1/recruit/applications/{applicationSlug}/private/offers/{offerId}/accept', methods: [Request::METHOD_POST])]
+    public function accept(string $applicationSlug, string $offerId, Request $request, User $loggedInUser): JsonResponse
+    {
+        return $this->apply($applicationSlug, $offerId, $request, $loggedInUser, 'accept');
+    }
+
+    #[Route(path: '/v1/recruit/applications/{applicationSlug}/private/offers/{offerId}/decline', methods: [Request::METHOD_POST])]
+    public function decline(string $applicationSlug, string $offerId, Request $request, User $loggedInUser): JsonResponse
+    {
+        return $this->apply($applicationSlug, $offerId, $request, $loggedInUser, 'decline');
+    }
+
+    #[Route(path: '/v1/recruit/applications/{applicationSlug}/private/offers/{offerId}/withdraw', methods: [Request::METHOD_POST])]
+    public function withdraw(string $applicationSlug, string $offerId, Request $request, User $loggedInUser): JsonResponse
+    {
+        return $this->apply($applicationSlug, $offerId, $request, $loggedInUser, 'withdraw');
+    }
+
+    private function apply(string $applicationSlug, string $offerId, Request $request, User $loggedInUser, string $action): JsonResponse
+    {
+        $request->attributes->set('applicationSlug', $applicationSlug);
+        $offer = $this->offerRepository->find($offerId);
+
+        if ($offer === null) {
+            throw new NotFoundHttpException('Offer not found.');
+        }
+
+        if ($offer->getApplication()->getJob()->getOwner()?->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You are not allowed to manage this offer.');
+        }
+
+        /** @var array<string,mixed> $payload */
+        $payload = $request->toArray();
+        $comment = is_string($payload['comment'] ?? null) ? $payload['comment'] : null;
+
+        match ($action) {
+            'send' => $this->offerWorkflowService->send($offer, $loggedInUser, $comment),
+            'accept' => $this->offerWorkflowService->accept($offer, $loggedInUser, $comment),
+            'decline' => $this->offerWorkflowService->decline($offer, $loggedInUser, $comment),
+            default => $this->offerWorkflowService->withdraw($offer, $loggedInUser, $comment),
+        };
+
+        $this->offerRepository->save($offer);
+        $this->applicationRepository->save($offer->getApplication());
+
+        return new JsonResponse([
+            'id' => $offer->getId(),
+            'status' => $offer->getStatus()->value,
+            'applicationStatus' => $offer->getApplication()->getStatus()->value,
+        ]);
+    }
+}

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Offer/OfferWorkflowControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Offer/OfferWorkflowControllerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Offer;
+
+use App\General\Domain\Utils\JSON;
+use App\Recruit\Domain\Entity\Application as RecruitApplication;
+use App\Recruit\Domain\Entity\Offer;
+use App\Recruit\Domain\Entity\OfferStatusHistory;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Recruit\Domain\Enum\ContractType;
+use App\Recruit\Domain\Enum\OfferStatus;
+use App\Tests\TestCase\WebTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+class OfferWorkflowControllerTest extends WebTestCase
+{
+    #[TestDox('Test offer send then accept transitions offer and application statuses and audit logs.')]
+    public function testSendThenAcceptTransitions(): void
+    {
+        $application = $this->prepareApplication();
+        $client = $this->getTestClient('john-root', 'password-root');
+        $baseUrl = self::API_URL_PREFIX . '/v1/recruit/applications/recruit-talent-core';
+
+        $client->request('POST', $baseUrl . '/private/applications/' . $application->getId() . '/offers', content: JSON::encode([
+            'salaryProposed' => 65000,
+            'startDate' => '2026-05-01',
+            'contractType' => ContractType::CDI->value,
+            'comment' => 'Création offre',
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode(), (string) $client->getResponse());
+
+        /** @var array<string,mixed> $created */
+        $created = JSON::decode((string) $client->getResponse()->getContent());
+
+        $client->request('POST', $baseUrl . '/private/offers/' . $created['id'] . '/send', content: JSON::encode([
+            'comment' => 'Envoi candidat',
+        ]));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode(), (string) $client->getResponse());
+
+        $client->request('POST', $baseUrl . '/private/offers/' . $created['id'] . '/accept', content: JSON::encode([
+            'comment' => 'Acceptée',
+        ]));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode(), (string) $client->getResponse());
+
+        self::bootKernel();
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $offer = $entityManager->getRepository(Offer::class)->find($created['id']);
+        self::assertInstanceOf(Offer::class, $offer);
+        self::assertSame(OfferStatus::ACCEPTED, $offer->getStatus());
+        self::assertSame(ApplicationStatus::HIRED, $offer->getApplication()->getStatus());
+
+        $history = $entityManager->getRepository(OfferStatusHistory::class)->findBy(['offer' => $offer], ['createdAt' => 'ASC']);
+        self::assertCount(3, $history);
+        self::assertSame('CREATED', $history[0]->getAction());
+        self::assertSame('SENT', $history[1]->getAction());
+        self::assertSame('ACCEPTED', $history[2]->getAction());
+    }
+
+    #[TestDox('Test offer send then decline moves application status to REJECTED.')]
+    public function testSendThenDeclineTransitions(): void
+    {
+        $application = $this->prepareApplication();
+        $client = $this->getTestClient('john-root', 'password-root');
+        $baseUrl = self::API_URL_PREFIX . '/v1/recruit/applications/recruit-talent-core';
+
+        $client->request('POST', $baseUrl . '/private/applications/' . $application->getId() . '/offers', content: JSON::encode([
+            'salaryProposed' => 50000,
+            'startDate' => '2026-06-15',
+            'contractType' => ContractType::CDD->value,
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+        /** @var array<string,mixed> $created */
+        $created = JSON::decode((string) $client->getResponse()->getContent());
+
+        $client->request('POST', $baseUrl . '/private/offers/' . $created['id'] . '/send');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request('POST', $baseUrl . '/private/offers/' . $created['id'] . '/decline');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        self::bootKernel();
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $offer = $entityManager->getRepository(Offer::class)->find($created['id']);
+        self::assertInstanceOf(Offer::class, $offer);
+        self::assertSame(OfferStatus::DECLINED, $offer->getStatus());
+        self::assertSame(ApplicationStatus::REJECTED, $offer->getApplication()->getStatus());
+    }
+
+    #[TestDox('Test offer withdraw is allowed from DRAFT and logs audit action.')]
+    public function testWithdrawFromDraft(): void
+    {
+        $application = $this->prepareApplication();
+        $client = $this->getTestClient('john-root', 'password-root');
+        $baseUrl = self::API_URL_PREFIX . '/v1/recruit/applications/recruit-talent-core';
+
+        $client->request('POST', $baseUrl . '/private/applications/' . $application->getId() . '/offers', content: JSON::encode([
+            'salaryProposed' => 58000,
+            'startDate' => '2026-07-01',
+            'contractType' => ContractType::FREELANCE->value,
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        /** @var array<string,mixed> $created */
+        $created = JSON::decode((string) $client->getResponse()->getContent());
+
+        $client->request('POST', $baseUrl . '/private/offers/' . $created['id'] . '/withdraw', content: JSON::encode([
+            'comment' => 'Retrait',
+        ]));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        self::bootKernel();
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $offer = $entityManager->getRepository(Offer::class)->find($created['id']);
+        self::assertInstanceOf(Offer::class, $offer);
+        self::assertSame(OfferStatus::WITHDRAWN, $offer->getStatus());
+
+        $history = $entityManager->getRepository(OfferStatusHistory::class)->findBy(['offer' => $offer], ['createdAt' => 'DESC']);
+        self::assertNotEmpty($history);
+        self::assertSame('WITHDRAWN', $history[0]->getAction());
+    }
+
+    private function prepareApplication(): RecruitApplication
+    {
+        self::bootKernel();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $application = $entityManager->getRepository(RecruitApplication::class)->findOneBy([
+            'status' => ApplicationStatus::INTERVIEW_DONE,
+        ]);
+
+        if (!$application instanceof RecruitApplication) {
+            $application = $entityManager->getRepository(RecruitApplication::class)->findOneBy([
+                'status' => ApplicationStatus::WAITING,
+            ]);
+        }
+
+        self::assertInstanceOf(RecruitApplication::class, $application);
+        self::assertSame('john-root', $application->getJob()->getOwner()?->getUsername());
+        $application->setStatus(ApplicationStatus::INTERVIEW_DONE);
+        $entityManager->flush();
+
+        return $application;
+    }
+}


### PR DESCRIPTION
### Motivation
- Support recruiter workflows by adding an `Offer` linked to an `Application` so recruiters can propose, send, accept, decline or withdraw offers and update application lifecycle accordingly.
- Ensure all offer actions are auditable for traceability and compliance.
- Provide API endpoints to manage offers from the application context.
- Add integration tests to validate the important offer transition scenarios and audit logging.

### Description
- Add domain model and persistence: `Offer` entity, `OfferStatus` enum and `OfferStatusHistory` audit entity, plus corresponding repository interfaces and repository implementations, and update `Application` to reference `offers`.
- Implement `OfferWorkflowService` to handle `create`, `send`, `accept`, `decline`, and `withdraw` transitions with validation, allowed-transition rules and sanitised audit `action` strings, and to update `Application` status (`OFFER_SENT -> HIRED` on accept, `OFFER_SENT -> REJECTED` on decline) while persisting application status history entries.
- Add controllers exposing endpoints `POST /v1/recruit/applications/{applicationSlug}/private/applications/{applicationId}/offers` and `POST /v1/recruit/applications/{applicationSlug}/private/offers/{offerId}/{send|accept|decline|withdraw}` to create and apply transitions.
- Add a migration `Version20260314143000` to create `recruit_offer` and `recruit_offer_status_history` tables and add integration tests covering send+accept, send+decline and withdraw scenarios plus audit assertions in `tests/Application/Recruit/Transport/Controller/Api/V1/Offer/OfferWorkflowControllerTest.php`.

### Testing
- Ran `php -l` (syntax check) on all modified and newly added PHP files and there were no syntax errors.
- Added integration tests covering offer lifecycle and audit checks in `tests/.../OfferWorkflowControllerTest.php` but these are new files only (not executed as part of this run).
- Attempted to run `./vendor/bin/phpunit tests/Application/Recruit/Transport/Controller/Api/V1/Offer/OfferWorkflowControllerTest.php` but the environment is missing PHPUnit binaries (`vendor/bin/phpunit` not found), so full test execution could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b526250c8326a7067991dc17c933)