### PR TITLE
Refactor CRM create controllers to dispatch Messenger commands and move persistence to handlers

### DIFF
--- a/src/Crm/Application/Message/CreateBillingCommand.php
+++ b/src/Crm/Application/Message/CreateBillingCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class CreateBillingCommand implements MessageHighInterface
+{
+    public function __construct(
+        public string $id,
+        public string $companyId,
+        public string $label,
+        public float $amount,
+        public string $currency,
+        public string $status,
+        public ?string $dueAt,
+        public string $applicationSlug,
+        public string $crmId,
+    ) {
+    }
+}

--- a/src/Crm/Application/Message/CreateContactCommand.php
+++ b/src/Crm/Application/Message/CreateContactCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class CreateContactCommand implements MessageHighInterface
+{
+    public function __construct(
+        public string $id,
+        public string $crmId,
+        public string $firstName,
+        public string $lastName,
+        public ?string $email,
+        public ?string $phone,
+        public ?string $jobTitle,
+        public ?string $city,
+        public int $score,
+        public ?string $companyId,
+        public string $applicationSlug,
+    ) {
+    }
+}

--- a/src/Crm/Application/Message/CreateEmployeeCommand.php
+++ b/src/Crm/Application/Message/CreateEmployeeCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageHighInterface;
+
+final readonly class CreateEmployeeCommand implements MessageHighInterface
+{
+    public function __construct(
+        public string $id,
+        public string $crmId,
+        public string $firstName,
+        public string $lastName,
+        public ?string $email,
+        public ?string $positionName,
+        public ?string $roleName,
+        public string $applicationSlug,
+    ) {
+    }
+}

