### PR TITLE
feat(crm): add scoped PUT & PATCH company controllers with UpdateCompanyRequest DTO

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/Company/PatchCompanyController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/PatchCompanyController.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Company;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\Crm\Transport\Request\UpdateCompanyRequest;
+use App\Role\Domain\Enum\Role;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class PatchCompanyController
+{
+    public function __construct(
+        private CompanyRepository $companyRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+        private ValidatorInterface $validator,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/companies/{companyId}', methods: [Request::METHOD_PATCH])]
+    public function __invoke(string $applicationSlug, string $companyId, Request $request): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $company = $this->companyRepository->findOneScopedById($companyId, $crm->getId());
+        if ($company === null) {
+            return $this->errorResponseFactory->notFoundReference('companyId');
+        }
+
+        try {
+            $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        $input = UpdateCompanyRequest::fromPatchArray($payload);
+        $violations = $this->validator->validate($input);
+        if ($violations->count() > 0) {
+            return $this->errorResponseFactory->validationFailed($violations);
+        }
+
+        if ($input->hasName) {
+            $company->setName((string) $input->name);
+        }
+        if ($input->hasIndustry) {
+            $company->setIndustry($input->industry);
+        }
+        if ($input->hasWebsite) {
+            $company->setWebsite($input->website);
+        }
+        if ($input->hasContactEmail) {
+            $company->setContactEmail($input->contactEmail);
+        }
+        if ($input->hasPhone) {
+            $company->setPhone($input->phone);
+        }
+
+        $this->companyRepository->save($company);
+
+        return new JsonResponse(['id' => $company->getId()]);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Company/PutCompanyController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/PutCompanyController.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Company;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\Crm\Transport\Request\UpdateCompanyRequest;
+use App\Role\Domain\Enum\Role;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class PutCompanyController
+{
+    public function __construct(
+        private CompanyRepository $companyRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+        private ValidatorInterface $validator,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/companies/{companyId}', methods: [Request::METHOD_PUT])]
+    public function __invoke(string $applicationSlug, string $companyId, Request $request): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $company = $this->companyRepository->findOneScopedById($companyId, $crm->getId());
+        if ($company === null) {
+            return $this->errorResponseFactory->notFoundReference('companyId');
+        }
+
+        try {
+            $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        $input = UpdateCompanyRequest::fromPutArray($payload);
+        $violations = $this->validator->validate($input, groups: ['Default', 'put']);
+        if ($violations->count() > 0) {
+            return $this->errorResponseFactory->validationFailed($violations);
+        }
+
+        $company
+            ->setName((string) $input->name)
+            ->setIndustry($input->industry)
+            ->setWebsite($input->website)
+            ->setContactEmail($input->contactEmail)
+            ->setPhone($input->phone);
+
+        $this->companyRepository->save($company);
+
+        return new JsonResponse(['id' => $company->getId()]);
+    }
+}

--- a/src/Crm/Transport/Request/UpdateCompanyRequest.php
+++ b/src/Crm/Transport/Request/UpdateCompanyRequest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class UpdateCompanyRequest
+{
+    #[Assert\NotBlank(groups: ['put'])]
+    #[Assert\Length(max: 255)]
+    public ?string $name = null;
+
+    #[Assert\Length(max: 255)]
+    public ?string $industry = null;
+
+    #[Assert\Length(max: 255)]
+    public ?string $website = null;
+
+    #[Assert\Email]
+    #[Assert\Length(max: 255)]
+    public ?string $contactEmail = null;
+
+    #[Assert\Length(max: 64)]
+    public ?string $phone = null;
+
+    public bool $hasName = false;
+    public bool $hasIndustry = false;
+    public bool $hasWebsite = false;
+    public bool $hasContactEmail = false;
+    public bool $hasPhone = false;
+
+    public static function fromPutArray(array $payload): self
+    {
+        $request = new self();
+        $request->hasName = true;
+        $request->name = isset($payload['name']) ? (string) $payload['name'] : null;
+
+        $request->hasIndustry = true;
+        $request->industry = isset($payload['industry']) ? (string) $payload['industry'] : null;
+
+        $request->hasWebsite = true;
+        $request->website = isset($payload['website']) ? (string) $payload['website'] : null;
+
+        $request->hasContactEmail = true;
+        $request->contactEmail = isset($payload['contactEmail']) ? (string) $payload['contactEmail'] : null;
+
+        $request->hasPhone = true;
+        $request->phone = isset($payload['phone']) ? (string) $payload['phone'] : null;
+
+        return $request;
+    }
+
+    public static function fromPatchArray(array $payload): self
+    {
+        $request = new self();
+
+        if (array_key_exists('name', $payload)) {
+            $request->hasName = true;
+            $request->name = $payload['name'] !== null ? (string) $payload['name'] : null;
+        }
+
+        if (array_key_exists('industry', $payload)) {
+            $request->hasIndustry = true;
+            $request->industry = $payload['industry'] !== null ? (string) $payload['industry'] : null;
+        }
+
+        if (array_key_exists('website', $payload)) {
+            $request->hasWebsite = true;
+            $request->website = $payload['website'] !== null ? (string) $payload['website'] : null;
+        }
+
+        if (array_key_exists('contactEmail', $payload)) {
+            $request->hasContactEmail = true;
+            $request->contactEmail = $payload['contactEmail'] !== null ? (string) $payload['contactEmail'] : null;
+        }
+
+        if (array_key_exists('phone', $payload)) {
+            $request->hasPhone = true;
+            $request->phone = $payload['phone'] !== null ? (string) $payload['phone'] : null;
+        }
+
+        return $request;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide API endpoints to update `Company` resources both fully (`PUT`) and partially (`PATCH`) while reusing existing parsing and validation patterns. 
- Centralize payload mapping and validation for update flows to match the style used by other domain controllers.
- Ensure updates are performed only inside the correct CRM scope using the existing scope resolver and repository helpers.

### Description
- Add `PutCompanyController` implementing `PUT /v1/crm/applications/{applicationSlug}/companies/{companyId}` that resolves the CRM scope with `CrmApplicationScopeResolver`, loads the entity via `CompanyRepository::findOneScopedById`, validates input via `UpdateCompanyRequest::fromPutArray` and the `put` validation group, and saves the updated entity.
- Add `PatchCompanyController` implementing `PATCH /v1/crm/applications/{applicationSlug}/companies/{companyId}` that parses JSON payloads, maps to `UpdateCompanyRequest::fromPatchArray`, validates, applies only provided fields (using `has*` flags) and saves via `CompanyRepository->save`.
- Introduce `UpdateCompanyRequest` DTO with `fromPutArray` and `fromPatchArray` factory methods, field constraints (including `NotBlank` for `put`), and boolean `has*` flags to drive partial updates.
- Use existing error response patterns via `CrmApiErrorResponseFactory` for invalid JSON, validation failures and missing scoped references.

### Testing
- Ran PHP syntax checks with `php -l` on `src/Crm/Transport/Request/UpdateCompanyRequest.php` and the two new controllers, and all files reported no syntax errors. 
- No additional automated test suites were executed in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ed5c8e748326803a841d5b7ee162)