### PR TITLE
feat(recruit): add SLA breach detection, reminders and stats indicators

### DIFF
--- a/src/Recruit/Application/Service/ApplicationSlaBreachFinderService.php
+++ b/src/Recruit/Application/Service/ApplicationSlaBreachFinderService.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+
+readonly class ApplicationSlaBreachFinderService
+{
+    public function __construct(
+        private ApplicationRepository $applicationRepository,
+        private ApplicationSlaService $applicationSlaService,
+    ) {
+    }
+
+    /**
+     * @return list<Application>
+     */
+    public function findAllBreaches(): array
+    {
+        return $this->applicationRepository->findSlaBreaches($this->applicationSlaService->getRulesInHours());
+    }
+}

--- a/src/Recruit/Application/Service/ApplicationSlaReminderService.php
+++ b/src/Recruit/Application/Service/ApplicationSlaReminderService.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\General\Domain\Service\Interfaces\MailerServiceInterface;
+use App\Recruit\Domain\Entity\Application;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+readonly class ApplicationSlaReminderService
+{
+    public function __construct(
+        private MailerServiceInterface $mailerService,
+        private HttpClientInterface $httpClient,
+        #[Autowire('%env(resolve:APP_SENDER_EMAIL)%')]
+        private string $appSenderEmail,
+        private string $slackWebhook = '',
+    ) {
+    }
+
+    /**
+     * @param list<Application> $applications
+     */
+    public function sendReminders(array $applications): void
+    {
+        foreach ($applications as $application) {
+            $email = $application->getJob()->getOwner()?->getEmail();
+            if (is_string($email) && $email !== '') {
+                $this->mailerService->sendMail(
+                    title: sprintf('[SLA] Candidature %s en dépassement', $application->getId()),
+                    from: $this->appSenderEmail,
+                    to: $email,
+                    body: $this->buildMessage($application),
+                );
+            }
+
+            if ($this->slackWebhook !== '') {
+                $this->httpClient->request('POST', $this->slackWebhook, [
+                    'json' => [
+                        'text' => sprintf(
+                            ':warning: SLA dépassée pour candidature `%s` (%s) sur le poste `%s`.',
+                            $application->getId(),
+                            $application->getStatus()->value,
+                            $application->getJob()->getTitle(),
+                        ),
+                    ],
+                ]);
+            }
+        }
+    }
+
+    private function buildMessage(Application $application): string
+    {
+        return sprintf(
+            "La candidature %s est en dépassement de SLA.\nStatut: %s\nPoste: %s\nDernière mise à jour: %s",
+            $application->getId(),
+            $application->getStatus()->value,
+            $application->getJob()->getTitle(),
+            $application->getUpdatedAt()?->format(DATE_ATOM) ?? 'n/a',
+        );
+    }
+}

--- a/src/Recruit/Application/Service/ApplicationSlaService.php
+++ b/src/Recruit/Application/Service/ApplicationSlaService.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use DateInterval;
+use DateTimeImmutable;
+
+readonly class ApplicationSlaService
+{
+    /**
+     * @var array<string, int>
+     */
+    private const HOURS_BY_STATUS = [
+        ApplicationStatus::WAITING->value => 72,
+        ApplicationStatus::SCREENING->value => 120,
+        ApplicationStatus::INTERVIEW_PLANNED->value => 168,
+        ApplicationStatus::INTERVIEW_DONE->value => 96,
+        ApplicationStatus::OFFER_SENT->value => 120,
+    ];
+
+    /**
+     * @return array<string, int>
+     */
+    public function getRulesInHours(): array
+    {
+        return self::HOURS_BY_STATUS;
+    }
+
+    public function hasRule(ApplicationStatus $status): bool
+    {
+        return isset(self::HOURS_BY_STATUS[$status->value]);
+    }
+
+    public function getThresholdHours(ApplicationStatus $status): ?int
+    {
+        return self::HOURS_BY_STATUS[$status->value] ?? null;
+    }
+
+    public function isBreached(ApplicationStatus $status, DateTimeImmutable $updatedAt, ?DateTimeImmutable $now = null): bool
+    {
+        $thresholdHours = $this->getThresholdHours($status);
+        if ($thresholdHours === null) {
+            return false;
+        }
+
+        $currentDate = $now ?? new DateTimeImmutable();
+        $deadline = $updatedAt->add(new DateInterval('PT' . $thresholdHours . 'H'));
+
+        return $deadline <= $currentDate;
+    }
+}