--- a/src/Crm/Application/MessageHandler/CreateBillingCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/CreateBillingCommandHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\MessageHandler;
+
+use App\Crm\Application\Message\CreateBillingCommand;
+use App\Crm\Domain\Entity\Billing;
+use App\Crm\Infrastructure\Repository\BillingRepository;
+use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\General\Application\Message\EntityCreated;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+final readonly class CreateBillingCommandHandler
+{
+    public function __construct(
+        private CompanyRepository $companyRepository,
+        private BillingRepository $billingRepository,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function __invoke(CreateBillingCommand $command): void
+    {
+        $company = $this->companyRepository->find($command->companyId);
+        if ($company === null) {
+            return;
+        }
+
+        $billing = (new Billing())
+            ->setId($command->id)
+            ->setCompany($company)
+            ->setLabel($command->label)
+            ->setAmount($command->amount)
+            ->setCurrency($command->currency)
+            ->setStatus($command->status);
+
+        if ($command->dueAt !== null) {
+            $billing->setDueAt(new \DateTimeImmutable($command->dueAt));
+        }
+
+        $this->billingRepository->save($billing);
+
+        $this->messageBus->dispatch(new EntityCreated('crm_billing', $billing->getId(), context: [
+            'applicationSlug' => $command->applicationSlug,
+            'crmId' => $command->crmId,
+            'companyId' => $command->companyId,
+        ]));
+    }
+}

--- a/src/Crm/Application/MessageHandler/CreateContactCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/CreateContactCommandHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\MessageHandler;
+
+use App\Crm\Application\Message\CreateContactCommand;
+use App\Crm\Domain\Entity\Contact;
+use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\Crm\Infrastructure\Repository\CrmRepository;
+use App\Crm\Infrastructure\Repository\ContactRepository;
+use App\General\Application\Message\EntityCreated;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+final readonly class CreateContactCommandHandler
+{
+    public function __construct(
+        private CrmRepository $crmRepository,
+        private CompanyRepository $companyRepository,
+        private ContactRepository $contactRepository,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function __invoke(CreateContactCommand $command): void
+    {
+        $crm = $this->crmRepository->find($command->crmId);
+        if ($crm === null) {
+            return;
+        }
+
+        $contact = (new Contact())
+            ->setId($command->id)
+            ->setCrm($crm)
+            ->setFirstName($command->firstName)
+            ->setLastName($command->lastName)
+            ->setEmail($command->email)
+            ->setPhone($command->phone)
+            ->setJobTitle($command->jobTitle)
+            ->setCity($command->city)
+            ->setScore($command->score);
+
+        if ($command->companyId !== null) {
+            $company = $this->companyRepository->findOneScopedById($command->companyId, $command->crmId);
+            if ($company !== null) {
+                $contact->setCompany($company);
+            }
+        }
+
+        $this->contactRepository->save($contact);
+
+        $this->messageBus->dispatch(new EntityCreated('crm_contact', $contact->getId(), context: [
+            'applicationSlug' => $command->applicationSlug,
+            'crmId' => $command->crmId,
+        ]));
+    }
+}

--- a/src/Crm/Application/MessageHandler/CreateEmployeeCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/CreateEmployeeCommandHandler.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\MessageHandler;
+
+use App\Crm\Application\Message\CreateEmployeeCommand;
+use App\Crm\Domain\Entity\Employee;
+use App\Crm\Infrastructure\Repository\CrmRepository;
+use App\Crm\Infrastructure\Repository\EmployeeRepository;
+use App\General\Application\Message\EntityCreated;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsMessageHandler]
+final readonly class CreateEmployeeCommandHandler
+{
+    public function __construct(
+        private CrmRepository $crmRepository,
+        private EmployeeRepository $employeeRepository,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    public function __invoke(CreateEmployeeCommand $command): void
+    {
+        $crm = $this->crmRepository->find($command->crmId);
+        if ($crm === null) {
+            return;
+        }
+
+        $employee = (new Employee())
+            ->setId($command->id)
+            ->setCrm($crm)
+            ->setFirstName($command->firstName)
+            ->setLastName($command->lastName)
+            ->setEmail($command->email)
+            ->setPositionName($command->positionName)
+            ->setRoleName($command->roleName);
+
+        $this->employeeRepository->save($employee);
+
+        $this->messageBus->dispatch(new EntityCreated('crm_employee', $employee->getId(), context: [
+            'applicationSlug' => $command->applicationSlug,
+            'crmId' => $command->crmId,
+        ]));
+    }
+}

--- a/src/Crm/Domain/Entity/Billing.php
+++ b/src/Crm/Domain/Entity/Billing.php
@@ -11,6 +11,7 @@ use DateTimeImmutable;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
+use Ramsey\Uuid\Uuid as RamseyUuid;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
 
@@ -52,6 +53,7 @@ class Billing implements EntityInterface
 
     #[Override]
     public function getId(): string { return $this->id->toString(); }
+    public function setId(string $id): self { $this->id = RamseyUuid::fromString($id); return $this; }
     public function getCompany(): ?Company { return $this->company; }
     public function setCompany(?Company $company): self { $this->company = $company; return $this; }
     public function getLabel(): string { return $this->label; }

--- a/src/Crm/Domain/Entity/Contact.php
+++ b/src/Crm/Domain/Entity/Contact.php
@@ -10,6 +10,7 @@ use App\General\Domain\Entity\Traits\Uuid;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
+use Ramsey\Uuid\Uuid as RamseyUuid;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
 
@@ -63,6 +64,13 @@ class Contact implements EntityInterface
     public function getId(): string
     {
         return $this->id->toString();
+    }
+
+    public function setId(string $id): self
+    {
+        $this->id = RamseyUuid::fromString($id);
+
+        return $this;
     }
 
     public function getCrm(): ?Crm { return $this->crm; }

--- a/src/Crm/Domain/Entity/Employee.php
+++ b/src/Crm/Domain/Entity/Employee.php
@@ -10,6 +10,7 @@ use App\General\Domain\Entity\Traits\Uuid;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
+use Ramsey\Uuid\Uuid as RamseyUuid;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
 
@@ -53,6 +54,13 @@ class Employee implements EntityInterface
     public function getId(): string
     {
         return $this->id->toString();
+    }
+
+    public function setId(string $id): self
+    {
+        $this->id = RamseyUuid::fromString($id);
+
+        return $this;
     }
 
     public function getCrm(): ?Crm { return $this->crm; }

--- a/src/Crm/Transport/Controller/Api/V1/Billing/CreateBillingController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Billing/CreateBillingController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Billing;
 
-use App\Crm\Application\Security\CrmPermissions;
+use App\Crm\Application\Message\CreateBillingCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Billing;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
@@ -12,13 +12,13 @@ use App\Crm\Transport\Request\CreateBillingRequest;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
 use DateTimeImmutable;
-use Doctrine\ORM\EntityManagerInterface;
 use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -33,7 +33,7 @@ final readonly class CreateBillingController
         private CompanyRepository $companyRepository,
         private CrmApiErrorResponseFactory $errorResponseFactory,
         private ValidatorInterface $validator,
-        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
     ) {}
 
     #[Route('/v1/crm/applications/{applicationSlug}/billings', methods: [Request::METHOD_POST])]
@@ -63,7 +63,6 @@ final readonly class CreateBillingController
         }
 
         $billing = (new Billing())
