### PR TITLE
Associate CRM Employee with optional User and expose userId

### DIFF
--- a/migrations/Version20260315120000.php
+++ b/migrations/Version20260315120000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260315120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Link CRM employee to optional user account.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE crm_employee ADD user_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql('ALTER TABLE crm_employee ADD CONSTRAINT FK_8B2F4355A76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE SET NULL');
+        $this->addSql('CREATE INDEX IDX_8B2F4355A76ED395 ON crm_employee (user_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_employee DROP FOREIGN KEY FK_8B2F4355A76ED395');
+        $this->addSql('DROP INDEX IDX_8B2F4355A76ED395 ON crm_employee');
+        $this->addSql('ALTER TABLE crm_employee DROP user_id');
+    }
+}

--- a/src/Crm/Application/Message/CreateEmployeeCommand.php
+++ b/src/Crm/Application/Message/CreateEmployeeCommand.php
@@ -16,6 +16,7 @@ final readonly class CreateEmployeeCommand implements MessageHighInterface
         public ?string $email,
         public ?string $positionName,
         public ?string $roleName,
+        public ?string $userId,
         public string $applicationSlug,
     ) {
     }

--- a/src/Crm/Application/MessageHandler/CreateEmployeeCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/CreateEmployeeCommandHandler.php
@@ -9,6 +9,7 @@ use App\Crm\Domain\Entity\Employee;
 use App\Crm\Infrastructure\Repository\CrmRepository;
 use App\Crm\Infrastructure\Repository\EmployeeRepository;
 use App\General\Application\Message\EntityCreated;
+use App\User\Domain\Repository\Interfaces\UserRepositoryInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -18,6 +19,7 @@ final readonly class CreateEmployeeCommandHandler
     public function __construct(
         private CrmRepository $crmRepository,
         private EmployeeRepository $employeeRepository,
+        private UserRepositoryInterface $userRepository,
         private MessageBusInterface $messageBus,
     ) {
     }
@@ -29,6 +31,8 @@ final readonly class CreateEmployeeCommandHandler
             return;
         }
 
+        $user = $command->userId !== null ? $this->userRepository->find($command->userId) : null;
+
         $employee = (new Employee())
             ->setId($command->id)
             ->setCrm($crm)
@@ -36,7 +40,8 @@ final readonly class CreateEmployeeCommandHandler
             ->setLastName($command->lastName)
             ->setEmail($command->email)
             ->setPositionName($command->positionName)
-            ->setRoleName($command->roleName);
+            ->setRoleName($command->roleName)
+            ->setUser($user);
 
         $this->employeeRepository->save($employee);
 

--- a/src/Crm/Domain/Entity/Employee.php
+++ b/src/Crm/Domain/Entity/Employee.php
@@ -7,6 +7,7 @@ namespace App\Crm\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
@@ -29,6 +30,10 @@ class Employee implements EntityInterface
     #[ORM\ManyToOne(targetEntity: Crm::class, inversedBy: 'employees')]
     #[ORM\JoinColumn(name: 'crm_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private ?Crm $crm = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?User $user = null;
 
     #[ORM\Column(name: 'first_name', type: Types::STRING, length: 120)]
     private string $firstName = '';
@@ -73,6 +78,24 @@ class Employee implements EntityInterface
 
         return $this;
     }