--- a/src/Recruit/Application/Service/JobStatsService.php
+++ b/src/Recruit/Application/Service/JobStatsService.php
@@ -6,6 +6,7 @@ namespace App\Recruit\Application\Service;
 
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Domain\Entity\Recruit;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
 use BackedEnum;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
@@ -15,6 +16,8 @@ readonly class JobStatsService
 {
     public function __construct(
         private EntityManagerInterface $entityManager,
+        private ApplicationSlaService $applicationSlaService,
+        private ApplicationRepository $applicationRepository,
     ) {
     }
 
@@ -30,6 +33,10 @@ readonly class JobStatsService
             'byContractType' => $this->getGroupedCounts($recruit, 'contractType'),
             'byWorkMode' => $this->getGroupedCounts($recruit, 'workMode'),
             'byExperienceLevel' => $this->getGroupedCounts($recruit, 'experienceLevel'),
+            'sla' => [
+                'rulesHours' => $this->applicationSlaService->getRulesInHours(),
+                'breachesByStatus' => $this->applicationRepository->countSlaBreachesByRecruit($recruit, $this->applicationSlaService->getRulesInHours()),
+            ],
         ];
     }
 

--- a/src/Recruit/Infrastructure/Repository/ApplicationRepository.php
+++ b/src/Recruit/Infrastructure/Repository/ApplicationRepository.php
@@ -8,8 +8,11 @@ use App\General\Infrastructure\Repository\BaseRepository;
 use App\Recruit\Domain\Entity\Applicant;
 use App\Recruit\Domain\Entity\Application as Entity;
 use App\Recruit\Domain\Entity\Job;
+use App\Recruit\Domain\Entity\Recruit;
 use App\Recruit\Domain\Enum\ApplicationStatus;
 use App\Recruit\Domain\Repository\Interfaces\ApplicationRepositoryInterface;
