### PR TITLE
Optimise TaskListService : pagination Elastic, filtre UUID IN et métriques

### DIFF
--- a/src/Crm/Application/Service/TaskListService.php
+++ b/src/Crm/Application/Service/TaskListService.php
@@ -9,7 +9,10 @@ use App\Crm\Domain\Entity\Task;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\ORM\QueryBuilder;
+use Psr\Log\LoggerInterface;
+use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Cache\CacheInterface;
@@ -20,16 +23,20 @@ use Throwable;
 use function array_filter;
 use function array_map;
 use function array_merge;
+use function array_unique;
 use function array_values;
 use function ceil;
-use function implode;
+use function count;
 use function max;
 use function method_exists;
+use function microtime;
 use function min;
 use function trim;
 
 readonly class TaskListService
 {
+    private const int ELASTIC_PAGE_SIZE = 200;
+
     public function __construct(
         private TaskRepository $taskRepository,
         private CacheInterface $cache,
@@ -37,6 +44,7 @@ readonly class TaskListService
         private CacheKeyConventionService $cacheKeyConventionService,
         private CrmApplicationScopeResolver $applicationScopeResolver,
         private CrmApiNormalizer $crmApiNormalizer,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -69,6 +77,7 @@ readonly class TaskListService
 
         /** @var array<string,mixed> $result */
         $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $filters, $page, $limit, $crm): array {
+            $startAt = microtime(true);
             $item->expiresAfter(120);
 
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
@@ -107,6 +116,17 @@ readonly class TaskListService
             );
 
             $totalItems = $this->countFilteredTasks($crm->getId(), $filters, $esIds);
+
+            $this->logger->info('CRM task list query completed', [
+                'applicationSlug' => $applicationSlug,
+                'page' => $page,
+                'limit' => $limit,
+                'filters' => array_keys(array_filter($filters, static fn (string $value): bool => $value !== '')),
+                'elasticIdsCount' => $esIds !== null ? count($esIds) : null,
+                'resultSetSize' => count($items),
+                'totalItems' => $totalItems,
+                'durationMs' => (int) ((microtime(true) - $startAt) * 1000),
+            ]);
 
             return [
                 'items' => $items,
@@ -245,15 +265,20 @@ readonly class TaskListService
             return;
         }
 
-        $parts = [];
+        $binaryIds = array_values(array_unique(array_filter(array_map(
+            static fn (string $id): ?string => Uuid::isValid($id) ? Uuid::fromString($id)->getBytes() : null,
+            $ids,
+        ))));
 
-        foreach (array_values($ids) as $index => $id) {
-            $parameterName = $parameterPrefix . $index;
-            $parts[] = $field . ' = :' . $parameterName;
-            $qb->setParameter($parameterName, $id, UuidBinaryOrderedTimeType::NAME);
+        if ($binaryIds === []) {
+            $qb->andWhere('1 = 0');
+
+            return;
         }
 
-        $qb->andWhere('(' . implode(' OR ', $parts) . ')');
+        $parameterName = $parameterPrefix . 'ids';
+        $qb->andWhere($field . ' IN (:' . $parameterName . ')')
+            ->setParameter($parameterName, $binaryIds, ArrayParameterType::BINARY);
     }
 
     /**
@@ -286,9 +311,11 @@ readonly class TaskListService
         }
 
         try {
-            $response = $this->elasticsearchService->search(
-                CrmTaskProjection::INDEX_NAME,
-                [
+            $ids = [];
+            $searchAfter = null;
+
+            do {
+                $body = [
                     'query' => [
                         'multi_match' => [
                             'query' => $filters['q'],
@@ -296,20 +323,39 @@ readonly class TaskListService
                             'fields' => ['title^3', 'projectName^2', 'sprintName', 'taskRequests'],
                         ],
                     ],
+                    'sort' => [
+                        ['_doc' => 'asc'],
+                    ],
+                    'track_total_hits' => true,
                     '_source' => ['id'],
-                ],
-                0,
-                200
-            );
+                ];
+
+                if ($searchAfter !== null) {
+                    $body['search_after'] = $searchAfter;
+                }
+
+                $response = $this->elasticsearchService->search(
+                    CrmTaskProjection::INDEX_NAME,
+                    $body,
+                    0,
+                    self::ELASTIC_PAGE_SIZE,
+                );
+
+                $hits = $response['hits']['hits'] ?? [];
+                foreach ($hits as $hit) {
+                    $id = $hit['_source']['id'] ?? $hit['_id'] ?? null;
+                    if (is_string($id) && $id !== '') {
+                        $ids[] = $id;
+                    }
+                }
+
+                $lastHit = $hits !== [] ? $hits[count($hits) - 1] : null;
+                $searchAfter = is_array($lastHit) ? ($lastHit['sort'] ?? null) : null;
+            } while ($hits !== [] && count($hits) === self::ELASTIC_PAGE_SIZE && is_array($searchAfter));
+
+            return array_values(array_unique($ids));
         } catch (Throwable) {
             return null;
         }
-
-        $hits = $response['hits']['hits'] ?? [];
-
-        return array_values(array_filter(array_map(
-            static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null,
-            $hits
-        )));
     }
 }

--- a/tests/Unit/Crm/Application/Service/TaskListServiceTest.php
+++ b/tests/Unit/Crm/Application/Service/TaskListServiceTest.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Crm\Application\Service;
+
+use App\Crm\Application\Service\CrmApiNormalizer;
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\TaskListService;
+use App\Crm\Domain\Entity\Crm;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use Doctrine\ORM\AbstractQuery;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use ReflectionClass;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+final class TaskListServiceTest extends TestCase
+{
+    public function testSearchIdsFromElasticPaginatesWhenMoreThanTwoHundredHits(): void
+    {
+        $taskRepository = $this->createMock(TaskRepository::class);
+        $cache = $this->createMock(CacheInterface::class);
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $scopeResolver = $this->createMock(CrmApplicationScopeResolver::class);
+        $normalizer = $this->createMock(CrmApiNormalizer::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $firstHits = [];
+        for ($i = 1; $i <= 200; ++$i) {
+            $firstHits[] = [
+                '_source' => ['id' => sprintf('00000000-0000-0000-0000-%012d', $i)],
+                'sort' => [$i],
+            ];
+        }
+
+        $secondHits = [];
+        for ($i = 201; $i <= 250; ++$i) {
+            $secondHits[] = [
+                '_source' => ['id' => sprintf('00000000-0000-0000-0000-%012d', $i)],
+                'sort' => [$i],
+            ];
+        }
+
+        $elastic
+            ->expects(self::exactly(2))
+            ->method('search')
+            ->with(
+                self::anything(),
+                self::callback(static function (array $body): bool {
+                    return isset($body['sort'], $body['track_total_hits'])
+                        && $body['sort'] === [['_doc' => 'asc']]
+                        && $body['track_total_hits'] === true;
+                }),
+                0,
+                200,
+            )
+            ->willReturnOnConsecutiveCalls(
+                ['hits' => ['hits' => $firstHits]],
+                ['hits' => ['hits' => $secondHits]],
+            );
+
+        $service = new TaskListService(
+            $taskRepository,
+            $cache,
+            $elastic,
+            new CacheKeyConventionService(),
+            $scopeResolver,
+            $normalizer,
+            $logger,
+        );
+
+        /** @var list<string> $ids */
+        $ids = $this->invokePrivate($service, 'searchIdsFromElastic', [['q' => 'important', 'title' => '', 'status' => '', 'priority' => '']]);
+
+        self::assertCount(250, $ids);
+    }
+
+    public function testGetListReturnsEmptyPaginationWhenElasticReturnsNoHit(): void
+    {
+        $taskRepository = $this->createMock(TaskRepository::class);
+        $cache = $this->createMock(CacheInterface::class);
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $scopeResolver = $this->createMock(CrmApplicationScopeResolver::class);
+        $normalizer = $this->createMock(CrmApiNormalizer::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $crm = $this->createMock(Crm::class);
+        $crm->method('getId')->willReturn('00000000-0000-0000-0000-000000000111');
+
+        $scopeResolver->method('resolveOrFail')->willReturn($crm);
+        $elastic->method('search')->willReturn(['hits' => ['hits' => []]]);
+
+        $cache->method('get')->willReturnCallback(static function (string $key, callable $callback): array {
+            $item = new class() implements ItemInterface {
+                public function getKey(): string { return 'key'; }
+                public function get(): mixed { return null; }
+                public function isHit(): bool { return false; }
+                public function set(mixed $value): static { return $this; }
+                public function expiresAt(?\DateTimeInterface $expiration): static { return $this; }
+                public function expiresAfter(\DateInterval|int|null $time): static { return $this; }
+                public function tag(string|iterable $tags): static { return $this; }
+                public function getMetadata(): array { return []; }
+            };
+
+            return $callback($item);
+        });
+
+        $service = new TaskListService(
+            $taskRepository,
+            $cache,
+            $elastic,
+            new CacheKeyConventionService(),
+            $scopeResolver,
+            $normalizer,
+            $logger,
+        );
+
+        $request = new Request(['q' => 'x', 'page' => 1, 'limit' => 20], [], ['applicationSlug' => 'crm-app']);
+        $result = $service->getList($request);
+
+        self::assertSame([], $result['items']);
+        self::assertSame(0, $result['pagination']['totalItems']);
+    }
+
+    public function testGetListKeepsItemsAndTotalItemsConsistentWithCombinedFiltersAndQ(): void
+    {
+        $taskRepository = $this->createMock(TaskRepository::class);
+        $cache = $this->createMock(CacheInterface::class);
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+        $scopeResolver = $this->createMock(CrmApplicationScopeResolver::class);
+        $normalizer = $this->createMock(CrmApiNormalizer::class);
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $crm = $this->createMock(Crm::class);
+        $crm->method('getId')->willReturn('00000000-0000-0000-0000-000000000222');
+        $scopeResolver->method('resolveOrFail')->willReturn($crm);
+
+        $elastic->method('search')->willReturn([
+            'hits' => [
+                'hits' => [
+                    ['_source' => ['id' => '2eea8e20-8f35-11ee-b9d1-0242ac120002'], 'sort' => [1]],
+                    ['_source' => ['id' => '3ddbf7e0-8f35-11ee-b9d1-0242ac120002'], 'sort' => [2]],
+                ],
+            ],
+        ]);
+
+        $idsQb = $this->mockQueryBuilderForIds([
+            ['id' => '2eea8e20-8f35-11ee-b9d1-0242ac120002'],
+            ['id' => '3ddbf7e0-8f35-11ee-b9d1-0242ac120002'],
+        ]);
+        $tasksQb = $this->mockQueryBuilderForTasks();
+        $countQb = $this->mockQueryBuilderForCount(2);
+
+        $taskRepository->expects(self::exactly(3))
+            ->method('createQueryBuilder')
+            ->with('task')
+            ->willReturnOnConsecutiveCalls($idsQb, $tasksQb, $countQb);
+
+        $taskA = $this->createMock(Task::class);
+        $taskA->method('getId')->willReturn('2eea8e20-8f35-11ee-b9d1-0242ac120002');
+        $taskB = $this->createMock(Task::class);
+        $taskB->method('getId')->willReturn('3ddbf7e0-8f35-11ee-b9d1-0242ac120002');
+
+        $tasksQuery = $this->createMock(AbstractQuery::class);
+        $tasksQuery->method('getResult')->willReturn([$taskA, $taskB]);
+        $tasksQb->method('getQuery')->willReturn($tasksQuery);
+
+        $normalizer->method('normalizeTask')->willReturnCallback(static fn (Task $task): array => ['id' => $task->getId()]);
+
+        $cache->method('get')->willReturnCallback(static function (string $key, callable $callback): array {
+            $item = new class() implements ItemInterface {
+                public function getKey(): string { return 'key'; }
+                public function get(): mixed { return null; }
+                public function isHit(): bool { return false; }
+                public function set(mixed $value): static { return $this; }
+                public function expiresAt(?\DateTimeInterface $expiration): static { return $this; }
+                public function expiresAfter(\DateInterval|int|null $time): static { return $this; }
+                public function tag(string|iterable $tags): static { return $this; }
+                public function getMetadata(): array { return []; }
+            };
+
+            return $callback($item);
+        });
+
+        $service = new TaskListService(
+            $taskRepository,
+            $cache,
+            $elastic,
+            new CacheKeyConventionService(),
+            $scopeResolver,
+            $normalizer,
+            $logger,
+        );
+
+        $request = new Request(
+            ['q' => 'deploy', 'title' => 'Sprint', 'status' => 'open', 'priority' => 'high', 'page' => 1, 'limit' => 20],
+            [],
+            ['applicationSlug' => 'crm-app']
+        );
+
+        $result = $service->getList($request);
+
+        self::assertCount(2, $result['items']);
+        self::assertSame(2, $result['pagination']['totalItems']);
+        self::assertSame(1, $result['pagination']['totalPages']);
+    }
+
+    /**
+     * @param list<array{id:string}> $rows
+     */
+    private function mockQueryBuilderForIds(array $rows): QueryBuilder
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $query = $this->createMock(AbstractQuery::class);
+        $query->method('getArrayResult')->willReturn($rows);
+
+        $qb->method('select')->willReturnSelf();
+        $qb->method('leftJoin')->willReturnSelf();
+        $qb->method('andWhere')->willReturnSelf();
+        $qb->method('setParameter')->willReturnSelf();
+        $qb->method('setFirstResult')->willReturnSelf();
+        $qb->method('setMaxResults')->willReturnSelf();
+        $qb->method('orderBy')->willReturnSelf();
+        $qb->method('getQuery')->willReturn($query);
+
+        return $qb;
+    }
+
+    private function mockQueryBuilderForTasks(): QueryBuilder
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $qb->method('distinct')->willReturnSelf();
+        $qb->method('leftJoin')->willReturnSelf();
+        $qb->method('addSelect')->willReturnSelf();
+        $qb->method('andWhere')->willReturnSelf();
+        $qb->method('setParameter')->willReturnSelf();
+
+        return $qb;
+    }
+
+    private function mockQueryBuilderForCount(int $count): QueryBuilder
+    {
+        $qb = $this->createMock(QueryBuilder::class);
+        $query = $this->createMock(AbstractQuery::class);
+        $query->method('getSingleScalarResult')->willReturn((string) $count);
+
+        $qb->method('select')->willReturnSelf();
+        $qb->method('leftJoin')->willReturnSelf();
+        $qb->method('andWhere')->willReturnSelf();
+        $qb->method('setParameter')->willReturnSelf();
+        $qb->method('getQuery')->willReturn($query);
+
+        return $qb;
+    }
+
+    /**
+     * @param array<int, mixed> $arguments
+     */
+    private function invokePrivate(object $service, string $method, array $arguments): mixed
+    {
+        $reflection = new ReflectionClass($service);
+        $reflectionMethod = $reflection->getMethod($method);
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod->invokeArgs($service, $arguments);
+    }
+}