+
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getUserId(): ?string
+    {
+        return $this->user?->getId();
+    }
+
     public function getFirstName(): string
     {
         return $this->firstName;

--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -20,6 +20,7 @@ use App\Crm\Domain\Enum\TaskRequestStatus;
 use App\Crm\Domain\Enum\TaskStatus;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PlatformKey;
+use App\User\Domain\Entity\User;
 use DateTimeImmutable;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
@@ -109,6 +110,7 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
         $faker->seed(self::FAKER_SEED);
 
         $profile = self::VOLUME_PROFILES[$this->resolveVolume()] ?? self::VOLUME_PROFILES[self::DEFAULT_VOLUME];
+        $crmUsers = $this->getCrmUsers($manager);
 
         foreach ($this->getApplicationsByPlatform(PlatformKey::CRM) as $application) {
             $crm = $this->findOrCreateCrm($manager, $application);
@@ -121,7 +123,7 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                 $this->generateContacts($manager, $faker, $crm, $company, $profile['contactsPerCompany']);
 
                 // Employees
-                $this->generateEmployees($manager, $faker, $crm, $profile['employeesPerCompany']);
+                $this->generateEmployees($manager, $faker, $crm, $profile['employeesPerCompany'], $crmUsers);
 
                 // Projects
                 $projects = $this->generateProjects(
@@ -244,8 +246,13 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
         }
     }
 
-    private function generateEmployees(ObjectManager $manager, Generator $faker, Crm $crm, int $count): void
+    /**
+     * @param array<int, User> $crmUsers
+     */
+    private function generateEmployees(ObjectManager $manager, Generator $faker, Crm $crm, int $count, array $crmUsers): void
     {
+        $crmUserCount = count($crmUsers);
+
         for ($index = 0; $index < $count; $index++) {
             $employee = (new Employee())
                 ->setCrm($crm)
@@ -254,6 +261,10 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                 ->setEmail($faker->companyEmail())
                 ->setPositionName($faker->jobTitle())
                 ->setRoleName($faker->randomElement(['sales', 'support', 'manager', 'finance']));
+
+            if ($crmUserCount > 0) {
+                $employee->setUser($crmUsers[$index % $crmUserCount]);
+            }
 
             $manager->persist($employee);
         }
@@ -438,6 +449,25 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
             'content' => $faker->paragraphs(3, true),
             'createdAt' => DateTimeImmutable::createFromMutable($faker->dateTimeBetween('-4 months', 'now'))->format(DATE_ATOM),
         ];
+    }
+
+    /**
+     * @return array<int, User>
+     */
+    private function getCrmUsers(ObjectManager $manager): array
+    {
+        /** @var array<int, User> $users */
+        $users = $manager->getRepository(User::class)->createQueryBuilder('u')
+            ->select('DISTINCT u')
+            ->innerJoin('u.userGroups', 'ug')
+            ->innerJoin('ug.role', 'r')
+            ->where('r.id LIKE :crmPrefix')
+            ->setParameter('crmPrefix', 'ROLE_CRM_%')
+            ->orderBy('u.username', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $users;
     }
 
     private function resolveVolume(): string

--- a/src/Crm/Transport/Controller/Api/V1/Employee/CreateEmployeeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Employee/CreateEmployeeController.php
@@ -69,6 +69,7 @@ final readonly class CreateEmployeeController
             email: $employee->getEmail(),
             positionName: $employee->getPositionName(),
             roleName: $employee->getRoleName(),
+            userId: $input->userId,
             applicationSlug: $applicationSlug,
         ));
 

--- a/src/Crm/Transport/Controller/Api/V1/Employee/ListEmployeesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Employee/ListEmployeesController.php
@@ -39,6 +39,7 @@ final readonly class ListEmployeesController
                 'firstName' => $employee->getFirstName(),
                 'lastName' => $employee->getLastName(),
                 'email' => $employee->getEmail(),
+                'userId' => $employee->getUserId(),
                 'positionName' => $employee->getPositionName(),
                 'roleName' => $employee->getRoleName(),
                 'createdAt' => $employee->getCreatedAt()->format(DATE_ATOM),

--- a/src/Crm/Transport/Request/CreateEmployeeRequest.php
+++ b/src/Crm/Transport/Request/CreateEmployeeRequest.php
@@ -26,6 +26,9 @@ final class CreateEmployeeRequest
     #[Assert\Length(max: 120)]
     public ?string $roleName = null;
 
+    #[Assert\Uuid]
+    public ?string $userId = null;
+
     public static function fromArray(array $payload): self
     {
         $r = new self();
@@ -34,6 +37,7 @@ final class CreateEmployeeRequest
         $r->email = isset($payload['email']) ? (string)$payload['email'] : null;
         $r->positionName = isset($payload['positionName']) ? (string)$payload['positionName'] : null;
         $r->roleName = isset($payload['roleName']) ? (string)$payload['roleName'] : null;
+        $r->userId = isset($payload['userId']) ? (string)$payload['userId'] : null;
 
         return $r;
     }


### PR DESCRIPTION
### Motivation

- Allow linking a CRM `Employee` record to an optional application `User` account so employees can be associated with system users.
- Surface the associated user identifier in the API and allow providing `userId` when creating employees.

### Description

- Add a Doctrine migration `Version20260315120000` to add a nullable `user_id` column (binary UUID), index, and foreign key to `user(id)` with `ON DELETE SET NULL`.
- Extend `App\Crm\Domain\Entity\Employee` with a `ManyToOne` `user` relation, `getUser`, `setUser`, and `getUserId` accessor methods.
- Propagate `userId` through the API and message flow by adding `userId` to `CreateEmployeeRequest`, `CreateEmployeeController`, `CreateEmployeeCommand`, and having `CreateEmployeeCommandHandler` resolve the `User` via `UserRepositoryInterface` and set it on the `Employee` entity before saving.
- Expose the associated `userId` in `ListEmployeesController` output.
- Update fixtures in `LoadCrmData` to query CRM users (`getCrmUsers`) and assign them to generated employees when available.

### Testing

- Ran the project's test suite with `vendor/bin/phpunit` and all tests passed.
- Executed the new migration locally to confirm it applies and the schema change is reversible without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6092d11dc832bb8630bd27cb2410d)