### PR TITLE
Refactor CRM Billing GET endpoints into cached read service with ES fallback and invalidation

### DIFF
--- a/docs/crm-get-endpoints.md
+++ b/docs/crm-get-endpoints.md
@@ -1,0 +1,26 @@
+# CRM GET endpoints inventory (V1)
+
+## List endpoints
+- `GET /v1/crm/applications/{applicationSlug}/billings` — filters: `q`, `status`, `companyId`; pagination: `page`, `limit`.
+- `GET /v1/crm/applications/{applicationSlug}/contacts` — filters: `q`; pagination: `page`, `limit`.
+- `GET /v1/crm/applications/{applicationSlug}/companies` — filters: `q`; pagination: `page`, `limit`.
+- `GET /v1/crm/applications/{applicationSlug}/projects` — filters: `q`, `status`; pagination: `page`, `limit`.
+- `GET /v1/crm/applications/{applicationSlug}/sprints` — filters: `q`, `status`; pagination: `page`, `limit`.
+- `GET /v1/crm/applications/{applicationSlug}/tasks` — filters: `q`, `title`, `status`, `priority`; pagination: `page`, `limit`.
+- `GET /v1/crm/applications/{applicationSlug}/task-requests` — filters: `q`, `status`; pagination: `page`, `limit`.
+- `GET /v1/crm/applications/{applicationSlug}/tasks/by-sprint` — business filters: board/sprint scope.
+- `GET /v1/crm/applications/{applicationSlug}/sprints/{sprint}/tasks` — business filters: sprint scope.
+- `GET /v1/crm/applications/{applicationSlug}/me/tasks` — business filters: current user tasks.
+
+## Detail endpoints
+- `GET /v1/crm/applications/{applicationSlug}/billings/{billing}`
+- `GET /v1/crm/applications/{applicationSlug}/contacts/{id}`
+- `GET /v1/crm/applications/{applicationSlug}/companies/{id}`
+- `GET /v1/crm/applications/{applicationSlug}/projects/{project}`
+- `GET /v1/crm/applications/{applicationSlug}/sprints/{sprint}`
+- `GET /v1/crm/applications/{applicationSlug}/tasks/{task}`
+- `GET /v1/crm/applications/{applicationSlug}/task-requests/{taskRequest}`
+
+## Other GET CRM endpoints (out of current refactor scope)
+- `GET /v1/crm/applications/{applicationSlug}/reports`
+- `GET /v1/crm/applications/{applicationSlug}/dashboard`

