### PR TITLE
docs(crm): complete OpenAPI payload and error docs for create endpoints

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/CreateCompanyByApplicationController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CreateCompanyByApplicationController.php
@@ -57,7 +57,52 @@ final readonly class CreateCompanyByApplicationController
             ),
         ),
         responses: [
-            new OA\Response(response: 201, description: 'Company created in the scoped CRM application.'),
+            new OA\Response(
+                response: 201,
+                description: 'Company created in the scoped CRM application.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'id', type: 'string', format: 'uuid', example: '7e2f5f7c-2878-438a-a2ff-27fc2382cedf'),
+                        new OA\Property(property: 'crmId', type: 'string', format: 'uuid', example: '0c9b6cba-4ed6-4977-9545-5f8564d5ac7e'),
+                        new OA\Property(property: 'applicationSlug', type: 'string', example: 'my-crm-app'),
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 400,
+                description: 'Invalid JSON payload.',
+                content: new OA\JsonContent(
+                    example: [
+                        'message' => 'Invalid JSON payload.',
+                        'errors' => [],
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Unknown CRM application scope.',
+                content: new OA\JsonContent(
+                    example: [
+                        'message' => 'Unknown application scope.',
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(
+                    example: [
+                        'message' => 'Validation failed.',
+                        'errors' => [
+                            [
+                                'propertyPath' => 'name',
+                                'message' => 'This value should not be blank.',
+                                'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                            ],
+                        ],
+                    ],
+                ),
+            ),
         ],
     )]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse

--- a/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
@@ -46,7 +46,83 @@ final readonly class CreateProjectController
      */
     #[Route('/v1/crm/applications/{applicationSlug}/projects', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    #[OA\Post(summary: 'POST /v1/crm/applications/{applicationSlug}/projects')]
+    #[OA\Post(
+        summary: 'POST /v1/crm/applications/{applicationSlug}/projects',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name', 'companyId'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', maxLength: 255, example: 'Refonte CRM 2026'),
+                    new OA\Property(property: 'code', type: 'string', maxLength: 64, nullable: true, example: 'CRM26'),
+                    new OA\Property(property: 'description', type: 'string', maxLength: 5000, nullable: true, example: 'Refonte des workflows commerciaux.'),
+                    new OA\Property(property: 'status', type: 'string', enum: ['planned', 'active', 'on_hold', 'completed'], nullable: true, example: 'active'),
+                    new OA\Property(property: 'startedAt', type: 'string', format: 'date-time', nullable: true, example: '2026-01-15T09:00:00+00:00'),
+                    new OA\Property(property: 'dueAt', type: 'string', format: 'date-time', nullable: true, example: '2026-06-30T18:00:00+00:00'),
+                    new OA\Property(property: 'companyId', type: 'string', format: 'uuid', example: '4db7f53d-cf31-4b36-9b9b-78e914c36a39'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Project created.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'id', type: 'string', format: 'uuid', example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12'),
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 400,
+                description: 'Invalid JSON payload or invalid date format.',
+                content: new OA\JsonContent(
+                    examples: [
+                        'invalidJson' => new OA\Examples(
+                            summary: 'JSON invalide',
+                            value: [
+                                'message' => 'Invalid JSON payload.',
+                                'errors' => [],
+                            ],
+                        ),
+                        'invalidDate' => new OA\Examples(
+                            summary: 'Date invalide',
+                            value: [
+                                'message' => 'Invalid date format for "startedAt".',
+                                'errors' => [],
+                            ],
+                        ),
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Referenced resource not found in CRM scope.',
+                content: new OA\JsonContent(
+                    example: [
+                        'message' => 'Unknown "companyId" in this CRM scope.',
+                        'errors' => [],
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(
+                    example: [
+                        'message' => 'Validation failed.',
+                        'errors' => [
+                            [
+                                'propertyPath' => 'companyId',
+                                'message' => 'This is not a valid UUID.',
+                                'code' => '51120b12-a2bc-41bf-aa53-cd73daf330d0',
+                            ],
+                        ],
+                    ],
+                ),
+            ),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/CreateSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/CreateSprintController.php
@@ -42,7 +42,70 @@ final readonly class CreateSprintController
 
     #[Route('/v1/crm/applications/{applicationSlug}/sprints', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    #[OA\Post(summary: 'POST /v1/crm/applications/{applicationSlug}/sprints')]
+    #[OA\Post(
+        summary: 'POST /v1/crm/applications/{applicationSlug}/sprints',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name', 'projectId'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', maxLength: 255, example: 'Sprint Q1 - Pipeline'),
+                    new OA\Property(property: 'goal', type: 'string', maxLength: 5000, nullable: true, example: 'Automatiser la qualification des leads.'),
+                    new OA\Property(property: 'status', type: 'string', enum: ['planned', 'active', 'closed'], nullable: true, example: 'planned'),
+                    new OA\Property(property: 'startDate', type: 'string', format: 'date-time', nullable: true, example: '2026-02-01T08:00:00+00:00'),
+                    new OA\Property(property: 'endDate', type: 'string', format: 'date-time', nullable: true, example: '2026-02-14T18:00:00+00:00'),
+                    new OA\Property(property: 'projectId', type: 'string', format: 'uuid', example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Sprint created.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'id', type: 'string', format: 'uuid', example: '220670e1-4bc3-40da-92bb-89d5dca347a8'),
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 400,
+                description: 'Invalid JSON payload or invalid date format.',
+                content: new OA\JsonContent(
+                    examples: [
+                        'invalidJson' => new OA\Examples(summary: 'JSON invalide', value: ['message' => 'Invalid JSON payload.', 'errors' => []]),
+                        'invalidDate' => new OA\Examples(summary: 'Date invalide', value: ['message' => 'Invalid date format for "endDate".', 'errors' => []]),
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Referenced resource not found in CRM scope.',
+                content: new OA\JsonContent(
+                    example: [
+                        'message' => 'Unknown "projectId" in this CRM scope.',
+                        'errors' => [],
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(
+                    example: [
+                        'message' => 'Validation failed.',
+                        'errors' => [
+                            [
+                                'propertyPath' => 'name',
+                                'message' => 'This value should not be blank.',
+                                'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                            ],
+                        ],
+                    ],
+                ),
+            ),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);

--- a/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
@@ -46,15 +46,85 @@ final readonly class CreateTaskController
 
     #[Route('/v1/crm/applications/{applicationSlug}/tasks', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    #[OA\Post(summary: 'POST /v1/crm/applications/{applicationSlug}/tasks')]
-
-    #[OA\RequestBody(required: false, content: new OA\JsonContent(
-        properties: [
-            new OA\Property(property: 'title', type: 'string'),
-            new OA\Property(property: 'description', type: 'string', nullable: true),
-            new OA\Property(property: 'assigneeIds', type: 'array', items: new OA\Items(type: 'string', format: 'uuid'), nullable: true),
-        ]
-    ))]
+    #[OA\Post(
+        summary: 'POST /v1/crm/applications/{applicationSlug}/tasks',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['title', 'projectId'],
+                properties: [
+                    new OA\Property(property: 'title', type: 'string', maxLength: 255, example: 'Configurer le scoring des leads'),
+                    new OA\Property(property: 'description', type: 'string', maxLength: 5000, nullable: true, example: 'Ajouter les règles de scoring côté back-office.'),
+                    new OA\Property(property: 'status', type: 'string', enum: ['todo', 'in_progress', 'blocked', 'done'], nullable: true, example: 'in_progress'),
+                    new OA\Property(property: 'priority', type: 'string', enum: ['low', 'medium', 'high', 'critical'], nullable: true, example: 'high'),
+                    new OA\Property(property: 'dueAt', type: 'string', format: 'date-time', nullable: true, example: '2026-03-15T17:00:00+00:00'),
+                    new OA\Property(property: 'estimatedHours', type: 'number', format: 'float', nullable: true, example: 12.5),
+                    new OA\Property(property: 'projectId', type: 'string', format: 'uuid', example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12'),
+                    new OA\Property(property: 'sprintId', type: 'string', format: 'uuid', nullable: true, example: '220670e1-4bc3-40da-92bb-89d5dca347a8'),
+                    new OA\Property(property: 'assigneeIds', type: 'array', nullable: true, items: new OA\Items(type: 'string', format: 'uuid'), example: ['7d3c919e-5d4e-406a-a615-ffaf6dddbd85']),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Task created.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'id', type: 'string', format: 'uuid', example: '8f6a3550-9a07-4f69-9f75-0089f7d83e7f'),
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 400,
+                description: 'Invalid JSON payload or invalid date format.',
+                content: new OA\JsonContent(
+                    examples: [
+                        'invalidJson' => new OA\Examples(summary: 'JSON invalide', value: ['message' => 'Invalid JSON payload.', 'errors' => []]),
+                        'invalidDate' => new OA\Examples(summary: 'Date invalide', value: ['message' => 'Invalid date format for "dueAt".', 'errors' => []]),
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Referenced resource not found in CRM scope.',
+                content: new OA\JsonContent(
+                    example: [
+                        'message' => 'Unknown "assigneeIds" in this CRM scope.',
+                        'errors' => [],
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation or scope consistency failed.',
+                content: new OA\JsonContent(
+                    examples: [
+                        'validationFailed' => new OA\Examples(
+                            summary: 'Validation DTO',
+                            value: [
+                                'message' => 'Validation failed.',
+                                'errors' => [
+                                    [
+                                        'propertyPath' => 'projectId',
+                                        'message' => 'This value should not be blank.',
+                                        'code' => 'c1051bb4-d103-4f74-8988-acbcafc7fdc3',
+                                    ],
+                                ],
+                            ],
+                        ),
+                        'outOfScopeSprint' => new OA\Examples(
+                            summary: 'Sprint hors projet',
+                            value: [
+                                'message' => 'Provided "sprintId" does not belong to the provided "projectId".',
+                                'errors' => [],
+                            ],
+                        ),
+                    ],
+                ),
+            ),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
@@ -43,15 +43,70 @@ final readonly class CreateTaskRequestController
 
     #[Route('/v1/crm/applications/{applicationSlug}/task-requests', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    #[OA\Post(summary: 'POST /v1/crm/applications/{applicationSlug}/task-requests')]
-
-    #[OA\RequestBody(required: false, content: new OA\JsonContent(
-        properties: [
-            new OA\Property(property: 'title', type: 'string'),
-            new OA\Property(property: 'description', type: 'string', nullable: true),
-            new OA\Property(property: 'assigneeIds', type: 'array', items: new OA\Items(type: 'string', format: 'uuid'), nullable: true),
-        ]
-    ))]
+    #[OA\Post(
+        summary: 'POST /v1/crm/applications/{applicationSlug}/task-requests',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['title', 'taskId'],
+                properties: [
+                    new OA\Property(property: 'title', type: 'string', maxLength: 255, example: 'Demande de revue produit'),
+                    new OA\Property(property: 'description', type: 'string', maxLength: 5000, nullable: true, example: 'Valider les nouveaux critères de qualification.'),
+                    new OA\Property(property: 'status', type: 'string', enum: ['pending', 'approved', 'rejected'], nullable: true, example: 'pending'),
+                    new OA\Property(property: 'resolvedAt', type: 'string', format: 'date-time', nullable: true, example: '2026-03-20T16:30:00+00:00'),
+                    new OA\Property(property: 'taskId', type: 'string', format: 'uuid', example: '8f6a3550-9a07-4f69-9f75-0089f7d83e7f'),
+                    new OA\Property(property: 'assigneeIds', type: 'array', nullable: true, items: new OA\Items(type: 'string', format: 'uuid'), example: ['7d3c919e-5d4e-406a-a615-ffaf6dddbd85']),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(
+                response: 201,
+                description: 'Task request created.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'id', type: 'string', format: 'uuid', example: 'a8ebfd5d-0fa8-4346-8ca2-ff5b7b1f6657'),
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 400,
+                description: 'Invalid JSON payload or invalid date format.',
+                content: new OA\JsonContent(
+                    examples: [
+                        'invalidJson' => new OA\Examples(summary: 'JSON invalide', value: ['message' => 'Invalid JSON payload.', 'errors' => []]),
+                        'invalidDate' => new OA\Examples(summary: 'Date invalide', value: ['message' => 'Invalid date format for "resolvedAt".', 'errors' => []]),
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 404,
+                description: 'Referenced resource not found in CRM scope.',
+                content: new OA\JsonContent(
+                    example: [
+                        'message' => 'Unknown "taskId" in this CRM scope.',
+                        'errors' => [],
+                    ],
+                ),
+            ),
+            new OA\Response(
+                response: 422,
+                description: 'Validation failed.',
+                content: new OA\JsonContent(
+                    example: [
+                        'message' => 'Validation failed.',
+                        'errors' => [
+                            [
+                                'propertyPath' => 'taskId',
+                                'message' => 'This is not a valid UUID.',
+                                'code' => '51120b12-a2bc-41bf-aa53-cd73daf330d0',
+                            ],
+                        ],
+                    ],
+                ),
+            ),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $request->attributes->set('applicationSlug', $applicationSlug);


### PR DESCRIPTION
### Motivation
- Improve and complete OpenAPI documentation for CRM create endpoints so generated API specs accurately reflect request DTO validation and runtime error responses.
- Provide concrete examples for success and common error payloads (invalid JSON, invalid dates, unknown scoped references, validation failures) to help API consumers and tooling.

### Description
- Added detailed `OA\RequestBody` annotations (required fields, types, max lengths, formats, enums and realistic examples) to the create controllers for Company, Project, Sprint, Task and TaskRequest under `src/Crm/Transport/Controller/Api/V1/` to match DTO constraints in `src/Crm/Transport/Request/`.
- Added explicit `OA\Response` entries for `201` success responses including response payload schemas, and for `400`, `404` and `422` error cases with example payloads and example variants where appropriate.
- Aligned enum values and date formats with domain enums and DTO validators (`ProjectStatus`, `SprintStatus`, `TaskStatus`, `TaskPriority`, `TaskRequestStatus`) and with the controllers' runtime date parsing behavior.
- Modified files: `CreateCompanyByApplicationController.php`, `Project/CreateProjectController.php`, `Sprint/CreateSprintController.php`, `Task/CreateTaskController.php`, `TaskRequest/CreateTaskRequestController.php` and committed the changes.

### Testing
- Ran PHP linter on each modified controller with `php -l` and there were no syntax errors for `CreateCompanyByApplicationController.php`, `CreateProjectController.php`, `CreateSprintController.php`, `CreateTaskController.php` and `CreateTaskRequestController.php`.
- Confirmed updated code was committed (local commit created with the applied changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b53ec3bc8326afe2b1804591cfce)