### PR TITLE
docs(school): compléter les annotations OpenAPI V1 et documenter le scope application

### DIFF
--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -87,3 +87,81 @@ curl -X GET "http://localhost/api/v1/application/private?title=recruit&page=2&li
 
 ## Recruit endpoints (module Recruit)
 - Voir la documentation détaillée: [docs/recruit.md](./recruit.md)
+
+
+## School API (scope application)
+
+### Règles de scope application
+- Tous les endpoints School de ce bloc sont préfixés par `/v1/school/applications/{applicationSlug}/...`.
+- `applicationSlug` détermine le **scope d'accès**: une ressource (`classes`, `students`, `teachers`, `exams`, `grades`) doit appartenir à l'école résolue pour cette application.
+- Si la ressource n'appartient pas au scope de l'application, l'API retourne `404` (même si l'ID existe ailleurs).
+- Les endpoints sont protégés: utilisateur non authentifié/non autorisé => `403`.
+- En cas de payload invalide (création/patch) ou de paramètres invalides (pagination/filtres), l'API retourne `422`.
+
+### Pagination et filtres (School)
+- Pagination standard: `page` (min `1`, défaut `1`) et `limit` (min `1`, max `100`, défaut `20`).
+- Filtres disponibles selon la ressource:
+  - classes: `q` (recherche sur le nom)
+  - exams: `q` (full-text) et `title` (filtre partiel)
+
+### Exemples request/response School
+
+#### List (classes)
+```bash
+curl -X GET "http://localhost/api/v1/school/applications/school-crm/classes?page=1&limit=20&q=term" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer <JWT_TOKEN>"
+```
+
+```json
+{
+  "items": [{ "id": "7600e750-f92f-4f9f-883a-26404b538f66", "name": "Terminale S" }],
+  "meta": {
+    "pagination": { "page": 1, "limit": 20, "totalItems": 1, "totalPages": 1 },
+    "filters": { "q": "term" }
+  }
+}
+```
+
+#### Detail (resource)
+```bash
+curl -X GET "http://localhost/api/v1/school/applications/school-crm/students/4cfada53-2cf2-49a7-a4fb-4a9682c3a0c0" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer <JWT_TOKEN>"
+```
+
+```json
+{ "id": "4cfada53-2cf2-49a7-a4fb-4a9682c3a0c0", "name": "Alice Martin" }
+```
+
+#### Create (student)
+```bash
+curl -X POST "http://localhost/api/v1/school/applications/school-crm/students" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <JWT_TOKEN>" \
+  -d '{"name":"Alice Martin","classId":"7600e750-f92f-4f9f-883a-26404b538f66"}'
+```
+
+```json
+{ "id": "4cfada53-2cf2-49a7-a4fb-4a9682c3a0c0" }
+```
+
+#### Patch (resource)
+```bash
+curl -X PATCH "http://localhost/api/v1/school/applications/school-crm/classes/7600e750-f92f-4f9f-883a-26404b538f66" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <JWT_TOKEN>" \
+  -d '{"name":"Terminale S1"}'
+```
+
+```json
+{ "id": "7600e750-f92f-4f9f-883a-26404b538f66", "name": "Terminale S1" }
+```
+
+#### Delete (class)
+```bash
+curl -X DELETE "http://localhost/api/v1/school/applications/school-crm/classes/7600e750-f92f-4f9f-883a-26404b538f66" \
+  -H "Authorization: Bearer <JWT_TOKEN>"
+```
+
+Réponse: `204 No Content`.

--- a/src/School/Transport/Controller/Api/V1/Application/GetSchoolApplicationResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/Application/GetSchoolApplicationResourceController.php
@@ -31,6 +31,18 @@ final readonly class GetSchoolApplicationResourceController
     #[Route('/v1/school/applications/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_GET], requirements: [
         'resource' => 'classes|students|teachers|exams|grades',
     ])]
