### PR TITLE
Add missing UUIDs for new role enums in user group fixtures

### DIFF
--- a/src/User/Infrastructure/DataFixtures/ORM/LoadUserGroupData.php
+++ b/src/User/Infrastructure/DataFixtures/ORM/LoadUserGroupData.php
@@ -33,6 +33,9 @@ final class LoadUserGroupData extends Fixture implements OrderedFixtureInterface
         'Role-user' => '10000000-0000-1000-8000-000000000003',
         'Role-admin' => '10000000-0000-1000-8000-000000000004',
         'Role-root' => '10000000-0000-1000-8000-000000000005',
+        'Role-recruiter' => '10000000-0000-1000-8000-000000000006',
+        'Role-hiring_manager' => '10000000-0000-1000-8000-000000000007',
+        'Role-interviewer' => '10000000-0000-1000-8000-000000000008',
     ];
 
     public function __construct(


### PR DESCRIPTION
### Motivation
- New role enum values (`RECRUITER`, `HIRING_MANAGER`, `INTERVIEWER`) caused `Undefined array key` warnings when creating `UserGroup` fixtures because the fixture UUID mapping did not include those keys.

### Description
- Added deterministic UUID mappings for `Role-recruiter`, `Role-hiring_manager`, and `Role-interviewer` in `src/User/Infrastructure/DataFixtures/ORM/LoadUserGroupData.php` so `RolesService::getRoles()` can be fully resolved during fixture creation.

### Testing
- Ran `php -l src/User/Infrastructure/DataFixtures/ORM/LoadUserGroupData.php` which reported no syntax errors. 
- Attempted `php bin/console doctrine:fixtures:load -n` but it was blocked in this environment due to missing project dependencies (`composer install` required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c1ee149c83269b28e46f06c14a33)