### PR TITLE
Use UserGroups for CRM permissions and auto-assign CRM_OWNER on CRM application create

### DIFF
--- a/src/Crm/Application/Security/Voter/CrmPermissionVoter.php
+++ b/src/Crm/Application/Security/Voter/CrmPermissionVoter.php
@@ -7,6 +7,7 @@ namespace App\Crm\Application\Security\Voter;
 use App\Crm\Application\Security\CrmPermissions;
 use App\Role\Domain\Enum\Role;
 use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserGroup;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
@@ -14,13 +15,37 @@ use function in_array;
 
 final class CrmPermissionVoter extends Voter
 {
+    /**
+     * @var array<string, array<int, Role>>
+     */
+    private const array PERMISSION_MATRIX = [
+        CrmPermissions::VIEW => [
+            Role::CRM_OWNER,
+            Role::CRM_ADMIN,
+            Role::CRM_MANAGER,
+            Role::CRM_SALES,
+            Role::CRM_SUPPORT,
+            Role::CRM_MARKETING,
+            Role::CRM_VIEWER,
+        ],
+        CrmPermissions::EDIT => [
+            Role::CRM_OWNER,
+            Role::CRM_ADMIN,
+            Role::CRM_MANAGER,
+            Role::CRM_SALES,
+            Role::CRM_SUPPORT,
+            Role::CRM_MARKETING,
+        ],
+        CrmPermissions::MANAGE => [
+            Role::CRM_OWNER,
+            Role::CRM_ADMIN,
+            Role::CRM_MANAGER,
+        ],
+    ];
+
     protected function supports(string $attribute, mixed $subject): bool
     {
-        return in_array($attribute, [
-            CrmPermissions::VIEW,
-            CrmPermissions::EDIT,
-            CrmPermissions::MANAGE,
-        ], true);
+        return isset(self::PERMISSION_MATRIX[$attribute]);
     }
 
     protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
@@ -30,36 +55,15 @@ final class CrmPermissionVoter extends Voter
             return false;
         }
 
-        $roles = $user->getRoles();
+        $roles = $user->getUserGroups()->map(
+            static fn (UserGroup $userGroup): string => $userGroup->getRole()->getId(),
+        )->toArray();
+
         if (in_array(Role::ROOT->value, $roles, true)) {
             return true;
         }
 
