### PR TITLE
Add blog payload normalization to CRM task detail responses

### DIFF
--- a/src/Crm/Application/Service/CrmApiNormalizer.php
+++ b/src/Crm/Application/Service/CrmApiNormalizer.php
@@ -11,6 +11,11 @@ use DateTimeInterface;
 
 final class CrmApiNormalizer
 {
+    public function __construct(
+        private readonly CrmBlogNormalizer $crmBlogNormalizer,
+    ) {
+    }
+
     /**
      * @return array<string,mixed>
      */
@@ -49,6 +54,7 @@ final class CrmApiNormalizer
             'attachments' => $task->getAttachments(),
             'assignees' => $assignees,
             'children' => $children,
+            'blog' => $this->crmBlogNormalizer->normalizeBlog($task->getBlog()),
         ];
     }
 
@@ -75,6 +81,7 @@ final class CrmApiNormalizer
             'resolvedAt' => $this->normalizeDate($taskRequest->getResolvedAt()),
             'attachments' => $taskRequest->getAttachments(),
             'assignees' => $assignees,
+            'blog' => $this->crmBlogNormalizer->normalizeBlog($taskRequest->getBlog()),
         ];
     }
 

--- a/src/Crm/Application/Service/CrmBlogNormalizer.php
+++ b/src/Crm/Application/Service/CrmBlogNormalizer.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Blog\Domain\Entity\Blog;
+use App\Blog\Domain\Entity\BlogComment;
+use App\Blog\Domain\Entity\BlogPost;
+
+use function array_map;
+
+final class CrmBlogNormalizer
+{
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function normalizeBlog(?Blog $blog): ?array
+    {
+        if (!$blog instanceof Blog) {
+            return null;
+        }
+
+        return [
+            'id' => $blog->getId(),
+            'title' => $blog->getTitle(),
+            'slug' => $blog->getSlug(),
+            'type' => $blog->getType()->value,
+            'visibility' => $blog->getVisibility()->value,
+            'posts' => array_map(
+                fn (BlogPost $post): array => $this->normalizePost($post),
+                $blog->getPosts()->toArray(),
+            ),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function normalizePost(BlogPost $post): array
+    {
+        $commentTreeByParent = $this->buildCommentTreeByParent($post->getComments()->toArray());
+
+        return [
+            'id' => $post->getId(),
+            'title' => $post->getTitle(),
+            'slug' => $post->getSlug(),
+            'comments' => $this->normalizeComments($commentTreeByParent, null),
+        ];
+    }
+
+    /**
+     * @param array<int, BlogComment> $comments
+     *
+     * @return array<string|null, list<BlogComment>>
+     */
+    private function buildCommentTreeByParent(array $comments): array
+    {
+        $tree = [];
+
+        foreach ($comments as $comment) {
+            $parentId = $comment->getParent()?->getId();
+            $tree[$parentId] ??= [];
+            $tree[$parentId][] = $comment;
+        }
+
+        return $tree;
+    }
+
+    /**
+     * @param array<string|null, list<BlogComment>> $commentTreeByParent
+     *
+     * @return array<int,array<string,mixed>>
+     */
+    private function normalizeComments(array $commentTreeByParent, ?string $parentId): array
+    {
+        return array_map(function (BlogComment $comment) use ($commentTreeByParent): array {
+            return [
+                'id' => $comment->getId(),
+                'content' => $comment->getContent(),
+                'filePath' => $comment->getFilePath(),
+                'children' => $this->normalizeComments($commentTreeByParent, $comment->getId()),
+            ];
+        }, $commentTreeByParent[$parentId] ?? []);
+    }
+}

--- a/src/Crm/Infrastructure/Repository/TaskRepository.php
+++ b/src/Crm/Infrastructure/Repository/TaskRepository.php
@@ -31,8 +31,14 @@ class TaskRepository extends BaseRepository
     public function findOneScopedById(string $id, string $crmId): ?Entity
     {
         $entity = $this->createQueryBuilder('task')
+            ->addSelect('blog', 'post', 'postComment', 'postReaction', 'commentReaction')
             ->leftJoin('task.project', 'project')
             ->leftJoin('project.company', 'company')
+            ->leftJoin('task.blog', 'blog')
+            ->leftJoin('blog.posts', 'post')
+            ->leftJoin('post.comments', 'postComment')
+            ->leftJoin('post.reactions', 'postReaction')
+            ->leftJoin('postComment.reactions', 'commentReaction')
             ->andWhere('task.id = :id')
             ->andWhere('company.crm = :crmId')
             ->setParameter('id', $id, UuidBinaryOrderedTimeType::NAME)

--- a/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
+++ b/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
@@ -36,7 +36,7 @@ class TaskRequestRepository extends BaseRepository
 
     public function findOneScopedById(string $id, string $crmId): ?Entity
     {
-        $qb = $this->createScopedBaseQb($crmId)
+        $qb = $this->createScopedBaseQb($crmId, true)
             ->andWhere('taskRequest.id = :id')
             ->setParameter('id', $id, UuidBinaryOrderedTimeType::NAME)
             ->setMaxResults(1);
@@ -181,14 +181,25 @@ class TaskRequestRepository extends BaseRepository
         return (int)$qb->getQuery()->getSingleScalarResult();
     }
 
-    private function createScopedBaseQb(string $crmId): QueryBuilder
+    private function createScopedBaseQb(string $crmId, bool $includeBlogDetails = false): QueryBuilder
     {
-        return $this->createQueryBuilder('taskRequest')
+        $qb = $this->createQueryBuilder('taskRequest')
             ->leftJoin('taskRequest.task', 'task')
             ->leftJoin('task.project', 'project')
             ->leftJoin('project.company', 'company')
             ->andWhere('IDENTITY(company.crm) = :crmId')
             ->setParameter('crmId', $crmId, UuidBinaryOrderedTimeType::NAME);
+
+        if ($includeBlogDetails) {
+            $qb->addSelect('blog', 'post', 'postComment', 'postReaction', 'commentReaction')
+                ->leftJoin('taskRequest.blog', 'blog')
+                ->leftJoin('blog.posts', 'post')
+                ->leftJoin('post.comments', 'postComment')
+                ->leftJoin('post.reactions', 'postReaction')
+                ->leftJoin('postComment.reactions', 'commentReaction');
+        }
+
+        return $qb;
     }
 
     private function createScopedCountQb(string $crmId): QueryBuilder


### PR DESCRIPTION
### Motivation

- Enrichir le payload de détail des tasks/taskRequests en exposant les données de `Blog` (id, title, slug, type, visibility, posts[] avec commentaires hiérarchiques) tout en gardant le reste du payload inchangé. 
- Prévenir les problèmes N+1 en eager-loading des relations blog/posts/comments/reactions lors des requêtes de détail.

### Description

- Ajout d'un nouveau service `CrmBlogNormalizer` qui normalise `Blog`, `BlogPost` et l'arbre de `BlogComment` en retournant `id`, `title`, `slug`, `type`, `visibility` et `posts[]` avec `comments` hiérarchiques et `filePath` pour chaque commentaire. 
- Injection de `CrmBlogNormalizer` dans `CrmApiNormalizer` et ajout du champ `blog` dans `normalizeTask()` et `normalizeTaskRequest()` en gardant toutes les clés existantes intactes. 
- Mise à jour de `TaskRepository::findOneScopedById()` pour `addSelect` et `leftJoin` des relations `task.blog`, `blog.posts`, `post.comments`, `post.reactions` et `postComment.reactions` afin d'éviter les N+1 sur la vue détail. 
- Mise à jour de `TaskRequestRepository` pour permettre un mode `includeBlogDetails` dans `createScopedBaseQb()` et appeler ce mode depuis `findOneScopedById()` pour eager-loading identique.

### Testing

- Lint PHP des fichiers modifiés avec `php -l` a été exécuté et a réussi pour `src/Crm/Application/Service/CrmApiNormalizer.php`, `src/Crm/Application/Service/CrmBlogNormalizer.php`, `src/Crm/Infrastructure/Repository/TaskRepository.php` et `src/Crm/Infrastructure/Repository/TaskRequestRepository.php`.
- Aucune erreur de syntaxe détectée après les changements.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6147ef564832b86e0092ba3846ee7)