### PR TITLE
Add missing OpenAPI example keys in CreateProjectController

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
@@ -79,6 +79,7 @@ final readonly class CreateProjectController
                 content: new OA\JsonContent(
                     examples: [
                         'invalidJson' => new OA\Examples(
+                            example: 'invalidJson',
                             summary: 'JSON invalide',
                             value: [
                                 'message' => 'Invalid JSON payload.',
@@ -86,6 +87,7 @@ final readonly class CreateProjectController
                             ],
                         ),
                         'invalidDate' => new OA\Examples(
+                            example: 'invalidDate',
                             summary: 'Date invalide',
                             value: [
                                 'message' => 'Invalid date format for "startedAt".',


### PR DESCRIPTION
### Motivation
- Fix a swagger-php validation warning by supplying the required `example` key to `OA\Examples` annotations in `CreateProjectController.php`.

### Description
- Added `example: 'invalidJson'` and `example: 'invalidDate'` to the two `OA\Examples` entries in the `400` response for the create project endpoint, changing only documentation annotations and not runtime logic.

### Testing
- Ran `php -l src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c5472ea08326a26ca518dce315fc)