-            ->setCompany($company)
             ->setLabel((string)$input->label)
             ->setAmount((float)$input->amount)
             ->setCurrency($input->currency ?: 'EUR')
@@ -73,8 +72,17 @@ final readonly class CreateBillingController
             $billing->setDueAt(new DateTimeImmutable((string)$input->dueAt));
         }
 
-        $this->entityManager->persist($billing);
-        $this->entityManager->flush();
+        $this->messageBus->dispatch(new CreateBillingCommand(
+            id: $billing->getId(),
+            companyId: $company->getId(),
+            label: $billing->getLabel(),
+            amount: $billing->getAmount(),
+            currency: $billing->getCurrency(),
+            status: $billing->getStatus(),
+            dueAt: $billing->getDueAt()?->format(DATE_ATOM),
+            applicationSlug: $applicationSlug,
+            crmId: $crm->getId(),
+        ));
 
         return new JsonResponse(['id' => $billing->getId(), 'companyId' => $company->getId()], JsonResponse::HTTP_CREATED);
     }

--- a/src/Crm/Transport/Controller/Api/V1/Contact/CreateContactController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Contact/CreateContactController.php
@@ -4,18 +4,19 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Contact;
 
+use App\Crm\Application\Message\CreateContactCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Contact;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Transport\Request\CreateContactRequest;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
-use Doctrine\ORM\EntityManagerInterface;
 use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -30,7 +31,7 @@ final readonly class CreateContactController
         private CompanyRepository $companyRepository,
         private CrmApiErrorResponseFactory $errorResponseFactory,
         private ValidatorInterface $validator,
-        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
     ) {}
 
     #[Route('/v1/crm/applications/{applicationSlug}/contacts', methods: [Request::METHOD_POST])]
@@ -55,7 +56,6 @@ final readonly class CreateContactController
         }
 
         $contact = (new Contact())
-            ->setCrm($crm)
             ->setFirstName((string)$input->firstName)
             ->setLastName((string)$input->lastName)
             ->setEmail($input->email)
@@ -64,15 +64,27 @@ final readonly class CreateContactController
             ->setCity($input->city)
             ->setScore($input->score ?? 0);
 
+        $companyId = null;
         if (($input->companyId ?? '') !== '') {
             $company = $this->companyRepository->findOneScopedById((string)$input->companyId, $crm->getId());
             if ($company !== null) {
-                $contact->setCompany($company);
+                $companyId = $company->getId();
             }
         }
 
-        $this->entityManager->persist($contact);
-        $this->entityManager->flush();
+        $this->messageBus->dispatch(new CreateContactCommand(
+            id: $contact->getId(),
+            crmId: $crm->getId(),
+            firstName: $contact->getFirstName(),
+            lastName: $contact->getLastName(),
+            email: $contact->getEmail(),
+            phone: $contact->getPhone(),
+            jobTitle: $contact->getJobTitle(),
+            city: $contact->getCity(),
+            score: $contact->getScore(),
+            companyId: $companyId,
+            applicationSlug: $applicationSlug,
+        ));
 
         return new JsonResponse(['id' => $contact->getId()], JsonResponse::HTTP_CREATED);
     }

--- a/src/Crm/Transport/Controller/Api/V1/Employee/CreateEmployeeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Employee/CreateEmployeeController.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Employee;
 
-use App\Crm\Application\Security\CrmPermissions;
+use App\Crm\Application\Message\CreateEmployeeCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Employee;
 use App\Crm\Transport\Request\CreateEmployeeRequest;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
-use Doctrine\ORM\EntityManagerInterface;
 use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -29,7 +29,7 @@ final readonly class CreateEmployeeController
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
         private ValidatorInterface $validator,
-        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
     ) {}
 
     #[Route('/v1/crm/applications/{applicationSlug}/employees', methods: [Request::METHOD_POST])]
