### PR TITLE
Ajouter endpoint privé de pipeline de recrutement (colonnes, candidats, filtres, métriques)

### DIFF
--- a/src/Recruit/Application/Service/PipelineBoardService.php
+++ b/src/Recruit/Application/Service/PipelineBoardService.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Recruit;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Request;
+
+use function array_fill_keys;
+use function array_map;
+use function array_values;
+use function ceil;
+use function max;
+use function min;
+use function strtolower;
+use function trim;
+
+readonly class PipelineBoardService
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getPipeline(Recruit $recruit, Request $request): array
+    {
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = min(100, max(1, $request->query->getInt('limit', 20)));
+        $offset = ($page - 1) * $limit;
+
+        $jobId = trim($request->query->getString('jobId', ''));
+        $owner = trim($request->query->getString('owner', ''));
+        $date = trim($request->query->getString('date', ''));
+        $source = strtolower(trim($request->query->getString('source', '')));
+        $tag = trim($request->query->getString('tags', ''));
+
+        $queryBuilder = $this->entityManager->getRepository(Application::class)
+            ->createQueryBuilder('application')
+            ->innerJoin('application.job', 'job')->addSelect('job')
+            ->innerJoin('application.applicant', 'applicant')->addSelect('applicant')
+            ->innerJoin('applicant.user', 'candidate')->addSelect('candidate')
+            ->leftJoin('applicant.resume', 'resume')->addSelect('resume')
+            ->leftJoin('job.owner', 'ownerUser')->addSelect('ownerUser')
+            ->andWhere('job.recruit = :recruit')
+            ->setParameter('recruit', $recruit->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->orderBy('application.createdAt', 'DESC')
+            ->addOrderBy('application.id', 'DESC');
+
+        if ($jobId !== '' && Uuid::isValid($jobId)) {
+            $queryBuilder
+                ->andWhere('job.id = :jobId')
+                ->setParameter('jobId', $jobId, UuidBinaryOrderedTimeType::NAME);
+        }
+
+        if ($owner !== '' && Uuid::isValid($owner)) {
+            $queryBuilder
+                ->andWhere('ownerUser.id = :owner')
+                ->setParameter('owner', $owner, UuidBinaryOrderedTimeType::NAME);
+        }
+
+        if ($date !== '') {
+            $queryBuilder
+                ->andWhere('DATE(application.createdAt) = :createdOn')
+                ->setParameter('createdOn', $date);
+        }
+
+        if ($source === 'resume') {
+            $queryBuilder->andWhere('resume.id IS NOT NULL');
+        } elseif ($source === 'manual') {
+            $queryBuilder->andWhere('resume.id IS NULL');
+        }
+
+        if ($tag !== '') {
+            $queryBuilder
+                ->innerJoin('job.tags', 'jobTagFilter')
+                ->andWhere('jobTagFilter.label = :tagLabel')
+                ->setParameter('tagLabel', $tag);
+        }
+
+        $aggregateQueryBuilder = clone $queryBuilder;
+        $aggregateRows = $aggregateQueryBuilder
+            ->select('application.status AS status', 'COUNT(application.id) AS statusCount', 'AVG(TIMESTAMPDIFF(DAY, application.createdAt, CURRENT_TIMESTAMP())) AS avgAgingDays')
+            ->groupBy('application.status')
+            ->getQuery()
+            ->getArrayResult();
+
+        $queryBuilder->setFirstResult($offset)->setMaxResults($limit);
+
+        $paginator = new Paginator($queryBuilder->getQuery(), true);
+
+        $statusOrder = array_map(static fn (ApplicationStatus $status): string => $status->value, ApplicationStatus::cases());
+
+        $metricsByStatus = array_fill_keys($statusOrder, ['count' => 0, 'avgAgingDays' => 0.0]);
+        foreach ($aggregateRows as $row) {
+            $status = (string)($row['status'] ?? '');
+            if (!isset($metricsByStatus[$status])) {
+                continue;
+            }
+
+            $metricsByStatus[$status] = [
+                'count' => (int)($row['statusCount'] ?? 0),
+                'avgAgingDays' => round((float)($row['avgAgingDays'] ?? 0), 2),
+            ];
+        }
+
+        $columns = array_fill_keys($statusOrder, []);
+
+        foreach ($paginator as $application) {
+            if (!$application instanceof Application) {
+                continue;
+            }
+
+            $status = $application->getStatusValue();
+            $applicant = $application->getApplicant();
+            $candidate = $applicant->getUser();
+            $job = $application->getJob();
+
+            $columns[$status][] = [
+                'id' => $application->getId(),
+                'status' => $status,
+                'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
+                'agingDays' => max(0, (int)$application->getCreatedAt()?->diff(new \DateTimeImmutable())->days),
+                'source' => $applicant->getResume() !== null ? 'resume' : 'manual',
+                'job' => [
+                    'id' => $job->getId(),
+                    'title' => $job->getTitle(),
+                    'ownerId' => $job->getOwner()?->getId(),
+                ],
+                'candidate' => [
+                    'id' => $candidate->getId(),
+                    'email' => $candidate->getEmail(),
+                    'firstName' => $candidate->getFirstName(),
+                    'lastName' => $candidate->getLastName(),
+                ],
+            ];
+        }
+
+        return [
+            'columns' => array_values(array_map(static fn (string $status) => [
+                'status' => $status,
+                'metrics' => $metricsByStatus[$status],
+                'candidates' => $columns[$status],
+            ], $statusOrder)),
+            'pagination' => [
+                'page' => $page,
+                'limit' => $limit,
+                'total' => count($paginator),
+                'pages' => (int)ceil(max(1, count($paginator)) / $limit),
+            ],
+            'filters' => [
+                'jobId' => $jobId,
+                'owner' => $owner,
+                'date' => $date,
+                'source' => $source,
+                'tags' => $tag,
+            ],
+        ];
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Application/PrivatePipelineController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/PrivatePipelineController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Application;
+
+use App\Recruit\Application\Service\PipelineBoardService;
+use App\Recruit\Application\Service\RecruitResolverService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Application')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class PrivatePipelineController
+{
+    public function __construct(
+        private RecruitResolverService $recruitResolverService,
+        private PipelineBoardService $pipelineBoardService,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/private/{applicationSlug}/pipeline', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'Kanban pipeline privé des candidatures (colonnes + candidats + métriques).',
+        parameters: [
+            new OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 1)),
+            new OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 20, minimum: 1, maximum: 100)),
+            new OA\Parameter(name: 'jobId', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'uuid')),
+            new OA\Parameter(name: 'owner', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'uuid')),
+            new OA\Parameter(name: 'date', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'date', description: 'YYYY-MM-DD')),
+            new OA\Parameter(name: 'source', in: 'query', required: false, schema: new OA\Schema(type: 'string', enum: ['resume', 'manual'])),
+            new OA\Parameter(name: 'tags', in: 'query', required: false, schema: new OA\Schema(type: 'string', description: 'Label du tag job.')),
+        ],
+    )]
+    public function __invoke(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
+    {
+        $recruit = $this->recruitResolverService->resolveByApplicationSlug($applicationSlug);
+
+        if ($recruit->getApplication()?->getUser()?->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot access pipeline for this application.');
+        }
+
+        return new JsonResponse($this->pipelineBoardService->getPipeline($recruit, $request));
+    }
+}

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Application/PrivatePipelineControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Application/PrivatePipelineControllerTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\Application;
+
+use App\General\Domain\Utils\JSON;
+use App\Platform\Domain\Entity\Application as PlatformApplication;
+use App\Recruit\Domain\Entity\Applicant;
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Entity\Recruit;
+use App\Recruit\Domain\Entity\Tag;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Domain\Entity\User;
+use DateTime;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+class PrivatePipelineControllerTest extends WebTestCase
+{
+    #[TestDox('GET /v1/recruit/private/{applicationSlug}/pipeline requires authentication.')]
+    public function testThatPrivatePipelineRequiresAuthentication(): void
+    {
+        $applicationSlug = $this->getApplicationSlugForUsername('john-root');
+
+        $client = $this->getTestClient();
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/private/' . $applicationSlug . '/pipeline');
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
+    }
+
+    #[TestDox('GET /v1/recruit/private/{applicationSlug}/pipeline applies pagination and filtering.')]
+    public function testThatPrivatePipelineSupportsPaginationAndFiltering(): void
+    {
+        [$applicationSlug, $jobId, $tagLabel] = $this->createPipelineFixtureData();
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/private/' . $applicationSlug . '/pipeline?limit=1&page=1');
+
+        $response = $client->getResponse();
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), (string)$response);
+        $payload = JSON::decode((string)$response->getContent(), true);
+
+        self::assertSame(1, $payload['pagination']['limit'] ?? null);
+        self::assertSame(1, $payload['pagination']['page'] ?? null);
+        self::assertGreaterThanOrEqual(2, (int)($payload['pagination']['total'] ?? 0));
+
+        $firstPageCount = 0;
+        foreach ($payload['columns'] as $column) {
+            $firstPageCount += count($column['candidates'] ?? []);
+            self::assertArrayHasKey('metrics', $column);
+            self::assertArrayHasKey('count', $column['metrics']);
+            self::assertArrayHasKey('avgAgingDays', $column['metrics']);
+        }
+
+        self::assertSame(1, $firstPageCount);
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/private/' . $applicationSlug . '/pipeline?limit=1&page=2');
+        $secondPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        $secondPageCount = 0;
+        foreach ($secondPayload['columns'] as $column) {
+            $secondPageCount += count($column['candidates'] ?? []);
+        }
+
+        self::assertSame(1, $secondPageCount);
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/private/' . $applicationSlug . '/pipeline?jobId=' . $jobId . '&source=manual&tags=' . urlencode($tagLabel));
+        $filteredPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        $filteredCandidates = [];
+        foreach ($filteredPayload['columns'] as $column) {
+            foreach ($column['candidates'] ?? [] as $candidate) {
+                $filteredCandidates[] = $candidate;
+            }
+        }
+
+        self::assertCount(1, $filteredCandidates);
+        self::assertSame($jobId, $filteredCandidates[0]['job']['id'] ?? null);
+        self::assertSame('manual', $filteredCandidates[0]['source'] ?? null);
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: string}
+     */
+    private function createPipelineFixtureData(): array
+    {
+        self::bootKernel();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => 'john-root']);
+        self::assertInstanceOf(User::class, $user);
+
+        $application = $entityManager->getRepository(PlatformApplication::class)->findOneBy([
+            'user' => $user,
+            'title' => 'Recruit Lite App',
+        ]);
+        self::assertInstanceOf(PlatformApplication::class, $application);
+
+        $recruit = $entityManager->getRepository(Recruit::class)->findOneBy(['application' => $application]);
+        self::assertInstanceOf(Recruit::class, $recruit);
+
+        $tagLabel = 'pipeline-test-tag-' . substr((string)microtime(true), -6);
+        $tag = (new Tag())
+            ->setLabel($tagLabel);
+
+        $manualApplicant = (new Applicant())
+            ->setUser($user)
+            ->setCoverLetter('Manual applicant without resume');
+
+        $resumeApplicant = $entityManager->getRepository(Applicant::class)->findOneBy(['user' => $user]);
+        self::assertInstanceOf(Applicant::class, $resumeApplicant);
+
+        $jobA = (new Job())
+            ->setRecruit($recruit)
+            ->setOwner($user)
+            ->setTitle('Pipeline fixture job A')
+            ->ensureGeneratedSlug()
+            ->addTag($tag);
+
+        $jobB = (new Job())
+            ->setRecruit($recruit)
+            ->setOwner($user)
+            ->setTitle('Pipeline fixture job B')
+            ->ensureGeneratedSlug();
+
+        $applicationA = (new Application())
+            ->setApplicant($manualApplicant)
+            ->setJob($jobA)
+            ->setStatus(ApplicationStatus::WAITING)
+            ->setCreatedAt(new DateTime('-3 days'));
+
+        $applicationB = (new Application())
+            ->setApplicant($resumeApplicant)
+            ->setJob($jobB)
+            ->setStatus(ApplicationStatus::SCREENING)
+            ->setCreatedAt(new DateTime('-1 days'));
+
+        $entityManager->persist($tag);
+        $entityManager->persist($manualApplicant);
+        $entityManager->persist($jobA);
+        $entityManager->persist($jobB);
+        $entityManager->persist($applicationA);
+        $entityManager->persist($applicationB);
+        $entityManager->flush();
+
+        return [$application->getSlug(), $jobA->getId(), $tagLabel];
+    }
+
+    private function getApplicationSlugForUsername(string $username): string
+    {
+        self::bootKernel();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $user = $entityManager->getRepository(User::class)->findOneBy(['username' => $username]);
+        self::assertInstanceOf(User::class, $user);
+
+        $application = $entityManager->getRepository(PlatformApplication::class)->findOneBy([
+            'user' => $user,
+            'title' => 'Recruit Lite App',
+        ]);
+        self::assertInstanceOf(PlatformApplication::class, $application);
+
+        return $application->getSlug();
+    }
+}