--- a/src/Crm/Application/Service/BillingReadService.php
+++ b/src/Crm/Application/Service/BillingReadService.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Infrastructure\Repository\BillingRepository;
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use DateTimeInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function ceil;
+use function max;
+use function method_exists;
+use function min;
+use function trim;
+
+readonly class BillingReadService
+{
+    public function __construct(
+        private BillingRepository $billingRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CacheInterface $cache,
+        private CacheKeyConventionService $cacheKeyConventionService,
+        private ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+    }
+
+    /** @return array<string,mixed> */
+    public function getList(string $applicationSlug, Request $request): array
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'q' => trim((string) $request->query->get('q', '')),
+            'status' => trim((string) $request->query->get('status', '')),
+            'companyId' => trim((string) $request->query->get('companyId', '')),
+        ];
+
+        $cacheKey = $this->cacheKeyConventionService->buildCrmBillingListKey($applicationSlug, $page, $limit, $filters);
+
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $page, $limit, $filters): array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->crmBillingListTag($applicationSlug));
+            }
+
+            $esFilters = $this->applyEsFilter($filters);
+            $items = $this->billingRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $esFilters);
+            $totalItems = $this->billingRepository->countScopedByCrm($crm->getId(), $esFilters);
+
+            return [
+                'items' => array_map(fn (array $row): array => $this->normalizeProjection($row), $items),
+                'pagination' => [
+                    'page' => $page,
+                    'limit' => $limit,
+                    'totalItems' => $totalItems,
+                    'totalPages' => $totalItems > 0 ? (int) ceil($totalItems / $limit) : 0,
+                ],
+                'meta' => [
+                    'filters' => array_filter($filters, static fn (string $value): bool => $value !== ''),
+                ],
+            ];
+        });
+
+        return $result;
+    }
+
+    /** @return array<string,mixed>|null */
+    public function getDetail(string $applicationSlug, string $billingId): ?array
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $cacheKey = $this->cacheKeyConventionService->buildCrmBillingDetailKey($applicationSlug, $billingId);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $billingId): ?array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag([
+                    $this->cacheKeyConventionService->crmBillingListTag($applicationSlug),
+                    $this->cacheKeyConventionService->crmBillingDetailTag($applicationSlug, $billingId),
+                ]);
+            }
+
+            $entity = $this->billingRepository->findOneScopedById($billingId, $crm->getId());
+            if ($entity === null) {
+                return null;
+            }
+
+            return [
+                'id' => $entity->getId(),
+                'companyId' => $entity->getCompany()?->getId(),
+                'label' => $entity->getLabel(),
+                'amount' => $entity->getAmount(),
+                'currency' => $entity->getCurrency(),
+                'status' => $entity->getStatus(),
+                'dueAt' => $entity->getDueAt()?->format(DATE_ATOM),
+                'paidAt' => $entity->getPaidAt()?->format(DATE_ATOM),
+            ];
+        });
+    }
+
+    /** @param array{q:string,status:string,companyId:string} $filters
+     * @return array{q:string,status:string,companyId:string}
+     */
+    private function applyEsFilter(array $filters): array
+    {
+        if ($filters['q'] === '') {
+            return $filters;
+        }
+
+        try {
+            $response = $this->elasticsearchService->search('crm_billings', [
+                'query' => [
+                    'multi_match' => [
+                        'query' => $filters['q'],
+                        'type' => 'phrase_prefix',
+                        'fields' => ['label^3', 'status', 'companyId'],
+                    ],
+                ],
+                '_source' => ['label'],
+            ], 0, 1);
+
+            if (($response['hits']['total']['value'] ?? 0) === 0) {
+                return ['q' => '__no_match__', 'status' => $filters['status'], 'companyId' => $filters['companyId']];
+            }
+        } catch (Throwable) {
+            return $filters;
+        }
+
+        return $filters;
+    }
+
+    /** @param array<string,mixed> $item
+     * @return array<string,mixed>
+     */
+    private function normalizeProjection(array $item): array
+    {
+        return [
+            'id' => (string) ($item['id'] ?? ''),
+            'companyId' => $item['companyId'] ?? null,
+            'label' => (string) ($item['label'] ?? ''),
+            'amount' => isset($item['amount']) ? (float) $item['amount'] : 0.0,
+            'currency' => (string) ($item['currency'] ?? 'EUR'),
+            'status' => (string) ($item['status'] ?? 'pending'),
+            'dueAt' => $this->normalizeDateValue($item['dueAt'] ?? null),
+            'paidAt' => $this->normalizeDateValue($item['paidAt'] ?? null),
+        ];
+    }
+
+    private function normalizeDateValue(mixed $value): ?string
+    {
+        if ($value instanceof DateTimeInterface) {
+            return $value->format(DATE_ATOM);
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Crm/Application/Service/CrmReadCacheInvalidator.php
+++ b/src/Crm/Application/Service/CrmReadCacheInvalidator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\General\Application\Service\CacheKeyConventionService;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+readonly class CrmReadCacheInvalidator
+{
+    public function __construct(
+        private CacheInterface $cache,
+        private CacheKeyConventionService $cacheKeyConventionService,
+    ) {
+    }
+
+    public function invalidateBilling(string $applicationSlug, string $billingId): void
+    {
+        if (!$this->cache instanceof TagAwareCacheInterface) {
+            return;
+        }
+
+        $this->cache->invalidateTags([
+            $this->cacheKeyConventionService->crmBillingListTag($applicationSlug),
+            $this->cacheKeyConventionService->crmBillingDetailTag($applicationSlug, $billingId),
+        ]);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Billing/CreateBillingController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Billing/CreateBillingController.php
@@ -6,6 +6,7 @@ namespace App\Crm\Transport\Controller\Api\V1\Billing;
 
 use App\Crm\Application\Message\CreateBillingCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Domain\Entity\Billing;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Transport\Request\CreateBillingRequest;
@@ -34,6 +35,7 @@ final readonly class CreateBillingController
         private CrmApiErrorResponseFactory $errorResponseFactory,
         private ValidatorInterface $validator,
         private MessageBusInterface $messageBus,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {}
 
     #[Route('/v1/crm/applications/{applicationSlug}/billings', methods: [Request::METHOD_POST])]
@@ -83,6 +85,8 @@ final readonly class CreateBillingController
             applicationSlug: $applicationSlug,
             crmId: $crm->getId(),
         ));
+
+        $this->cacheInvalidator->invalidateBilling($applicationSlug, $billing->getId());
 
         return new JsonResponse(['id' => $billing->getId(), 'companyId' => $company->getId()], JsonResponse::HTTP_CREATED);
     }

--- a/src/Crm/Transport/Controller/Api/V1/Billing/DeleteBillingController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Billing/DeleteBillingController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Controller\Api\V1\Billing;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Infrastructure\Repository\BillingRepository;
 use App\Role\Domain\Enum\Role;
 use Doctrine\ORM\EntityManagerInterface;
@@ -25,6 +26,7 @@ final readonly class DeleteBillingController
         private BillingRepository $billingRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private EntityManagerInterface $entityManager,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -38,7 +40,9 @@ final readonly class DeleteBillingController
         }
 
         $this->entityManager->remove($entity);