+    #[OA\Get(
+        summary: 'Détail d\'une ressource school dans le scope application',
+        parameters: [
+            new OA\Parameter(name: 'resource', in: 'path', required: true, schema: new OA\Schema(type: 'string', enum: ['classes', 'students', 'teachers', 'exams', 'grades'])),
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid')),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Ressource trouvée.', content: new OA\JsonContent(example: ['id' => '4cfada53-2cf2-49a7-a4fb-4a9682c3a0c0', 'name' => 'Alice Martin'])),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Ressource introuvable dans ce scope application.'),
+        ],
+    )]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $resource, string $id, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
@@ -36,6 +36,25 @@ final readonly class PatchSchoolApplicationResourceController
     #[Route('/v1/school/applications/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_PATCH], requirements: [
         'resource' => 'classes|students|teachers|exams|grades',
     ])]
+    #[OA\Patch(
+        summary: 'Mettre à jour partiellement une ressource school',
+        parameters: [
+            new OA\Parameter(name: 'resource', in: 'path', required: true, schema: new OA\Schema(type: 'string', enum: ['classes', 'students', 'teachers', 'exams', 'grades'])),
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid')),
+        ],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                example: ['name' => 'Terminale S1', 'status' => 'PUBLISHED'],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Ressource mise à jour.', content: new OA\JsonContent(example: ['id' => '7600e750-f92f-4f9f-883a-26404b538f66', 'name' => 'Terminale S1'])),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Ressource introuvable dans ce scope application.'),
+            new OA\Response(response: 422, description: 'Payload invalide.'),
+        ],
+    )]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $resource, string $id, Request $request, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
@@ -30,6 +30,24 @@ final readonly class CreateClassByApplicationController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_POST])]
+    #[OA\Post(
+        summary: 'Créer une classe dans une application',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', example: 'Terminale S'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 201, description: 'Classe créée.', content: new OA\JsonContent(example: ['id' => '7600e750-f92f-4f9f-883a-26404b538f66', 'schoolId' => 'b7c23d65-11e0-4f26-8ad7-3f58c48f1290', 'applicationSlug' => 'school-crm'])),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Application introuvable.'),
+            new OA\Response(response: 422, description: 'Erreur de validation.'),
+        ],
+    )]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Class/DeleteClassController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/DeleteClassController.php
@@ -27,6 +27,17 @@ final readonly class DeleteClassController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/classes/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Delete(
+        summary: 'Supprimer une classe',
+        parameters: [
+            new OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid')),
+        ],
+        responses: [
+            new OA\Response(response: 204, description: 'Classe supprimée.'),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Classe introuvable dans ce scope application.'),
+        ],
+    )]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Class/ListClassesByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/ListClassesByApplicationController.php
@@ -33,6 +33,20 @@ final readonly class ListClassesByApplicationController
      * @throws JsonException
      */
     #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'Lister les classes d\'une application',
+        parameters: [
+            new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, default: 1)),
+            new OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20)),
+            new OA\Parameter(name: 'q', in: 'query', required: false, schema: new OA\Schema(type: 'string'), description: 'Filtre partiel sur le nom de classe.'),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Liste des classes.', content: new OA\JsonContent(example: ['items' => [['id' => '7600e750-f92f-4f9f-883a-26404b538f66', 'name' => 'Terminale S']], 'meta' => ['pagination' => ['page' => 1, 'limit' => 20, 'totalItems' => 1, 'totalPages' => 1], 'filters' => ['q' => 'term']]])),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Application introuvable.'),
+            new OA\Response(response: 422, description: 'Pagination ou filtres invalides.'),
+        ],
+    )]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php
+++ b/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php
@@ -31,6 +31,38 @@ final readonly class SchoolApplicationResourceListController
     #[Route('/v1/school/applications/{applicationSlug}/{resource}', methods: [Request::METHOD_GET], requirements: [
         'resource' => 'students|teachers|exams|grades',
     ])]