### PR DESCRIPTION
### Motivation
- Fournir un endpoint privé de type Kanban pour afficher les candidatures groupées par statut afin que le propriétaire de l'application puisse visualiser rapidement les colonnes et candidats. 
- Permettre le filtrage fin des candidatures via `jobId`, `owner`, `date`, `source` et `tags` pour naviguer efficacement dans des pipelines volumineux. 
- Exposer des métriques par colonne (`count`, `avgAgingDays`) et optimiser les requêtes pour éviter des problèmes N+1 lors de l'agrégation et de la récupération des relations.

### Description
- Ajout d'un nouveau contrôleur `PrivatePipelineController` exposant `GET /v1/recruit/private/{applicationSlug}/pipeline` et appliquant l'autorisation propriétaire (accès authentifié et matching application owner). 
- Implémentation du service `PipelineBoardService` qui construit la requête avec jointures eager, applique les filtres (`jobId`, `owner`, `date`, `source`, `tags`), pagine les résultats et assemble les colonnes par statut. 
- Calcul des métriques par colonne via une requête agrégée SQL groupée (count + moyenne d'aging) exécutée séparément pour éviter N+1 et garder la lecture des candidats paginée efficace. 
- Ajout de documentation OpenAPI des paramètres et d'un test d'intégration `PrivatePipelineControllerTest` vérifiant l'authentification, la pagination, le filtrage combiné et la présence des métriques.

### Testing
- Vérification syntaxique PHP (`php -l`) sur les nouveaux fichiers et tests : tous les fichiers nouvellement ajoutés sont valides PHP (succès). 
- Exécution de PHPUnit impossible dans cet environnement car `vendor/bin/phpunit` est introuvable, donc les tests d'intégration nouvellement ajoutés n'ont pas été exécutés ici (échec d'exécution, binaire absent). 
- Un test d'intégration a été ajouté (`tests/Application/Recruit/Transport/Controller/Api/V1/Application/PrivatePipelineControllerTest.php`) couvrant authentification, pagination, filtrage et métriques, prêt à être exécuté dans l'environnement CI où `phpunit` est disponible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b520600c832699672e226db079f8)