-        return match ($attribute) {
-            CrmPermissions::VIEW => $this->hasAnyRole($roles, [
-                Role::CRM_OWNER,
-                Role::CRM_ADMIN,
-                Role::CRM_MANAGER,
-                Role::CRM_SALES,
-                Role::CRM_SUPPORT,
-                Role::CRM_MARKETING,
-                Role::CRM_VIEWER,
-            ]),
-            CrmPermissions::EDIT => $this->hasAnyRole($roles, [
-                Role::CRM_OWNER,
-                Role::CRM_ADMIN,
-                Role::CRM_MANAGER,
-                Role::CRM_SALES,
-                Role::CRM_SUPPORT,
-                Role::CRM_MARKETING,
-            ]),
-            CrmPermissions::MANAGE => $this->hasAnyRole($roles, [
-                Role::CRM_OWNER,
-                Role::CRM_ADMIN,
-                Role::CRM_MANAGER,
-            ]),
-            default => false,
-        };
+        return $this->hasAnyRole($roles, self::PERMISSION_MATRIX[$attribute] ?? []);
     }
 
     /**

--- a/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php
@@ -12,9 +12,12 @@ use App\Platform\Application\Resource\PluginResource;
 use App\Platform\Application\Service\ApplicationPluginProvisioningService;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Entity\ApplicationPlugin;
+use App\Platform\Domain\Enum\PlatformKey;
 use App\Platform\Domain\Enum\PlatformStatus;
 use App\Platform\Domain\Enum\PluginKey;
+use App\Role\Domain\Enum\Role;
 use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserGroup;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenApi\Attributes as OA;
 use OpenApi\Attributes\JsonContent;
@@ -197,6 +200,8 @@ class ApplicationCreateController
             $application->addApplicationPlugin($applicationPlugin);
         }
 
+        $this->grantCrmOwnerRoleIfNeeded($loggedInUser, $platform->getPlatformKey());
+
         $this->entityManager->persist($application);
         $this->applicationPluginProvisioningService->provision($application, array_values($detectedPluginKeys));
         $this->entityManager->flush();
@@ -211,6 +216,30 @@ class ApplicationCreateController
             'status' => $application->getStatus()->value,
             'private' => $application->isPrivate(),
         ], JsonResponse::HTTP_CREATED);
+    }
+
+
+    private function grantCrmOwnerRoleIfNeeded(User $loggedInUser, PlatformKey $platformKey): void
+    {
+        if ($platformKey !== PlatformKey::CRM) {
+            return;
+        }
+
+        foreach ($loggedInUser->getUserGroups() as $userGroup) {
+            if ($userGroup->getRole()->getId() === Role::CRM_OWNER->value) {
+                return;
+            }
+        }
+
+        $crmOwnerGroup = $this->entityManager->getRepository(UserGroup::class)->findOneBy([
+            'role' => Role::CRM_OWNER->value,
+        ]);
+
+        if (!$crmOwnerGroup instanceof UserGroup) {
+            throw new HttpException(JsonResponse::HTTP_INTERNAL_SERVER_ERROR, 'CRM owner group is not configured.');
+        }
+
+        $loggedInUser->addUserGroup($crmOwnerGroup);
     }
 
     /**

--- a/tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/Profile/ApplicationCreateControllerTest.php
@@ -18,6 +18,7 @@ use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PluginKey;
 use App\Quiz\Infrastructure\Repository\QuizQuestionRepository;
 use App\Quiz\Infrastructure\Repository\QuizRepository;
+use App\Role\Domain\Enum\Role;
 use App\Recruit\Domain\Entity\Recruit;
 use App\School\Domain\Entity\School;
 use App\Shop\Domain\Entity\Shop;
@@ -169,6 +170,8 @@ class ApplicationCreateControllerTest extends WebTestCase
         self::assertCount(1, $entityManager->getRepository(Crm::class)->findBy([
             'application' => $crmApplication,
         ]));
+
+        self::assertContains(Role::CRM_OWNER->value, $crmApplication->getUser()->getRoles());
         self::assertCount(1, $entityManager->getRepository(Shop::class)->findBy([
             'application' => $shopApplication,
         ]));
@@ -178,6 +181,13 @@ class ApplicationCreateControllerTest extends WebTestCase
         self::assertCount(1, $entityManager->getRepository(Recruit::class)->findBy([
             'application' => $recruitApplication,
         ]));
+
+        $crmOwnerGroups = array_filter(
+            $crmApplication->getUser()->getUserGroups()->toArray(),
+            static fn ($userGroup): bool => $userGroup->getRole()->getId() === Role::CRM_OWNER->value,
+        );
+
+        self::assertCount(1, $crmOwnerGroups);
 
         $crmApplication->setDescription('CRM app updated');
         $shopApplication->setDescription('Shop app updated');
@@ -188,6 +198,8 @@ class ApplicationCreateControllerTest extends WebTestCase
         self::assertCount(1, $entityManager->getRepository(Crm::class)->findBy([
             'application' => $crmApplication,
         ]));
+
+        self::assertContains(Role::CRM_OWNER->value, $crmApplication->getUser()->getRoles());
         self::assertCount(1, $entityManager->getRepository(Shop::class)->findBy([
             'application' => $shopApplication,
         ]));
@@ -197,6 +209,13 @@ class ApplicationCreateControllerTest extends WebTestCase
         self::assertCount(1, $entityManager->getRepository(Recruit::class)->findBy([
             'application' => $recruitApplication,
         ]));
+
+        $crmOwnerGroups = array_filter(
+            $crmApplication->getUser()->getUserGroups()->toArray(),
+            static fn ($userGroup): bool => $userGroup->getRole()->getId() === Role::CRM_OWNER->value,
+        );
+
+        self::assertCount(1, $crmOwnerGroups);
     }
 
     /**

--- a/tests/Unit/Crm/Application/Security/Voter/CrmPermissionVoterTest.php
+++ b/tests/Unit/Crm/Application/Security/Voter/CrmPermissionVoterTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Crm\Application\Security\Voter;
+
+use App\Crm\Application\Security\CrmPermissions;
+use App\Crm\Application\Security\Voter\CrmPermissionVoter;
+use App\Role\Domain\Entity\Role as RoleEntity;
+use App\Role\Domain\Enum\Role;
+use App\User\Domain\Entity\User;
+use App\User\Domain\Entity\UserGroup;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+final class CrmPermissionVoterTest extends TestCase
+{
+    public function testSupportsCrmPermissionsOnly(): void
+    {
+        $voter = new TestableCrmPermissionVoter();
+
+        self::assertTrue($voter->supportsAttribute(CrmPermissions::VIEW));
+        self::assertTrue($voter->supportsAttribute(CrmPermissions::EDIT));
+        self::assertTrue($voter->supportsAttribute(CrmPermissions::MANAGE));
+        self::assertFalse($voter->supportsAttribute('UNKNOWN_PERMISSION'));
+    }
+
+    public function testViewPermissionGrantedWithCrmViewerGroupRole(): void
+    {
+        $voter = new TestableCrmPermissionVoter();
+        $user = $this->createUserWithRoles([Role::CRM_VIEWER]);
+
+        self::assertTrue($voter->voteAttribute(CrmPermissions::VIEW, $this->createToken($user)));
+        self::assertFalse($voter->voteAttribute(CrmPermissions::EDIT, $this->createToken($user)));
+    }
+
+    public function testRootRoleAlwaysGranted(): void
+    {
+        $voter = new TestableCrmPermissionVoter();
+        $user = $this->createUserWithRoles([Role::ROOT]);
+
+        self::assertTrue($voter->voteAttribute(CrmPermissions::VIEW, $this->createToken($user)));
+        self::assertTrue($voter->voteAttribute(CrmPermissions::EDIT, $this->createToken($user)));
+        self::assertTrue($voter->voteAttribute(CrmPermissions::MANAGE, $this->createToken($user)));
+    }
+
+    /**
+     * @param list<Role> $roles
+     */
+    private function createUserWithRoles(array $roles): User
+    {
+        $user = new User();
+
+        foreach ($roles as $role) {
+            $group = (new UserGroup())
+                ->setName($role->value)
+                ->setRole(new RoleEntity($role->value));
+
+            $user->addUserGroup($group);
+        }
+
+        return $user;
+    }
+
+    private function createToken(User $user): TokenInterface&MockObject
+    {
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($user);
+
+        return $token;
+    }
+}
+
+final class TestableCrmPermissionVoter extends CrmPermissionVoter
+{
+    public function supportsAttribute(string $attribute): bool
+    {
+        return $this->supports($attribute, null);
+    }
+
+    public function voteAttribute(string $attribute, TokenInterface $token): bool
+    {
+        return $this->voteOnAttribute($attribute, null, $token);
+    }
+}


