### PR TITLE
Add structured Shop failure telemetry and alerting thresholds

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,6 +1,7 @@
 monolog:
     channels:
         - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+        - monitoring
 
 when@dev:
     monolog:
@@ -10,6 +11,11 @@ when@dev:
                 path: '%kernel.logs_dir%/%kernel.environment%.log'
                 level: debug
                 channels: [ '!event' ]
+            monitoring_stream:
+                type: stream
+                path: '%kernel.logs_dir%/monitoring_%kernel.environment%.log'
+                level: info
+                channels: [ monitoring ]
             buffered:
                 type: buffer
                 handler: easylog
@@ -44,6 +50,12 @@ when@prod: &prod
                 path: php://stderr
                 level: debug
                 formatter: monolog.formatter.json
+            monitoring_stream:
+                type: stream
+                path: php://stderr
+                level: info
+                formatter: monolog.formatter.json
+                channels: [ monitoring ]
             console:
                 type: console
                 process_psr_3_messages: false
@@ -70,6 +82,11 @@ when@test:
                 type: stream
                 path: '%kernel.logs_dir%/%kernel.environment%.log'
                 level: debug
+            monitoring_stream:
+                type: stream
+                path: '%kernel.logs_dir%/monitoring_%kernel.environment%.log'
+                level: info
+                channels: [ monitoring ]
             buffered:
                 type: buffer
                 handler: easylog

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -128,6 +128,11 @@ services:
         arguments:
             $serializer: '@app.serializer.external_message'
 
+
+    App\Shop\Application\Monitoring\ShopMonitoringService:
+        arguments:
+            $monitoringLogger: '@monolog.logger.monitoring'
+
     App\Shop\Domain\Service\Interfaces\PaymentProviderInterface:
         class: App\Shop\Infrastructure\Payment\MockPaymentProvider
         arguments:

--- a/docs/shop-monitoring-alerting.md
+++ b/docs/shop-monitoring-alerting.md
@@ -1,0 +1,64 @@
+# Monitoring & alerting — Shop checkout/paiement/webhooks
+
+## Signaux ajoutés
+
+Les services Shop émettent maintenant :
+
+- **Logs applicatifs structurés** (`event` + contexte JSON) pour :
+  - refus d'accès scope checkout (`shop.checkout.scope_access_denied`),
+  - stock insuffisant (`shop.checkout.insufficient_stock`),
+  - refus d'accès scope paiement (`shop.payment.scope_access_denied`),
+  - échec de confirmation paiement (`shop.payment.confirm_failed`),
+  - webhook invalide (`shop.webhook.invalid`),
+  - webhook replay/rejeté (`shop.webhook.replayed`).
+- **Compteurs (via événement log monitoring `metric.counter.increment`)** pour :
+  - `shop.checkout.failures_total`,
+  - `shop.payment_confirm.failures_total`,
+  - `shop.webhook.invalid_total`,
+  - `shop.webhook.replayed_total`.
+
+## Intégration stack existante
+
+L'intégration passe par la stack de logs existante (Monolog) :
+
+- nouveau canal `monitoring` déclaré ;
+- en `prod`, émission JSON vers `stderr` (ingestion actuelle de la plateforme) ;
+- en `dev`/`test`, fichier dédié `var/log/monitoring_<env>.log`.
+
+Les métriques sont publiées comme logs structurés sur le canal `monitoring` (`metric`, `value`, `labels`) pour permettre le mapping vers les compteurs de l'outil de monitoring/alerting déjà en place.
+
+## Seuils d'alerte recommandés
+
+Fenêtre glissante 5 min :
+
+- **Checkout failures** (`shop.checkout.failures_total`)
+  - warning: `>= 10`
+  - critical: `>= 25`
+- **Payment confirm failures** (`shop.payment_confirm.failures_total`)
+  - warning: `>= 5`
+  - critical: `>= 15`
+- **Webhook invalid** (`shop.webhook.invalid_total`)
+  - warning: `>= 5`
+  - critical: `>= 20`
+- **Webhook replayed** (`shop.webhook.replayed_total`)
+  - warning: `>= 3`
+  - critical: `>= 10`
+
+Seuil de ratio (sur 15 min) :
+
+- **Payment confirm failure ratio**
+  - warning: `payment_confirm_failures / payment_confirm_total >= 5%`
+  - critical: `>= 10%`
+
+## Exemples de labels
+
+- `reason`: `scope_access_denied`, `insufficient_stock`, `provider_failed`, `missing_signature`, `invalid_signature_or_payload`
+- `provider`: ex. `mockpay`
+
+## Vérification opérationnelle
+
+1. Déclencher un scénario de refus scope checkout/paiement.
+2. Déclencher un checkout avec stock insuffisant.
+3. Déclencher un confirm paiement en status `failed` côté provider.
+4. Déclencher webhook invalide puis webhook dupliqué (même clé idempotence).
+5. Vérifier présence des événements `event` et `metric.counter.increment` dans la pipeline de logs/metrics.