@@ -54,15 +54,22 @@ final readonly class CreateEmployeeController
         }
 
         $employee = (new Employee())
-            ->setCrm($crm)
             ->setFirstName((string)$input->firstName)
             ->setLastName((string)$input->lastName)
             ->setEmail($input->email)
             ->setPositionName($input->positionName)
             ->setRoleName($input->roleName);
 
-        $this->entityManager->persist($employee);
-        $this->entityManager->flush();
+        $this->messageBus->dispatch(new CreateEmployeeCommand(
+            id: $employee->getId(),
+            crmId: $crm->getId(),
+            firstName: $employee->getFirstName(),
+            lastName: $employee->getLastName(),
+            email: $employee->getEmail(),
+            positionName: $employee->getPositionName(),
+            roleName: $employee->getRoleName(),
+            applicationSlug: $applicationSlug,
+        ));
 
         return new JsonResponse(['id' => $employee->getId()], JsonResponse::HTTP_CREATED);
     }

--- a/tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php
@@ -4,9 +4,15 @@ declare(strict_types=1);
 
 namespace App\Tests\Application\Crm\Transport\Controller\Api\V1;
 
+use App\Crm\Application\Message\CreateBillingCommand;
+use App\Crm\Application\Message\CreateContactCommand;
+use App\Crm\Application\Message\CreateEmployeeCommand;
 use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Infrastructure\Repository\BillingRepository;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\Crm\Infrastructure\Repository\ContactRepository;
 use App\Crm\Infrastructure\Repository\CrmRepository;
+use App\Crm\Infrastructure\Repository\EmployeeRepository;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\General\Application\Message\EntityCreated;
@@ -295,6 +301,104 @@ final class CrmControllerTest extends WebTestCase
         self::assertSame($this->getCrmIdByApplicationSlug(self::PRIMARY_APPLICATION_SLUG), $message->context['crmId'] ?? null);
     }
 
+    #[TestDox('CreateBillingController dispatches CreateBillingCommand and does not flush in controller.')] 
+    public function testCreateBillingDispatchesCommandWithoutImmediatePersistence(): void
+    {
+        $companyId = $this->createCompany();
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        /** @var InMemoryTransport $transport */
+        $transport = static::getContainer()->get('messenger.transport.async_priority_high');
+        $transport->reset();
+
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/billings', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode([
+                'companyId' => $companyId,
+                'label' => 'Billing ' . uniqid('', true),
+                'amount' => 42.5,
+                'currency' => 'EUR',
+            ])
+        );
+
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode(), "Response:\n" . $client->getResponse());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        self::assertArrayHasKey('id', $payload);
+        self::assertSame($companyId, $payload['companyId'] ?? null);
+
+        $message = $this->getLastDispatchedMessage($transport);
+        self::assertInstanceOf(CreateBillingCommand::class, $message);
+        self::assertSame(self::PRIMARY_APPLICATION_SLUG, $message->applicationSlug);
+        self::assertSame($this->getCrmIdByApplicationSlug(self::PRIMARY_APPLICATION_SLUG), $message->crmId);
+
+        $billingRepository = static::getContainer()->get(BillingRepository::class);
+        self::assertNull($billingRepository->find($payload['id']));
+    }
+
+    #[TestDox('CreateContactController dispatches CreateContactCommand and does not flush in controller.')]
+    public function testCreateContactDispatchesCommandWithoutImmediatePersistence(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        /** @var InMemoryTransport $transport */
+        $transport = static::getContainer()->get('messenger.transport.async_priority_high');
+        $transport->reset();
+
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/contacts', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode([
+                'firstName' => 'Test',
+                'lastName' => 'Contact',
+                'email' => 'test.contact@example.com',
+            ])
+        );
+
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode(), "Response:\n" . $client->getResponse());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        $message = $this->getLastDispatchedMessage($transport);
+        self::assertInstanceOf(CreateContactCommand::class, $message);
+        self::assertSame(self::PRIMARY_APPLICATION_SLUG, $message->applicationSlug);
+        self::assertSame($this->getCrmIdByApplicationSlug(self::PRIMARY_APPLICATION_SLUG), $message->crmId);
+
+        $contactRepository = static::getContainer()->get(ContactRepository::class);
+        self::assertNull($contactRepository->find($payload['id']));
+    }
+
+    #[TestDox('CreateEmployeeController dispatches CreateEmployeeCommand and does not flush in controller.')]
+    public function testCreateEmployeeDispatchesCommandWithoutImmediatePersistence(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        /** @var InMemoryTransport $transport */
+        $transport = static::getContainer()->get('messenger.transport.async_priority_high');
+        $transport->reset();
+
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/employees', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode([
+                'firstName' => 'Test',
+                'lastName' => 'Employee',
+                'email' => 'test.employee@example.com',
+            ])
+        );
+
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode(), "Response:\n" . $client->getResponse());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        $message = $this->getLastDispatchedMessage($transport);
+        self::assertInstanceOf(CreateEmployeeCommand::class, $message);
+        self::assertSame(self::PRIMARY_APPLICATION_SLUG, $message->applicationSlug);
+        self::assertSame($this->getCrmIdByApplicationSlug(self::PRIMARY_APPLICATION_SLUG), $message->crmId);
+
+        $employeeRepository = static::getContainer()->get(EmployeeRepository::class);
+        self::assertNull($employeeRepository->find($payload['id']));
+    }
+
     #[TestDox('Delete endpoints reject IDs from another CRM application scope.')]
     #[DataProvider('crossScopeDeleteProvider')]
     public function testDeleteRejectsForeignScopeIds(string $resource, string $foreignIdKey): void
