### PR TITLE
Fix School cache invalidation scoping and add cache regression tests

### DIFF
--- a/src/General/Application/MessageHandler/EntityProjectionHandler.php
+++ b/src/General/Application/MessageHandler/EntityProjectionHandler.php
@@ -117,7 +117,7 @@ final readonly class EntityProjectionHandler
             || $message->entityType === self::SCHOOL_STUDENT
             || $message->entityType === self::SCHOOL_GRADE
         ) {
-            $this->projectSchoolSupportEntities();
+            $this->projectSchoolSupportEntities($message);
         }
     }
 
@@ -256,8 +256,10 @@ final readonly class EntityProjectionHandler
     private function projectSchoolExam(EntityMutationMessage $message): void
     {
         if ($message instanceof EntityDeleted) {
+            $applicationSlug = isset($message->context['applicationSlug']) ? (string)$message->context['applicationSlug'] : null;
             $this->elasticsearchService->delete(SchoolExamProjection::INDEX_NAME, $message->entityId);
-            $this->cacheInvalidationService->invalidateSchoolExamListCaches(isset($message->context['applicationSlug']) ? (string)$message->context['applicationSlug'] : null);
+            $this->cacheInvalidationService->invalidateSchoolExamListCaches($applicationSlug);
+            $this->cacheInvalidationService->invalidateSchoolClassListCaches($applicationSlug);
 
             return;
         }
@@ -278,6 +280,10 @@ final readonly class EntityProjectionHandler
 
         $applicationSlug = $exam->getSchoolClass()?->getSchool()?->getApplication()?->getSlug();
         $this->cacheInvalidationService->invalidateSchoolExamListCaches($applicationSlug);
+
+        if ($exam->getSchoolClass() !== null) {
+            $this->cacheInvalidationService->invalidateSchoolClassListCaches($applicationSlug);
+        }
     }
 
     private function projectShopCatalog(): void
@@ -290,8 +296,11 @@ final readonly class EntityProjectionHandler
         $this->cacheInvalidationService->invalidateCrmTaskListCaches();
     }
 
-    private function projectSchoolSupportEntities(): void
+    private function projectSchoolSupportEntities(EntityMutationMessage $message): void
     {
-        $this->cacheInvalidationService->invalidateSchoolExamListCaches(null);
+        $applicationSlug = isset($message->context['applicationSlug']) ? (string)$message->context['applicationSlug'] : null;
+
+        $this->cacheInvalidationService->invalidateSchoolExamListCaches($applicationSlug);
+        $this->cacheInvalidationService->invalidateSchoolClassListCaches($applicationSlug);
     }
 }

--- a/src/General/Application/Service/CacheInvalidationService.php
+++ b/src/General/Application/Service/CacheInvalidationService.php
@@ -81,6 +81,21 @@ class CacheInvalidationService
         }
     }
 
+    public function invalidateSchoolClassListCaches(?string $applicationSlug = null): void
+    {
+        if ($applicationSlug === null || $applicationSlug === '') {
+            return;
+        }
+
+        if ($this->cache instanceof TagAwareCacheInterface) {
+            $this->cache->invalidateTags([$this->cacheKeyConventionService->schoolClassListByApplicationTag($applicationSlug)]);
+        }
+
+        $this->cache->delete($this->cacheKeyConventionService->buildSchoolClassApplicationListKey($applicationSlug, 1, 20, [
+            'q' => '',
+        ]));
+    }
+
     public function invalidateRecruitJobListCaches(string $applicationSlug): void
     {
         if ($this->cache instanceof TagAwareCacheInterface) {

--- a/src/School/Application/Service/CreateClassService.php
+++ b/src/School/Application/Service/CreateClassService.php
@@ -37,7 +37,10 @@ final readonly class CreateClassService
 
         $this->entityManager->persist($class);
         $this->entityManager->flush();
-        $this->messageBus->dispatch(new EntityCreated('school_class', $class->getId()));
+        $applicationSlug = $school->getApplication()?->getSlug();
+        $this->messageBus->dispatch(new EntityCreated('school_class', $class->getId(), context: [
+            'applicationSlug' => $applicationSlug,
+        ]));
 
         return $class;
     }

--- a/src/School/Application/Service/DeleteClassService.php
+++ b/src/School/Application/Service/DeleteClassService.php
@@ -28,9 +28,13 @@ final readonly class DeleteClassService
             return false;
         }
 
