### PR TITLE
feat(crm): add patch/get and assignee management endpoints

### DIFF
--- a/src/Crm/Domain/Entity/Project.php
+++ b/src/Crm/Domain/Entity/Project.php
@@ -6,6 +6,7 @@ namespace App\Crm\Domain\Entity;
 
 use App\Crm\Domain\Enum\ProjectStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\User\Domain\Entity\User;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
 use DateTimeImmutable;
@@ -63,11 +64,19 @@ class Project implements EntityInterface
     #[ORM\OneToMany(targetEntity: Sprint::class, mappedBy: 'project')]
     private Collection|ArrayCollection $sprints;
 
+    /** @var Collection<int, User>|ArrayCollection<int, User> */
+    #[ORM\ManyToMany(targetEntity: User::class)]
+    #[ORM\JoinTable(name: 'crm_project_assignee')]
+    #[ORM\JoinColumn(name: 'project_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    private Collection|ArrayCollection $assignees;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
         $this->tasks = new ArrayCollection();
         $this->sprints = new ArrayCollection();
+        $this->assignees = new ArrayCollection();
     }
 
     #[Override]
@@ -175,4 +184,31 @@ class Project implements EntityInterface
     {
         return $this->sprints;
     }
+
+    /**
+     * @return Collection<int, User>|ArrayCollection<int, User>
+     */
+    public function getAssignees(): Collection|ArrayCollection
+    {
+        return $this->assignees;
+    }
+
+    public function addAssignee(User $user): self
+    {
+        if (!$this->assignees->contains($user)) {
+            $this->assignees->add($user);
+        }
+
+        return $this;
+    }
+
+    public function removeAssignee(User $user): self
+    {
+        if ($this->assignees->contains($user)) {
+            $this->assignees->removeElement($user);
+        }
+
+        return $this;
+    }
+
 }

--- a/src/Crm/Domain/Entity/Sprint.php
+++ b/src/Crm/Domain/Entity/Sprint.php
@@ -6,6 +6,7 @@ namespace App\Crm\Domain\Entity;
 
 use App\Crm\Domain\Enum\SprintStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\User\Domain\Entity\User;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
 use DateTimeImmutable;
@@ -57,6 +58,13 @@ class Sprint implements EntityInterface
     #[ORM\OneToMany(targetEntity: Task::class, mappedBy: 'sprint')]
     private Collection|ArrayCollection $tasks;
 
+    /** @var Collection<int, User>|ArrayCollection<int, User> */
+    #[ORM\ManyToMany(targetEntity: User::class)]
+    #[ORM\JoinTable(name: 'crm_sprint_assignee')]
+    #[ORM\JoinColumn(name: 'sprint_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    private Collection|ArrayCollection $assignees;
+
     /**
      * @throws Throwable
      */
@@ -64,6 +72,7 @@ class Sprint implements EntityInterface
     {
         $this->id = $this->createUuid();
         $this->tasks = new ArrayCollection();
+        $this->assignees = new ArrayCollection();
     }
 
     #[Override]
@@ -151,4 +160,31 @@ class Sprint implements EntityInterface
     {
         return $this->tasks;
     }
+
+    /**
+     * @return Collection<int, User>|ArrayCollection<int, User>
+     */
+    public function getAssignees(): Collection|ArrayCollection
+    {
+        return $this->assignees;
+    }
+
+    public function addAssignee(User $user): self
+    {
+        if (!$this->assignees->contains($user)) {
+            $this->assignees->add($user);
+        }
+
+        return $this;
+    }
+
+    public function removeAssignee(User $user): self
+    {
+        if ($this->assignees->contains($user)) {
+            $this->assignees->removeElement($user);
+        }
+
+        return $this;
+    }
+
 }

--- a/src/Crm/Domain/Entity/Task.php
+++ b/src/Crm/Domain/Entity/Task.php
@@ -212,6 +212,15 @@ class Task implements EntityInterface
         return $this;
     }
 
