### PR TITLE
Harmonize Shop v1 validation flow and standardize error payloads

### DIFF
--- a/src/Shop/Transport/Controller/Api/V1/Cart/AddCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Cart/AddCartItemController.php
@@ -9,6 +9,9 @@ use App\Shop\Domain\Entity\Product;
 use App\Shop\Domain\Entity\Shop;
 use App\Shop\Infrastructure\Repository\ProductRepository;
 use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Shop\Transport\Controller\Api\V1\Input\Cart\AddCartItemInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Cart\CartInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
@@ -33,6 +36,7 @@ final readonly class AddCartItemController
         private ShopRepository $shopRepository,
         private ProductRepository $productRepository,
         private CartService $cartService,
+        private CartInputValidator $cartInputValidator,
     ) {
     }
 
@@ -58,9 +62,20 @@ final readonly class AddCartItemController
             ], JsonResponse::HTTP_NOT_FOUND);
         }
 
-        $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        $productId = (string)($payload['productId'] ?? '');
-        $quantity = max(1, (int)($payload['quantity'] ?? 1));
+        try {
+            $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
+
+        $input = AddCartItemInput::fromArray($payload);
+        $validationResponse = $this->cartInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $productId = $input->productId;
+        $quantity = $input->quantity;
 
         $product = $this->productRepository->find($productId);
         if (!$product instanceof Product || $product->getShop()?->getId() !== $shop->getId()) {

--- a/src/Shop/Transport/Controller/Api/V1/Cart/PatchCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Cart/PatchCartItemController.php
@@ -9,6 +9,9 @@ use App\Shop\Domain\Entity\CartItem;
 use App\Shop\Domain\Entity\Shop;
 use App\Shop\Infrastructure\Repository\CartItemRepository;
 use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Shop\Transport\Controller\Api\V1\Input\Cart\CartInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Cart\PatchCartItemInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
@@ -33,6 +36,7 @@ final readonly class PatchCartItemController
         private ShopRepository $shopRepository,
         private CartItemRepository $cartItemRepository,
         private CartService $cartService,
+        private CartInputValidator $cartInputValidator,
     ) {
     }
 
@@ -67,13 +71,19 @@ final readonly class PatchCartItemController
             ], JsonResponse::HTTP_NOT_FOUND);
         }
 
-        $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        $quantity = (int)($payload['quantity'] ?? 0);
-        if ($quantity <= 0) {
-            return new JsonResponse([
-                'message' => 'Quantity must be greater than 0.',
-            ], JsonResponse::HTTP_BAD_REQUEST);
+        try {
+            $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
         }
+
+        $input = PatchCartItemInput::fromArray($payload);
+        $validationResponse = $this->cartInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $quantity = $input->quantity;
 
         $cart = $this->cartService->updateItemQuantity($cart, $item, $quantity);
 

--- a/src/Shop/Transport/Controller/Api/V1/Input/Cart/AddCartItemInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Cart/AddCartItemInput.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Cart;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class AddCartItemInput
+{
+    #[Assert\NotBlank(message: 'productId is required.')]
+    public string $productId = '';
+
+    #[Assert\GreaterThan(value: 0, message: 'quantity must be greater than 0.')]
+    public int $quantity = 1;
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $input = new self();
+        $input->productId = trim((string)($payload['productId'] ?? ''));
+        $input->quantity = (int)($payload['quantity'] ?? 1);
+
+        return $input;
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Cart/CartInputValidator.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Cart/CartInputValidator.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Cart;
+
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final readonly class CartInputValidator
+{
+    public function __construct(
+        private ValidatorInterface $validator,
+    ) {
+    }
+
+    public function validate(AddCartItemInput|PatchCartItemInput $input): ?JsonResponse
+    {
+        $violations = $this->validator->validate($input);
+        if ($violations->count() === 0) {
+            return null;
+        }
+
+        return ValidationResponseFactory::fromViolations($violations);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Cart/PatchCartItemInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Cart/PatchCartItemInput.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\Input\Cart;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class PatchCartItemInput
+{
+    #[Assert\GreaterThan(value: 0, message: 'quantity must be greater than 0.')]
+    public int $quantity = 0;
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        $input = new self();
+        $input->quantity = (int)($payload['quantity'] ?? 0);
+
+        return $input;
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Product/ProductInputValidator.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Product/ProductInputValidator.php
@@ -60,9 +60,6 @@ final readonly class ProductInputValidator
             return null;
         }
 
-        return new JsonResponse([
-            'message' => 'Validation failed.',
-            'errors' => $errors,
-        ], JsonResponse::HTTP_UNPROCESSABLE_ENTITY);
+        return ValidationResponseFactory::fromErrors($errors);
     }
 }

--- a/src/Shop/Transport/Controller/Api/V1/Input/Support/ValidationResponseFactory.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Support/ValidationResponseFactory.php
@@ -29,16 +29,27 @@ final class ValidationResponseFactory
      */
     public static function fromViolations(iterable $violations): JsonResponse
     {
+        /** @var list<array{field: string, message: string, code: string|null}> $errors */
+        $errors = array_map(
+            static fn (ConstraintViolationInterface $violation): array => [
+                'field' => $violation->getPropertyPath(),
+                'message' => $violation->getMessage(),
+                'code' => $violation->getCode(),
+            ],
+            iterator_to_array($violations),
+        );
+
+        return self::fromErrors($errors);
+    }
+
+    /**
+     * @param list<array{field: string, message: string, code: string|null}> $errors
+     */
+    public static function fromErrors(array $errors): JsonResponse
+    {
         return new JsonResponse([
             'message' => 'Validation failed.',
-            'errors' => array_map(
-                static fn (ConstraintViolationInterface $violation): array => [
-                    'field' => $violation->getPropertyPath(),
-                    'message' => $violation->getMessage(),
-                    'code' => $violation->getCode(),
-                ],
-                iterator_to_array($violations),
-            ),
+            'errors' => $errors,
         ], JsonResponse::HTTP_UNPROCESSABLE_ENTITY);
     }
 }

--- a/src/Shop/Transport/Controller/Api/V1/Payment/PaymentWebhookController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/PaymentWebhookController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shop\Transport\Controller\Api\V1\Payment;
 
 use App\Shop\Application\Service\PaymentService;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use JsonException;
@@ -39,7 +40,11 @@ final readonly class PaymentWebhookController
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);
-        $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        try {
+            $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
         $signature = $request->headers->get('x-signature');
 
         $transaction = $this->paymentService->processWebhook($payload, $signature);

--- a/tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php
+++ b/tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php
@@ -130,4 +130,98 @@ final class ShopMutationControllerTest extends WebTestCase
 
         self::assertNull($productRepository->find($product->getId()));
     }