+        $applicationSlug = $class->getSchool()?->getApplication()?->getSlug();
+
         $this->entityManager->remove($class);
         $this->entityManager->flush();
-        $this->messageBus->dispatch(new EntityDeleted('school_class', $id));
+        $this->messageBus->dispatch(new EntityDeleted('school_class', $id, context: [
+            'applicationSlug' => $applicationSlug,
+        ]));
 
         return true;
     }

--- a/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
@@ -46,7 +46,9 @@ final readonly class PatchSchoolApplicationResourceController
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Resource not found in application scope.');
         }
         $this->resourcePatchService->patch($entity, $resource, $request->toArray());
-        $this->messageBus->dispatch(new EntityPatched('school_' . substr($resource, 0, -1), $id));
+        $this->messageBus->dispatch(new EntityPatched('school_' . substr($resource, 0, -1), $id, context: [
+            'applicationSlug' => $applicationSlug,
+        ]));
 
         return new JsonResponse($this->resourceViewService->map($entity));
     }

--- a/src/School/Transport/Controller/Api/V1/School/PatchSchoolResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/School/PatchSchoolResourceController.php
@@ -31,7 +31,9 @@ final readonly class PatchSchoolResourceController
         $request->attributes->set('applicationSlug', $applicationSlug);
         $entity = $this->resourceViewService->findOr404($resource, $id);
         $this->resourcePatchService->patch($entity, $resource, $request->toArray());
-        $this->messageBus->dispatch(new EntityPatched('school_' . substr($resource, 0, -1), $id));
+        $this->messageBus->dispatch(new EntityPatched('school_' . substr($resource, 0, -1), $id, context: [
+            'applicationSlug' => $applicationSlug,
+        ]));
 
         return new JsonResponse($this->resourceViewService->map($entity));
     }