### PR DESCRIPTION
### Motivation
- Remplacer la construction en chaîne de `OR` sur UUID par une approche plus performante et compatible UUID binaire pour éviter des requêtes lourdes sur Doctrine.
- Gérer correctement les très grands jeux de résultats retournés par Elasticsearch (au-delà de 200 hits) pour éviter des coupes invisibles et garantir un comptage fiable.
- Assurer la cohérence entre `items` et `totalItems` lorsque la recherche texte `q` est utilisée.
- Ajouter métriques / logs pour pouvoir monitorer la latence et la taille des jeux de résultats en production et faciliter le diagnostic.

### Description
- `applyBinaryUuidIdsFilter` remplace la génération d’une liste d’expressions `OR` par un `IN (:ids)` binaire en convertissant les UUID en bytes et en passant un paramètre de type `ArrayParameterType::BINARY`, avec fallback `1 = 0` pour listes vides ou invalides. (modifié : `src/Crm/Application/Service/TaskListService.php`)
- `searchIdsFromElastic` itère maintenant en pages avec `search_after` et tri `_doc` en lots de 200 (`ELASTIC_PAGE_SIZE`) pour agréger tous les IDs et dédupliquer le résultat afin de supporter >200 hits. (modifié : `src/Crm/Application/Service/TaskListService.php`)
- Ajout d’un `LoggerInterface` injecté, et journalisation structurée dans le callback du cache avec durée (ms), taille du jeu de résultats, nombre d’IDs Elastic et totalItems pour surveillance opérationnelle. (modifié : `src/Crm/Application/Service/TaskListService.php`)
- Ajout de tests unitaires couvrant les cas limites : pagination Elastic >200 hits, résultat vide et combinaison de filtres (`title + status + priority + q`). Le fichier de tests ajouté est `tests/Unit/Crm/Application/Service/TaskListServiceTest.php`.

### Testing
- Surcharge syntaxique : `php -l src/Crm/Application/Service/TaskListService.php` a réussi sans erreurs.
- Surcharge syntaxique des tests : `php -l tests/Unit/Crm/Application/Service/TaskListServiceTest.php` a réussi sans erreurs.
- Exécution des tests unitaires : tentative `phpunit tests/Unit/Crm/Application/Service/TaskListServiceTest.php` non exécutée dans cet environnement car le binaire `phpunit` est absent (échec dû à l’environnement, pas au code).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b801563ec0832bae52afba4cb19f30)