### PR TITLE
Add PATCH and DELETE endpoints for employee role management

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/Employee/DetachEmployeeRoleController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Employee/DetachEmployeeRoleController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Employee;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Infrastructure\Repository\EmployeeRepository;
+use App\Role\Domain\Enum\Role;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class DetachEmployeeRoleController
+{
+    public function __construct(
+        private CrmApplicationScopeResolver $scopeResolver,
+        private EmployeeRepository $employeeRepository,
+        private EntityManagerInterface $entityManager,
+    ) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/employees/{employeeId}/roles', methods: [Request::METHOD_DELETE])]
+    public function __invoke(string $applicationSlug, string $employeeId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $employee = $this->employeeRepository->findOneScopedById($employeeId, $crm->getId());
+        if ($employee === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Employee not found for this CRM scope.');
+        }
+
+        $employee->setRoleName(null);
+        $this->entityManager->flush();
+
+        return new JsonResponse(['id' => $employee->getId(), 'role' => $employee->getRoleName()]);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Employee/PatchEmployeeRoleController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Employee/PatchEmployeeRoleController.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Employee;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Infrastructure\Repository\EmployeeRepository;
+use App\Crm\Transport\Request\AssignEmployeeRoleRequest;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\Role\Domain\Enum\Role;
+use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class PatchEmployeeRoleController
+{
+    public function __construct(
+        private CrmApplicationScopeResolver $scopeResolver,
+        private EmployeeRepository $employeeRepository,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+        private ValidatorInterface $validator,
+        private EntityManagerInterface $entityManager,
+    ) {}
+
+    #[Route('/v1/crm/applications/{applicationSlug}/employees/{employeeId}/roles', methods: [Request::METHOD_PATCH])]
+    public function __invoke(string $applicationSlug, string $employeeId, Request $request): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $employee = $this->employeeRepository->findOneScopedById($employeeId, $crm->getId());
+        if ($employee === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Employee not found for this CRM scope.');
+        }
+
+        try {
+            $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        $input = AssignEmployeeRoleRequest::fromArray($payload);
+        $violations = $this->validator->validate($input);
+        if ($violations->count() > 0) {
+            return $this->errorResponseFactory->validationFailed($violations);
+        }
+
+        $employee->setRoleName($input->role);
+        $this->entityManager->flush();
+
+        return new JsonResponse(['id' => $employee->getId(), 'role' => $employee->getRoleName()]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide API endpoints to update and remove an employee's role within a CRM application scope.
- Map the “detach” semantics to the existing `Employee::setRoleName(null)` behavior to keep domain model simple.
- Reuse existing scope resolution and repository methods to enforce CRM scoping and permissions.

### Description
- Add `PatchEmployeeRoleController` with route `PATCH /v1/crm/applications/{applicationSlug}/employees/{employeeId}/roles` that parses JSON, validates input via `AssignEmployeeRoleRequest`, and updates the role with `setRoleName($input->role)`.
- Add `DetachEmployeeRoleController` with route `DELETE /v1/crm/applications/{applicationSlug}/employees/{employeeId}/roles` that sets the employee role to `null` via `setRoleName(null)`.
- Both controllers resolve the CRM scope using `CrmApplicationScopeResolver`, load employees with `EmployeeRepository::findOneScopedById`, and require `IsGranted(Role::CRM_ADMIN->value)`.
- Both controllers flush changes via `EntityManagerInterface` and return the employee `id` and current `role` in the JSON response.

### Testing
- Ran `php -l src/Crm/Transport/Controller/Api/V1/Employee/PatchEmployeeRoleController.php` and it succeeded.
- Ran `php -l src/Crm/Transport/Controller/Api/V1/Employee/DetachEmployeeRoleController.php` and it succeeded.
- No automated unit/integration tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ed6153088326a02f5615d47cbb38)