### PR TITLE
Uniformiser les clés project/sprint en `name`

### DIFF
--- a/src/Crm/Application/Service/CrmApiNormalizer.php
+++ b/src/Crm/Application/Service/CrmApiNormalizer.php
@@ -83,7 +83,7 @@ final class CrmApiNormalizer
     {
         return [
             'id' => (string)($item['id'] ?? ''),
-            'title' => (string)($item['name'] ?? ''),
+            'name' => (string)($item['name'] ?? ''),
             'status' => (string)($item['status'] ?? ''),
             'projectId' => $item['projectId'] ?? null,
             'startDate' => $this->normalizeDateValue($item['startDate'] ?? null),
@@ -98,7 +98,7 @@ final class CrmApiNormalizer
     {
         return [
             'id' => (string)($item['id'] ?? ''),
-            'title' => (string)($item['name'] ?? ''),
+            'name' => (string)($item['name'] ?? ''),
             'status' => (string)($item['status'] ?? ''),
             'companyId' => $item['companyId'] ?? null,
         ];

--- a/src/Crm/Application/Service/TaskBoardService.php
+++ b/src/Crm/Application/Service/TaskBoardService.php
@@ -49,7 +49,7 @@ final readonly class TaskBoardService
                 $items[$sprintId] = [
                     'sprint' => [
                         'id' => $task->getSprint()?->getId(),
-                        'title' => $task->getSprint()?->getName(),
+                        'name' => $task->getSprint()?->getName(),
                         'status' => $task->getSprint()?->getStatus()->value,
                     ],
                     'tasks' => [],

--- a/src/Crm/Transport/Controller/Api/V1/Project/ListProjectsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/ListProjectsController.php
@@ -29,6 +29,7 @@ final readonly class ListProjectsController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Response(response: 200, description: 'Projects list with normalized name field.')]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/ListSprintsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/ListSprintsController.php
@@ -29,6 +29,7 @@ final readonly class ListSprintsController
 
     #[Route('/v1/crm/applications/{applicationSlug}/sprints', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Response(response: 200, description: 'Sprints list with normalized name field.')]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);

--- a/src/Crm/Transport/Controller/Api/V1/Task/ListTasksBySprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/ListTasksBySprintController.php
@@ -26,6 +26,7 @@ final readonly class ListTasksBySprintController
     #[Route('/v1/crm/applications/{applicationSlug}/tasks/by-sprint', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Get(summary: 'Liste les tasks et task-requests regroupées par sprint')]
+    #[OA\Response(response: 200, description: 'Board payload grouped by sprint with sprint.name.')]
     public function __invoke(string $applicationSlug): JsonResponse
     {
         return new JsonResponse($this->taskBoardService->listBySprint($applicationSlug));

--- a/tests/Application/Crm/Transport/Controller/Api/V1/CrmEndpointsSmokeTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/CrmEndpointsSmokeTest.php
@@ -288,6 +288,100 @@ final class CrmEndpointsSmokeTest extends WebTestCase
         self::assertSame([], $payload['errors'] ?? null);
     }
 
+
+    #[TestDox('Project and sprint list payloads expose "name" instead of legacy "title".')]
+    public function testProjectAndSprintListUseNameField(): void
+    {
+        $companyId = $this->createCompany();
+        $projectId = $this->createProject($companyId);
+        $sprintId = $this->createSprint($projectId);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', sprintf('%s/v1/crm/applications/%s/projects?page=1&limit=100', self::API_URL_PREFIX, self::APPLICATION_SLUG));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $projectsPayload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        $projectItem = $this->findItemById($projectsPayload['items'] ?? [], $projectId);
+        self::assertNotNull($projectItem);
+        self::assertArrayHasKey('name', $projectItem);
+        self::assertArrayNotHasKey('title', $projectItem);
+
+        $client->request('GET', sprintf('%s/v1/crm/applications/%s/sprints?page=1&limit=100', self::API_URL_PREFIX, self::APPLICATION_SLUG));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $sprintsPayload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        $sprintItem = $this->findItemById($sprintsPayload['items'] ?? [], $sprintId);
+        self::assertNotNull($sprintItem);
+        self::assertArrayHasKey('name', $sprintItem);
+        self::assertArrayNotHasKey('title', $sprintItem);
+
+        $this->assertDeleteSucceeds('sprints', $sprintId);
+        $this->assertDeleteSucceeds('projects', $projectId);
+        $this->assertDeleteSucceeds('companies', $companyId);
+    }
+
+    #[TestDox('Tasks by sprint board payload exposes sprint.name instead of sprint.title.')]
+    public function testTasksBySprintBoardUsesSprintNameField(): void
+    {
+        $companyId = $this->createCompany();
+        $projectId = $this->createProject($companyId);
+        $sprintId = $this->createSprint($projectId);
+
+        $taskClient = $this->getTestClient('john-root', 'password-root');
+        $taskClient->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/tasks', self::API_URL_PREFIX, self::APPLICATION_SLUG),
+            content: JSON::encode([
+                'title' => 'Board task ' . uniqid('', true),
+                'projectId' => $projectId,
+                'sprintId' => $sprintId,
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $taskClient->getResponse()->getStatusCode());
+        $taskPayload = $this->decodeJsonResponse($taskClient->getResponse()->getContent());
+        $taskId = (string)($taskPayload['id'] ?? '');
+        self::assertNotSame('', $taskId);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', sprintf('%s/v1/crm/applications/%s/tasks/by-sprint', self::API_URL_PREFIX, self::APPLICATION_SLUG));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertIsArray($payload['items'] ?? null);
+
+        $group = null;
+        foreach ($payload['items'] as $item) {
+            if (($item['sprint']['id'] ?? null) === $sprintId) {
+                $group = $item;
+                break;
+            }
+        }
+
+        self::assertIsArray($group);
+        self::assertArrayHasKey('sprint', $group);
+        self::assertArrayHasKey('name', $group['sprint']);
+        self::assertArrayNotHasKey('title', $group['sprint']);
+
+        $this->assertDeleteSucceeds('tasks', $taskId);
+        $this->assertDeleteSucceeds('sprints', $sprintId);
+        $this->assertDeleteSucceeds('projects', $projectId);
+        $this->assertDeleteSucceeds('companies', $companyId);
+    }
+
+    #[TestDox('OpenAPI documentation exposes name for CRM projects/sprints and by-sprint board schema example.')]
+    public function testOpenApiShowsNameForProjectSprintAndBoardPayloads(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', '/api/doc.json');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        $paths = $payload['paths'] ?? [];
+
+        self::assertSame('Projects list with normalized name field.', $paths['/v1/crm/applications/{applicationSlug}/projects']['get']['responses']['200']['description'] ?? null);
+        self::assertSame('Sprints list with normalized name field.', $paths['/v1/crm/applications/{applicationSlug}/sprints']['get']['responses']['200']['description'] ?? null);
+        self::assertSame('Board payload grouped by sprint with sprint.name.', $paths['/v1/crm/applications/{applicationSlug}/tasks/by-sprint']['get']['responses']['200']['description'] ?? null);
+    }
+
     /**
      * @return array<int, array{string}>
      */
@@ -436,6 +530,21 @@ final class CrmEndpointsSmokeTest extends WebTestCase
         $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
         self::assertArrayHasKey('message', $payload);
         self::assertSame([], $payload['errors'] ?? null);
+    }
+
+    /**
+     * @param list<array<string,mixed>> $items
+     * @return array<string,mixed>|null
+     */
+    private function findItemById(array $items, string $id): ?array
+    {
+        foreach ($items as $item) {
+            if (($item['id'] ?? null) === $id) {
+                return $item;
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Harmoniser la convention d'API pour les entités CRM project et sprint afin d'exposer un seul champ cohérent (`name`) au lieu d'un mélange `title`/`name`.
- Éviter les régressions frontend et faciliter la consommation des payloads board/list en normalisant les projections et le regroupement par sprint.

### Description
- `CrmApiNormalizer::normalizeProjectProjection` et `::normalizeSprintProjection` remplacent la clé `title` par `name` pour les projections retournées par les listes. (`src/Crm/Application/Service/CrmApiNormalizer.php`).
- Le payload board groupé par sprint (`TaskBoardService::listBySprint`) expose désormais `sprint.name` au lieu de `sprint.title`. (`src/Crm/Application/Service/TaskBoardService.php`).
- Ajout d'annotations OpenAPI `#[OA\Response(...)]` sur les contrôleurs list/board impactés pour documenter la convention finale. (`src/Crm/Transport/Controller/Api/V1/*`).
- Mise à jour des tests smoke CRM pour vérifier la présence de `name`, l'absence de `title` et la présence des descriptions OpenAPI, et ajout d'un utilitaire `findItemById` pour ces assertions. (`tests/Application/Crm/Transport/Controller/Api/V1/CrmEndpointsSmokeTest.php`).

### Testing
- Vérification de syntaxe PHP sur les fichiers modifiés via `php -l` : tous les fichiers modifiés sont valides. 
- Exécution des tests PHPUnit n'a pas pu être lancée dans cet environnement car le binaire `./vendor/bin/phpunit` et `bin/phpunit` sont absents. 
- Les modifications ont été exercées localement en ajoutant assertions ciblées dans le test smoke CRM pour couvrir les changements de payload et d'OpenAPI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b53facdc8326b18ae0a4a06d2f97)