### PR TITLE
Add CRM employee and Platform application detail endpoints and assignment notifications

### DIFF
--- a/config/packages/event_listeners.yaml
+++ b/config/packages/event_listeners.yaml
@@ -44,3 +44,8 @@ services:
             - { name: doctrine.event_listener, event: prePersist }
             - { name: doctrine.event_listener, event: preUpdate }
 
+    App\Crm\Transport\EventListener\CrmAssignmentEventListener:
+        tags:
+            - { name: doctrine.event_listener, event: onFlush }
+            - { name: doctrine.event_listener, event: postFlush }
+

--- a/src/Crm/Transport/Controller/Api/V1/Employee/GetEmployeeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Employee/GetEmployeeController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Employee;
+
+use App\Crm\Domain\Entity\Employee;
+use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_VIEWER->value)]
+final readonly class GetEmployeeController
+{
+    #[Route('/v1/crm/applications/{applicationSlug}/employees/{employee}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Employee $employee): JsonResponse
+    {
+        return new JsonResponse([
+            'id' => $employee->getId(),
+            'firstName' => $employee->getFirstName(),
+            'lastName' => $employee->getLastName(),
+            'email' => $employee->getEmail(),
+            'userId' => $employee->getUserId(),
+            'positionName' => $employee->getPositionName(),
+            'photo' => $employee->getUser()->getPhoto(),
+            'roleName' => $employee->getRoleName(),
+            'createdAt' => $employee->getCreatedAt()->format(DATE_ATOM),
+            'updatedAt' => $employee->getUpdatedAt()->format(DATE_ATOM),
+        ]);
+    }
+}

--- a/src/Crm/Transport/EventListener/CrmAssignmentEventListener.php
+++ b/src/Crm/Transport/EventListener/CrmAssignmentEventListener.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\EventListener;
+
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Domain\Entity\TaskRequest;
+use App\General\Domain\Service\Interfaces\MailerServiceInterface;
+use App\Notification\Application\Service\NotificationPublisher;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
+use Doctrine\ORM\PersistentCollection;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Twig\Environment as Twig;
+
+use function sprintf;
+
+final class CrmAssignmentEventListener
+{
+    /**
+     * @var array<int, array{entityType: string, entityId: string, assignee: User}>
+     */
+    private array $pendingAssignments = [];
+
+    public function __construct(
+        private readonly MailerServiceInterface $mailerService,
+        private readonly NotificationPublisher $notificationPublisher,
+        private readonly Security $security,
+        private readonly Twig $twig,
+        #[Autowire('%env(resolve:APP_SENDER_EMAIL)%')]
+        private readonly string $appSenderEmail,
+    ) {
+    }
+
+    public function onFlush(OnFlushEventArgs $args): void
+    {
+        $unitOfWork = $args->getObjectManager()->getUnitOfWork();
+
+        foreach ($unitOfWork->getScheduledCollectionUpdates() as $collection) {
+            if (!$collection instanceof PersistentCollection) {
+                continue;
+            }
+
+            if (!$this->isSupportedAssigneeCollection($collection)) {
+                continue;
+            }
+
+            $owner = $collection->getOwner();
+            foreach ($collection->getInsertDiff() as $inserted) {
+                if (!$inserted instanceof User) {
+                    continue;
+                }
+
+                $this->pendingAssignments[] = [
+                    'entityType' => $this->resolveEntityType($owner),
+                    'entityId' => $owner->getId(),
+                    'assignee' => $inserted,
+                ];
+            }
+        }
+    }
+
+    public function postFlush(PostFlushEventArgs $args): void
+    {
+        if ($this->pendingAssignments === []) {
+            return;
+        }
+
+        $assignments = $this->pendingAssignments;
+        $this->pendingAssignments = [];
+
+        $actor = $this->security->getUser();
+        if (!$actor instanceof User) {
+            return;
+        }
+
+        foreach ($assignments as $assignment) {
+            $assignee = $assignment['assignee'];
+            $context = [
+                'assignee' => $assignee,
+                'entityType' => $assignment['entityType'],
+                'entityId' => $assignment['entityId'],
+                'actor' => $actor,
+            ];
+
+            try {
+                $body = $this->twig->render('Emails/crm_assignment_created.html.twig', $context);
+                $this->mailerService->sendMail(
+                    'Nouvelle assignation CRM',
+                    $this->appSenderEmail,
+                    $assignee->getEmail(),
+                    $body,
+                );
+            } catch (\Throwable) {
+            }
+
+            try {
+                $this->notificationPublisher->publish(
+                    from: $actor,
+                    recipient: $assignee,
+                    title: sprintf('Vous avez été assigné à un(e) %s', $assignment['entityType']),
+                    type: 'crm_assignment',
+                    description: sprintf('ID: %s', $assignment['entityId']),
+                );
+            } catch (\Throwable) {
+            }
+        }
+    }
+
+    private function isSupportedAssigneeCollection(PersistentCollection $collection): bool
+    {
+        return $collection->getMapping()['fieldName'] === 'assignees'
+            && ($collection->getOwner() instanceof Project
+                || $collection->getOwner() instanceof Task
+                || $collection->getOwner() instanceof Sprint
+                || $collection->getOwner() instanceof TaskRequest);
+    }
+
+    private function resolveEntityType(object $entity): string
+    {
+        return match (true) {
+            $entity instanceof Project => 'project',
+            $entity instanceof Task => 'task',
+            $entity instanceof Sprint => 'sprint',
+            $entity instanceof TaskRequest => 'task request',
+            default => 'élément',
+        };
+    }
+}

