### PR TITLE
Refactor CRM controllers to use centralized request handling

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/Billing/CreateBillingController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Billing/CreateBillingController.php
@@ -12,8 +12,6 @@ use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Transport\Request\CreateBillingRequest;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
-use DateTimeImmutable;
-use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,7 +20,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
+use App\Crm\Transport\Request\CrmRequestHandler;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -33,7 +31,7 @@ final readonly class CreateBillingController
         private CrmApplicationScopeResolver $scopeResolver,
         private CompanyRepository $companyRepository,
         private CrmApiErrorResponseFactory $errorResponseFactory,
-        private ValidatorInterface $validator,
+        private CrmRequestHandler $crmRequestHandler,
         private MessageBusInterface $messageBus,
         private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
@@ -44,20 +42,14 @@ final readonly class CreateBillingController
     {
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
 
-        try {
-            $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return $this->errorResponseFactory->invalidJson();
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
         }
 
-        if (!is_array($payload)) {
-            return $this->errorResponseFactory->invalidJson();
-        }
-
-        $input = CreateBillingRequest::fromArray($payload);
-        $violations = $this->validator->validate($input);
-        if ($violations->count() > 0) {
-            return $this->errorResponseFactory->validationFailed($violations);
+        $input = $this->crmRequestHandler->mapAndValidate($payload, CreateBillingRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
         }
 
         $company = $this->companyRepository->findOneScopedById((string)$input->companyId, $crm->getId());
@@ -71,9 +63,12 @@ final readonly class CreateBillingController
             ->setCurrency($input->currency ?: 'EUR')
             ->setStatus($input->status ?: 'pending');
 
-        if (($input->dueAt ?? '') !== '') {
-            $billing->setDueAt(new DateTimeImmutable((string)$input->dueAt));
+        $dueAt = $this->crmRequestHandler->parseNullableIso8601($input->dueAt, 'dueAt');
+        if ($dueAt instanceof JsonResponse) {
+            return $dueAt;
         }
+
+        $billing->setDueAt($dueAt);
 
         $this->messageBus->dispatch(new CreateBillingCommand(
             id: $billing->getId(),

--- a/src/Crm/Transport/Controller/Api/V1/Billing/PutBillingController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Billing/PutBillingController.php
@@ -11,8 +11,6 @@ use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Transport\Request\CreateBillingRequest;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
-use DateTimeImmutable;
-use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +18,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
+use App\Crm\Transport\Request\CrmRequestHandler;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -32,7 +30,7 @@ final readonly class PutBillingController
         private CompanyRepository $companyRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
-        private ValidatorInterface $validator,
+        private CrmRequestHandler $crmRequestHandler,
         private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
@@ -46,20 +44,14 @@ final readonly class PutBillingController
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Billing not found for this CRM scope.');
         }
 
-        try {
-            $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return $this->errorResponseFactory->invalidJson();
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
         }
 
-        if (!is_array($payload)) {
-            return $this->errorResponseFactory->invalidJson();
-        }
-
-        $input = CreateBillingRequest::fromArray($payload);
-        $violations = $this->validator->validate($input);
-        if ($violations->count() > 0) {
-            return $this->errorResponseFactory->validationFailed($violations);
+        $input = $this->crmRequestHandler->mapAndValidate($payload, CreateBillingRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
         }
 
         $companyId = (string)($input->companyId ?? '');
@@ -72,13 +64,18 @@ final readonly class PutBillingController
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Company not found for this CRM scope.');
         }
 
+        $dueAt = $this->crmRequestHandler->parseNullableIso8601($input->dueAt, 'dueAt');
+        if ($dueAt instanceof JsonResponse) {
+            return $dueAt;
+        }
+
         $entity
             ->setCompany($company)
             ->setLabel((string)$input->label)
             ->setAmount((float)$input->amount)
             ->setCurrency($input->currency ?: 'EUR')
             ->setStatus($input->status ?: 'pending')
-            ->setDueAt(($input->dueAt ?? '') !== '' ? new DateTimeImmutable((string)$input->dueAt) : null);
+            ->setDueAt($dueAt);
 
         $this->billingRepository->save($entity);
 

--- a/src/Crm/Transport/Controller/Api/V1/Company/CreateCompanyByApplicationController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/CreateCompanyByApplicationController.php
@@ -11,7 +11,6 @@ use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityCreated;
 use App\Role\Domain\Enum\Role;
 use Doctrine\ORM\EntityManagerInterface;
-use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +19,7 @@ use Symfony\Component\Messenger\Exception\ExceptionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
+use App\Crm\Transport\Request\CrmRequestHandler;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -30,7 +29,7 @@ final readonly class CreateCompanyByApplicationController
     public function __construct(
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
-        private ValidatorInterface $validator,
+        private CrmRequestHandler $crmRequestHandler,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -110,20 +109,14 @@ final readonly class CreateCompanyByApplicationController
         $request->attributes->set('applicationSlug', $applicationSlug);
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
 
-        try {
-            $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return $this->errorResponseFactory->invalidJson();
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
         }
 
-        if (!is_array($payload)) {
-            return $this->errorResponseFactory->invalidJson();
-        }
-
-        $input = CreateCompanyRequest::fromArray($payload);
-        $violations = $this->validator->validate($input);
-        if ($violations->count() > 0) {
-            return $this->errorResponseFactory->validationFailed($violations);
+        $input = $this->crmRequestHandler->mapAndValidate($payload, CreateCompanyRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
         }
 
         $company = new Company()

--- a/src/Crm/Transport/Controller/Api/V1/Company/PatchCompanyController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/PatchCompanyController.php
@@ -9,14 +9,13 @@ use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Crm\Transport\Request\UpdateCompanyRequest;
 use App\Role\Domain\Enum\Role;
-use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
+use App\Crm\Transport\Request\CrmRequestHandler;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -27,7 +26,7 @@ final readonly class PatchCompanyController
         private CompanyRepository $companyRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
-        private ValidatorInterface $validator,
+        private CrmRequestHandler $crmRequestHandler,
     ) {
     }
 
@@ -40,20 +39,14 @@ final readonly class PatchCompanyController
             return $this->errorResponseFactory->notFoundReference('companyId');
         }
 
-        try {
-            $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return $this->errorResponseFactory->invalidJson();
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
         }
 
-        if (!is_array($payload)) {
-            return $this->errorResponseFactory->invalidJson();
-        }
-
-        $input = UpdateCompanyRequest::fromPatchArray($payload);
-        $violations = $this->validator->validate($input);
-        if ($violations->count() > 0) {
-            return $this->errorResponseFactory->validationFailed($violations);
+        $input = $this->crmRequestHandler->mapAndValidate($payload, UpdateCompanyRequest::class, mapperMethod: 'fromPatchArray');
+        if ($input instanceof JsonResponse) {
+            return $input;
         }
 
         if ($input->hasName) {

--- a/src/Crm/Transport/Controller/Api/V1/Company/PutCompanyController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/PutCompanyController.php
@@ -9,14 +9,13 @@ use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Crm\Transport\Request\UpdateCompanyRequest;
 use App\Role\Domain\Enum\Role;
-use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
+use App\Crm\Transport\Request\CrmRequestHandler;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -27,7 +26,7 @@ final readonly class PutCompanyController
         private CompanyRepository $companyRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
-        private ValidatorInterface $validator,
+        private CrmRequestHandler $crmRequestHandler,
     ) {
     }
 
@@ -40,20 +39,14 @@ final readonly class PutCompanyController
             return $this->errorResponseFactory->notFoundReference('companyId');
         }
 
-        try {
-            $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return $this->errorResponseFactory->invalidJson();
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
         }
 
-        if (!is_array($payload)) {
-            return $this->errorResponseFactory->invalidJson();
-        }
-
-        $input = UpdateCompanyRequest::fromPutArray($payload);
-        $violations = $this->validator->validate($input, groups: ['Default', 'put']);
-        if ($violations->count() > 0) {
-            return $this->errorResponseFactory->validationFailed($violations);
+        $input = $this->crmRequestHandler->mapAndValidate($payload, UpdateCompanyRequest::class, ['Default', 'put'], 'fromPutArray');
+        if ($input instanceof JsonResponse) {
+            return $input;
         }
 
         $company

--- a/src/Crm/Transport/Controller/Api/V1/Contact/CreateContactController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Contact/CreateContactController.php
@@ -11,7 +11,6 @@ use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Transport\Request\CreateContactRequest;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
-use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,7 +18,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
+use App\Crm\Transport\Request\CrmRequestHandler;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -30,7 +29,7 @@ final readonly class CreateContactController
         private CrmApplicationScopeResolver $scopeResolver,
         private CompanyRepository $companyRepository,
         private CrmApiErrorResponseFactory $errorResponseFactory,
-        private ValidatorInterface $validator,
+        private CrmRequestHandler $crmRequestHandler,
         private MessageBusInterface $messageBus,
     ) {
     }
@@ -40,20 +39,14 @@ final readonly class CreateContactController
     {
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
 
-        try {
-            $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return $this->errorResponseFactory->invalidJson();
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
         }
 
-        if (!is_array($payload)) {
-            return $this->errorResponseFactory->invalidJson();
-        }
-
-        $input = CreateContactRequest::fromArray($payload);
-        $violations = $this->validator->validate($input);
-        if ($violations->count() > 0) {
-            return $this->errorResponseFactory->validationFailed($violations);
+        $input = $this->crmRequestHandler->mapAndValidate($payload, CreateContactRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
         }
 
         $contact = (new Contact())

--- a/src/Crm/Transport/Controller/Api/V1/Contact/PutContactController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Contact/PutContactController.php
@@ -10,14 +10,13 @@ use App\Crm\Infrastructure\Repository\ContactRepository;
 use App\Crm\Transport\Request\CreateContactRequest;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
-use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
+use App\Crm\Transport\Request\CrmRequestHandler;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -29,7 +28,7 @@ final readonly class PutContactController
         private ContactRepository $contactRepository,
         private CompanyRepository $companyRepository,
         private CrmApiErrorResponseFactory $errorResponseFactory,
-        private ValidatorInterface $validator,
+        private CrmRequestHandler $crmRequestHandler,
     ) {
     }
 
@@ -42,20 +41,14 @@ final readonly class PutContactController
             return $this->errorResponseFactory->notFoundReference('contactId');
         }
 
-        try {
-            $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return $this->errorResponseFactory->invalidJson();
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
         }
 
-        if (!is_array($payload)) {
-            return $this->errorResponseFactory->invalidJson();
-        }
-
-        $input = CreateContactRequest::fromArray($payload);
-        $violations = $this->validator->validate($input);
-        if ($violations->count() > 0) {
-            return $this->errorResponseFactory->validationFailed($violations);
+        $input = $this->crmRequestHandler->mapAndValidate($payload, CreateContactRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
         }
 
         $contact

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
@@ -14,10 +14,7 @@ use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\General\Application\Message\EntityCreated;
 use App\Role\Domain\Enum\Role;
 use App\User\Domain\Entity\User;
-use DateTimeImmutable;
-use DateTimeInterface;
 use Doctrine\ORM\EntityManagerInterface;
-use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -26,7 +23,8 @@ use Symfony\Component\Messenger\Exception\ExceptionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-use Symfony\Component\Validator\Validator\ValidatorInterface;
+use App\Crm\Transport\Request\CrmDateParser;
+use App\Crm\Transport\Request\CrmRequestHandler;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
@@ -38,7 +36,8 @@ final readonly class CreateTaskRequestController
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
         private CrmTaskBlogProvisioningService $crmTaskBlogProvisioningService,
-        private ValidatorInterface $validator,
+        private CrmRequestHandler $crmRequestHandler,
+        private CrmDateParser $crmDateParser,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -124,23 +123,17 @@ final readonly class CreateTaskRequestController
         $request->attributes->set('applicationSlug', $applicationSlug);
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
 
-        try {
-            $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return $this->errorResponseFactory->invalidJson();
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
         }
 
-        if (!is_array($payload)) {
-            return $this->errorResponseFactory->invalidJson();
+        $input = $this->crmRequestHandler->mapAndValidate($payload, CreateTaskRequestEntryRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
         }
 
-        $input = CreateTaskRequestEntryRequest::fromArray($payload);
-        $violations = $this->validator->validate($input);
-        if ($violations->count() > 0) {
-            return $this->errorResponseFactory->validationFailed($violations);
-        }
-
-        $resolvedAt = $this->parseDate($input->resolvedAt, 'resolvedAt');
+        $resolvedAt = $this->crmDateParser->parseNullableIso8601($input->resolvedAt, 'resolvedAt');
         if ($resolvedAt instanceof JsonResponse) {
             return $resolvedAt;
         }
@@ -183,17 +176,4 @@ final readonly class CreateTaskRequestController
         ], JsonResponse::HTTP_CREATED);
     }
 
-    private function parseDate(?string $value, string $field): DateTimeImmutable|JsonResponse|null
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        $date = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
-        if ($date === false) {
-            return $this->errorResponseFactory->invalidDate($field);
-        }
-
-        return $date;
-    }
 }

--- a/src/Crm/Transport/Request/CrmRequestHandler.php
+++ b/src/Crm/Transport/Request/CrmRequestHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Request;
 
 use JsonException;
+use DateTimeImmutable;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -14,6 +15,7 @@ final readonly class CrmRequestHandler
     public function __construct(
         private ValidatorInterface $validator,
         private CrmApiErrorResponseFactory $errorResponseFactory,
+        private CrmDateParser $crmDateParser,
     ) {
     }
 
@@ -34,19 +36,34 @@ final readonly class CrmRequestHandler
 
     /**
      * @param class-string $dtoClass
+     * @param list<string>|string|null $validationGroups
      */
-    public function mapAndValidate(array $payload, string $dtoClass): mixed
+    public function mapAndValidate(
+        array $payload,
+        string $dtoClass,
+        array|string|null $validationGroups = null,
+        string $mapperMethod = 'fromArray',
+    ): mixed
     {
-        if (!method_exists($dtoClass, 'fromArray')) {
-            throw new \InvalidArgumentException(sprintf('DTO class "%s" must implement static fromArray(array $payload): self.', $dtoClass));
+        if (!method_exists($dtoClass, $mapperMethod)) {
+            throw new \InvalidArgumentException(sprintf(
+                'DTO class "%s" must implement static %s(array $payload): self.',
+                $dtoClass,
+                $mapperMethod,
+            ));
         }
 
-        $input = $dtoClass::fromArray($payload);
-        $violations = $this->validator->validate($input);
+        $input = $dtoClass::{$mapperMethod}($payload);
+        $violations = $this->validator->validate($input, groups: $validationGroups);
         if ($violations->count() > 0) {
             return $this->errorResponseFactory->validationFailed($violations);
         }
 
         return $input;
+    }
+
+    public function parseNullableIso8601(?string $value, string $field): DateTimeImmutable|JsonResponse|null
+    {
+        return $this->crmDateParser->parseNullableIso8601($value, $field);
     }
 }


### PR DESCRIPTION
### Motivation
- Centraliser le parsing JSON, le mapping DTO, la validation et le parsing de date pour éviter du code de parsing/validation ad hoc dans les contrôleurs.
- Permettre la gestion de groupes de validation et de différents mappers (`fromArray` / `fromPutArray` / `fromPatchArray`) depuis un point unique.

### Description
- Étendu `CrmRequestHandler` pour accepter une dépendance `CrmDateParser`, exposer `decodeJson()`, `mapAndValidate()` avec paramètres `validationGroups` et `mapperMethod`, et ajouter `parseNullableIso8601()` qui délègue à `CrmDateParser`.
- Remplacé les blocs `json_decode(...)` + création DTO + `validator->validate(...)` par `CrmRequestHandler::decodeJson()` puis `CrmRequestHandler::mapAndValidate(...)` dans les contrôleurs CRUD suivants : `Company/CreateCompanyByApplicationController`, `Company/PutCompanyController`, `Company/PatchCompanyController`, `Contact/CreateContactController`, `Contact/PutContactController`, `Billing/CreateBillingController`, `Billing/PutBillingController`, et `TaskRequest/CreateTaskRequestController`.
- Ajout de l’utilisation explicite du mapper et des groupes pour les opérations `PUT`/`PATCH` sur `UpdateCompanyRequest` (ex. `fromPutArray` + groupes `['Default', 'put']`, `fromPatchArray`).
- Standardisé le parsing des dates ISO8601 en remplaçant les conversions manuelles par `CrmRequestHandler::parseNullableIso8601()` / `CrmDateParser::parseNullableIso8601()` dans les contrôleurs de facturation et de demandes de tâche.

### Testing
- Vérification syntaxique PHP lancée sur tous les fichiers modifiés avec `php -l` (tous les fichiers modifiés sont passés sans erreur).
- Exécution de `vendor/bin/phpunit tests/Unit/ExampleTest.php` impossible dans cet environnement car `vendor/bin/phpunit` est indisponible (test non exécuté).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b803a1c4b4832b8c638913435c2809)