--- a/tests/Unit/General/Application/MessageHandler/EntityProjectionHandlerSchoolCacheTest.php
+++ b/tests/Unit/General/Application/MessageHandler/EntityProjectionHandlerSchoolCacheTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\General\Application\MessageHandler;
+
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\General\Application\Message\EntityCreated;
+use App\General\Application\Message\EntityDeleted;
+use App\General\Application\Message\EntityPatched;
+use App\General\Application\MessageHandler\EntityProjectionHandler;
+use App\General\Application\Service\CacheInvalidationService;
+use App\General\Application\Service\CriticalViewWarmer;
+use App\General\Application\Service\MessageIdempotenceGuard;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Infrastructure\Repository\JobRepository;
+use App\School\Domain\Entity\Exam;
+use App\School\Domain\Entity\School;
+use App\School\Domain\Entity\SchoolClass;
+use App\School\Domain\Entity\Teacher;
+use App\School\Infrastructure\Repository\ExamRepository;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use PHPUnit\Framework\TestCase;
+
+final class EntityProjectionHandlerSchoolCacheTest extends TestCase
+{
+    public function testSchoolExamCreateInvalidatesExamAndClassCachesWithResolvedApplicationSlug(): void
+    {
+        $exam = $this->buildExamWithApplicationSlug('campus-alpha');
+
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+        $cacheInvalidationService->expects(self::once())
+            ->method('invalidateSchoolExamListCaches')
+            ->with('campus-alpha');
+        $cacheInvalidationService->expects(self::once())
+            ->method('invalidateSchoolClassListCaches')
+            ->with('campus-alpha');
+
+        $examRepository = $this->createMock(ExamRepository::class);
+        $examRepository->expects(self::once())->method('find')->with('exam-1')->willReturn($exam);
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $elastic->expects(self::once())->method('index');
+
+        $handler = $this->buildHandler(
+            examRepository: $examRepository,
+            cacheInvalidationService: $cacheInvalidationService,
+            elasticsearchService: $elastic,
+        );
+
+        $handler(new EntityCreated('school_exam', 'exam-1', 'evt_1', ['applicationSlug' => 'from-message']));
+    }
+
+    public function testSchoolExamDeleteInvalidatesExamAndClassCachesWithMessageContextSlug(): void
+    {
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+        $cacheInvalidationService->expects(self::once())
+            ->method('invalidateSchoolExamListCaches')
+            ->with('campus-beta');
+        $cacheInvalidationService->expects(self::once())
+            ->method('invalidateSchoolClassListCaches')
+            ->with('campus-beta');
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $elastic->expects(self::once())->method('delete');
+
+        $handler = $this->buildHandler(
+            cacheInvalidationService: $cacheInvalidationService,
+            elasticsearchService: $elastic,
+        );
+
+        $handler(new EntityDeleted('school_exam', 'exam-1', 'evt_2', ['applicationSlug' => 'campus-beta']));
+    }
+
+    public function testSchoolClassPatchInvalidatesOnlyScopedSchoolCaches(): void
+    {
+        $capturedExamSlugs = [];
+        $capturedClassSlugs = [];
+
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+        $cacheInvalidationService->expects(self::exactly(2))
+            ->method('invalidateSchoolExamListCaches')
+            ->willReturnCallback(static function (?string $applicationSlug) use (&$capturedExamSlugs): void {
+                $capturedExamSlugs[] = $applicationSlug;
+            });
+        $cacheInvalidationService->expects(self::exactly(2))
+            ->method('invalidateSchoolClassListCaches')
+            ->willReturnCallback(static function (?string $applicationSlug) use (&$capturedClassSlugs): void {
+                $capturedClassSlugs[] = $applicationSlug;
+            });
+
+        $handler = $this->buildHandler(cacheInvalidationService: $cacheInvalidationService);
+
+        $handler(new EntityPatched('school_class', 'class-1', 'evt_3', ['applicationSlug' => 'campus-alpha']));
+        $handler(new EntityPatched('school_class', 'class-2', 'evt_4', ['applicationSlug' => 'campus-beta']));
+
+        self::assertSame(['campus-alpha', 'campus-beta'], $capturedExamSlugs);
+        self::assertSame(['campus-alpha', 'campus-beta'], $capturedClassSlugs);
+    }
+
+    private function buildHandler(
+        ?ExamRepository $examRepository = null,
+        ?CacheInvalidationService $cacheInvalidationService = null,
+        ?ElasticsearchServiceInterface $elasticsearchService = null,
+    ): EntityProjectionHandler {
+        $guard = $this->createMock(MessageIdempotenceGuard::class);
+        $guard->method('shouldProcess')->willReturn(true);
+
+        return new EntityProjectionHandler(
+            $this->createMock(ApplicationRepository::class),
+            $this->createMock(JobRepository::class),
+            $this->createMock(ProductRepository::class),
+            $this->createMock(TaskRepository::class),
+            $examRepository ?? $this->createMock(ExamRepository::class),
+            $cacheInvalidationService ?? $this->createMock(CacheInvalidationService::class),
+            $this->createMock(CriticalViewWarmer::class),
+            $elasticsearchService ?? $this->createMock(ElasticsearchServiceInterface::class),
+            $guard,
+        );
+    }
+
+    private function buildExamWithApplicationSlug(string $applicationSlug): Exam
+    {
+        $application = (new Application())
+            ->setTitle(str_replace('-', ' ', $applicationSlug))
+            ->setDescription('Desc')
+            ->ensureGeneratedSlug();
+
+        $school = (new School())
+            ->setName('School')
+            ->setApplication($application);
+
+        $class = (new SchoolClass())
+            ->setName('Class A')
+            ->setSchool($school);
+
+        $teacher = (new Teacher())
+            ->setName('Teacher A');
+
+        return (new Exam())
+            ->setTitle('Exam A')
+            ->setSchoolClass($class)
+            ->setTeacher($teacher);
+    }
+}

--- a/tests/Unit/General/Application/Service/CacheInvalidationServiceTest.php
+++ b/tests/Unit/General/Application/Service/CacheInvalidationServiceTest.php
@@ -28,18 +28,86 @@ final class CacheInvalidationServiceTest extends TestCase
         $service->invalidateBlogCaches('my-app', ['actor', 'author', 'actor', '', null]);
     }
 
