### PR TITLE
Refactor CRM task write controllers with shared request and date handling

### DIFF
--- a/src/Crm/Application/Exception/CrmOutOfScopeException.php
+++ b/src/Crm/Application/Exception/CrmOutOfScopeException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Exception;
+
+use RuntimeException;
+
+final class CrmOutOfScopeException extends RuntimeException
+{
+}

--- a/src/Crm/Application/Exception/CrmReferenceNotFoundException.php
+++ b/src/Crm/Application/Exception/CrmReferenceNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Exception;
+
+use RuntimeException;
+
+final class CrmReferenceNotFoundException extends RuntimeException
+{
+    public function __construct(public readonly string $field)
+    {
+        parent::__construct(sprintf('Unknown "%s" in this CRM scope.', $field));
+    }
+}

--- a/src/Crm/Application/Service/CreateTaskHandler.php
+++ b/src/Crm/Application/Service/CreateTaskHandler.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Application\Exception\CrmOutOfScopeException;
+use App\Crm\Application\Exception\CrmReferenceNotFoundException;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Domain\Enum\TaskPriority;
+use App\Crm\Domain\Enum\TaskStatus;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Transport\Request\CreateTaskRequest;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use App\User\Domain\Entity\User;
+
+final readonly class CreateTaskHandler
+{
+    public function __construct(
+        private ProjectRepository $projectRepository,
+        private SprintRepository $sprintRepository,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function handle(CreateTaskRequest $input, string $crmId, ?DateTimeImmutable $dueAt): Task
+    {
+        $task = new Task();
+        $task->setTitle((string) $input->title)
+            ->setDescription($input->description)
+            ->setStatus(TaskStatus::tryFrom((string) $input->status) ?? TaskStatus::TODO)
+            ->setPriority(TaskPriority::tryFrom((string) $input->priority) ?? TaskPriority::MEDIUM)
+            ->setDueAt($dueAt)
+            ->setEstimatedHours($input->estimatedHours !== null ? (float) $input->estimatedHours : null);
+
+        $project = null;
+        if (is_string($input->projectId)) {
+            $project = $this->projectRepository->findOneScopedById($input->projectId, $crmId);
+            if ($project === null) {
+                throw new CrmReferenceNotFoundException('projectId');
+            }
+
+            $task->setProject($project);
+        }
+
+        if (is_string($input->sprintId)) {
+            $sprint = $this->sprintRepository->findOneScopedById($input->sprintId, $crmId);
+            if ($sprint === null) {
+                throw new CrmReferenceNotFoundException('sprintId');
+            }
+
+            if ($project !== null && $sprint->getProject()?->getId() !== $project->getId()) {
+                throw new CrmOutOfScopeException('Provided "sprintId" does not belong to the provided "projectId".');
+            }
+
+            $task->setSprint($sprint);
+        }
+
+        if (is_array($input->assigneeIds)) {
+            foreach ($input->assigneeIds as $assigneeId) {
+                $assignee = $this->entityManager->getRepository(User::class)->find($assigneeId);
+                if (!$assignee instanceof User) {
+                    throw new CrmReferenceNotFoundException('assigneeIds');
+                }
+
+                $task->addAssignee($assignee);
+            }
+        }
+
+        return $task;
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
@@ -6,20 +6,13 @@ namespace App\Crm\Transport\Controller\Api\V1\Task;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Application\Service\CrmTaskBlogProvisioningService;
-use App\Crm\Domain\Entity\Task;
-use App\Crm\Domain\Enum\TaskPriority;
-use App\Crm\Domain\Enum\TaskStatus;
-use App\Crm\Infrastructure\Repository\ProjectRepository;
-use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Application\Exception\CrmOutOfScopeException;
+use App\Crm\Application\Exception\CrmReferenceNotFoundException;
+use App\Crm\Application\Service\CreateTaskHandler;
 use App\Crm\Transport\Request\CreateTaskRequest;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityCreated;
 use App\Role\Domain\Enum\Role;
-use App\User\Domain\Entity\User;
-use DateTimeImmutable;
-use DateTimeInterface;
-use Doctrine\ORM\EntityManagerInterface;
-use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -28,7 +21,9 @@ use Symfony\Component\Messenger\Exception\ExceptionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
+use App\Crm\Transport\Request\CrmDateParser;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use Doctrine\ORM\EntityManagerInterface;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -36,12 +31,12 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 final readonly class CreateTaskController
 {
     public function __construct(
-        private ProjectRepository $projectRepository,
-        private SprintRepository $sprintRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
         private CrmTaskBlogProvisioningService $crmTaskBlogProvisioningService,
-        private ValidatorInterface $validator,
+        private CrmRequestHandler $crmRequestHandler,
+        private CrmDateParser $crmDateParser,
+        private CreateTaskHandler $createTaskHandler,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -144,67 +139,27 @@ final readonly class CreateTaskController
         $request->attributes->set('applicationSlug', $applicationSlug);
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
 
-        try {
-            $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return $this->errorResponseFactory->invalidJson();
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
         }
 
-        if (!is_array($payload)) {
-            return $this->errorResponseFactory->invalidJson();
+        $input = $this->crmRequestHandler->mapAndValidate($payload, CreateTaskRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
         }
 
-        $input = CreateTaskRequest::fromArray($payload);
-        $violations = $this->validator->validate($input);
-        if ($violations->count() > 0) {
-            return $this->errorResponseFactory->validationFailed($violations);
-        }
-
-        $dueAt = $this->parseDate($input->dueAt, 'dueAt');
+        $dueAt = $this->crmDateParser->parseNullableIso8601($input->dueAt, 'dueAt');
         if ($dueAt instanceof JsonResponse) {
             return $dueAt;
         }
 
-        $task = new Task();
-        $task->setTitle((string)$input->title)
-            ->setDescription($input->description)
-            ->setStatus(TaskStatus::tryFrom((string)$input->status) ?? TaskStatus::TODO)
-            ->setPriority(TaskPriority::tryFrom((string)$input->priority) ?? TaskPriority::MEDIUM)
-            ->setDueAt($dueAt)
-            ->setEstimatedHours($input->estimatedHours !== null ? (float)$input->estimatedHours : null);
-
-        $project = null;
-        if (is_string($input->projectId)) {
-            $project = $this->projectRepository->findOneScopedById($input->projectId, $crm->getId());
-            if ($project === null) {
-                return $this->errorResponseFactory->notFoundReference('projectId');
-            }
-
-            $task->setProject($project);
-        }
-
-        if (is_string($input->sprintId)) {
-            $sprint = $this->sprintRepository->findOneScopedById($input->sprintId, $crm->getId());
-            if ($sprint === null) {
-                return $this->errorResponseFactory->notFoundReference('sprintId');
-            }
-
-            if ($project !== null && $sprint->getProject()?->getId() !== $project->getId()) {
-                return $this->errorResponseFactory->outOfScopeReference('Provided "sprintId" does not belong to the provided "projectId".');
-            }
-
-            $task->setSprint($sprint);
-        }
-
-        if (is_array($input->assigneeIds)) {
-            foreach ($input->assigneeIds as $assigneeId) {
-                $assignee = $this->entityManager->getRepository(User::class)->find($assigneeId);
-                if (!$assignee instanceof User) {
-                    return $this->errorResponseFactory->notFoundReference('assigneeIds');
-                }
-
-                $task->addAssignee($assignee);
-            }
+        try {
+            $task = $this->createTaskHandler->handle($input, $crm->getId(), $dueAt);
+        } catch (CrmReferenceNotFoundException $exception) {
+            return $this->errorResponseFactory->notFoundReference($exception->field);
+        } catch (CrmOutOfScopeException $exception) {
+            return $this->errorResponseFactory->outOfScopeReference($exception->getMessage());
         }
 
         $this->entityManager->persist($task);
@@ -219,17 +174,4 @@ final readonly class CreateTaskController
         ], JsonResponse::HTTP_CREATED);
     }
 
-    private function parseDate(?string $value, string $field): DateTimeImmutable|JsonResponse|null
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        $date = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
-        if ($date === false) {
-            return $this->errorResponseFactory->invalidDate($field);
-        }
-
-        return $date;
-    }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Task/PatchTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/PatchTaskController.php
@@ -11,10 +11,9 @@ use App\Crm\Domain\Enum\TaskStatus;
 use App\Crm\Infrastructure\Repository\SprintRepository;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmDateParser;
+use App\Crm\Transport\Request\CrmRequestHandler;
 use App\Role\Domain\Enum\Role;
-use DateTimeImmutable;
-use DateTimeInterface;
-use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -32,6 +31,8 @@ final readonly class PatchTaskController
         private SprintRepository $sprintRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
+        private CrmRequestHandler $crmRequestHandler,
+        private CrmDateParser $crmDateParser,
     ) {
     }
 
@@ -40,20 +41,16 @@ final readonly class PatchTaskController
     {
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
 
-        try {
-            $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return $this->errorResponseFactory->invalidJson();
-        }
-        if (!is_array($payload)) {
-            return $this->errorResponseFactory->invalidJson();
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
         }
 
         if (isset($payload['title'])) {
-            $task->setTitle((string)$payload['title']);
+            $task->setTitle((string) $payload['title']);
         }
         if (array_key_exists('description', $payload)) {
-            $task->setDescription($payload['description'] !== null ? (string)$payload['description'] : null);
+            $task->setDescription($payload['description'] !== null ? (string) $payload['description'] : null);
         }
         if (isset($payload['status']) && is_string($payload['status'])) {
             $status = TaskStatus::tryFrom($payload['status']);
@@ -68,10 +65,19 @@ final readonly class PatchTaskController
             }
         }
         if (array_key_exists('dueAt', $payload)) {
-            $task->setDueAt($this->parseDate($payload['dueAt']));
+            if (!is_string($payload['dueAt']) && $payload['dueAt'] !== null) {
+                return $this->errorResponseFactory->invalidDate('dueAt');
+            }
+
+            $dueAt = $this->crmDateParser->parseNullableIso8601($payload['dueAt'], 'dueAt');
+            if ($dueAt instanceof JsonResponse) {
+                return $dueAt;
+            }
+
+            $task->setDueAt($dueAt);
         }
         if (array_key_exists('estimatedHours', $payload)) {
-            $task->setEstimatedHours(is_numeric($payload['estimatedHours']) ? (float)$payload['estimatedHours'] : null);
+            $task->setEstimatedHours(is_numeric($payload['estimatedHours']) ? (float) $payload['estimatedHours'] : null);
         }
         if (array_key_exists('sprintId', $payload)) {
             if ($payload['sprintId'] === null || $payload['sprintId'] === '') {
@@ -89,15 +95,5 @@ final readonly class PatchTaskController
         return new JsonResponse([
             'id' => $task->getId(),
         ]);
-    }
-
-    private function parseDate(mixed $value): ?DateTimeImmutable
-    {
-        if ($value === null || $value === '' || !is_string($value)) {
-            return null;
-        }
-        $parsed = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
-
-        return $parsed === false ? null : $parsed;
     }
 }

--- a/src/Crm/Transport/Request/CrmDateParser.php
+++ b/src/Crm/Transport/Request/CrmDateParser.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+final readonly class CrmDateParser
+{
+    public function __construct(private CrmApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    public function parseNullableIso8601(?string $value, string $field): DateTimeImmutable|JsonResponse|null
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $date = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
+        if ($date === false) {
+            return $this->errorResponseFactory->invalidDate($field);
+        }
+
+        return $date;
+    }
+}

--- a/src/Crm/Transport/Request/CrmRequestHandler.php
+++ b/src/Crm/Transport/Request/CrmRequestHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use JsonException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final readonly class CrmRequestHandler
+{
+    public function __construct(
+        private ValidatorInterface $validator,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    public function decodeJson(Request $request): array|JsonResponse
+    {
+        try {
+            $payload = json_decode((string) $request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        if (!is_array($payload)) {
+            return $this->errorResponseFactory->invalidJson();
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @param class-string $dtoClass
+     */
+    public function mapAndValidate(array $payload, string $dtoClass): mixed
+    {
+        if (!method_exists($dtoClass, 'fromArray')) {
+            throw new \InvalidArgumentException(sprintf('DTO class "%s" must implement static fromArray(array $payload): self.', $dtoClass));
+        }
+
+        $input = $dtoClass::fromArray($payload);
+        $violations = $this->validator->validate($input);
+        if ($violations->count() > 0) {
+            return $this->errorResponseFactory->validationFailed($violations);
+        }
+
+        return $input;
+    }
+}

--- a/tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php
@@ -424,6 +424,53 @@ final class CrmControllerTest extends WebTestCase
         }
     }
 
+
+    #[TestDox('CreateTaskController returns standardized date parsing error payload.')]
+    public function testCreateTaskInvalidDateUsesStandardizedError(): void
+    {
+        $companyId = $this->createCompany();
+        $projectId = $this->createProject($companyId);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/tasks', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode([
+                'title' => 'Task invalid dueAt',
+                'projectId' => $projectId,
+                'dueAt' => 'invalid-date',
+            ])
+        );
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertSame('Invalid date format for "dueAt".', $payload['message'] ?? null);
+        self::assertSame([], $payload['errors'] ?? null);
+    }
+
+    #[TestDox('PatchTaskController returns standardized date parsing error payload.')]
+    public function testPatchTaskInvalidDateUsesStandardizedError(): void
+    {
+        $companyId = $this->createCompany();
+        $projectId = $this->createProject($companyId);
+        $sprintId = $this->createSprint($projectId);
+        $taskId = $this->createTask($projectId, $sprintId);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            'PATCH',
+            sprintf('%s/v1/crm/applications/%s/tasks/%s', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG, $taskId),
+            content: JSON::encode([
+                'dueAt' => 'still-not-a-date',
+            ])
+        );
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+        self::assertSame('Invalid date format for "dueAt".', $payload['message'] ?? null);
+        self::assertSame([], $payload['errors'] ?? null);
+    }
+
     #[TestDox('Delete endpoints reject IDs from another CRM application scope.')]
     #[DataProvider('crossScopeDeleteProvider')]
     public function testDeleteRejectsForeignScopeIds(string $resource, string $foreignIdKey): void


### PR DESCRIPTION
### Motivation

- Harmoniser le traitement des requêtes JSON et des erreurs dans les contrôleurs d’écriture CRM pour réduire la duplication. 
- Extraire le parsing de dates réutilisable pour éviter les variantes de `parseDate` par contrôleur. 
- Dégager la logique métier de création d’entités hors des contrôleurs pour obtenir des contrôleurs fins et testables.

### Description

- Ajout de `CrmRequestHandler` qui centralise le décodage JSON, le mapping DTO via `fromArray`, la validation Symfony et les réponses d’erreur standardisées via `CrmApiErrorResponseFactory` (`src/Crm/Transport/Request/CrmRequestHandler.php`).
- Ajout de `CrmDateParser` pour le parsing ISO-8601 centralisé et la remontée d’erreur standardisée (`src/Crm/Transport/Request/CrmDateParser.php`).
- Extraction de la logique de création de tâche dans un service applicatif `CreateTaskHandler` avec exceptions métier dédiées `CrmReferenceNotFoundException` et `CrmOutOfScopeException` (`src/Crm/Application/Service/CreateTaskHandler.php` et `src/Crm/Application/Exception/*`).
- Refactor des contrôleurs `CreateTaskController` et `PatchTaskController` pour utiliser `CrmRequestHandler` + `CrmDateParser` et pour mapper proprement les exceptions métier vers les réponses d’erreur standardisées, ainsi qu’ajout d’un cas de test d’intégration sur le parsing de date invalide (`tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php`).

### Testing

- Vérifications de syntaxe PHP effectuées avec `php -l` sur les fichiers nouveaux/modifiés (`src/Crm/Application/Service/CreateTaskHandler.php`, `src/Crm/Transport/Request/CrmRequestHandler.php`, `src/Crm/Transport/Request/CrmDateParser.php`, `src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php`, `src/Crm/Transport/Controller/Api/V1/Task/PatchTaskController.php`, `tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php`) et elles sont passées. 
- Ajout d’un scénario d’intégration pour vérifier la réponse standardisée lors d’un `dueAt` invalide dans `tests/Application/Crm/Transport/Controller/Api/V1/CrmControllerTest.php`.
- Tentative d’exécution ciblée de PHPUnit avec `./vendor/bin/phpunit ...` a échoué car le binaire n’est pas disponible dans l’environnement d’exécution, donc les tests PHPUnit n’ont pas été exécutés ici. 
- Les fichiers et changements ont été lintés et validés côté syntaxe avant PR, mais une exécution complète de la suite de tests CI est requise dans l’environnement de build pour valider l’intégration finale.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7ffbc5df4832bab7131cacf273c9b)