+        $billingId = $entity->getId();
         $this->entityManager->flush();
+        $this->cacheInvalidator->invalidateBilling($applicationSlug, $billingId);
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }

--- a/src/Crm/Transport/Controller/Api/V1/Billing/GetBillingController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Billing/GetBillingController.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Billing;
 
-use App\Crm\Application\Service\CrmApplicationScopeResolver;
-use App\Crm\Infrastructure\Repository\BillingRepository;
+use App\Crm\Application\Service\BillingReadService;
 use App\Role\Domain\Enum\Role;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -20,30 +19,18 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_VIEWER->value)]
 final readonly class GetBillingController
 {
-    public function __construct(
-        private BillingRepository $billingRepository,
-        private CrmApplicationScopeResolver $scopeResolver,
-    ) {
+    public function __construct(private BillingReadService $billingReadService)
+    {
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/billings/{billing}', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug, string $billing): JsonResponse
     {
-        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $entity = $this->billingRepository->findOneScopedById($billing, $crm->getId());
-        if ($entity === null) {
+        $payload = $this->billingReadService->getDetail($applicationSlug, $billing);
+        if ($payload === null) {
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Billing not found for this CRM scope.');
         }
 
-        return new JsonResponse([
-            'id' => $entity->getId(),
-            'companyId' => $entity->getCompany()?->getId(),
-            'label' => $entity->getLabel(),
-            'amount' => $entity->getAmount(),
-            'currency' => $entity->getCurrency(),
-            'status' => $entity->getStatus(),
-            'dueAt' => $entity->getDueAt()?->format(DATE_ATOM),
-            'paidAt' => $entity->getPaidAt()?->format(DATE_ATOM),
-        ]);
+        return new JsonResponse($payload);
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Billing/ListBillingsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Billing/ListBillingsController.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Billing;
 
-use App\Crm\Application\Service\CrmApplicationScopeResolver;
-use App\Crm\Infrastructure\Repository\BillingRepository;
+use App\Crm\Application\Service\BillingReadService;
 use App\Role\Domain\Enum\Role;
-use DateTimeInterface;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,64 +18,13 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_VIEWER->value)]
 final readonly class ListBillingsController
 {
-    public function __construct(
-        private BillingRepository $billingRepository,
-        private CrmApplicationScopeResolver $scopeResolver,
-    ) {
+    public function __construct(private BillingReadService $billingReadService)
+    {
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/billings', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
-        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $page = max(1, $request->query->getInt('page', 1));
-        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
-        $filters = [
-            'q' => trim((string) $request->query->get('q', '')),
-            'status' => trim((string) $request->query->get('status', '')),
-            'companyId' => trim((string) $request->query->get('companyId', '')),
-        ];
-
-        $items = array_map(
-            fn (array $item): array => [
-                'id' => (string) ($item['id'] ?? ''),
-                'companyId' => $item['companyId'] ?? null,
-                'label' => (string) ($item['label'] ?? ''),
-                'amount' => isset($item['amount']) ? (float) $item['amount'] : 0.0,
-                'currency' => (string) ($item['currency'] ?? 'EUR'),
-                'status' => (string) ($item['status'] ?? 'pending'),
-                'dueAt' => $this->normalizeDateValue($item['dueAt'] ?? null),
-                'paidAt' => $this->normalizeDateValue($item['paidAt'] ?? null),
-            ],
-            $this->billingRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $filters),
-        );
-
-        $totalItems = $this->billingRepository->countScopedByCrm($crm->getId(), $filters);
-
-        return new JsonResponse([
-            'items' => $items,
-            'pagination' => [
-                'page' => $page,
-                'limit' => $limit,
-                'totalItems' => $totalItems,
-                'totalPages' => $totalItems > 0 ? (int) ceil($totalItems / $limit) : 0,
-            ],
-            'meta' => [
-                'filters' => array_filter($filters),
-            ],
-        ]);
-    }
-
-    private function normalizeDateValue(mixed $value): ?string
-    {
-        if ($value instanceof DateTimeInterface) {
-            return $value->format(DATE_ATOM);
-        }
-
-        if (is_string($value)) {
-            return $value;
-        }
-
-        return null;
+        return new JsonResponse($this->billingReadService->getList($applicationSlug, $request));
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Billing/PatchBillingController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Billing/PatchBillingController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Controller\Api\V1\Billing;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Infrastructure\Repository\BillingRepository;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
@@ -30,6 +31,7 @@ final readonly class PatchBillingController
         private CompanyRepository $companyRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -87,6 +89,8 @@ final readonly class PatchBillingController
         }
 
         $this->billingRepository->save($entity);
+
+        $this->cacheInvalidator->invalidateBilling($applicationSlug, $entity->getId());
 
         return new JsonResponse(['id' => $entity->getId()]);
     }

--- a/src/Crm/Transport/Controller/Api/V1/Billing/PutBillingController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Billing/PutBillingController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Controller\Api\V1\Billing;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Infrastructure\Repository\BillingRepository;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Transport\Request\CreateBillingRequest;
@@ -32,6 +33,7 @@ final readonly class PutBillingController
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
         private ValidatorInterface $validator,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -79,6 +81,8 @@ final readonly class PutBillingController
             ->setDueAt(($input->dueAt ?? '') !== '' ? new DateTimeImmutable((string) $input->dueAt) : null);
 
         $this->billingRepository->save($entity);
+
+        $this->cacheInvalidator->invalidateBilling($applicationSlug, $entity->getId());
 
         return new JsonResponse([
             'id' => $entity->getId(),

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -176,6 +176,25 @@ class CacheKeyConventionService
      * @param array<string, mixed> $filters
      * @throws JsonException
      */
+    public function buildCrmBillingListKey(string $applicationSlug, int $page, int $limit, array $filters): string
+    {
+        return 'crm_billing_list_' . md5((string)json_encode([
+            'applicationSlug' => $applicationSlug,
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function buildCrmBillingDetailKey(string $applicationSlug, string $billingId): string
+    {
+        return 'crm_billing_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($billingId);
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     * @throws JsonException
+     */
     public function buildSchoolExamListKey(string $applicationSlug, int $page, int $limit, array $filters): string
     {
         return 'school_exam_list_' . md5((string)json_encode([
@@ -298,6 +317,16 @@ class CacheKeyConventionService
     public function crmCompanyListByApplicationTag(string $applicationSlug): string
     {
         return 'cache_crm_company_list_' . $this->sanitizeSegment($applicationSlug);
+    }
+
+    public function crmBillingListTag(string $applicationSlug): string
+    {
+        return 'cache_crm_billing_list_' . $this->sanitizeSegment($applicationSlug);
+    }
+
+    public function crmBillingDetailTag(string $applicationSlug, string $billingId): string
+    {
+        return 'cache_crm_billing_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($billingId);
     }
 
     public function schoolExamListTag(): string

--- a/tests/Unit/Crm/Application/Service/BillingReadServiceTest.php
+++ b/tests/Unit/Crm/Application/Service/BillingReadServiceTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Crm\Application\Service;
+
+use App\Crm\Application\Service\BillingReadService;
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
+use App\Crm\Domain\Entity\Billing;
+use App\Crm\Domain\Entity\Crm;
+use App\Crm\Infrastructure\Repository\BillingRepository;
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+
+final class BillingReadServiceTest extends TestCase
+{
+    public function testListUsesCacheAndFallbackWhenElasticFails(): void
+    {
+        $billingRepository = $this->createMock(BillingRepository::class);
+        $scopeResolver = $this->createMock(CrmApplicationScopeResolver::class);
+        $elasticsearch = $this->createMock(ElasticsearchServiceInterface::class);
+        $cache = new TagAwareAdapter(new ArrayAdapter());
+        $keys = new CacheKeyConventionService();
+
+        $crm = $this->createMock(Crm::class);
+        $crm->method('getId')->willReturn('crm-1');
+        $scopeResolver->method('resolveOrFail')->with('app')->willReturn($crm);
+
+        $filters = ['q' => 'invoice', 'status' => '', 'companyId' => ''];
+
+        $elasticsearch->expects(self::exactly(2))->method('search')->willThrowException(new \RuntimeException('es down'));
+
+        $billingRepository->expects(self::once())->method('findScopedProjection')->with('crm-1', 20, 0, $filters)->willReturn([
+            ['id' => 'b-1', 'label' => 'Invoice #1', 'amount' => 10.0, 'currency' => 'EUR', 'status' => 'pending', 'companyId' => 'c-1', 'dueAt' => null, 'paidAt' => null],
+        ]);
+        $billingRepository->expects(self::once())->method('countScopedByCrm')->with('crm-1', $filters)->willReturn(1);
+
+        $service = new BillingReadService($billingRepository, $scopeResolver, $cache, $keys, $elasticsearch);
+        $request = new \Symfony\Component\HttpFoundation\Request(['q' => 'invoice']);
+
+        $first = $service->getList('app', $request);
+        $second = $service->getList('app', $request);
+
+        self::assertSame(1, $first['pagination']['totalItems']);
+        self::assertSame($first, $second);
+    }
+
+    public function testDetailCacheIsInvalidatedAfterMutation(): void
+    {
+        $billingRepository = $this->createMock(BillingRepository::class);
+        $scopeResolver = $this->createMock(CrmApplicationScopeResolver::class);
+        $elasticsearch = $this->createMock(ElasticsearchServiceInterface::class);
+        $cache = new TagAwareAdapter(new ArrayAdapter());
+        $keys = new CacheKeyConventionService();
+
+        $crm = $this->createMock(Crm::class);
+        $crm->method('getId')->willReturn('crm-1');
+        $scopeResolver->method('resolveOrFail')->with('app')->willReturn($crm);
+
+        $billing = $this->createMock(Billing::class);
+        $version = 'A';
+        $billing->method('getId')->willReturn('b-1');
+        $billing->method('getCompany')->willReturn(null);
+        $billing->method('getLabel')->willReturnCallback(static fn (): string => 'Bill-' . $version);
+        $billing->method('getAmount')->willReturn(10.0);
+        $billing->method('getCurrency')->willReturn('EUR');
+        $billing->method('getStatus')->willReturn('pending');
+        $billing->method('getDueAt')->willReturn(null);
+        $billing->method('getPaidAt')->willReturn(null);
+
+        $billingRepository->expects(self::exactly(2))->method('findOneScopedById')->with('b-1', 'crm-1')->willReturn($billing);
+
+        $service = new BillingReadService($billingRepository, $scopeResolver, $cache, $keys, $elasticsearch);
+        $invalidator = new CrmReadCacheInvalidator($cache, $keys);
+
+        $first = $service->getDetail('app', 'b-1');
+        self::assertSame('Bill-A', $first['label']);
+
+        $version = 'B';
+        $stale = $service->getDetail('app', 'b-1');
+        self::assertSame('Bill-A', $stale['label']);
+
+        $invalidator->invalidateBilling('app', 'b-1');
+
+        $fresh = $service->getDetail('app', 'b-1');
+        self::assertSame('Bill-B', $fresh['label']);
+    }
+}


### PR DESCRIPTION
### Motivation
- Extract GET read logic out of Billing controllers to a reusable service to standardize response shape and remove business logic from controllers.
- Add systematic caching (list + detail) with normalized keys and tags to improve read performance and allow safe invalidation on mutations.
- Use `ElasticsearchServiceInterface` for text search with a graceful DB fallback when ES is unavailable.
- Provide a small pattern (service + keys + invalidator) that can be applied to other CRM resources (Contact/Company/Project/Task/TaskRequest/Sprint/Employee).

### Description
- Introduce `BillingReadService` to handle list/detail reads, response harmonization (`items`, `pagination`, `meta.filters`), ES-backed q-search with fallback, and cache via `CacheInterface`/`TagAwareCacheInterface` (`src/Crm/Application/Service/BillingReadService.php`).
- Add `CrmReadCacheInvalidator` to invalidate list/detail tags for billing reads (`src/Crm/Application/Service/CrmReadCacheInvalidator.php`).
- Wire billing GET controllers to `BillingReadService` (`ListBillingsController`, `GetBillingController`) and update create/patch/put/delete controllers to call the invalidator after mutations (`src/Crm/Transport/Controller/Api/V1/Billing/*.php`).
- Extend `CacheKeyConventionService` with billing list/detail key builders and tag functions (`buildCrmBillingListKey`, `buildCrmBillingDetailKey`, `crmBillingListTag`, `crmBillingDetailTag`).
- Add unit tests exercising cache hit/miss, ES fallback when search throws, and detail cache invalidation after mutation (`tests/Unit/Crm/Application/Service/BillingReadServiceTest.php`).
- Add a short inventory doc of CRM GET endpoints and parameters (`docs/crm-get-endpoints.md`).

### Testing
- Created unit tests for `BillingReadService` covering cache behavior, ES fallback, and invalidation and added them to `tests/Unit/Crm/Application/Service/BillingReadServiceTest.php` (tests not executed in this environment due to missing `phpunit` binary).
- Performed syntax checks with `php -l` on the new/modified PHP files and the new test file, and they all passed (`No syntax errors detected`).
- Attempted to run `./vendor/bin/phpunit` and `tools/01_phpunit/vendor/bin/phpunit` but the binary was not available in this environment, so unit tests were not run here (they are included and should run in CI/developer environment where `phpunit` is available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5f30c4694832b8f13e685d41b4f58)