@@ -429,6 +533,14 @@ final class CrmControllerTest extends WebTestCase
         self::assertInstanceOf(EntityCreated::class, $message);
 
         return $message;
+    }
+
+    private function getLastDispatchedMessage(InMemoryTransport $transport): object
+    {
+        $envelopes = $transport->getSent();
+        self::assertNotEmpty($envelopes);
+
+        return $envelopes[array_key_last($envelopes)]->getMessage();
     }
 
     private function createSprint(string $projectId): string


### PR DESCRIPTION
### Motivation
- Align `CreateBillingController`, `CreateContactController`, and `CreateEmployeeController` with the existing pattern used by task/project/company endpoints so controllers only instantiate/validate and dispatch work. 
- Generate the entity UUID at instantiation and return it immediately in the HTTP response without performing final persistence in the controller. 
- Move persistence and `flush()` responsibilities to application-level message handlers so creation can be processed asynchronously (or synchronously via bus configuration) while publishing `EntityCreated` with the correct context.

### Description
- Updated controllers `src/Crm/Transport/Controller/Api/V1/Billing/CreateBillingController.php`, `src/Crm/Transport/Controller/Api/V1/Contact/CreateContactController.php`, and `src/Crm/Transport/Controller/Api/V1/Employee/CreateEmployeeController.php` to instantiate entities (UUID generated in constructor), validate input, dispatch dedicated Messages, and return standardized JSON creation responses (`{ "id": "..." }` plus `companyId` for billing). 
- Added application messages `CreateBillingCommand`, `CreateContactCommand`, and `CreateEmployeeCommand` under `src/Crm/Application/Message/` and corresponding handlers `CreateBillingCommandHandler`, `CreateContactCommandHandler`, and `CreateEmployeeCommandHandler` under `src/Crm/Application/MessageHandler/` which perform persistence and then dispatch `EntityCreated` with `applicationSlug` and `crmId` (and `companyId` for billing). 
- Added `setId(string $id)` to CRM entities `Billing`, `Contact`, and `Employee` to allow handlers to persist the ID pre-generated by controllers. 
- Adjusted tests in `tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php` to assert that controllers dispatch the new commands, propagate `applicationSlug`/`crmId` context, and do not perform immediate persistence (repositories return null for the entity immediately after the `201` response in the test environment). 

### Testing
- Ran syntax checks with `php -l` on the touched PHP files (controllers, messages, handlers, entity changes and updated tests) and they reported no syntax errors. 
- Verified via static search that controllers no longer call `persist()`/`flush()` directly. 
- Attempted to run the API test file with PHPUnit but full test execution could not be performed because `composer install` failed in this environment due to missing PHP extensions (`ext-amqp` and `ext-sodium`) and `bin/phpunit` was not available, preventing an end-to-end phpunit run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5f151e52c832bb12271a6470fe0a4)