--- a/src/Platform/Transport/Controller/Api/V1/Application/ApplicationViewController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Application/ApplicationViewController.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Transport\Controller\Api\V1\Application;
+
+use App\Configuration\Domain\Entity\Configuration;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\ApplicationPlugin;
+use App\Platform\Infrastructure\Repository\ApplicationRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Application')]
+readonly class ApplicationViewController
+{
+    public function __construct(
+        private ApplicationRepository $applicationRepository,
+    ) {
+    }
+
+    #[Route(path: '/v1/application/{applicationSlug}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, ?User $loggedInUser = null): JsonResponse
+    {
+        $application = $this->applicationRepository->findOneBy(['slug' => $applicationSlug]);
+        if (!$application instanceof Application) {
+            return new JsonResponse(['message' => 'Application not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        if ($application->isPrivate() && ($loggedInUser?->getId() !== $application->getUser()?->getId())) {
+            return new JsonResponse(['message' => 'Application not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $pluginKeys = [];
+        foreach ($application->getApplicationPlugins() as $applicationPlugin) {
+            $pluginKey = $applicationPlugin->getPlugin()?->getPluginKeyValue();
+            if ($pluginKey !== null) {
+                $pluginKeys[$pluginKey] = true;
+            }
+        }
+
+        return new JsonResponse([
+            'id' => $application->getId(),
+            'title' => $application->getTitle(),
+            'slug' => $application->getSlug(),
+            'description' => $application->getDescription(),
+            'photo' => $application->getPhoto(),
+            'status' => $application->getStatus()->value,
+            'private' => $application->isPrivate(),
+            'platformId' => $application->getPlatform()?->getId(),
+            'platformName' => $application->getPlatform()?->getName(),
+            'platformKey' => $application->getPlatform()?->getPlatformKeyValue(),
+            'pluginKeys' => array_keys($pluginKeys),
+            'plugins' => array_map(static fn (ApplicationPlugin $applicationPlugin) => [
+                'id' => $applicationPlugin->getId(),
+                'name' => $applicationPlugin->getPlugin()?->getName() ?? '',
+                'configurations' => array_map(static fn (Configuration $configuration) => [
+                    'id' => $configuration->getId(),
+                    'name' => $configuration->getConfigurationKey() ?? '',
+                    'configuration' => $configuration->getConfigurationValue(),
+                ], $applicationPlugin->getConfigurations()->toArray())
+            ], $application->getApplicationPlugins()->toArray()),
+            'author' => [
+                'id' => $application->getUser()?->getId(),
+                'firstName' => $application->getUser()?->getFirstName() ?? '',
+                'lastName' => $application->getUser()?->getLastName() ?? '',
+                'photo' => $application->getUser()?->getPhoto() ?? '',
+            ],
+            'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
+            'isOwner' => $loggedInUser !== null && $application->getUser()?->getId() === $loggedInUser->getId(),
+        ]);
+    }
+}

--- a/templates/Emails/crm_assignment_created.html.twig
+++ b/templates/Emails/crm_assignment_created.html.twig
@@ -1,0 +1,6 @@
+<h2>Nouvelle assignation CRM</h2>
+<p>Bonjour {{ assignee.firstName }},</p>
+<p>
+    {{ actor.firstName }} {{ actor.lastName }} vous a assigné à un(e) {{ entityType }}.
+</p>
+<p><strong>Identifiant:</strong> {{ entityId }}</p>


### PR DESCRIPTION
### Motivation
- Provide single-entity read endpoints so clients can request one CRM employee and one Platform application individually.
- Allow Platform application details to be retrieved with proper visibility checks for private applications.
- Notify users when they are assigned to CRM work items (project/task/sprint/task request) by sending an email and publishing a real-time notification.

### Description
- Add `GET /v1/crm/applications/{applicationSlug}/employees/{employee}` implemented in `src/Crm/Transport/Controller/Api/V1/Employee/GetEmployeeController.php` to return a single employee payload.
- Add `GET /v1/application/{applicationSlug}` implemented in `src/Platform/Transport/Controller/Api/V1/Application/ApplicationViewController.php` which returns an application payload and enforces private visibility for non-owners.
- Add a Doctrine listener `CrmAssignmentEventListener` in `src/Crm/Transport/EventListener/CrmAssignmentEventListener.php` that detects newly inserted assignees on `project`, `task`, `sprint` and `task request` collections and then sends an email and publishes a notification via `MailerServiceInterface` and `NotificationPublisher`.
- Register the listener in `config/packages/event_listeners.yaml` and add the email template used for assignment mails at `templates/Emails/crm_assignment_created.html.twig`.

### Testing
- Linted new PHP files with `php -l` which returned no syntax errors for `GetEmployeeController`, `ApplicationViewController` and `CrmAssignmentEventListener` (all succeeded).
- Attempted to validate routes with `php bin/console debug:router` but this failed in the environment due to missing dependencies (run `composer install` to allow full runtime checks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b62365b6a0832ba8ef13ff8273926c)