### PR TITLE
Fix duplicate OpenAPI response annotations on class creation endpoint

### DIFF
--- a/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
@@ -43,9 +43,6 @@ final readonly class CreateClassByApplicationController
         ),
         responses: [
             new OA\Response(response: 201, description: 'Classe créée.', content: new OA\JsonContent(example: ['id' => '7600e750-f92f-4f9f-883a-26404b538f66', 'schoolId' => 'b7c23d65-11e0-4f26-8ad7-3f58c48f1290', 'applicationSlug' => 'school-crm'])),
-            new OA\Response(response: 403, description: 'Accès refusé.'),
-            new OA\Response(response: 404, description: 'Application introuvable.'),
-            new OA\Response(response: 422, description: 'Erreur de validation.'),
         ],
     )]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]


### PR DESCRIPTION
### Motivation
- The OpenAPI generator emitted warnings about duplicate `@OA\Response` entries for response codes (notably `403`) in `CreateClassByApplicationController`, so duplicates were removed to prevent schema conflicts.

### Description
- Removed the duplicate `403`, `404`, and `422` `OA\Response` entries from the `responses` array inside the `OA\Post` attribute in `src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php` and retained the standalone `#[OA\Response(...)]` attributes so each response code is declared only once.

### Testing
- Ran `php -l src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php` and the file reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c99241d08326a001c4f27db11ff9)