+    public function removeAssignee(User $user): self
+    {
+        if ($this->assignees->contains($user)) {
+            $this->assignees->removeElement($user);
+        }
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return [

--- a/src/Crm/Domain/Entity/TaskRequest.php
+++ b/src/Crm/Domain/Entity/TaskRequest.php
@@ -162,6 +162,15 @@ class TaskRequest implements EntityInterface
         return $this;
     }
 
+    public function removeAssignee(User $user): self
+    {
+        if ($this->assignees->contains($user)) {
+            $this->assignees->removeElement($user);
+        }
+
+        return $this;
+    }
+
     public function toArray(): array
     {
         return [

--- a/src/Crm/Infrastructure/Repository/TaskRepository.php
+++ b/src/Crm/Infrastructure/Repository/TaskRepository.php
@@ -71,4 +71,26 @@ class TaskRepository extends BaseRepository
             ->getQuery()
             ->getSingleScalarResult();
     }
+
+    /**
+     * @return list<Entity>
+     */
+    public function findScopedBySprint(string $crmId, string $sprintId): array
+    {
+        /** @var list<Entity> $items */
+        $items = $this->createQueryBuilder('task')
+            ->leftJoin('task.project', 'project')
+            ->leftJoin('project.company', 'company')
+            ->leftJoin('task.sprint', 'sprint')
+            ->andWhere('company.crm = :crmId')
+            ->andWhere('sprint.id = :sprintId')
+            ->setParameter('crmId', $crmId, UuidBinaryOrderedTimeType::NAME)
+            ->setParameter('sprintId', $sprintId, UuidBinaryOrderedTimeType::NAME)
+            ->orderBy('task.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        return $items;
+    }
+
 }

--- a/src/Crm/Transport/Controller/Api/V1/Company/GetCompanyController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/GetCompanyController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Company;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Company;
+use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class GetCompanyController
+{
+    public function __construct(private CompanyRepository $companyRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/companies/{id}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $company = $this->companyRepository->findOneScopedById($id, $crm->getId());
+        if (!$company instanceof Company) { return $this->errorResponseFactory->notFoundReference('companyId'); }
+
+        return new JsonResponse([
+            'id' => $company->getId(),
+            'name' => $company->getName(),
+            'industry' => $company->getIndustry(),
+            'website' => $company->getWebsite(),
+            'contactEmail' => $company->getContactEmail(),
+            'phone' => $company->getPhone(),
+        ]);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/AddProjectAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/AddProjectAssigneeController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class AddProjectAssigneeController
+{
+    public function __construct(private ProjectRepository $projectRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory, private EntityManagerInterface $entityManager) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{id}/assignees/{userId}', methods: [Request::METHOD_PUT])]
+    public function __invoke(string $applicationSlug, string $id, string $userId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $project = $this->projectRepository->findOneScopedById($id, $crm->getId());
+        if (!$project instanceof Project) { return $this->errorResponseFactory->notFoundReference('projectId'); }
+
+        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        if (!$user instanceof User) { return $this->errorResponseFactory->notFoundReference('userId'); }
+
+        $project->addAssignee($user);
+        $this->projectRepository->save($project);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/GetProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/GetProjectController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class GetProjectController
+{
+    public function __construct(private ProjectRepository $projectRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{id}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $project = $this->projectRepository->findOneScopedById($id, $crm->getId());
+        if (!$project instanceof Project) { return $this->errorResponseFactory->notFoundReference('projectId'); }
+
+        return new JsonResponse([
+            'id' => $project->getId(),
+            'companyId' => $project->getCompany()?->getId(),
+            'name' => $project->getName(),
+            'code' => $project->getCode(),
+            'description' => $project->getDescription(),
+            'status' => $project->getStatus()->value,
+            'startedAt' => $project->getStartedAt()?->format(DATE_ATOM),
+            'dueAt' => $project->getDueAt()?->format(DATE_ATOM),
+        ]);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/PatchProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/PatchProjectController.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Domain\Enum\ProjectStatus;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use DateTimeImmutable;
+use DateTimeInterface;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class PatchProjectController
+{
+    public function __construct(
+        private ProjectRepository $projectRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{id}', methods: [Request::METHOD_PATCH])]
+    public function __invoke(string $applicationSlug, string $id, Request $request): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $project = $this->projectRepository->findOneScopedById($id, $crm->getId());
+        if (!$project instanceof Project) {
+            return $this->errorResponseFactory->notFoundReference('projectId');
+        }
+
+        try {
+            $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (isset($payload['name'])) {
+            $project->setName((string) $payload['name']);
+        }
+        if (array_key_exists('code', $payload)) {
+            $project->setCode($payload['code'] !== null ? (string) $payload['code'] : null);
+        }
+        if (array_key_exists('description', $payload)) {
+            $project->setDescription($payload['description'] !== null ? (string) $payload['description'] : null);
+        }
+        if (isset($payload['status']) && is_string($payload['status'])) {
+            $status = ProjectStatus::tryFrom($payload['status']);
+            if ($status !== null) {
+                $project->setStatus($status);
+            }
+        }
+        if (array_key_exists('startedAt', $payload)) {
+            $project->setStartedAt($this->parseDate($payload['startedAt']));
+        }
+        if (array_key_exists('dueAt', $payload)) {
+            $project->setDueAt($this->parseDate($payload['dueAt']));
+        }
+
+        $this->projectRepository->save($project);
+
+        return new JsonResponse(['id' => $project->getId()]);
+    }
+
+    private function parseDate(mixed $value): ?DateTimeImmutable
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $parsed = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
+
+        return $parsed === false ? null : $parsed;
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/RemoveProjectAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/RemoveProjectAssigneeController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class RemoveProjectAssigneeController
+{
+    public function __construct(private ProjectRepository $projectRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory, private EntityManagerInterface $entityManager) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{id}/assignees/{userId}', methods: [Request::METHOD_DELETE])]
+    public function __invoke(string $applicationSlug, string $id, string $userId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $project = $this->projectRepository->findOneScopedById($id, $crm->getId());
+        if (!$project instanceof Project) { return $this->errorResponseFactory->notFoundReference('projectId'); }
+
+        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        if (!$user instanceof User) { return $this->errorResponseFactory->notFoundReference('userId'); }
+
+        $project->removeAssignee($user);
+        $this->projectRepository->save($project);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/AddSprintAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/AddSprintAssigneeController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Sprint;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class AddSprintAssigneeController
+{
+    public function __construct(private SprintRepository $sprintRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory, private EntityManagerInterface $entityManager) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/sprints/{id}/assignees/{userId}', methods: [Request::METHOD_PUT])]
+    public function __invoke(string $applicationSlug, string $id, string $userId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $sprint = $this->sprintRepository->findOneScopedById($id, $crm->getId());
+        if (!$sprint instanceof Sprint) { return $this->errorResponseFactory->notFoundReference('sprintId'); }
+
+        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        if (!$user instanceof User) { return $this->errorResponseFactory->notFoundReference('userId'); }
+
+        $sprint->addAssignee($user);
+        $this->sprintRepository->save($sprint);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/GetSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/GetSprintController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Sprint;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class GetSprintController
+{
+    public function __construct(private SprintRepository $sprintRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/sprints/{id}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $sprint = $this->sprintRepository->findOneScopedById($id, $crm->getId());
+        if (!$sprint instanceof Sprint) { return $this->errorResponseFactory->notFoundReference('sprintId'); }
+
+        return new JsonResponse([
+            'id' => $sprint->getId(),
+            'projectId' => $sprint->getProject()?->getId(),
+            'name' => $sprint->getName(),
+            'goal' => $sprint->getGoal(),
+            'status' => $sprint->getStatus()->value,
+            'startDate' => $sprint->getStartDate()?->format('Y-m-d'),
+            'endDate' => $sprint->getEndDate()?->format('Y-m-d'),
+        ]);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/PatchSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/PatchSprintController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Sprint;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Domain\Enum\SprintStatus;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use DateTimeImmutable;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class PatchSprintController
+{
+    public function __construct(
+        private SprintRepository $sprintRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/sprints/{id}', methods: [Request::METHOD_PATCH])]
+    public function __invoke(string $applicationSlug, string $id, Request $request): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $sprint = $this->sprintRepository->findOneScopedById($id, $crm->getId());
+        if (!$sprint instanceof Sprint) {
+            return $this->errorResponseFactory->notFoundReference('sprintId');
+        }
+
+        try { $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);} catch (JsonException) { return $this->errorResponseFactory->invalidJson(); }
+        if (!is_array($payload)) { return $this->errorResponseFactory->invalidJson(); }
+
+        if (isset($payload['name'])) { $sprint->setName((string) $payload['name']); }
+        if (array_key_exists('goal', $payload)) { $sprint->setGoal($payload['goal'] !== null ? (string) $payload['goal'] : null); }
+        if (isset($payload['status']) && is_string($payload['status'])) { $status = SprintStatus::tryFrom($payload['status']); if ($status) { $sprint->setStatus($status); } }
+        if (array_key_exists('startDate', $payload)) { $sprint->setStartDate($this->parseDate($payload['startDate'])); }
+        if (array_key_exists('endDate', $payload)) { $sprint->setEndDate($this->parseDate($payload['endDate'])); }
+
+        $this->sprintRepository->save($sprint);
+
+        return new JsonResponse(['id' => $sprint->getId()]);
+    }
+
+    private function parseDate(mixed $value): ?DateTimeImmutable
+    {
+        if ($value === null || $value === '' || !is_string($value)) { return null; }
+        try { return new DateTimeImmutable($value); } catch (\Throwable) { return null; }
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/RemoveSprintAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/RemoveSprintAssigneeController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Sprint;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class RemoveSprintAssigneeController
+{
+    public function __construct(private SprintRepository $sprintRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory, private EntityManagerInterface $entityManager) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/sprints/{id}/assignees/{userId}', methods: [Request::METHOD_DELETE])]
+    public function __invoke(string $applicationSlug, string $id, string $userId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $sprint = $this->sprintRepository->findOneScopedById($id, $crm->getId());
+        if (!$sprint instanceof Sprint) { return $this->errorResponseFactory->notFoundReference('sprintId'); }
+
+        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        if (!$user instanceof User) { return $this->errorResponseFactory->notFoundReference('userId'); }
+
+        $sprint->removeAssignee($user);
+        $this->sprintRepository->save($sprint);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Task/AddTaskAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/AddTaskAssigneeController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Task;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class AddTaskAssigneeController
+{
+    public function __construct(private TaskRepository $taskRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory, private EntityManagerInterface $entityManager) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/tasks/{id}/assignees/{userId}', methods: [Request::METHOD_PUT])]
+    public function __invoke(string $applicationSlug, string $id, string $userId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $task = $this->taskRepository->findOneScopedById($id, $crm->getId());
+        if (!$task instanceof Task) { return $this->errorResponseFactory->notFoundReference('taskId'); }
+
+        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        if (!$user instanceof User) { return $this->errorResponseFactory->notFoundReference('userId'); }
+
+        $task->addAssignee($user);
+        $this->taskRepository->save($task);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Task/GetTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/GetTaskController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Task;
+
+use App\Crm\Application\Service\CrmApiNormalizer;
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class GetTaskController
+{
+    public function __construct(private TaskRepository $taskRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory, private CrmApiNormalizer $normalizer) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/tasks/{id}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $task = $this->taskRepository->findOneScopedById($id, $crm->getId());
+        if (!$task instanceof Task) { return $this->errorResponseFactory->notFoundReference('taskId'); }
+
+        return new JsonResponse($this->normalizer->normalizeTask($task));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Task/ListTasksByApplicationAndSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/ListTasksByApplicationAndSprintController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Task;
+
+use App\Crm\Application\Service\CrmApiNormalizer;
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ListTasksByApplicationAndSprintController
+{
+    public function __construct(
+        private TaskRepository $taskRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiNormalizer $crmApiNormalizer,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/sprints/{sprintId}/tasks', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, string $sprintId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $tasks = $this->taskRepository->findScopedBySprint($crm->getId(), $sprintId);
+
+        return new JsonResponse([
+            'items' => array_map(fn ($task): array => $this->crmApiNormalizer->normalizeTask($task), $tasks),
+        ]);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Task/PatchTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/PatchTaskController.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Task;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Domain\Enum\TaskPriority;
+use App\Crm\Domain\Enum\TaskStatus;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use DateTimeImmutable;
+use DateTimeInterface;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class PatchTaskController
+{
+    public function __construct(
+        private TaskRepository $taskRepository,
+        private SprintRepository $sprintRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/tasks/{id}', methods: [Request::METHOD_PATCH])]
+    public function __invoke(string $applicationSlug, string $id, Request $request): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $task = $this->taskRepository->findOneScopedById($id, $crm->getId());
+        if (!$task instanceof Task) {
+            return $this->errorResponseFactory->notFoundReference('taskId');
+        }
+
+        try { $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);} catch (JsonException) { return $this->errorResponseFactory->invalidJson(); }
+        if (!is_array($payload)) { return $this->errorResponseFactory->invalidJson(); }
+
+        if (isset($payload['title'])) { $task->setTitle((string) $payload['title']); }
+        if (array_key_exists('description', $payload)) { $task->setDescription($payload['description'] !== null ? (string) $payload['description'] : null); }
+        if (isset($payload['status']) && is_string($payload['status'])) { $status = TaskStatus::tryFrom($payload['status']); if ($status) { $task->setStatus($status); } }
+        if (isset($payload['priority']) && is_string($payload['priority'])) { $priority = TaskPriority::tryFrom($payload['priority']); if ($priority) { $task->setPriority($priority); } }
+        if (array_key_exists('dueAt', $payload)) { $task->setDueAt($this->parseDate($payload['dueAt'])); }
+        if (array_key_exists('estimatedHours', $payload)) { $task->setEstimatedHours(is_numeric($payload['estimatedHours']) ? (float) $payload['estimatedHours'] : null); }
+        if (array_key_exists('sprintId', $payload)) {
+            if ($payload['sprintId'] === null || $payload['sprintId'] === '') {
+                $task->setSprint(null);
+            } elseif (is_string($payload['sprintId'])) {
+                $sprint = $this->sprintRepository->findOneScopedById($payload['sprintId'], $crm->getId());
+                if ($sprint !== null) { $task->setSprint($sprint); }
+            }
+        }
+
+        $this->taskRepository->save($task);
+
+        return new JsonResponse(['id' => $task->getId()]);
+    }
+
+    private function parseDate(mixed $value): ?DateTimeImmutable
+    {
+        if ($value === null || $value === '' || !is_string($value)) { return null; }
+        $parsed = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
+
+        return $parsed === false ? null : $parsed;
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Task/RemoveTaskAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/RemoveTaskAssigneeController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Task;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class RemoveTaskAssigneeController
+{
+    public function __construct(private TaskRepository $taskRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory, private EntityManagerInterface $entityManager) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/tasks/{id}/assignees/{userId}', methods: [Request::METHOD_DELETE])]
+    public function __invoke(string $applicationSlug, string $id, string $userId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $task = $this->taskRepository->findOneScopedById($id, $crm->getId());
+        if (!$task instanceof Task) { return $this->errorResponseFactory->notFoundReference('taskId'); }
+
+        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        if (!$user instanceof User) { return $this->errorResponseFactory->notFoundReference('userId'); }
+
+        $task->removeAssignee($user);
+        $this->taskRepository->save($task);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/AddTaskRequestAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/AddTaskRequestAssigneeController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Infrastructure\Repository\TaskRequestRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class AddTaskRequestAssigneeController
+{
+    public function __construct(private TaskRequestRepository $taskRequestRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory, private EntityManagerInterface $entityManager) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/task-requests/{id}/assignees/{userId}', methods: [Request::METHOD_PUT])]
+    public function __invoke(string $applicationSlug, string $id, string $userId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $taskRequest = $this->taskRequestRepository->findOneScopedById($id, $crm->getId());
+        if (!$taskRequest instanceof TaskRequest) { return $this->errorResponseFactory->notFoundReference('taskRequestId'); }
+
+        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        if (!$user instanceof User) { return $this->errorResponseFactory->notFoundReference('userId'); }
+
+        $taskRequest->addAssignee($user);
+        $this->taskRequestRepository->save($taskRequest);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/GetTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/GetTaskRequestController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
+
+use App\Crm\Application\Service\CrmApiNormalizer;
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Infrastructure\Repository\TaskRequestRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class GetTaskRequestController
+{
+    public function __construct(private TaskRequestRepository $taskRequestRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory, private CrmApiNormalizer $normalizer) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/task-requests/{id}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $taskRequest = $this->taskRequestRepository->findOneScopedById($id, $crm->getId());
+        if (!$taskRequest instanceof TaskRequest) { return $this->errorResponseFactory->notFoundReference('taskRequestId'); }
+
+        return new JsonResponse($this->normalizer->normalizeTaskRequest($taskRequest));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/PatchTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/PatchTaskRequestController.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Domain\Enum\TaskRequestStatus;
+use App\Crm\Infrastructure\Repository\TaskRequestRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use DateTimeImmutable;
+use DateTimeInterface;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class PatchTaskRequestController
+{
+    public function __construct(
+        private TaskRequestRepository $taskRequestRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/task-requests/{id}', methods: [Request::METHOD_PATCH])]
+    public function __invoke(string $applicationSlug, string $id, Request $request): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $taskRequest = $this->taskRequestRepository->findOneScopedById($id, $crm->getId());
+        if (!$taskRequest instanceof TaskRequest) {
+            return $this->errorResponseFactory->notFoundReference('taskRequestId');
+        }
+
+        try { $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);} catch (JsonException) { return $this->errorResponseFactory->invalidJson(); }
+        if (!is_array($payload)) { return $this->errorResponseFactory->invalidJson(); }
+
+        if (isset($payload['title'])) { $taskRequest->setTitle((string) $payload['title']); }
+        if (array_key_exists('description', $payload)) { $taskRequest->setDescription($payload['description'] !== null ? (string) $payload['description'] : null); }
+        if (isset($payload['status']) && is_string($payload['status'])) { $status = TaskRequestStatus::tryFrom($payload['status']); if ($status) { $taskRequest->setStatus($status); } }
+        if (array_key_exists('resolvedAt', $payload)) { $taskRequest->setResolvedAt($this->parseDate($payload['resolvedAt'])); }
+
+        $this->taskRequestRepository->save($taskRequest);
+
+        return new JsonResponse(['id' => $taskRequest->getId()]);
+    }
+
+    private function parseDate(mixed $value): ?DateTimeImmutable
+    {
+        if ($value === null || $value === '' || !is_string($value)) { return null; }
+        $parsed = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
+
+        return $parsed === false ? null : $parsed;
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/RemoveTaskRequestAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/RemoveTaskRequestAssigneeController.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Infrastructure\Repository\TaskRequestRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class RemoveTaskRequestAssigneeController
+{
+    public function __construct(private TaskRequestRepository $taskRequestRepository, private CrmApplicationScopeResolver $scopeResolver, private CrmApiErrorResponseFactory $errorResponseFactory, private EntityManagerInterface $entityManager) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/task-requests/{id}/assignees/{userId}', methods: [Request::METHOD_DELETE])]
+    public function __invoke(string $applicationSlug, string $id, string $userId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $taskRequest = $this->taskRequestRepository->findOneScopedById($id, $crm->getId());
+        if (!$taskRequest instanceof TaskRequest) { return $this->errorResponseFactory->notFoundReference('taskRequestId'); }
+
+        $user = $this->entityManager->getRepository(User::class)->find($userId);
+        if (!$user instanceof User) { return $this->errorResponseFactory->notFoundReference('userId'); }
+
+        $taskRequest->removeAssignee($user);
+        $this->taskRequestRepository->save($taskRequest);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/UpdateTaskRequestStatusController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/UpdateTaskRequestStatusController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Domain\Enum\TaskRequestStatus;
+use App\Crm\Infrastructure\Repository\TaskRequestRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\Crm\Transport\Request\UpdateTaskRequestStatusRequest;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class UpdateTaskRequestStatusController
+{
+    public function __construct(
+        private TaskRequestRepository $taskRequestRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+        private ValidatorInterface $validator,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/task-requests/{id}/status', methods: [Request::METHOD_PATCH, Request::METHOD_PUT])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Patch(
+        summary: 'Update task request status.',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['status'],
+                properties: [
+                    new OA\Property(property: 'status', type: 'string', enum: ['pending', 'approved', 'rejected'], example: 'approved'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Task request status updated.'),
+            new OA\Response(response: 400, description: 'Invalid JSON payload.'),
+            new OA\Response(response: 404, description: 'Task request not found in CRM scope.'),
+            new OA\Response(response: 422, description: 'Validation failed.'),
+        ],
+    )]
+    public function __invoke(string $applicationSlug, string $id, Request $request): JsonResponse
+    {
+        $request->attributes->set('applicationSlug', $applicationSlug);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $taskRequest = $this->taskRequestRepository->findOneScopedById($id, $crm->getId());
+
+        if (!$taskRequest instanceof TaskRequest) {
+            return $this->errorResponseFactory->notFoundReference('taskRequestId');
+        }
+
+        try {
+            $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        $input = UpdateTaskRequestStatusRequest::fromArray($payload);
+        $violations = $this->validator->validate($input);
+        if ($violations->count() > 0) {
+            return $this->errorResponseFactory->validationFailed($violations);
+        }
+
+        $taskRequest->setStatus(TaskRequestStatus::from((string) $input->status));
+        $this->taskRequestRepository->save($taskRequest);
+
+        return new JsonResponse([
+            'id' => $taskRequest->getId(),
+            'status' => $taskRequest->getStatus()->value,
+        ]);
+    }
+}

--- a/src/Crm/Transport/Request/UpdateTaskRequestStatusRequest.php
+++ b/src/Crm/Transport/Request/UpdateTaskRequestStatusRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use App\Crm\Domain\Enum\TaskRequestStatus;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class UpdateTaskRequestStatusRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Choice(callback: [self::class, 'statusChoices'])]
+    public ?string $status = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->status = isset($payload['status']) ? (string) $payload['status'] : null;
+
+        return $request;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function statusChoices(): array
+    {
+        return array_map(static fn (TaskRequestStatus $status): string => $status->value, TaskRequestStatus::cases());
+    }
+}


### PR DESCRIPTION
## Summary
- add `PATCH` endpoints for CRM project/sprint/task/task-request updates
- add detail `GET` endpoints for single company/project/sprint/task/task-request
- add assignee add/remove endpoints for project, sprint, task and task-request
- add `removeAssignee()` helpers on entities and new `TaskRepository::findScopedBySprint()` query
- add list endpoint: `GET /v1/crm/applications/{applicationSlug}/sprints/{sprintId}/tasks`

## Notes
- This PR focuses on API endpoints and entity relationships for assignees.
- More advanced requirements (photo listeners/default images, file attachments, wiki/blog links, and calendar event automation) are not implemented in this commit and should be handled in dedicated follow-up PRs because they require additional schema + cross-module integrations.

## Validation
- `git status --short | awk '{print $2}' | rg '\.php$' | xargs -n1 php -l`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4f42cf25483268b978733909373c2)