### PR TITLE
test(shop): align money assertions with centimes contract

### DIFF
--- a/tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php
+++ b/tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php
@@ -43,6 +43,7 @@ final class ShopMutationControllerTest extends WebTestCase
 
         self::assertNotEmpty($products);
         self::assertSame($products[0]->getId(), $payload['id']);
+        self::assertSame(1234, $products[0]->getPrice());
     }
 
     public function testCreateApplicationProductReturnsCreatedWithIdAndPersistsEntity(): void
@@ -77,6 +78,7 @@ final class ShopMutationControllerTest extends WebTestCase
 
         self::assertNotEmpty($products);
         self::assertSame($products[0]->getId(), $payload['id']);
+        self::assertSame(2345, $products[0]->getPrice());
     }
 
 
@@ -101,6 +103,15 @@ final class ShopMutationControllerTest extends WebTestCase
         self::assertSame('true', $client->getResponse()->headers->get('Deprecation'));
         self::assertSame('Wed, 31 Dec 2026 23:59:59 GMT', $client->getResponse()->headers->get('Sunset'));
         self::assertNotFalse(strpos((string)$client->getResponse()->headers->get('Warning'), 'Deprecated endpoint'));
+
+        /** @var ProductRepository $productRepository */
+        $productRepository = static::getContainer()->get(ProductRepository::class);
+        $products = $productRepository->findBy([
+            'name' => 'Legacy Messenger Product',
+        ]);
+
+        self::assertNotEmpty($products);
+        self::assertSame(4567, $products[0]->getPrice());
     }
 
     public function testDeleteProductDispatchesCommandAndRemovesEntity(): void

--- a/tests/Unit/Shop/Application/MessageHandler/CheckoutServiceTest.php
+++ b/tests/Unit/Shop/Application/MessageHandler/CheckoutServiceTest.php
@@ -32,21 +32,21 @@ final class CheckoutServiceTest extends TestCase
             ->setShop($shop)
             ->setName('Gaming Keyboard')
             ->setSku('kb-01')
-            ->setPrice(49.9)
+            ->setPrice(4990)
             ->setStock(10);
 
         $cartItem = (new CartItem())
             ->setProduct($product)
             ->setQuantity(2)
             ->setUnitPriceSnapshot($product->getPrice())
-            ->setLineTotal(99.8);
+            ->setLineTotal(9980);
 
         $cart = (new Cart())
             ->setShop($shop)
             ->setUser($user)
             ->setIsActive(true)
             ->setItemsCount(2)
-            ->setSubtotal(99.8)
+            ->setSubtotal(9980)
             ->addItem($cartItem);
 
         $service = $this->buildService($shop, $user, $cart, $product);
@@ -56,8 +56,8 @@ final class CheckoutServiceTest extends TestCase
         self::assertSame(8, $product->getStock());
         self::assertFalse($cart->isActive());
         self::assertSame(0, $cart->getItemsCount());
-        self::assertSame(0.0, $cart->getSubtotal());
-        self::assertSame(99.8, $order->getSubtotal());
+        self::assertSame(0, $cart->getSubtotal());
+        self::assertSame(9980, $order->getSubtotal());
         self::assertCount(1, $order->getItems());
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the Shop codebase follows the money contract: internal storage/calculations in integer centimes and API output as decimals via the central `MoneyFormatter` utility.
- Remove ambiguous float/int usages in tests and fixtures that could mask contract violations between domain entities (centimes) and REST payloads (decimal). 

### Description
- Confirmed existing Shop serialization and controllers already use `MoneyFormatter::toApiAmount` for API output (cart, checkout, payment intent, product listing) and left runtime code unchanged.
- Updated unit test `tests/Unit/Shop/Application/MessageHandler/CheckoutServiceTest.php` to use integer centimes for storage/calculation (`4990`, `9980`) and adjusted assertions accordingly (`0`, `9980`).
- Updated application tests `tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php` to keep API inputs decimal but assert persisted `Product::getPrice()` values in centimes (`1234`, `2345`, `4567`).

### Testing
- Ran PHP lint (`php -l`) on modified test files and they reported no syntax errors. 
- Attempted to run PHPUnit targeted to Shop tests but `vendor/bin/phpunit` is not available in this environment so full test suite execution could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b53597e48326887bb04a3cd1794c)