+    #[OA\Get(
+        summary: 'Lister les ressources school par application',
+        description: 'Retourne une collection d\'items selon la ressource demandée (students, teachers, exams, grades) dans le scope de l\'application.',
+        parameters: [
+            new OA\Parameter(name: 'resource', in: 'path', required: true, schema: new OA\Schema(type: 'string', enum: ['students', 'teachers', 'exams', 'grades'])),
+            new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, default: 1), description: 'Pagination (si supportée par la ressource).'),
+            new OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20), description: 'Nombre d\'éléments par page (si supporté).'),
+            new OA\Parameter(name: 'q', in: 'query', required: false, schema: new OA\Schema(type: 'string'), description: 'Filtre texte libre (si supporté).'),
+            new OA\Parameter(name: 'title', in: 'query', required: false, schema: new OA\Schema(type: 'string'), description: 'Filtre de titre (notamment pour exams).'),
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Liste des ressources retournée.',
+                content: new OA\JsonContent(
+                    example: [
+                        'items' => [
+                            ['id' => '4cfada53-2cf2-49a7-a4fb-4a9682c3a0c0', 'name' => 'Alice Martin', 'classId' => '7600e750-f92f-4f9f-883a-26404b538f66'],
+                        ],
+                        'meta' => [
+                            'pagination' => ['page' => 1, 'limit' => 20, 'totalItems' => 1, 'totalPages' => 1],
+                            'filters' => ['q' => 'alice'],
+                            'applicationSlug' => 'school-crm',
+                        ],
+                    ],
+                ),
+            ),
+            new OA\Response(response: 403, description: 'Accès refusé (authentification requise).'),
+            new OA\Response(response: 404, description: 'Application ou ressource introuvable dans le scope.'),
+            new OA\Response(response: 422, description: 'Paramètres de pagination/filtres invalides.'),
+        ],
+    )]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $resource, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
@@ -30,6 +30,25 @@ final readonly class CreateStudentController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/students', methods: [Request::METHOD_POST])]
+    #[OA\Post(
+        summary: 'Créer un étudiant',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name', 'classId'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', example: 'Alice Martin'),
+                    new OA\Property(property: 'classId', type: 'string', format: 'uuid', example: '7600e750-f92f-4f9f-883a-26404b538f66'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 201, description: 'Étudiant créé.', content: new OA\JsonContent(example: ['id' => '4cfada53-2cf2-49a7-a4fb-4a9682c3a0c0'])),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Application introuvable.'),
+            new OA\Response(response: 422, description: 'Erreur de validation.'),
+        ],
+    )]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {


### PR DESCRIPTION
### Motivation
- Compléter les annotations OpenAPI sur les endpoints School V1 afin d'avoir une documentation Swagger complète pour les opérations list/detail/create/patch/delete et expliciter le comportement lié au scope d'application.
- Fournir des exemples request/response et clarifier la pagination, les filtres et les codes d'erreur courants (`403`, `404`, `422`) pour faciliter l'intégration API.

### Description
- Ajout d'annotations OpenAPI (`OA") et d'exemples sur les controllers list/detail/patch/create/delete pour les routes sous `src/School/Transport/Controller/Api/V1/*` (notamment `SchoolApplicationResourceListController`, `Application/GetSchoolApplicationResourceController`, `Application/PatchSchoolApplicationResourceController`, `Class/CreateClassByApplicationController`, `Class/ListClassesByApplicationController`, `Class/DeleteClassController`, `Student/CreateStudentController`).
- Ajout des paramètres de requête `page`, `limit`, `q`, `title` et du paramètre `resource` en path pour les endpoints listés, et description des comportements attendus (pagination et filtres).
- Ajout d'exemples JSON pour list/detail/create/patch/delete dans les annotations OpenAPI afin que Swagger génère des exemples concrets.
- Mise à jour de `docs/swagger.md` avec une nouvelle section **"School API (scope application)"** précisant les règles de scope application, la pagination/les filtres et des exemples cURL request/response pour list/detail/create/patch/delete.

### Testing
- Exécution de la vérification syntaxique PHP (`php -l`) sur les fichiers modifiés : tous les fichiers contrôleurs modifiés sont passés sans erreurs après corrections; la vérification a réussi.
- Aucune autre suite de tests automatisés n'a été exécutée dans ce changement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b5131cf08326b2f761510007950e)