### PR TITLE
Remove duplicate OpenAPI responses in CreateStudentController

### DIFF
--- a/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
@@ -44,9 +44,6 @@ final readonly class CreateStudentController
         ),
         responses: [
             new OA\Response(response: 201, description: 'Étudiant créé.', content: new OA\JsonContent(example: ['id' => '4cfada53-2cf2-49a7-a4fb-4a9682c3a0c0'])),
-            new OA\Response(response: 403, description: 'Accès refusé.'),
-            new OA\Response(response: 404, description: 'Application introuvable.'),
-            new OA\Response(response: 422, description: 'Erreur de validation.'),
         ],
     )]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]


### PR DESCRIPTION
### Motivation
- swagger-php produced a "Multiple @OA\Response() with the same response=\"403\"" warning because error responses were declared twice for the create-student endpoint (inline in the `OA\Post` `responses` array and again as method-level `#[OA\Response]` attributes).

### Description
- Removed the inline `403`, `404`, and `422` `OA\Response` entries from the `responses` array in `src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php`, keeping the method-level `#[OA\Response]` attributes as the single source of truth.

### Testing
- Ran `php -l src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php` which reported "No syntax errors detected", confirming the modified file is syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4d02209dc8326965af802118657b2)