### PR TITLE
Add blog one-to-one relation to CRM Task/TaskRequest with migration

### DIFF
--- a/migrations/Version20260315130000.php
+++ b/migrations/Version20260315130000.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260315130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add optional blog relation to CRM task and task request with unique one-to-one constraints.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE crm_task ADD blog_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql("ALTER TABLE crm_task_request ADD blog_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+
+        $this->addSql('ALTER TABLE crm_task ADD CONSTRAINT UNIQ_CRM_TASK_BLOG UNIQUE (blog_id)');
+        $this->addSql('ALTER TABLE crm_task_request ADD CONSTRAINT UNIQ_CRM_TASK_REQUEST_BLOG UNIQUE (blog_id)');
+
+        $this->addSql('ALTER TABLE crm_task ADD CONSTRAINT FK_CRM_TASK_BLOG FOREIGN KEY (blog_id) REFERENCES blog (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE crm_task_request ADD CONSTRAINT FK_CRM_TASK_REQUEST_BLOG FOREIGN KEY (blog_id) REFERENCES blog (id) ON DELETE SET NULL');
+
+        $this->addSql('UPDATE crm_task_request tr INNER JOIN crm_task t ON tr.task_id = t.id SET tr.blog_id = t.blog_id WHERE tr.blog_id IS NULL AND t.blog_id IS NOT NULL');
+        $this->addSql('UPDATE crm_task t INNER JOIN crm_task_request tr ON tr.task_id = t.id SET t.blog_id = tr.blog_id WHERE t.blog_id IS NULL AND tr.blog_id IS NOT NULL');
+
+        $taskNullCount = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM crm_task WHERE blog_id IS NULL');
+        if (0 === $taskNullCount) {
+            $this->addSql("ALTER TABLE crm_task CHANGE blog_id blog_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        }
+
+        $taskRequestNullCount = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM crm_task_request WHERE blog_id IS NULL');
+        if (0 === $taskRequestNullCount) {
+            $this->addSql("ALTER TABLE crm_task_request CHANGE blog_id blog_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_task DROP FOREIGN KEY FK_CRM_TASK_BLOG');
+        $this->addSql('ALTER TABLE crm_task_request DROP FOREIGN KEY FK_CRM_TASK_REQUEST_BLOG');
+
+        $this->addSql('ALTER TABLE crm_task DROP INDEX UNIQ_CRM_TASK_BLOG');
+        $this->addSql('ALTER TABLE crm_task_request DROP INDEX UNIQ_CRM_TASK_REQUEST_BLOG');
+
+        $this->addSql('ALTER TABLE crm_task DROP blog_id');
+        $this->addSql('ALTER TABLE crm_task_request DROP blog_id');
+    }
+}

--- a/src/Crm/Domain/Entity/Task.php
+++ b/src/Crm/Domain/Entity/Task.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Domain\Entity;
 
+use App\Blog\Domain\Entity\Blog;
 use App\Crm\Domain\Enum\TaskPriority;
 use App\Crm\Domain\Enum\TaskStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
@@ -41,6 +42,10 @@ class Task implements EntityInterface
     #[ORM\ManyToOne(targetEntity: Sprint::class, inversedBy: 'tasks')]
     #[ORM\JoinColumn(name: 'sprint_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     private ?Sprint $sprint = null;
+
+    #[ORM\OneToOne(targetEntity: Blog::class, cascade: ['persist'])]
+    #[ORM\JoinColumn(name: 'blog_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Blog $blog = null;
 
     #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
     private string $title = '';
@@ -117,6 +122,18 @@ class Task implements EntityInterface
     public function setSprint(?Sprint $sprint): self
     {
         $this->sprint = $sprint;
+
+        return $this;
+    }
+
+    public function getBlog(): ?Blog
+    {
+        return $this->blog;
+    }
+
+    public function setBlog(?Blog $blog): self
+    {
+        $this->blog = $blog;
 
         return $this;
     }

--- a/src/Crm/Domain/Entity/TaskRequest.php
+++ b/src/Crm/Domain/Entity/TaskRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Domain\Entity;
 
+use App\Blog\Domain\Entity\Blog;
 use App\Crm\Domain\Enum\TaskRequestStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
@@ -35,6 +36,10 @@ class TaskRequest implements EntityInterface
     #[ORM\JoinColumn(name: 'task_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     #[Assert\NotNull]
     private ?Task $task = null;
+
+    #[ORM\OneToOne(targetEntity: Blog::class, cascade: ['persist'])]
+    #[ORM\JoinColumn(name: 'blog_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Blog $blog = null;
 
     #[ORM\Column(name: 'title', type: Types::STRING, length: 255)]
     private string $title = '';
@@ -87,6 +92,18 @@ class TaskRequest implements EntityInterface
     public function setTask(?Task $task): self
     {
         $this->task = $task;
+
+        return $this;
+    }
+
+    public function getBlog(): ?Blog
+    {
+        return $this->blog;
+    }
+
+    public function setBlog(?Blog $blog): self
+    {
+        $this->blog = $blog;
 
         return $this;
     }


### PR DESCRIPTION
### Motivation
- Permettre d’associer un `Blog` à une `Task` et à une `TaskRequest` en ajoutant une relation one-to-one persistable et référençable en base.
- Ajouter la colonne `blog_id` côté base de données avec contraintes `UNIQUE` et `FOREIGN KEY` vers `blog(id)` pour garantir l’unicité et l’intégrité référentielle.
- Prévoir un backfill croisé entre `crm_task` et `crm_task_request` puis rendre les colonnes non-null conditionnellement uniquement si le backfill supprime tous les `NULL`.

### Description
- Ajout de la migration `migrations/Version20260315130000.php` qui crée `blog_id` (nullable BINARY(16) avec `'(DC2Type:uuid_binary_ordered_time)'`) dans `crm_task` et `crm_task_request`, ajoute les contraintes `UNIQ_*` et les `FOREIGN KEY` vers `blog(id)` avec `ON DELETE SET NULL`, effectue un backfill croisé et applique `NOT NULL` uniquement si aucun enregistrement `NULL` n’existe après backfill.
- Mise à jour de l’entité `Task` (`src/Crm/Domain/Entity/Task.php`) : ajout de `use App\Blog\Domain\Entity\Blog;`, de la propriété `private ?Blog $blog = null;` annotée `#[ORM\OneToOne(targetEntity: Blog::class, cascade: ['persist'])]` et `#[ORM\JoinColumn(name: 'blog_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]`, et des méthodes `getBlog()` / `setBlog()`.
- Mise à jour de l’entité `TaskRequest` (`src/Crm/Domain/Entity/TaskRequest.php`) avec la même propriété, mappings et accesseurs `getBlog()` / `setBlog()`.

### Testing
- Vérification de la syntaxe PHP sur les fichiers modifiés avec `php -l src/Crm/Domain/Entity/Task.php`, `php -l src/Crm/Domain/Entity/TaskRequest.php` et `php -l migrations/Version20260315130000.php`, tous sans erreurs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b60f86a658832b802e5263d085a85e)