### PR TITLE
feat(crm): provision blogs when creating tasks and task requests

### DIFF
--- a/src/Crm/Application/Service/CrmTaskBlogProvisioningService.php
+++ b/src/Crm/Application/Service/CrmTaskBlogProvisioningService.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Enum\BlogType;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\ApplicationPlugin;
+use App\Platform\Domain\Enum\PlatformKey;
+use App\Platform\Domain\Enum\PluginKey;
+use Doctrine\ORM\EntityManagerInterface;
+
+use function preg_replace;
+use function sprintf;
+use function strtolower;
+use function trim;
+
+final readonly class CrmTaskBlogProvisioningService
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function provision(Task|TaskRequest $subject): void
+    {
+        if ($subject->getBlog() instanceof Blog) {
+            return;
+        }
+
+        $application = $this->resolveApplication($subject);
+        if (!$application instanceof Application) {
+            return;
+        }
+
+        if ($application->getPlatform()?->getPlatformKey() !== PlatformKey::CRM || !$this->hasBlogPlugin($application)) {
+            return;
+        }
+
+        $owner = $application->getUser();
+        if ($owner === null) {
+            return;
+        }
+
+        $blog = (new Blog())
+            ->setApplication($application)
+            ->setOwner($owner)
+            ->setType(BlogType::APPLICATION)
+            ->setTitle($this->buildTitle($subject))
+            ->setSlug($this->buildUniqueSlug($subject));
+
+        $subject->setBlog($blog);
+        $this->entityManager->persist($blog);
+    }
+
+    private function resolveApplication(Task|TaskRequest $subject): ?Application
+    {
+        if ($subject instanceof TaskRequest) {
+            $subject = $subject->getTask();
+        }
+
+        return $subject?->getProject()?->getCompany()?->getCrm()?->getApplication();
+    }
+
+    private function hasBlogPlugin(Application $application): bool
+    {
+        foreach ($application->getApplicationPlugins() as $applicationPlugin) {
+            if (!$applicationPlugin instanceof ApplicationPlugin) {
+                continue;
+            }
+
+            if ($applicationPlugin->getPlugin()?->getPluginKey() === PluginKey::BLOG) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function buildTitle(Task|TaskRequest $subject): string
+    {
+        if ($subject instanceof TaskRequest) {
+            return sprintf('Task Request: %s', $subject->getTitle());
+        }
+
+        return sprintf('Task: %s', $subject->getTitle());
+    }
+
+    private function buildUniqueSlug(Task|TaskRequest $subject): string
+    {
+        $prefix = $subject instanceof TaskRequest ? 'task-request' : 'task';
+        $baseSlug = $this->slugify(sprintf('%s-%s', $prefix, $subject->getTitle()));
+        $slug = $baseSlug;
+        $index = 1;
+
+        while ($this->entityManager->getRepository(Blog::class)->findOneBy(['slug' => $slug]) instanceof Blog) {
+            $index++;
+            $slug = sprintf('%s-%d', $baseSlug, $index);
+        }
+
+        return $slug;
+    }
+
+    private function slugify(string $value): string
+    {
+        $slug = strtolower(trim((string) preg_replace('/[^a-zA-Z0-9]+/', '-', $value), '-'));
+
+        return $slug !== '' ? $slug : 'crm-task-blog';
+    }
+}
+

--- a/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Controller\Api\V1\Task;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmTaskBlogProvisioningService;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Enum\TaskPriority;
 use App\Crm\Domain\Enum\TaskStatus;
@@ -39,6 +40,7 @@ final readonly class CreateTaskController
         private SprintRepository $sprintRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
+        private CrmTaskBlogProvisioningService $crmTaskBlogProvisioningService,
         private ValidatorInterface $validator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
@@ -206,6 +208,7 @@ final readonly class CreateTaskController
         }
 
         $this->entityManager->persist($task);
+        $this->crmTaskBlogProvisioningService->provision($task);
         $this->entityManager->flush();
         $this->messageBus->dispatch(new EntityCreated('crm_task', $task->getId(), context: [
             'applicationSlug' => $applicationSlug,

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmTaskBlogProvisioningService;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Crm\Domain\Enum\TaskRequestStatus;
 use App\Crm\Infrastructure\Repository\TaskRepository;
@@ -36,6 +37,7 @@ final readonly class CreateTaskRequestController
         private TaskRepository $taskRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
+        private CrmTaskBlogProvisioningService $crmTaskBlogProvisioningService,
         private ValidatorInterface $validator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
@@ -170,6 +172,7 @@ final readonly class CreateTaskRequestController
         }
 
         $this->entityManager->persist($taskRequest);
+        $this->crmTaskBlogProvisioningService->provision($taskRequest);
         $this->entityManager->flush();
         $this->messageBus->dispatch(new EntityCreated('crm_task_request', $taskRequest->getId(), context: [
             'applicationSlug' => $applicationSlug,


### PR DESCRIPTION
### Motivation
- Automatiser la création d’un `Blog` lié à une `Task` ou une `TaskRequest` pour les applications CRM disposant du plugin `BLOG` afin d’assurer une destination de contenu cohérente lors de la création d’artefacts CRM.
- Empêcher la duplication en rendant la création idempotente si l’entité possède déjà un `Blog`.

### Description
- Ajout du service applicatif `CrmTaskBlogProvisioningService` qui accepte `Task|TaskRequest`, résout l’`Application` via la chaîne `task -> project -> company -> crm -> application`, vérifie `PlatformKey::CRM` et la présence du `PluginKey::BLOG`, puis crée un `Blog` avec `owner` = user de l’application, `type` = `BlogType::APPLICATION`, titre explicite (`Task: {title}` / `Task Request: {title}`), et `slug` unique avant d’assigner le blog à l’entité et de `persist` le blog.
- Génération de slugs uniques par vérification en base et incrémentation si nécessaire, et garde-fou idempotent qui ne recrée rien si un `Blog` est déjà présent sur l’entité.
- Intégration de l’appel au service dans `CreateTaskController` et `CreateTaskRequestController` juste avant le `flush()` final pour provisionner automatiquement le blog lors de la création.

### Testing
- Validation de syntaxe PHP exécutée avec `php -l` sur `src/Crm/Application/Service/CrmTaskBlogProvisioningService.php` et les deux contrôleurs, et toutes les vérifications ont réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b61290a8c8832b8b4e86fb83c294c0)