+use DateInterval;
+use DateTimeImmutable;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -48,5 +51,90 @@ class ApplicationRepository extends BaseRepository implements ApplicationReposit
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();
+    }
+
+    /**
+     * @param array<string, int> $slaRulesInHours
+     *
+     * @return list<Entity>
+     */
+    public function findSlaBreaches(array $slaRulesInHours): array
+    {
+        $queryBuilder = $this->createQueryBuilder('application')
+            ->innerJoin('application.job', 'job')
+            ->addSelect('job', 'owner')
+            ->leftJoin('job.owner', 'owner');
+
+        $this->applySlaFilters($queryBuilder, $slaRulesInHours);
+
+        /** @var list<Entity> $results */
+        $results = $queryBuilder
+            ->orderBy('application.updatedAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $results;
+    }
+
+    /**
+     * @param array<string, int> $slaRulesInHours
+     *
+     * @return array<string, int>
+     */
+    public function countSlaBreachesByRecruit(Recruit $recruit, array $slaRulesInHours): array
+    {
+        $queryBuilder = $this->createQueryBuilder('application')
+            ->select('application.status AS status', 'COUNT(application.id) AS breaches')
+            ->innerJoin('application.job', 'job')
+            ->andWhere('job.recruit = :recruit')
+            ->setParameter('recruit', $recruit);
+
+        $this->applySlaFilters($queryBuilder, $slaRulesInHours);
+
+        $rows = $queryBuilder
+            ->groupBy('application.status')
+            ->getQuery()
+            ->getArrayResult();
+
+        $result = [];
+
+        foreach ($rows as $row) {
+            $status = (string)($row['status'] ?? '');
+            if ($status === '') {
+                continue;
+            }
+
+            $result[$status] = (int)($row['breaches'] ?? 0);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<string, int> $slaRulesInHours
+     */
+    private function applySlaFilters(\Doctrine\ORM\QueryBuilder $queryBuilder, array $slaRulesInHours): void
+    {
+        $orX = $queryBuilder->expr()->orX();
+        $now = new DateTimeImmutable();
+        $index = 0;
+
+        foreach ($slaRulesInHours as $status => $hours) {
+            $statusParam = 'slaStatus' . $index;
+            $dateParam = 'slaDate' . $index;
+            $index++;
+
+            $cutoff = $now->sub(new DateInterval('PT' . $hours . 'H'));
+            $orX->add(sprintf('(application.status = :%s AND application.updatedAt <= :%s)', $statusParam, $dateParam));
+            $queryBuilder
+                ->setParameter($statusParam, ApplicationStatus::from($status))
+                ->setParameter($dateParam, $cutoff);
+        }
+
+        if ($orX->count() > 0) {
+            $queryBuilder->andWhere($orX);
+        } else {
+            $queryBuilder->andWhere('1 = 0');
+        }
     }
 }

--- a/src/Recruit/Transport/Command/Scheduler/DetectApplicationsSlaBreachScheduledCommand.php
+++ b/src/Recruit/Transport/Command/Scheduler/DetectApplicationsSlaBreachScheduledCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Command\Scheduler;
+
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Recruit\Application\Service\ApplicationSlaBreachFinderService;
+use App\Recruit\Application\Service\ApplicationSlaReminderService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Détecte les candidatures en dépassement de SLA et relance les recruteurs (email/slack).',
+)]
+class DetectApplicationsSlaBreachScheduledCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'scheduler:recruit-applications-sla-breach-detect';
+
+    public function __construct(
+        private readonly ApplicationSlaBreachFinderService $applicationSlaBreachFinderService,
+        private readonly ApplicationSlaReminderService $applicationSlaReminderService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = $this->getSymfonyStyle($input, $output);
+
+        $applications = $this->applicationSlaBreachFinderService->findAllBreaches();
+        $this->applicationSlaReminderService->sendReminders($applications);
+
+        if ($input->isInteractive()) {
+            $io->success(sprintf('SLA check done. %d candidature(s) en dépassement traitée(s).', count($applications)));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Unit/Recruit/Application/Service/ApplicationSlaServiceTest.php
+++ b/tests/Unit/Recruit/Application/Service/ApplicationSlaServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Recruit\Application\Service;
+
+use App\Recruit\Application\Service\ApplicationSlaService;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+class ApplicationSlaServiceTest extends TestCase
+{
+    public function testWaitingStatusIsBreachedAfter72Hours(): void
+    {
+        $service = new ApplicationSlaService();
+        $now = new DateTimeImmutable('2025-01-01 12:00:00');
+        $updatedAt = $now->modify('-72 hours');
+
+        self::assertTrue($service->isBreached(ApplicationStatus::WAITING, $updatedAt, $now));
+    }
+
+    public function testWaitingStatusIsNotBreachedBefore72Hours(): void
+    {
+        $service = new ApplicationSlaService();
+        $now = new DateTimeImmutable('2025-01-01 12:00:00');
+        $updatedAt = $now->modify('-71 hours');
+
+        self::assertFalse($service->isBreached(ApplicationStatus::WAITING, $updatedAt, $now));
+    }
+
+    public function testFinalStatusesHaveNoSlaRule(): void
+    {
+        $service = new ApplicationSlaService();
+        $now = new DateTimeImmutable('2025-01-01 12:00:00');
+        $updatedAt = $now->modify('-500 hours');
+
+        self::assertFalse($service->hasRule(ApplicationStatus::HIRED));
+        self::assertFalse($service->isBreached(ApplicationStatus::HIRED, $updatedAt, $now));
+        self::assertFalse($service->hasRule(ApplicationStatus::REJECTED));
+        self::assertFalse($service->isBreached(ApplicationStatus::REJECTED, $updatedAt, $now));
+    }
+}

--- a/tests/Unit/Recruit/Application/Service/JobStatsServiceTest.php
+++ b/tests/Unit/Recruit/Application/Service/JobStatsServiceTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Recruit\Application\Service;
 
 use App\Recruit\Application\Service\JobStatsService;
+use App\Recruit\Application\Service\ApplicationSlaService;
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Domain\Entity\Recruit;
 use App\Recruit\Domain\Enum\ContractType;
 use App\Recruit\Domain\Enum\ExperienceLevel;
 use App\Recruit\Domain\Enum\WorkMode;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
@@ -25,6 +27,12 @@ class JobStatsServiceTest extends TestCase
         $jobs = $this->createRepresentativeJobs();
 
         $expectedStats = $this->computeLegacyStats($jobs);
+        $expectedSlaRules = ['WAITING' => 72];
+        $expectedBreaches = ['WAITING' => 3];
+        $expectedStats['sla'] = [
+            'rulesHours' => $expectedSlaRules,
+            'breachesByStatus' => $expectedBreaches,
+        ];
 
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $repository = $this->getMockBuilder(stdClass::class)
@@ -35,6 +43,19 @@ class JobStatsServiceTest extends TestCase
             ->expects(self::exactly(6))
             ->method('getRepository')
             ->willReturn($repository);
+
+        $applicationSlaService = $this->createMock(ApplicationSlaService::class);
+        $applicationSlaService
+            ->expects(self::exactly(2))
+            ->method('getRulesInHours')
+            ->willReturn($expectedSlaRules);
+
+        $applicationRepository = $this->createMock(ApplicationRepository::class);
+        $applicationRepository
+            ->expects(self::once())
+            ->method('countSlaBreachesByRecruit')
+            ->with($recruit, $expectedSlaRules)
+            ->willReturn($expectedBreaches);
 
         $repository
             ->expects(self::exactly(6))
@@ -49,7 +70,7 @@ class JobStatsServiceTest extends TestCase
                 $this->createGroupedQueryBuilderMock($expectedStats['byExperienceLevel']),
             );
 
-        $service = new JobStatsService($entityManager);
+        $service = new JobStatsService($entityManager, $applicationSlaService, $applicationRepository);
 
         self::assertSame($expectedStats, $service->getStats($recruit));
     }