+
+    public function testCreateProductReturnsStandardValidationErrorForMalformedJsonPayload(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/products',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            '{"name":"Broken payload"'
+        );
+
+        self::assertResponseStatusCodeSame(400);
+
+        /** @var array{message?: string, errors?: list<array{field?: string, code?: string}>} $payload */
+        $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('Validation failed.', $payload['message'] ?? null);
+        self::assertSame('payload', $payload['errors'][0]['field'] ?? null);
+        self::assertSame('INVALID_JSON', $payload['errors'][0]['code'] ?? null);
+    }
+
+    public function testCreateProductReturnsStandardValidationErrorWhenSkuIsMissing(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/products',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'name' => 'SKU missing product',
+                'price' => 12.34,
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(422);
+
+        /** @var array{message?: string, errors?: list<array{field?: string, message?: string}>} $payload */
+        $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('Validation failed.', $payload['message'] ?? null);
+        self::assertContains('sku', array_column($payload['errors'] ?? [], 'field'));
+    }
+
+    public function testCreateProductReturnsStandardValidationErrorsForInvalidBusinessValues(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/products',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'name' => 'Invalid business values',
+                'sku' => 'INVALID-BUSINESS',
+                'price' => 0,
+                'stock' => -1,
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(422);
+
+        /** @var array{message?: string, errors?: list<array{field?: string}>} $payload */
+        $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('Validation failed.', $payload['message'] ?? null);
+        self::assertContains('price', array_column($payload['errors'] ?? [], 'field'));
+        self::assertContains('stock', array_column($payload['errors'] ?? [], 'field'));
+    }
+
+    public function testConfirmPaymentReturnsStandardValidationErrorWhenProviderReferenceIsMissing(): void
+    {
+        $client = $this->getTestClient('john-user', 'password-user');
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/applications/shop-ops-center/orders/11111111-1111-1111-1111-111111111111/payment-confirm',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(422);
+
+        /** @var array{message?: string, errors?: list<array{field?: string}>} $payload */
+        $payload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('Validation failed.', $payload['message'] ?? null);
+        self::assertSame('providerReference', $payload['errors'][0]['field'] ?? null);
+    }
 }


### PR DESCRIPTION
### Motivation
- Ensure controllers under `src/Shop/Transport/Controller/Api/V1` use strict JSON parsing and a single, stable error envelope so frontends can rely on a predictable validation response structure.
- Centralize DTO + validation for cart-related endpoints and reuse the same `ValidationResponseFactory` for custom validator errors to remove ad-hoc responses.
- Add integration tests that cover malformed JSON, missing required fields and invalid business values to prevent regressions in error shapes.

### Description
- Added cart input DTOs and validator: `AddCartItemInput`, `PatchCartItemInput`, and `CartInputValidator` under `src/Shop/Transport/Controller/Api/V1/Input/Cart` and wired them into the cart controllers.
- Updated `AddCartItemController` and `PatchCartItemController` to parse request body with `JSON_THROW_ON_ERROR`, convert to input DTOs via `fromArray`, validate with `CartInputValidator`, and return standardized errors via `ValidationResponseFactory` on failure.
- Updated `PaymentWebhookController` to handle malformed JSON with a standardized `ValidationResponseFactory::invalidJson()` response.
- Extended `ValidationResponseFactory` with `fromErrors()` and refactored `fromViolations()` to reuse it, and updated `ProductInputValidator` to use `fromErrors()` for handcrafted business validation errors.
- Added integration tests in `tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php` for malformed JSON, missing required fields (`sku`, `providerReference`), and invalid business values (`price <= 0`, `stock < 0`).

### Testing
- Ran PHP syntax checks with `php -l` on modified controllers, input DTOs, validator and the updated test file and they all reported no syntax errors.
- Attempted to run PHPUnit (`vendor/bin/phpunit`, `bin/phpunit`, and `composer test`) but test runner binaries are not available in this environment so full test suite execution could not be performed (automated test run failed due to missing binaries).
- Committed changes after local validations; CI should run the full PHPUnit suite and confirm integration tests added in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b536c130832685c6b01c925d9fc3)