### PR TITLE
feat(recruit): add role-based recruit permissions and sensitive data guards

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -44,7 +44,10 @@ security:
     role_hierarchy:
         ROLE_API: [ROLE_LOGGED]
         ROLE_USER: [ROLE_LOGGED]
-        ROLE_ADMIN: [ROLE_USER]
+        ROLE_INTERVIEWER: [ROLE_USER]
+        ROLE_RECRUITER: [ROLE_INTERVIEWER]
+        ROLE_HIRING_MANAGER: [ROLE_INTERVIEWER]
+        ROLE_ADMIN: [ROLE_USER, ROLE_RECRUITER, ROLE_HIRING_MANAGER]
         ROLE_ROOT: [ROLE_ADMIN]
 
     access_decision_manager:

--- a/docs/recruit.md
+++ b/docs/recruit.md
@@ -399,3 +399,42 @@ Retourne:
 - `byContractType`
 - `byWorkMode`
 - `byExperienceLevel`
+
+---
+
+## 6) Matrice des permissions métier (RBAC recrutement)
+
+Rôles métier introduits:
+- `ROLE_RECRUITER`
+- `ROLE_HIRING_MANAGER`
+- `ROLE_INTERVIEWER`
+
+Permissions fonctionnelles:
+- `RECRUIT_INTERVIEW_MANAGE`
+- `RECRUIT_INTERVIEW_VIEW`
+- `RECRUIT_APPLICATION_STATUS_TRANSITION`
+- `RECRUIT_APPLICATION_STATUS_HISTORY_VIEW`
+- `RECRUIT_OFFER_MANAGE`
+- `RECRUIT_SENSITIVE_DATA_VIEW`
+
+### Matrice d'accès
+
+| Endpoint clé | Permission requise | RECRUITER | HIRING_MANAGER | INTERVIEWER |
+|---|---|---:|---:|---:|
+| `POST/PATCH/DELETE /v1/recruit/private/interviews/...` | `RECRUIT_INTERVIEW_MANAGE` | ✅ | ✅ | ❌ |
+| `GET /v1/recruit/private/applications/{id}/interviews` | `RECRUIT_INTERVIEW_VIEW` | ✅ | ✅ | ✅ |
+| `PATCH /v1/recruit/applications/{slug}/private/applications/{id}/status` | `RECRUIT_APPLICATION_STATUS_TRANSITION` | ✅ | ✅ | ❌ |
+| `GET /v1/recruit/applications/{slug}/private/applications/{id}/status-history` | `RECRUIT_APPLICATION_STATUS_HISTORY_VIEW` | ✅ | ✅ | ✅ |
+| `POST/PATCH/DELETE /v1/recruit/applications/{slug}/jobs/...` (offers) | `RECRUIT_OFFER_MANAGE` | ✅ | ✅ | ❌ |
+| Lecture de données sensibles (`CV`, `notes`, `feedback/comment`) | `RECRUIT_SENSITIVE_DATA_VIEW` | ✅ | ✅ | ❌ |
+
+### Règles de confidentialité appliquées
+
+- Les champs sensibles sont masqués (`null`) lorsque l'utilisateur n'a pas `RECRUIT_SENSITIVE_DATA_VIEW`.
+- Sont considérés sensibles dans le module Recruit:
+  - le CV (référence de resume),
+  - les notes internes d'entretien,
+  - les commentaires d'historique de statut (feedback interne),
+  - les données personnelles non nécessaires (`email`, `coverLetter`).
+
+> `ROLE_ADMIN` et `ROLE_ROOT` gardent un accès complet (override) via le voter Recruit.

--- a/src/Recruit/Application/Security/RecruitPermissions.php
+++ b/src/Recruit/Application/Security/RecruitPermissions.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Security;
+
+final class RecruitPermissions
+{
+    public const string INTERVIEW_MANAGE = 'RECRUIT_INTERVIEW_MANAGE';
+    public const string INTERVIEW_VIEW = 'RECRUIT_INTERVIEW_VIEW';
+    public const string APPLICATION_STATUS_TRANSITION = 'RECRUIT_APPLICATION_STATUS_TRANSITION';
+    public const string APPLICATION_STATUS_HISTORY_VIEW = 'RECRUIT_APPLICATION_STATUS_HISTORY_VIEW';
+    public const string OFFER_MANAGE = 'RECRUIT_OFFER_MANAGE';
+    public const string SENSITIVE_DATA_VIEW = 'RECRUIT_SENSITIVE_DATA_VIEW';
+}

