### PR TITLE
feat(crm): ajouter un endpoint de liste des employés

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/Employee/ListEmployeesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Employee/ListEmployeesController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Employee;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\Employee;
+use App\Crm\Infrastructure\Repository\EmployeeRepository;
+use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_VIEWER->value)]
+final readonly class ListEmployeesController
+{
+    public function __construct(
+        private CrmApplicationScopeResolver $scopeResolver,
+        private EmployeeRepository $employeeRepository,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/employees', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Request $request): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+
+        $items = array_map(
+            static fn (Employee $employee): array => [
+                'id' => $employee->getId(),
+                'firstName' => $employee->getFirstName(),
+                'lastName' => $employee->getLastName(),
+                'email' => $employee->getEmail(),
+                'positionName' => $employee->getPositionName(),
+                'roleName' => $employee->getRoleName(),
+                'createdAt' => $employee->getCreatedAt()->format(DATE_ATOM),
+                'updatedAt' => $employee->getUpdatedAt()->format(DATE_ATOM),
+            ],
+            $this->employeeRepository->findScoped($crm->getId(), $limit, ($page - 1) * $limit)
+        );
+        $totalItems = $this->employeeRepository->countByCrm($crm->getId());
+
+        return new JsonResponse([
+            'items' => $items,
+            'pagination' => [
+                'page' => $page,
+                'limit' => $limit,
+                'totalItems' => $totalItems,
+                'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
+            ],
+        ]);
+    }
+}

--- a/tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php
@@ -396,6 +396,34 @@ final class CrmControllerTest extends WebTestCase
         self::assertNull($employeeRepository->find($payload['id']));
     }
 
+    #[TestDox('ListEmployeesController returns a paginated employee list scoped by CRM application.')]
+    public function testListEmployeesReturnsPaginatedList(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(
+            'GET',
+            sprintf('%s/v1/crm/applications/%s/employees?page=1&limit=5', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG)
+        );
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode(), "Response:\n" . $client->getResponse());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        self::assertArrayHasKey('items', $payload);
+        self::assertArrayHasKey('pagination', $payload);
+        self::assertSame(1, $payload['pagination']['page'] ?? null);
+        self::assertSame(5, $payload['pagination']['limit'] ?? null);
+        self::assertIsInt($payload['pagination']['totalItems'] ?? null);
+        self::assertIsInt($payload['pagination']['totalPages'] ?? null);
+
+        if (($payload['items'][0] ?? null) !== null) {
+            self::assertArrayHasKey('id', $payload['items'][0]);
+            self::assertArrayHasKey('firstName', $payload['items'][0]);
+            self::assertArrayHasKey('lastName', $payload['items'][0]);
+            self::assertArrayHasKey('email', $payload['items'][0]);
+        }
+    }
+
     #[TestDox('Delete endpoints reject IDs from another CRM application scope.')]
     #[DataProvider('crossScopeDeleteProvider')]
     public function testDeleteRejectsForeignScopeIds(string $resource, string $foreignIdKey): void


### PR DESCRIPTION
### Motivation

- Exposer une API paginée pour récupérer la liste des employés d'une application CRM en respectant le scope par `applicationSlug` et les permissions CRM.
- Fournir une réponse normalisée (`items`, `pagination`) contenant les champs essentiels des employés pour simplifier les clients front-end et les intégrations.

### Description

- Ajout du contrôleur `ListEmployeesController` dans `src/Crm/Transport/Controller/Api/V1/Employee/ListEmployeesController.php` exposant `GET /v1/crm/applications/{applicationSlug}/employees` et appliquant `CrmApplicationScopeResolver` et `IsGranted(Role::CRM_VIEWER->value)`.
- L’endpoint gère la pagination (`page`, `limit` bornés), récupère les entités via `EmployeeRepository::findScoped` et renvoie les champs `id`, `firstName`, `lastName`, `email`, `positionName`, `roleName`, `createdAt`, `updatedAt` ainsi qu’un bloc `pagination` avec `totalItems` et `totalPages`.
- Ajout d’un test d’intégration `testListEmployeesReturnsPaginatedList` dans `tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php` qui vérifie le code HTTP, la présence des clés `items`/`pagination` et la structure des items retournés.

### Testing

- Exécution de la vérification de syntaxe PHP sur les fichiers ajoutés avec `php -l` qui a renvoyé « No syntax errors detected » pour `src/Crm/Transport/Controller/Api/V1/Employee/ListEmployeesController.php` et pour `tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php`.
- Tentative d’exécution ciblée de PHPUnit (`--filter testListEmployeesReturnsPaginatedList`) impossible dans cet environnement car le binaire PHPUnit est absent; le test a été ajouté et devra être exécuté par la CI ou localement pour validation complète.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6011c8ce4832b86258a333151bf63)