### PR TITLE
feat(crm): add endpoint to update task request status

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/UpdateTaskRequestStatusController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/UpdateTaskRequestStatusController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Domain\Enum\TaskRequestStatus;
+use App\Crm\Infrastructure\Repository\TaskRequestRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\Crm\Transport\Request\UpdateTaskRequestStatusRequest;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class UpdateTaskRequestStatusController
+{
+    public function __construct(
+        private TaskRequestRepository $taskRequestRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+        private ValidatorInterface $validator,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/task-requests/{id}/status', methods: [Request::METHOD_PATCH, Request::METHOD_PUT])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Patch(
+        summary: 'Update task request status.',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['status'],
+                properties: [
+                    new OA\Property(property: 'status', type: 'string', enum: ['pending', 'approved', 'rejected'], example: 'approved'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Task request status updated.'),
+            new OA\Response(response: 400, description: 'Invalid JSON payload.'),
+            new OA\Response(response: 404, description: 'Task request not found in CRM scope.'),
+            new OA\Response(response: 422, description: 'Validation failed.'),
+        ],
+    )]
+    public function __invoke(string $applicationSlug, string $id, Request $request): JsonResponse
+    {
+        $request->attributes->set('applicationSlug', $applicationSlug);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $taskRequest = $this->taskRequestRepository->findOneScopedById($id, $crm->getId());
+
+        if (!$taskRequest instanceof TaskRequest) {
+            return $this->errorResponseFactory->notFoundReference('taskRequestId');
+        }
+
+        try {
+            $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        $input = UpdateTaskRequestStatusRequest::fromArray($payload);
+        $violations = $this->validator->validate($input);
+        if ($violations->count() > 0) {
+            return $this->errorResponseFactory->validationFailed($violations);
+        }
+
+        $taskRequest->setStatus(TaskRequestStatus::from((string) $input->status));
+        $this->taskRequestRepository->save($taskRequest);
+
+        return new JsonResponse([
+            'id' => $taskRequest->getId(),
+            'status' => $taskRequest->getStatus()->value,
+        ]);
+    }
+}

--- a/src/Crm/Transport/Request/UpdateTaskRequestStatusRequest.php
+++ b/src/Crm/Transport/Request/UpdateTaskRequestStatusRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use App\Crm\Domain\Enum\TaskRequestStatus;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class UpdateTaskRequestStatusRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Choice(callback: [self::class, 'statusChoices'])]
+    public ?string $status = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->status = isset($payload['status']) ? (string) $payload['status'] : null;
+
+        return $request;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function statusChoices(): array
+    {
+        return array_map(static fn (TaskRequestStatus $status): string => $status->value, TaskRequestStatus::cases());
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose an API to allow updating the status of a CRM `TaskRequest` (pending/approved/rejected) scoped to a CRM application.
- Reuse existing CRM scoping, error factory and validation patterns so status transitions are safe and return consistent API errors.

### Description
- Add `UpdateTaskRequestStatusController` with route `PATCH|PUT /v1/crm/applications/{applicationSlug}/task-requests/{id}/status` that resolves CRM scope, validates JSON, enforces existence and updates the `TaskRequest` status. 
- Introduce `UpdateTaskRequestStatusRequest` DTO to validate the required `status` field against `TaskRequestStatus` enum choices. 
- Controller uses `CrmApiErrorResponseFactory` for structured errors, `ValidatorInterface` for payload validation and `TaskRequestRepository::save()` to persist changes, and returns `{ id, status }` on success. 
- Include OpenAPI attributes for request/response documentation and authentication via `AuthenticatedVoter`.

### Testing
- Ran `php -l src/Crm/Transport/Controller/Api/V1/TaskRequest/UpdateTaskRequestStatusController.php` and it returned no syntax errors. 
- Ran `php -l src/Crm/Transport/Request/UpdateTaskRequestStatusRequest.php` and it returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4f42cf25483268b978733909373c2)