--- a/src/Recruit/Application/Security/Voter/RecruitPermissionVoter.php
+++ b/src/Recruit/Application/Security/Voter/RecruitPermissionVoter.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Security\Voter;
+
+use App\Recruit\Application\Security\RecruitPermissions;
+use App\User\Domain\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+use function in_array;
+
+class RecruitPermissionVoter extends Voter
+{
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        return in_array($attribute, [
+            RecruitPermissions::INTERVIEW_MANAGE,
+            RecruitPermissions::INTERVIEW_VIEW,
+            RecruitPermissions::APPLICATION_STATUS_TRANSITION,
+            RecruitPermissions::APPLICATION_STATUS_HISTORY_VIEW,
+            RecruitPermissions::OFFER_MANAGE,
+            RecruitPermissions::SENSITIVE_DATA_VIEW,
+        ], true);
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+        if (!$user instanceof User) {
+            return false;
+        }
+
+        $roles = $user->getRoles();
+        if (in_array('ROLE_ROOT', $roles, true) || in_array('ROLE_ADMIN', $roles, true)) {
+            return true;
+        }
+
+        return match ($attribute) {
+            RecruitPermissions::INTERVIEW_MANAGE => in_array('ROLE_RECRUITER', $roles, true) || in_array('ROLE_HIRING_MANAGER', $roles, true),
+            RecruitPermissions::INTERVIEW_VIEW => in_array('ROLE_RECRUITER', $roles, true) || in_array('ROLE_HIRING_MANAGER', $roles, true) || in_array('ROLE_INTERVIEWER', $roles, true),
+            RecruitPermissions::APPLICATION_STATUS_TRANSITION => in_array('ROLE_RECRUITER', $roles, true) || in_array('ROLE_HIRING_MANAGER', $roles, true),
+            RecruitPermissions::APPLICATION_STATUS_HISTORY_VIEW => in_array('ROLE_RECRUITER', $roles, true) || in_array('ROLE_HIRING_MANAGER', $roles, true) || in_array('ROLE_INTERVIEWER', $roles, true),
+            RecruitPermissions::OFFER_MANAGE => in_array('ROLE_RECRUITER', $roles, true) || in_array('ROLE_HIRING_MANAGER', $roles, true),
+            RecruitPermissions::SENSITIVE_DATA_VIEW => in_array('ROLE_RECRUITER', $roles, true) || in_array('ROLE_HIRING_MANAGER', $roles, true),
+            default => false,
+        };
+    }
+}

--- a/src/Recruit/Application/Service/JobApplicationListService.php
+++ b/src/Recruit/Application/Service/JobApplicationListService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Application\Service;
 
+use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Domain\Entity\Application;
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Infrastructure\Repository\JobRepository;
@@ -13,6 +14,7 @@ use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 use function array_map;
 use function is_string;