### PR DESCRIPTION
### Motivation
- Implement SLA rules for application statuses (e.g. `WAITING` > 72h) to detect when candidate applications are overdue. 
- Provide a scheduled task and internal relances (email + optional Slack) so recruiters are notified of SLA breaches. 
- Surface SLA indicators in the job stats endpoint to help recruiters monitor outstanding items. 
- Add unit tests that validate SLA timing rules and adapt existing stats tests for the new payload.

### Description
- Add `ApplicationSlaService` to define SLA thresholds per `ApplicationStatus` and expose `isBreached()` and rule accessors. (new file `src/Recruit/Application/Service/ApplicationSlaService.php`)
- Add `ApplicationSlaBreachFinderService` to query the repository for breached applications. (new file `src/Recruit/Application/Service/ApplicationSlaBreachFinderService.php`)
- Add `ApplicationSlaReminderService` to send internal reminders by email and optionally via a Slack webhook, with safe defaults for DI. (new file `src/Recruit/Application/Service/ApplicationSlaReminderService.php`)
- Add scheduler command `scheduler:recruit-applications-sla-breach-detect` which runs the finder and triggers reminders. (new file `src/Recruit/Transport/Command/Scheduler/DetectApplicationsSlaBreachScheduledCommand.php`)
- Extend `ApplicationRepository` with `findSlaBreaches()`, `countSlaBreachesByRecruit()` and a shared `applySlaFilters()` implementation that computes time cutoffs per-status. (modified `src/Recruit/Infrastructure/Repository/ApplicationRepository.php`)
- Enrich `JobStatsService::getStats()` to include an `sla` section containing `rulesHours` and `breachesByStatus`, wired to the new SLA services and repository. (modified `src/Recruit/Application/Service/JobStatsService.php`)
- Add unit tests for SLA logic and update `JobStatsServiceTest` to expect the SLA payload (`tests/Unit/Recruit/Application/Service/ApplicationSlaServiceTest.php` and updated `tests/Unit/Recruit/Application/Service/JobStatsServiceTest.php`).

### Testing
- `php -l` (syntax check) was run against all new/modified files and reported no syntax errors. 
- Unit tests were added (`ApplicationSlaServiceTest`) and `JobStatsServiceTest` was updated to cover the new SLA data, but running `phpunit` in this environment failed because `./vendor/bin/phpunit` is not available. 
- No runtime/integration tests were executed in this environment due to missing test tooling and external dependencies (mailer/httpclient) configuration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b522c7f8832681d032376b50dfaf)