--- a/src/Shop/Application/Monitoring/ShopMonitoringService.php
+++ b/src/Shop/Application/Monitoring/ShopMonitoringService.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Monitoring;
+
+use Psr\Log\LoggerInterface;
+
+final readonly class ShopMonitoringService
+{
+    public function __construct(
+        private LoggerInterface $logger,
+        private LoggerInterface $monitoringLogger,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function logStructured(string $event, string $message, array $context = [], string $level = 'warning'): void
+    {
+        $payload = [
+            'event' => $event,
+            ...$context,
+        ];
+
+        match ($level) {
+            'critical' => $this->logger->critical($message, $payload),
+            'error' => $this->logger->error($message, $payload),
+            'info' => $this->logger->info($message, $payload),
+            default => $this->logger->warning($message, $payload),
+        };
+    }
+
+    /**
+     * @param array<string, scalar|null> $labels
+     */
+    public function incrementCounter(string $name, array $labels = []): void
+    {
+        $this->monitoringLogger->info('metric.counter.increment', [
+            'metric' => $name,
+            'value' => 1,
+            'labels' => $labels,
+        ]);
+    }
+}
+

--- a/src/Shop/Application/Service/CheckoutService.php
+++ b/src/Shop/Application/Service/CheckoutService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shop\Application\Service;
 
+use App\Shop\Application\Monitoring\ShopMonitoringService;
 use App\Shop\Application\Message\CheckoutCommand;
 use App\Shop\Domain\Entity\Cart;
 use App\Shop\Domain\Entity\Order;
@@ -33,6 +34,7 @@ final readonly class CheckoutService
         private OrderItemRepository $orderItemRepository,
         private ShopRepository $shopRepository,
         private UserRepository $userRepository,
+        private ShopMonitoringService $monitoringService,
     ) {
     }
 
@@ -48,6 +50,20 @@ final readonly class CheckoutService
         }
 
         if ($shop->getApplication()?->getSlug() !== $command->applicationSlug) {
+            $this->monitoringService->logStructured(
+                event: 'shop.checkout.scope_access_denied',
+                message: 'Checkout rejected due to scope access refusal.',
+                context: [
+                    'applicationSlug' => $command->applicationSlug,
+                    'shopId' => $shop->getId(),
+                    'shopApplicationSlug' => $shop->getApplication()?->getSlug(),
+                    'userId' => $command->userId,
+                ],
+            );
+            $this->monitoringService->incrementCounter('shop.checkout.failures_total', [
+                'reason' => 'scope_access_denied',
+            ]);
+
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Shop does not belong to the requested application scope.');
         }
 
@@ -84,6 +100,23 @@ final readonly class CheckoutService
             }
 
             if ($product->getStock() < $cartItem->getQuantity()) {
+                $this->monitoringService->logStructured(
+                    event: 'shop.checkout.insufficient_stock',
+                    message: 'Checkout rejected due to insufficient stock.',
+                    context: [
+                        'applicationSlug' => $command->applicationSlug,
+                        'shopId' => $shop->getId(),
+                        'userId' => $command->userId,
+                        'productId' => $product->getId(),
+                        'sku' => $product->getSku(),
+                        'requestedQuantity' => $cartItem->getQuantity(),
+                        'availableStock' => $product->getStock(),
+                    ],
+                );
+                $this->monitoringService->incrementCounter('shop.checkout.failures_total', [
+                    'reason' => 'insufficient_stock',
+                ]);
+
                 throw new HttpException(JsonResponse::HTTP_CONFLICT, sprintf('Insufficient stock for SKU %s.', $product->getSku()));
             }
 

--- a/src/Shop/Application/Service/PaymentService.php
+++ b/src/Shop/Application/Service/PaymentService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shop\Application\Service;
 
+use App\Shop\Application\Monitoring\ShopMonitoringService;
 use App\Shop\Domain\Entity\Order;
 use App\Shop\Domain\Entity\PaymentTransaction;
 use App\Shop\Domain\Enum\OrderStatus;
@@ -30,6 +31,7 @@ final readonly class PaymentService
         private PaymentProviderInterface $paymentProvider,
         private Security $security,
         private string $environment,
+        private ShopMonitoringService $monitoringService,
     ) {
     }
 
@@ -106,6 +108,24 @@ final readonly class PaymentService
 
         $this->applyOrderStateFromPayment($order, $transaction->getStatus());
 
+        if ($transaction->getStatus() === PaymentStatus::FAILED) {
+            $this->monitoringService->logStructured(
+                event: 'shop.payment.confirm_failed',
+                message: 'Payment confirmation failed.',
+                context: [
+                    'applicationSlug' => $applicationSlug,
+                    'orderId' => $order->getId(),
+                    'providerReference' => $providerReference,
+                    'provider' => $transaction->getProvider(),
+                ],
+                level: 'error',
+            );
+            $this->monitoringService->incrementCounter('shop.payment_confirm.failures_total', [
+                'reason' => 'provider_failed',
+                'provider' => $transaction->getProvider(),
+            ]);
+        }
+
         $this->orderRepository->save($order, false);
         $this->paymentTransactionRepository->save($transaction, true);
 