@@ -21,8 +23,9 @@ use function trim;
 readonly class JobApplicationListService
 {
     public function __construct(
-        private JobRepository          $jobRepository,
+        private JobRepository $jobRepository,
         private EntityManagerInterface $entityManager,
+        private AuthorizationCheckerInterface $authorizationChecker,
     ) {
     }
 
@@ -33,6 +36,7 @@ readonly class JobApplicationListService
     {
         $job = $this->resolveJob($jobId, $jobSlug);
         $this->assertJobOwnership($job, $loggedInUser);
+        $canViewSensitiveData = $this->authorizationChecker->isGranted(RecruitPermissions::SENSITIVE_DATA_VIEW);
 
         /** @var list<Application> $applications */
         $applications = $this->entityManager
@@ -48,7 +52,7 @@ readonly class JobApplicationListService
             ->getQuery()
             ->getResult();
 
-        return array_map(static function (Application $application): array {
+        return array_map(static function (Application $application) use ($canViewSensitiveData): array {
             $applicant = $application->getApplicant();
             $applicantUser = $applicant->getUser();
 
@@ -58,16 +62,16 @@ readonly class JobApplicationListService
                 'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
                 'applicant' => [
                     'id' => $applicant->getId(),
-                    'coverLetter' => $applicant->getCoverLetter(),
+                    'coverLetter' => $canViewSensitiveData ? $applicant->getCoverLetter() : null,
                     'user' => [
                         'id' => $applicantUser->getId(),
                         'username' => $applicantUser->getUsername(),
                         'firstName' => $applicantUser->getFirstName(),
                         'lastName' => $applicantUser->getLastName(),
-                        'email' => $applicantUser->getEmail(),
+                        'email' => $canViewSensitiveData ? $applicantUser->getEmail() : null,
                     ],
                     'resume' => [
-                        'id' => $applicant->getResume()?->getId(),
+                        'id' => $canViewSensitiveData ? $applicant->getResume()?->getId() : null,
                     ],
                 ],
             ];

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusHistoryListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusHistoryListController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\Application;
 
+use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Domain\Entity\ApplicationStatusHistory;
 use App\Recruit\Infrastructure\Repository\ApplicationRepository;
 use App\Recruit\Infrastructure\Repository\ApplicationStatusHistoryRepository;
@@ -15,17 +16,20 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
 #[OA\Tag(name: 'Recruit Application')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::APPLICATION_STATUS_HISTORY_VIEW)]
 readonly class ApplicationStatusHistoryListController
 {
     public function __construct(
         private ApplicationRepository $applicationRepository,
         private ApplicationStatusHistoryRepository $applicationStatusHistoryRepository,
+        private AuthorizationCheckerInterface $authorizationChecker,
     ) {
     }
 
@@ -45,6 +49,7 @@ readonly class ApplicationStatusHistoryListController
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You are not allowed to view the status history for this application.');
         }
 
+        $canViewSensitiveData = $this->authorizationChecker->isGranted(RecruitPermissions::SENSITIVE_DATA_VIEW);
         $historyEntries = $this->applicationStatusHistoryRepository->findBy([
             'application' => $application,
         ], [
@@ -52,12 +57,12 @@ readonly class ApplicationStatusHistoryListController
         ]);
 
         return new JsonResponse(array_map(
-            static fn (ApplicationStatusHistory $history): array => [
+            fn (ApplicationStatusHistory $history): array => [
                 'id' => $history->getId(),
                 'fromStatus' => $history->getFromStatus()->value,
                 'toStatus' => $history->getToStatus()->value,
-                'authorId' => $history->getAuthor()->getId(),
-                'comment' => $history->getComment(),
+                'authorId' => $canViewSensitiveData ? $history->getAuthor()->getId() : null,
+                'comment' => $canViewSensitiveData ? $history->getComment() : null,
                 'createdAt' => $history->getCreatedAt()?->format(DATE_ATOM),
             ],
             $historyEntries,

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\Application;
 
+use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Application\Service\ApplicationStatusTransitionService;
 use App\Recruit\Infrastructure\Repository\ApplicationRepository;
 use App\User\Domain\Entity\User;
@@ -24,6 +25,7 @@ use function is_string;
 #[AsController]
 #[OA\Tag(name: 'Recruit Application')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::APPLICATION_STATUS_TRANSITION)]
 readonly class ApplicationStatusUpdateController
 {
     public function __construct(

--- a/src/Recruit/Transport/Controller/Api/V1/Application/JobApplicationListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/JobApplicationListController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\Application;
 
+use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Application\Service\JobApplicationListService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
@@ -17,6 +18,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[AsController]
 #[OA\Tag(name: 'Recruit Application')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::INTERVIEW_VIEW)]
 readonly class JobApplicationListController
 {
     public function __construct(

--- a/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewCreateController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\Interview;
 
+use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Application\Service\InterviewService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
@@ -17,6 +18,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[AsController]
 #[OA\Tag(name: 'Recruit Interview')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::INTERVIEW_MANAGE)]
 readonly class InterviewCreateController
 {
     public function __construct(private InterviewService $interviewService)

--- a/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewDeleteController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewDeleteController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\Interview;
 
+use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Application\Service\InterviewService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
@@ -17,6 +18,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[AsController]
 #[OA\Tag(name: 'Recruit Interview')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::INTERVIEW_MANAGE)]
 readonly class InterviewDeleteController
 {
     public function __construct(private InterviewService $interviewService)

--- a/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewListController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewListController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\Interview;
 
+use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Application\Service\InterviewService;
 use App\Recruit\Domain\Entity\Interview;
 use App\User\Domain\Entity\User;
@@ -13,6 +14,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 use function array_map;
@@ -20,18 +22,22 @@ use function array_map;
 #[AsController]
 #[OA\Tag(name: 'Recruit Interview')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::INTERVIEW_VIEW)]
 readonly class InterviewListController
 {
-    public function __construct(private InterviewService $interviewService)
-    {
+    public function __construct(
+        private InterviewService $interviewService,
+        private AuthorizationCheckerInterface $authorizationChecker,
+    ) {
     }
 
     #[Route(path: '/v1/recruit/private/applications/{applicationId}/interviews', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationId, User $loggedInUser): JsonResponse
     {
         $items = $this->interviewService->listByApplication($applicationId, $loggedInUser);
+        $canViewSensitiveData = $this->authorizationChecker->isGranted(RecruitPermissions::SENSITIVE_DATA_VIEW);
 
-        return new JsonResponse(array_map(static fn (Interview $interview): array => [
+        return new JsonResponse(array_map(fn (Interview $interview): array => [
             'id' => $interview->getId(),
             'scheduledAt' => $interview->getScheduledAt()->format(DATE_ATOM),
             'durationMinutes' => $interview->getDurationMinutes(),
@@ -39,7 +45,7 @@ readonly class InterviewListController
             'locationOrUrl' => $interview->getLocationOrUrl(),
             'interviewerIds' => $interview->getInterviewerIds(),
             'status' => $interview->getStatus()->value,
-            'notes' => $interview->getNotes(),
+            'notes' => $canViewSensitiveData ? $interview->getNotes() : null,
         ], $items));
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewPatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Interview/InterviewPatchController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\Interview;
 
+use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Application\Service\InterviewService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
@@ -17,6 +18,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[AsController]
 #[OA\Tag(name: 'Recruit Interview')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::INTERVIEW_MANAGE)]
 readonly class InterviewPatchController
 {
     public function __construct(private InterviewService $interviewService)

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Recruit\Transport\Controller\Api\V1\Job;
 
 use App\General\Application\Message\EntityCreated;
+use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Application\Service\ApplicationJobAccessService;
 use App\Recruit\Application\Service\JobPayloadHydratorService;
 use App\Recruit\Domain\Entity\Job;
@@ -29,6 +30,7 @@ use function trim;
 #[AsController]
 #[OA\Tag(name: 'Recruit Job')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::OFFER_MANAGE)]
 readonly class JobCreateFromApplicationController
 {
     public function __construct(

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobDeleteFromApplicationController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Recruit\Transport\Controller\Api\V1\Job;
 
 use App\General\Application\Message\EntityDeleted;
+use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Application\Service\ApplicationJobAccessService;
 use App\Recruit\Infrastructure\Repository\JobRepository;
 use App\User\Domain\Entity\User;
@@ -20,6 +21,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[AsController]
 #[OA\Tag(name: 'Recruit Job')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::OFFER_MANAGE)]
 readonly class JobDeleteFromApplicationController
 {
     public function __construct(

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Recruit\Transport\Controller\Api\V1\Job;
 
 use App\General\Application\Message\EntityPatched;
+use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Application\Service\ApplicationJobAccessService;
 use App\Recruit\Application\Service\JobPayloadHydratorService;
 use App\Recruit\Infrastructure\Repository\JobRepository;
@@ -21,6 +22,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[AsController]
 #[OA\Tag(name: 'Recruit Job')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::OFFER_MANAGE)]
 readonly class JobPatchFromApplicationController
 {
     public function __construct(

--- a/src/Role/Domain/Enum/Role.php
+++ b/src/Role/Domain/Enum/Role.php
@@ -16,6 +16,9 @@ enum Role: string
     case ADMIN = 'ROLE_ADMIN';
     case ROOT = 'ROLE_ROOT';
     case API = 'ROLE_API';
+    case RECRUITER = 'ROLE_RECRUITER';
+    case HIRING_MANAGER = 'ROLE_HIRING_MANAGER';
+    case INTERVIEWER = 'ROLE_INTERVIEWER';
 
     public function label(): string
     {
@@ -25,6 +28,9 @@ enum Role: string
             self::ADMIN => 'Admin users',
             self::ROOT => 'Root users',
             self::API => 'API users',
+            self::RECRUITER => 'Recruiters',
+            self::HIRING_MANAGER => 'Hiring managers',
+            self::INTERVIEWER => 'Interviewers',
         };
     }
 }

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationStatusUpdateControllerTest.php
@@ -101,6 +101,23 @@ class ApplicationStatusUpdateControllerTest extends WebTestCase
         self::assertCount(2, $participants);
     }
 
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Status transition endpoint is forbidden for ROLE_USER.')]
+    public function testThatStatusTransitionEndpointIsForbiddenForRegularRole(): void
+    {
+        [$recruitApplication] = $this->prepareApplicationForScreeningTransition();
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request('PATCH', self::API_URL_PREFIX . '/v1/recruit/applications/recruit-talent-core/private/applications/' . $recruitApplication->getId() . '/status', content: JSON::encode([
+            'status' => ApplicationStatus::SCREENING->value,
+        ]));
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $client->getResponse()->getStatusCode());
+    }
+
     /**
      * @throws Throwable
      */

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Interview/PrivateInterviewControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Interview/PrivateInterviewControllerTest.php
@@ -104,6 +104,18 @@ class PrivateInterviewControllerTest extends WebTestCase
         self::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
     }
 
+    /** @throws Throwable */
+    #[TestDox('Interview endpoints are forbidden for ROLE_USER.')]
+    public function testInterviewListIsForbiddenForRegularUserRole(): void
+    {
+        [$applicationId] = $this->createDedicatedInterview('john-root');
+
+        $client = $this->getTestClient('john-user', 'password-user');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/private/applications/' . $applicationId . '/interviews');
+
+        self::assertSame(Response::HTTP_FORBIDDEN, $client->getResponse()->getStatusCode());
+    }
+
     /**
      * @return array{0: string, 1?: string}
      */


### PR DESCRIPTION
### Motivation
- Introduire des rôles métier (`RECRUITER`, `HIRING_MANAGER`, `INTERVIEWER`) et des permissions métier pour sécuriser les endpoints Recruit (interviews, feedbacks, status transitions, offers) et protéger les données sensibles (CV, notes internes, feedbacks). 
- Appliquer une matrice RBAC et masquer les champs sensibles pour les rôles qui n'ont pas le droit de lecture.

### Description
- Ajout des rôles métier dans l'énumération `Role` et branchement dans la hiérarchie Symfony via `config/packages/security.yaml` (`ROLE_RECRUITER`, `ROLE_HIRING_MANAGER`, `ROLE_INTERVIEWER`).
- Nouveau fichier `RecruitPermissions` définissant les constantes de permission et nouveau voter `RecruitPermissionVoter` qui centralise les règles d'accès (override pour `ROLE_ADMIN`/`ROLE_ROOT`).
- Protection par guards `#[IsGranted(...)]` ajoutée sur les endpoints clés : interviews (create/patch/delete/list), status transition/history, offers (create/patch/delete), et listing des candidatures d'un job. 
- Masquage des données sensibles lorsque l'utilisateur n'a pas `RECRUIT_SENSITIVE_DATA_VIEW` : notes d'entretien, `authorId`/`comment` dans l'historique de statut, et `coverLetter`/`email`/`resume id` dans la liste des candidatures (implémenté dans les contrôleurs et `JobApplicationListService`).
- Ajout de tests d'intégration ciblés vérifiant que les endpoints sensibles renvoient `403 Forbidden` pour un utilisateur standard (`ROLE_USER`).
- Documentation mise à jour avec la matrice de permissions et les règles de confidentialité dans `docs/recruit.md`.

### Testing
- Syntax-check PHP des fichiers modifiés avec `php -l` (tous les fichiers PHP modifiés sont passés sans erreur).
- Vérification rapide de syntaxe sur tous les fichiers PHP modifiés: `for f in $(git status --short | awk '{print $2}' | rg '\.php$'); do php -l "$f" >/dev/null || exit 1; done; echo OK` (retour `OK`).
- Exécution de `php bin/phpunit ...` et `php bin/console lint:container` impossible dans cet environnement car les dépendances ne sont pas installées (`vendor/` / `bin/phpunit` absents), ces checks sont donc signalés comme non exécutés ici.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b52ae698832686529541b4b605ec)