### PR TITLE
Ajouter BlogType TASK et TASK_REQUEST et sécuriser les lectures de blog applicatif

### DIFF
--- a/src/Blog/Domain/Enum/BlogType.php
+++ b/src/Blog/Domain/Enum/BlogType.php
@@ -8,4 +8,6 @@ enum BlogType: string
 {
     case GENERAL = 'general';
     case APPLICATION = 'application';
+    case TASK = 'task';
+    case TASK_REQUEST = 'task_request';
 }

--- a/src/Blog/Infrastructure/Repository/BlogRepository.php
+++ b/src/Blog/Infrastructure/Repository/BlogRepository.php
@@ -24,6 +24,7 @@ class BlogRepository extends BaseRepository
     {
         $result = $this->findOneBy([
             'application' => $application,
+            'type' => BlogType::APPLICATION,
         ]);
 
         return $result instanceof Blog ? $result : null;
@@ -44,7 +45,9 @@ class BlogRepository extends BaseRepository
             ->innerJoin('blog.application', 'application')
             ->addSelect('application')
             ->where('application.slug = :applicationSlug')
+            ->andWhere('blog.type = :blogType')
             ->setParameter('applicationSlug', $applicationSlug)
+            ->setParameter('blogType', BlogType::APPLICATION)
             ->getQuery()
             ->getOneOrNullResult();
 

--- a/src/Crm/Application/Service/CrmTaskBlogProvisioningService.php
+++ b/src/Crm/Application/Service/CrmTaskBlogProvisioningService.php
@@ -46,10 +46,12 @@ final readonly class CrmTaskBlogProvisioningService
             return;
         }
 
+        $blogType = $subject instanceof TaskRequest ? BlogType::TASK_REQUEST : BlogType::TASK;
+
         $blog = (new Blog())
             ->setApplication($application)
             ->setOwner($owner)
-            ->setType(BlogType::APPLICATION)
+            ->setType($blogType)
             ->setTitle($this->buildTitle($subject))
             ->setSlug($this->buildUniqueSlug($subject));
 


### PR DESCRIPTION
### Motivation
- Introduire des types de blog spécifiques pour les workflows CRM afin de permettre la création de blogs liés aux tâches sans confondre le blog applicatif canonique. 
- Préserver les flux existants qui attendent un seul blog de type `APPLICATION` pour une application afin d'éviter les ambiguïtés lors de résolutions/lectures.

### Description
- Ajout des nouvelles valeurs d'enum `BlogType::TASK = 'task'` et `BlogType::TASK_REQUEST = 'task_request'` dans `src/Blog/Domain/Enum/BlogType.php`.
- Modification de la provision des blogs CRM dans `src/Crm/Application/Service/CrmTaskBlogProvisioningService.php` pour affecter `BlogType::TASK` pour un `Task` et `BlogType::TASK_REQUEST` pour un `TaskRequest` au lieu de forcer `BlogType::APPLICATION`.
- Durcissement des recherches de blog applicatif dans `src/Blog/Infrastructure/Repository/BlogRepository.php` en filtrant explicitement sur `type = BlogType::APPLICATION` dans `findOneByApplication()` et `findOneByApplicationSlug()` pour garantir que les lectures renvoient le blog applicatif canonique.

### Testing
- `php -l src/Blog/Domain/Enum/BlogType.php` : réussi.
- `php -l src/Crm/Application/Service/CrmTaskBlogProvisioningService.php` : réussi.
- `php -l src/Blog/Infrastructure/Repository/BlogRepository.php` : réussi.
- `composer test` : échec car la commande `test` n'est pas définie dans `composer.json` (aucun script de test automatisé présent).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b613bc9220832b9203f37e6b569599)