### PR TITLE
Fix Symfony env default parameters for interview invitation templates

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,10 +5,12 @@
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
     locale: 'en'
+    recruit.interview_invitation.template_create_default: 'Emails/interview_invitation_created.html.twig'
+    recruit.interview_invitation.template_update_default: 'Emails/interview_invitation_updated.html.twig'
     recruit.interview_calendar.default_timezone: '%env(default:UTC:RECRUIT_INTERVIEW_CALENDAR_DEFAULT_TIMEZONE)%'
     recruit.interview_invitation.sender_email: '%env(resolve:RECRUIT_INTERVIEW_INVITATION_SENDER_EMAIL)%'
-    recruit.interview_invitation.template_create: '%env(default:Emails/interview_invitation_created.html.twig:RECRUIT_INTERVIEW_TEMPLATE_CREATE)%'
-    recruit.interview_invitation.template_update: '%env(default:Emails/interview_invitation_updated.html.twig:RECRUIT_INTERVIEW_TEMPLATE_UPDATE)%'
+    recruit.interview_invitation.template_create: '%env(default:recruit.interview_invitation.template_create_default:RECRUIT_INTERVIEW_TEMPLATE_CREATE)%'
+    recruit.interview_invitation.template_update: '%env(default:recruit.interview_invitation.template_update_default:RECRUIT_INTERVIEW_TEMPLATE_UPDATE)%'
 
 services:
     # default configuration for services in *this* file


### PR DESCRIPTION
### Motivation
- The `env(default:...)` processor in `config/services.yaml` was given raw Twig path strings containing `/`, which Symfony treats as invalid env var names and caused an error at container build time.

### Description
- Added `recruit.interview_invitation.template_create_default` and `recruit.interview_invitation.template_update_default` parameters and updated `recruit.interview_invitation.template_create` and `recruit.interview_invitation.template_update` to use `env(default:<parameter>:RECRUIT_INTERVIEW_TEMPLATE_...)` instead of embedding Twig paths directly in the `env` default; changes are in `config/services.yaml`.

### Testing
- Attempted to run `php bin/console about` to validate the container, but the command failed in this environment because PHP dependencies are not installed (run `composer install` to enable runtime validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c0c786d08326a1c9ed0e89152fab)