-    public function testInvalidateSchoolExamCachesByApplicationUsesScopedTag(): void
+    public function testInvalidateSchoolExamCachesByApplicationUsesScopedTagAndDefaultKey(): void
     {
+        $cacheKeyConventionService = new CacheKeyConventionService();
         $cache = $this->createMock(TagAwareCacheInterface::class);
         $cache->expects(self::once())
             ->method('invalidateTags')
             ->with(['cache_school_exam_list_school-campus-core']);
         $cache->expects(self::once())
             ->method('delete')
-            ->with(self::stringStartsWith('school_exam_list_'));
+            ->with($cacheKeyConventionService->buildSchoolExamListKey('school-campus-core', 1, 20, [
+                'q' => '',
+                'title' => '',
+            ]));
+
+        $service = new CacheInvalidationService($cache, $cacheKeyConventionService);
+
+        $service->invalidateSchoolExamListCaches('school-campus-core');
+    }
+
+    public function testInvalidateSchoolExamCachesWithoutApplicationUsesGlobalTagOnly(): void
+    {
+        $cache = $this->createMock(TagAwareCacheInterface::class);
+        $cache->expects(self::once())
+            ->method('invalidateTags')
+            ->with(['cache_school_exam_list']);
+        $cache->expects(self::never())->method('delete');
 
         $service = new CacheInvalidationService($cache, new CacheKeyConventionService());
 
-        $service->invalidateSchoolExamListCaches('school-campus-core');
+        $service->invalidateSchoolExamListCaches(null);
+    }
+
+    public function testInvalidateSchoolClassCachesByApplicationUsesScopedTagAndDefaultKey(): void
+    {
+        $cacheKeyConventionService = new CacheKeyConventionService();
+        $cache = $this->createMock(TagAwareCacheInterface::class);
+        $cache->expects(self::once())
+            ->method('invalidateTags')
+            ->with(['cache_school_class_list_school-campus-core']);
+        $cache->expects(self::once())
+            ->method('delete')
+            ->with($cacheKeyConventionService->buildSchoolClassApplicationListKey('school-campus-core', 1, 20, [
+                'q' => '',
+            ]));
+
+        $service = new CacheInvalidationService($cache, $cacheKeyConventionService);
+
+        $service->invalidateSchoolClassListCaches('school-campus-core');
+    }
+
+    public function testInvalidateSchoolClassCachesWithoutApplicationDoesNothing(): void
+    {
+        $cache = $this->createMock(TagAwareCacheInterface::class);
+        $cache->expects(self::never())->method('invalidateTags');
+        $cache->expects(self::never())->method('delete');
+
+        $service = new CacheInvalidationService($cache, new CacheKeyConventionService());
+
+        $service->invalidateSchoolClassListCaches(null);
+    }
+
+    public function testSchoolCacheConventionsAreIsolatedByApplicationSlug(): void
+    {
+        $service = new CacheKeyConventionService();
+
+        self::assertNotSame(
+            $service->schoolExamListTagByApplication('app-alpha'),
+            $service->schoolExamListTagByApplication('app-beta'),
+        );
+        self::assertNotSame(
+            $service->schoolClassListByApplicationTag('app-alpha'),
+            $service->schoolClassListByApplicationTag('app-beta'),
+        );
+        self::assertNotSame(
+            $service->buildSchoolExamListKey('app-alpha', 1, 20, ['q' => '', 'title' => '']),
+            $service->buildSchoolExamListKey('app-beta', 1, 20, ['q' => '', 'title' => '']),
+        );
+        self::assertNotSame(
+            $service->buildSchoolClassApplicationListKey('app-alpha', 1, 20, ['q' => '']),
+            $service->buildSchoolClassApplicationListKey('app-beta', 1, 20, ['q' => '']),
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure School entity mutation events (`EntityCreated`/`EntityPatched`/`EntityDeleted`) cause correct cache invalidation for both exams and classes, scoped by `applicationSlug` when available to avoid stale or cross-application cache pollution.

### Description
- Add `invalidateSchoolClassListCaches(?string $applicationSlug)` to `CacheInvalidationService` to invalidate class list tags and delete the default per-application key.  
- Propagate `applicationSlug` in School flows by adding message `context` when creating/deleting/patching classes and when patching school-scoped resources so handlers can scope invalidation.  
- Update `EntityProjectionHandler` to invalidate both exam and class list caches on create/patch/delete and to use `applicationSlug` from the message or resolved from the entity.  
- Add unit tests covering cache invalidation behavior: expanded `CacheInvalidationServiceTest` and new `EntityProjectionHandlerSchoolCacheTest` to exercise scoped vs global invalidation and isolation across distinct `applicationSlug` values.

### Testing
- Ran PHP syntax checks with `php -l` on the modified source and test files, and all files reported "No syntax errors detected".  
- Added unit tests `tests/Unit/General/Application/Service/CacheInvalidationServiceTest.php` and `tests/Unit/General/Application/MessageHandler/EntityProjectionHandlerSchoolCacheTest.php` (not executed here).  
- Attempted to run PHPUnit but could not execute `./vendor/bin/phpunit` in this environment because dependencies are not installed, so full test run was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b5107f4c8326899afe8b3fc0be9f)