### PR TITLE
Fix missing OpenAPI example keys in CreateTaskController

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
@@ -101,6 +101,7 @@ final readonly class CreateTaskController
                 content: new OA\JsonContent(
                     examples: [
                         'validationFailed' => new OA\Examples(
+                            example: 'validationFailed',
                             summary: 'Validation DTO',
                             value: [
                                 'message' => 'Validation failed.',
@@ -114,6 +115,7 @@ final readonly class CreateTaskController
                             ],
                         ),
                         'outOfScopeSprint' => new OA\Examples(
+                            example: 'outOfScopeSprint',
                             summary: 'Sprint hors projet',
                             value: [
                                 'message' => 'Provided "sprintId" does not belong to the provided "projectId".',


### PR DESCRIPTION
### Motivation
- Resolve swagger-php validation warning about `@OA\Examples()` missing the required `example` key in the 422 response of the task creation endpoint.

### Description
- Add `example: 'validationFailed'` and `example: 'outOfScopeSprint'` to the corresponding `OA\Examples` entries in `src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php` so OpenAPI annotations include the required key.

### Testing
- Ran `php -l src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c89e23348326a342f2c2d9273ea8)