### PR TITLE
Include assignees in CRM task-request list projection

### DIFF
--- a/src/Crm/Application/Service/CrmApiNormalizer.php
+++ b/src/Crm/Application/Service/CrmApiNormalizer.php
@@ -109,6 +109,21 @@ final class CrmApiNormalizer
      */
     public function normalizeTaskRequestProjection(array $item): array
     {
+        $assignees = [];
+        foreach ((array)($item['assignees'] ?? []) as $assignee) {
+            if (!is_array($assignee)) {
+                continue;
+            }
+
+            $assignees[] = [
+                'id' => $assignee['id'] ?? null,
+                'username' => $assignee['username'] ?? null,
+                'firstName' => $assignee['firstName'] ?? null,
+                'lastName' => $assignee['lastName'] ?? null,
+                'photo' => $assignee['photo'] ?? null,
+            ];
+        }
+
         return [
             'id' => (string)($item['id'] ?? ''),
             'taskId' => $item['taskId'] ?? null,
@@ -116,7 +131,7 @@ final class CrmApiNormalizer
             'status' => (string)($item['status'] ?? ''),
             'requestedAt' => $this->normalizeDateValue($item['requestedAt'] ?? null),
             'resolvedAt' => $this->normalizeDateValue($item['resolvedAt'] ?? null),
-            'assignees' => [],
+            'assignees' => $assignees,
         ];
     }
 

--- a/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
+++ b/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
@@ -116,7 +116,49 @@ class TaskRequestRepository extends BaseRepository
             $qb->andWhere('taskRequest.status = :status')->setParameter('status', $status);
         }
 
