### PR TITLE
feat(crm): add endpoints to attach/detach task to/from sprint

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/Sprint/AttachTaskToSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/AttachTaskToSprintController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Sprint;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\Role\Domain\Enum\Role;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class AttachTaskToSprintController
+{
+    public function __construct(
+        private CrmApplicationScopeResolver $scopeResolver,
+        private SprintRepository $sprintRepository,
+        private TaskRepository $taskRepository,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/applications/{applicationSlug}/sprints/{sprintId}/tasks/{taskId}', methods: [Request::METHOD_PUT])]
+    public function __invoke(string $applicationSlug, string $sprintId, string $taskId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $sprint = $this->sprintRepository->findOneScopedById($sprintId, $crm->getId());
+        if ($sprint === null) {
+            return $this->errorResponseFactory->notFoundReference('sprintId');
+        }
+
+        $task = $this->taskRepository->findOneScopedById($taskId, $crm->getId());
+        if ($task === null) {
+            return $this->errorResponseFactory->notFoundReference('taskId');
+        }
+
+        if ($task->getProject()?->getId() !== $sprint->getProject()?->getId()) {
+            return $this->errorResponseFactory->outOfScopeReference('Task and sprint must belong to the same project.');
+        }
+
+        $task->setSprint($sprint);
+        $this->taskRepository->save($task);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/DetachTaskFromSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/DetachTaskFromSprintController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Sprint;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\Role\Domain\Enum\Role;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class DetachTaskFromSprintController
+{
+    public function __construct(
+        private CrmApplicationScopeResolver $scopeResolver,
+        private SprintRepository $sprintRepository,
+        private TaskRepository $taskRepository,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/applications/{applicationSlug}/sprints/{sprintId}/tasks/{taskId}', methods: [Request::METHOD_DELETE])]
+    public function __invoke(string $applicationSlug, string $sprintId, string $taskId): JsonResponse
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $sprint = $this->sprintRepository->findOneScopedById($sprintId, $crm->getId());
+        if ($sprint === null) {
+            return $this->errorResponseFactory->notFoundReference('sprintId');
+        }
+
+        $task = $this->taskRepository->findOneScopedById($taskId, $crm->getId());
+        if ($task === null) {
+            return $this->errorResponseFactory->notFoundReference('taskId');
+        }
+
+        if ($task->getSprint()?->getId() === $sprint->getId()) {
+            $task->setSprint(null);
+            $this->taskRepository->save($task);
+        }
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose API endpoints to attach a `Task` to a `Sprint` and to detach a `Task` from a `Sprint`, scoped to a CRM application so frontends can manage task-sprint relations safely.

### Description
- Added `AttachTaskToSprintController` (`src/Crm/Transport/Controller/Api/V1/Sprint/AttachTaskToSprintController.php`) which implements `PUT /v1/crm/applications/{applicationSlug}/sprints/{sprintId}/tasks/{taskId}` and sets the task's sprint after CRM scope and project membership checks.
- Added `DetachTaskFromSprintController` (`src/Crm/Transport/Controller/Api/V1/Sprint/DetachTaskFromSprintController.php`) which implements `DELETE /v1/crm/applications/{applicationSlug}/sprints/{sprintId}/tasks/{taskId}` and clears the task's sprint when it is attached to the target sprint.
- Both controllers use `CrmApplicationScopeResolver`, `SprintRepository`, `TaskRepository`, and `CrmApiErrorResponseFactory` and return CRM-style error responses for missing or out-of-scope references.

### Testing
- Ran `php -l` on both new controller files and there were no syntax errors.
- Attempted to run `vendor/bin/phpunit --testsuite Unit --filter Crm --stop-on-failure` but the `phpunit` binary is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7fcada718832b975415f7f29a7350)