@@ -123,11 +143,34 @@ final readonly class PaymentService
     {
         $normalizedSignature = is_string($signature) ? trim($signature) : '';
         if ($this->environment === 'prod' && $normalizedSignature === '') {
+            $this->monitoringService->logStructured(
+                event: 'shop.webhook.invalid',
+                message: 'Webhook rejected because signature header is missing in production.',
+                context: [
+                    'environment' => $this->environment,
+                    'reason' => 'missing_signature',
+                ],
+            );
+            $this->monitoringService->incrementCounter('shop.webhook.invalid_total', [
+                'reason' => 'missing_signature',
+            ]);
+
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Webhook signature is required in production.');
         }
 
         $verifiedPayload = $this->paymentProvider->verifyWebhook($payload, $normalizedSignature !== '' ? $normalizedSignature : null);
         if ($verifiedPayload === null) {
+            $this->monitoringService->logStructured(
+                event: 'shop.webhook.invalid',
+                message: 'Webhook rejected because signature or payload is invalid.',
+                context: [
+                    'reason' => 'invalid_signature_or_payload',
+                ],
+            );
+            $this->monitoringService->incrementCounter('shop.webhook.invalid_total', [
+                'reason' => 'invalid_signature_or_payload',
+            ]);
+
             throw new HttpException(JsonResponse::HTTP_UNAUTHORIZED, 'Invalid webhook signature or payload.');
         }
 
@@ -136,6 +179,19 @@ final readonly class PaymentService
                 'webhookIdempotenceKey' => $verifiedPayload['webhookKey'],
             ]) instanceof PaymentTransaction
         ) {
+            $this->monitoringService->logStructured(
+                event: 'shop.webhook.replayed',
+                message: 'Webhook replay detected and rejected.',
+                context: [
+                    'provider' => (string)$verifiedPayload['provider'],
+                    'providerReference' => (string)$verifiedPayload['providerReference'],
+                    'webhookKey' => (string)$verifiedPayload['webhookKey'],
+                ],
+            );
+            $this->monitoringService->incrementCounter('shop.webhook.replayed_total', [
+                'provider' => (string)$verifiedPayload['provider'],
+            ]);
+
             return null;
         }
 
@@ -168,6 +224,20 @@ final readonly class PaymentService
     {
         $orderApplicationSlug = $order->getShop()?->getApplication()?->getSlug();
         if ($orderApplicationSlug !== trim($applicationSlug)) {
+            $this->monitoringService->logStructured(
+                event: 'shop.payment.scope_access_denied',
+                message: 'Payment access rejected due to scope access refusal.',
+                context: [
+                    'applicationSlug' => trim($applicationSlug),
+                    'orderId' => $order->getId(),
+                    'orderApplicationSlug' => $orderApplicationSlug,
+                    'shopId' => $order->getShop()?->getId(),
+                ],
+            );
+            $this->monitoringService->incrementCounter('shop.payment_confirm.failures_total', [
+                'reason' => 'scope_access_denied',
+            ]);
+
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'This order does not belong to the requested application scope.');
         }
 


### PR DESCRIPTION
### Motivation

- Provide structured application logs and simple metric counters for Shop checkout/payment/webhook failure modes to improve observability and enable alerting. 

### Description

- Add `ShopMonitoringService` to centralize structured event logging and counter emission (`metric.counter.increment`) for monitoring ingestion (`src/Shop/Application/Monitoring/ShopMonitoringService.php`).
- Wire a dedicated Monolog `monitoring` channel and environment-specific handlers (JSON to `stderr` in `prod`, dedicated `var/log/monitoring_<env>.log` in `dev`/`test`) and register the monitoring service in DI (`config/packages/monolog.yaml`, `config/services.yaml`).
- Instrument checkout flow to emit structured events and counters for scope access refusals and insufficient stock (`shop.checkout.scope_access_denied`, `shop.checkout.insufficient_stock`) and increment `shop.checkout.failures_total` (`src/Shop/Application/Service/CheckoutService.php`).
- Instrument payment and webhook flows to emit events and counters for scope access refusals, payment confirm failures, invalid webhooks and replayed webhooks (`shop.payment.scope_access_denied`, `shop.payment.confirm_failed`, `shop.webhook.invalid`, `shop.webhook.replayed`) and increment `shop.payment_confirm.failures_total`, `shop.webhook.invalid_total`, and `shop.webhook.replayed_total` (`src/Shop/Application/Service/PaymentService.php`).
- Add documentation explaining signal names, metric mapping and recommended alert thresholds (`docs/shop-monitoring-alerting.md`).

### Testing

- Syntax checks passed for modified PHP files using `php -l` on `src/Shop/Application/Monitoring/ShopMonitoringService.php`, `src/Shop/Application/Service/CheckoutService.php`, and `src/Shop/Application/Service/PaymentService.php` (no syntax errors).
- Attempted to run unit/functional tests (`vendor/bin/phpunit` / `bin/phpunit`) but PHPUnit binary and project vendor dependencies are not available in this environment, so tests could not be executed here.
- Changes committed locally with message `Add structured shop failure signals and monitoring counters`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b53974c88326a8aa5ad997a200bc)