-        return $qb->getQuery()->getArrayResult();
+        $items = $qb->getQuery()->getArrayResult();
+        if ($items === []) {
+            return [];
+        }
+
+        /** @var list<string> $taskRequestIds */
+        $taskRequestIds = array_values(array_filter(array_map(static fn (array $item): string => (string)($item['id'] ?? ''), $items)));
+        if ($taskRequestIds === []) {
+            return $items;
+        }
+
+        $assigneeRows = $this->createQueryBuilder('taskRequest')
+            ->select('taskRequest.id AS taskRequestId, assignee.id, assignee.username, assignee.firstName, assignee.lastName, assignee.photo')
+            ->leftJoin('taskRequest.assignees', 'assignee')
+            ->andWhere('taskRequest.id IN (:taskRequestIds)')
+            ->andWhere('assignee.id IS NOT NULL')
+            ->setParameter('taskRequestIds', $taskRequestIds)
+            ->getQuery()
+            ->getArrayResult();
+
+        /** @var array<string,list<array<string,mixed>>> $assigneesByTaskRequest */
+        $assigneesByTaskRequest = [];
+        foreach ($assigneeRows as $assigneeRow) {
+            $taskRequestId = (string)($assigneeRow['taskRequestId'] ?? '');
+            if ($taskRequestId === '') {
+                continue;
+            }
+
+            $assigneesByTaskRequest[$taskRequestId][] = [
+                'id' => $assigneeRow['id'] ?? null,
+                'username' => $assigneeRow['username'] ?? null,
+                'firstName' => $assigneeRow['firstName'] ?? null,
+                'lastName' => $assigneeRow['lastName'] ?? null,
+                'photo' => $assigneeRow['photo'] ?? null,
+            ];
+        }
+
+        foreach ($items as $index => $item) {
+            $taskRequestId = (string)($item['id'] ?? '');
+            $items[$index]['assignees'] = $assigneesByTaskRequest[$taskRequestId] ?? [];
+        }
+
+        return $items;
     }
 
     /**

--- a/tests/Application/Crm/Transport/Controller/Api/V1/CrmEndpointsSmokeTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/CrmEndpointsSmokeTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Tests\Application\Crm\Transport\Controller\Api\V1;
 
+use App\Crm\Infrastructure\Repository\TaskRequestRepository;
 use App\General\Domain\Utils\JSON;
 use App\Tests\TestCase\WebTestCase;
+use App\User\Infrastructure\Repository\UserRepository;
+use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\HttpFoundation\Response;
@@ -259,6 +262,72 @@ final class CrmEndpointsSmokeTest extends WebTestCase
     public function testTaskRequestDeleteErrorCase(): void
     {
         $this->assertDeleteNotFound('task-requests');
+    }
+
+    #[TestDox('GET /task-requests includes assignees projection fields for each assignee.')]
+    public function testTaskRequestListIncludesAssigneesProjection(): void
+    {
+        static::bootKernel();
+
+        $container = static::getContainer();
+        $entityManager = $container->get(EntityManagerInterface::class);
+        $taskRequestRepository = $container->get(TaskRequestRepository::class);
+        $userRepository = $container->get(UserRepository::class);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', sprintf('%s/v1/crm/applications/%s/task-requests?limit=1', self::API_URL_PREFIX, self::APPLICATION_SLUG));
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode(), "Response:\n" . $client->getResponse());
+        $initialPayload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        $taskRequestId = (string)($initialPayload['items'][0]['id'] ?? '');
+        self::assertNotSame('', $taskRequestId);
+
+        $taskRequest = $taskRequestRepository->find($taskRequestId);
+        self::assertNotNull($taskRequest);
+
+        $johnRoot = $userRepository->findOneBy(['username' => 'john-root']);
+        $alice = $userRepository->findOneBy(['username' => 'alice']);
+        self::assertNotNull($johnRoot);
+        self::assertNotNull($alice);
+
+        $taskRequest->addAssignee($johnRoot);
+        $taskRequest->addAssignee($alice);
+        $entityManager->persist($taskRequest);
+        $entityManager->flush();
+
+        $client->request('GET', sprintf('%s/v1/crm/applications/%s/task-requests?limit=100', self::API_URL_PREFIX, self::APPLICATION_SLUG));
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode(), "Response:\n" . $client->getResponse());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        $item = null;
+        foreach ((array)($payload['items'] ?? []) as $candidate) {
+            if (($candidate['id'] ?? null) === $taskRequest->getId()) {
+                $item = $candidate;
+                break;
+            }
+        }
+
+        self::assertIsArray($item);
+        self::assertArrayHasKey('assignees', $item);
+        self::assertCount(2, $item['assignees']);
+
+        $assigneesByUsername = [];
+        foreach ($item['assignees'] as $assignee) {
+            self::assertArrayHasKey('id', $assignee);
+            self::assertArrayHasKey('username', $assignee);
+            self::assertArrayHasKey('firstName', $assignee);
+            self::assertArrayHasKey('lastName', $assignee);
+            self::assertArrayHasKey('photo', $assignee);
+            $assigneesByUsername[$assignee['username']] = $assignee;
+        }
+
+        self::assertArrayHasKey('john-root', $assigneesByUsername);
+        self::assertArrayHasKey('alice', $assigneesByUsername);
+        self::assertSame($johnRoot->getId(), $assigneesByUsername['john-root']['id']);
+        self::assertSame($alice->getId(), $assigneesByUsername['alice']['id']);
+        self::assertSame($johnRoot->getFirstName(), $assigneesByUsername['john-root']['firstName']);
+        self::assertSame($alice->getLastName(), $assigneesByUsername['alice']['lastName']);
     }
 
     #[TestDox('GET /dashboard returns 200 and expected keys.')]


### PR DESCRIPTION
### Motivation

- Return `assignees` on the CRM `GET /task-requests` list with the same minimal user shape as other CRM endpoints while avoiding an N+1 query pattern.

### Description

- Extend `TaskRequestRepository::findScopedProjection` to fetch assignees in batch for the page, map them by `taskRequestId` and inject an `assignees` array into each projection with fields `id`, `username`, `firstName`, `lastName`, `photo` (`src/Crm/Infrastructure/Repository/TaskRequestRepository.php`).
- Update `CrmApiNormalizer::normalizeTaskRequestProjection` to consume the incoming `assignees` array and return the minimal assignee shape instead of an empty array (`src/Crm/Application/Service/CrmApiNormalizer.php`).
- Add an integration test `testTaskRequestListIncludesAssigneesProjection` that attaches two users to an existing task request and asserts the `assignees` key and each assignee's fields in the list response (`tests/Application/Crm/Transport/Controller/Api/V1/CrmEndpointsSmokeTest.php`).

### Testing

- Ran syntax checks with `php -l` on the modified files and they reported no syntax errors for `src/Crm/Infrastructure/Repository/TaskRequestRepository.php`, `src/Crm/Application/Service/CrmApiNormalizer.php` and `tests/Application/Crm/Transport/Controller/Api/V1/CrmEndpointsSmokeTest.php`.
- Attempted to run the related PHPUnit test (`vendor/bin/phpunit tests/Application/Crm/Transport/Controller/Api/V1/CrmEndpointsSmokeTest.php`) but `vendor/bin/phpunit` is not available in this environment so the integration test could not be executed here.
- Verified code compiles for basic linting and added the integration test to the test suite for CI to run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b54184988326968d98c2dc481201)