### PR DESCRIPTION
### Motivation
- Move CRM permission checks to derive roles from `UserGroup` entities instead of raw user `roles` and centralize permission-role mapping.
- Ensure the user who creates a CRM platform application is granted the `CRM_OWNER` group when none exists so CRM provisioning is consistent.

### Description
- Replace manual attribute list with a `PERMISSION_MATRIX` constant in `CrmPermissionVoter` and change `supports()` to consult that matrix via `isset` for cleaner permission support checks.
- Update `CrmPermissionVoter` to compute the current user's role ids from `User::getUserGroups()` and use the matrix with `hasAnyRole()` to determine access, keeping `Role::ROOT` as a bypass.
- Add `grantCrmOwnerRoleIfNeeded()` to `ApplicationCreateController` to auto-assign the `UserGroup` with role `Role::CRM_OWNER` to the logged-in user when creating a CRM platform application, and throw a 500 error if the group is not configured.
- Update integration test `ApplicationCreateControllerTest` to assert the `CRM_OWNER` role/group is assigned and add a new unit test `CrmPermissionVoterTest` covering supported attributes, viewer permission, and root bypass behavior.

### Testing
- Added and ran unit tests: `CrmPermissionVoterTest` to cover voter behavior and attribute support, which passed.
- Ran updated integration tests in `ApplicationCreateControllerTest` verifying CRM provisioning and idempotency plus the `CRM_OWNER` assignment, which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d22ca164832680498e029b135012)