### PR TITLE
Add missing School OpenAPI schemas to Nelmio config

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -28,6 +28,51 @@ when@dev: &dev
                         name: Authorization
                         description: 'Value: ApiKey {token}'
                         in: header
+                schemas:
+                    SchoolError:
+                        type: object
+                        required:
+                            - message
+                            - code
+                            - details
+                        properties:
+                            message:
+                                type: string
+                                example: Forbidden application scope access.
+                            code:
+                                type: string
+                                example: SCHOOL_FORBIDDEN
+                            details:
+                                type: array
+                                items:
+                                    type: object
+                    SchoolValidationError:
+                        type: object
+                        required:
+                            - message
+                            - code
+                            - details
+                        properties:
+                            message:
+                                type: string
+                                example: Validation failed.
+                            code:
+                                type: string
+                                example: SCHOOL_VALIDATION_FAILED
+                            details:
+                                type: array
+                                items:
+                                    type: object
+                                    properties:
+                                        propertyPath:
+                                            type: string
+                                            example: classId
+                                        message:
+                                            type: string
+                                            example: This value should not be blank.
+                                        code:
+                                            type: string
+                                            nullable: true
             security:
                 -   Bearer: []
                 -   ApiKey: []


### PR DESCRIPTION
### Motivation
- Resolve unresolved OpenAPI `$ref` warnings for `#/components/schemas/SchoolError` and `#/components/schemas/SchoolValidationError` that appear when generating docs for School controllers.
- Provide a static, centralized definition so Nelmio/OpenAPI doc generation can reference these schemas without altering controller annotations.

### Description
- Added a `schemas` section under `components` in `config/packages/nelmio_api_doc.yaml` to declare `SchoolError` and `SchoolValidationError` OpenAPI schemas.
- Defined `SchoolError` as an object with `message`, `code`, and `details` properties and `SchoolValidationError` with similar shape and item properties including `propertyPath`, `message`, and nullable `code`.
- Kept the change scoped to the Nelmio documentation configuration (`when@dev` / `when@test`) and made no runtime or controller logic changes.

### Testing
- Attempted to validate the YAML with `php bin/console lint:yaml config/packages/nelmio_api_doc.yaml`, which failed due to missing project dependencies in the environment (`composer install` required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4cec356c0832694db4f9a159aa169)