### PR TITLE
Refactor CRM reporting to typed DTOs with dynamic KPIs and export service

### DIFF
--- a/src/Crm/Application/Dto/Report/CrmRecommendedActionDto.php
+++ b/src/Crm/Application/Dto/Report/CrmRecommendedActionDto.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Dto\Report;
+
+final readonly class CrmRecommendedActionDto
+{
+    public function __construct(
+        public string $priority,
+        public string $title,
+        public string $owner,
+        public int $etaDays,
+    ) {
+    }
+
+    /**
+     * @return array{priority:string,title:string,owner:string,etaDays:int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'priority' => $this->priority,
+            'title' => $this->title,
+            'owner' => $this->owner,
+            'etaDays' => $this->etaDays,
+        ];
+    }
+}

--- a/src/Crm/Application/Dto/Report/CrmReportContactDto.php
+++ b/src/Crm/Application/Dto/Report/CrmReportContactDto.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Dto\Report;
+
+final readonly class CrmReportContactDto
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public ?string $email,
+        public ?string $jobTitle,
+        public ?string $city,
+        public int $score,
+    ) {
+    }
+
+    /**
+     * @return array{id:string,name:string,email:?string,jobTitle:?string,city:?string,score:int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'jobTitle' => $this->jobTitle,
+            'city' => $this->city,
+            'score' => $this->score,
+        ];
+    }
+}

--- a/src/Crm/Application/Dto/Report/CrmReportCountsDto.php
+++ b/src/Crm/Application/Dto/Report/CrmReportCountsDto.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Dto\Report;
+
+final readonly class CrmReportCountsDto
+{
+    public function __construct(
+        public int $companies,
+        public int $contacts,
+        public int $employees,
+        public int $billings,
+        public int $tasks,
+    ) {
+    }
+
+    /**
+     * @return array<string,int>
+     */
+    public function toArray(): array
+    {
+        return [
+            'companies' => $this->companies,
+            'contacts' => $this->contacts,
+            'employees' => $this->employees,
+            'billings' => $this->billings,
+            'tasks' => $this->tasks,
+        ];
+    }
+}

--- a/src/Crm/Application/Dto/Report/CrmReportDto.php
+++ b/src/Crm/Application/Dto/Report/CrmReportDto.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Dto\Report;
+
+final readonly class CrmReportDto
+{
+    /**
+     * @param list<CrmReportContactDto> $contacts
+     * @param list<CrmRecommendedActionDto> $recommendedActions
+     */
+    public function __construct(
+        public CrmReportMetadataDto $metadata,
+        public CrmReportKpisDto $kpis,
+        public CrmReportCountsDto $counts,
+        public array $contacts,
+        public array $recommendedActions,
+    ) {
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'metadata' => $this->metadata->toArray(),
+            'kpis' => $this->kpis->toArray(),
+            'counts' => $this->counts->toArray(),
+            'contacts' => array_map(static fn (CrmReportContactDto $contact) => $contact->toArray(), $this->contacts),
+            'recommendedActions' => array_map(static fn (CrmRecommendedActionDto $action) => $action->toArray(), $this->recommendedActions),
+        ];
+    }
+}

--- a/src/Crm/Application/Dto/Report/CrmReportKpisDto.php
+++ b/src/Crm/Application/Dto/Report/CrmReportKpisDto.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Dto\Report;
+
+final readonly class CrmReportKpisDto
+{
+    public function __construct(
+        public float $pipeline,
+        public int $dealsWon,
+        public int $cycleDays,
+        public int $npsClients,
+    ) {
+    }
+
+    /**
+     * @return array<string,int|float>
+     */
+    public function toArray(): array
+    {
+        return [
+            'pipeline' => $this->pipeline,
+            'dealsWon' => $this->dealsWon,
+            'cycleDays' => $this->cycleDays,
+            'npsClients' => $this->npsClients,
+        ];
+    }
+}

--- a/src/Crm/Application/Dto/Report/CrmReportMetadataDto.php
+++ b/src/Crm/Application/Dto/Report/CrmReportMetadataDto.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Dto\Report;
+
+final readonly class CrmReportMetadataDto
+{
+    public function __construct(
+        public string $period,
+        public string $timezone,
+        public string $generatedAt,
+        public string $version,
+    ) {
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function toArray(): array
+    {
+        return [
+            'period' => $this->period,
+            'timezone' => $this->timezone,
+            'generatedAt' => $this->generatedAt,
+            'version' => $this->version,
+        ];
+    }
+}

--- a/src/Crm/Application/Service/CrmReportService.php
+++ b/src/Crm/Application/Service/CrmReportService.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace App\Crm\Application\Service;
 
+use App\Crm\Application\Dto\Report\CrmRecommendedActionDto;
+use App\Crm\Application\Dto\Report\CrmReportContactDto;
+use App\Crm\Application\Dto\Report\CrmReportCountsDto;
+use App\Crm\Application\Dto\Report\CrmReportDto;
+use App\Crm\Application\Dto\Report\CrmReportKpisDto;
+use App\Crm\Application\Dto\Report\CrmReportMetadataDto;
 use App\Crm\Domain\Entity\Crm;
 use App\Crm\Infrastructure\Repository\BillingRepository;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
@@ -26,83 +32,97 @@ final readonly class CrmReportService
     ) {
     }
 
-    /**
-     * @return array<string,mixed>
-     */
-    public function build(Crm $crm): array
+    public function build(Crm $crm): CrmReportDto
     {
         $companies = $this->companyRepository->findScoped($crm->getId(), 100, 0);
         $contacts = $this->contactRepository->findScoped($crm->getId(), 200, 0);
         $employees = $this->employeeRepository->findScoped($crm->getId(), 200, 0);
         $billings = $this->billingRepository->findByCrm($crm->getId(), 200, 0);
+        $projects = $this->projectRepository->findScoped($crm->getId(), 200, 0);
 
         $totalBilling = 0.0;
         foreach ($billings as $billing) {
             $totalBilling += $billing->getAmount();
         }
 
-        return [
-            'kpis' => [
-                'pipeline' => round($totalBilling, 2),
-                'dealsWon' => $this->projectRepository->countProjectsByCrm($crm->getId()),
-                'cycleDays' => 23,
-                'npsClients' => 68,
-            ],
-            'counts' => [
-                'companies' => count($companies),
-                'contacts' => count($contacts),
-                'employees' => count($employees),
-                'billings' => count($billings),
-                'tasks' => $this->taskRepository->countTasksByCrm($crm->getId()),
-            ],
-            'contacts' => array_map(static fn ($c) => [
-                'id' => $c->getId(),
-                'name' => trim($c->getFirstName() . ' ' . $c->getLastName()),
-                'email' => $c->getEmail(),
-                'jobTitle' => $c->getJobTitle(),
-                'city' => $c->getCity(),
-                'score' => $c->getScore(),
-            ], $contacts),
-            'recommendedActions' => [
-                [
-                    'priority' => 'P0',
-                    'title' => 'Automatiser séquences email',
-                    'owner' => 'RevOps',
-                    'etaDays' => 5,
-                ],
-                [
-                    'priority' => 'P1',
-                    'title' => 'Rapports forecast avancés',
-                    'owner' => 'Finance',
-                    'etaDays' => 8,
-                ],
-                [
-                    'priority' => 'P1',
-                    'title' => 'Vue 360 contacts',
-                    'owner' => 'Sales',
-                    'etaDays' => 6,
-                ],
-            ],
-        ];
+        $averageContactScore = 0.0;
+        if ($contacts !== []) {
+            $scoreSum = 0;
+            foreach ($contacts as $contact) {
+                $scoreSum += $contact->getScore();
+            }
+            $averageContactScore = $scoreSum / count($contacts);
+        }
+
+        $cycleDays = 0;
+        if ($projects !== []) {
+            $totalCycleDays = 0;
+            $projectCount = 0;
+            foreach ($projects as $project) {
+                $startedAt = $project->getStartedAt();
+                $dueAt = $project->getDueAt();
+                if ($startedAt === null || $dueAt === null) {
+                    continue;
+                }
+                $days = (int)$startedAt->diff($dueAt)->format('%a');
+                $totalCycleDays += $days;
+                ++$projectCount;
+            }
+
+            if ($projectCount > 0) {
+                $cycleDays = (int)round($totalCycleDays / $projectCount);
+            }
+        }
+
+        $counts = new CrmReportCountsDto(
+            companies: count($companies),
+            contacts: count($contacts),
+            employees: count($employees),
+            billings: count($billings),
+            tasks: $this->taskRepository->countTasksByCrm($crm->getId()),
+        );
+
+        return new CrmReportDto(
+            metadata: new CrmReportMetadataDto(
+                period: 'rolling-30d',
+                timezone: 'UTC',
+                generatedAt: (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format(\DateTimeInterface::ATOM),
+                version: 'v1',
+            ),
+            kpis: new CrmReportKpisDto(
+                pipeline: round($totalBilling, 2),
+                dealsWon: $this->projectRepository->countProjectsByCrm($crm->getId()),
+                cycleDays: $cycleDays,
+                npsClients: (int)round(max(0.0, min(100.0, $averageContactScore))),
+            ),
+            counts: $counts,
+            contacts: array_map(static fn ($c) => new CrmReportContactDto(
+                id: $c->getId(),
+                name: trim($c->getFirstName() . ' ' . $c->getLastName()),
+                email: $c->getEmail(),
+                jobTitle: $c->getJobTitle(),
+                city: $c->getCity(),
+                score: $c->getScore(),
+            ), $contacts),
+            recommendedActions: $this->buildRecommendedActions($counts),
+        );
     }
 
-    /**
-     * @param array<string,mixed> $report
-     */
-    public function toCsv(array $report): string
+    public function toCsv(CrmReportDto $report): string
     {
+        $reportData = $report->toArray();
         $h = fopen('php://temp', 'r+');
         if ($h === false) {
             return '';
         }
         fputcsv($h, ['section', 'metric', 'value']);
-        foreach (($report['kpis'] ?? []) as $metric => $value) {
+        foreach (($reportData['kpis'] ?? []) as $metric => $value) {
             fputcsv($h, ['kpis', (string)$metric, (string)$value]);
         }
-        foreach (($report['counts'] ?? []) as $metric => $value) {
+        foreach (($reportData['counts'] ?? []) as $metric => $value) {
             fputcsv($h, ['counts', (string)$metric, (string)$value]);
         }
-        foreach (($report['contacts'] ?? []) as $contact) {
+        foreach (($reportData['contacts'] ?? []) as $contact) {
             fputcsv($h, ['contact', (string)($contact['name'] ?? ''), (string)($contact['score'] ?? 0)]);
         }
         rewind($h);
@@ -111,14 +131,25 @@ final readonly class CrmReportService
     }
 
     /**
-     * @param array<string,mixed> $report
+     * @return list<CrmRecommendedActionDto>
      */
-    public function toPdf(array $report): string
+    private function buildRecommendedActions(CrmReportCountsDto $counts): array
     {
-        $text = 'CRM REPORT\nPipeline: ' . ($report['kpis']['pipeline'] ?? 0) . '\nDeals: ' . ($report['kpis']['dealsWon'] ?? 0);
-        $stream = 'BT /F1 18 Tf 40 760 Td (' . str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $text) . ') Tj ET';
-        $len = strlen($stream);
+        $actions = [];
+        if ($counts->tasks > 50) {
+            $actions[] = new CrmRecommendedActionDto('P0', 'Réduire le backlog des tâches', 'Delivery', 7);
+        }
+        if ($counts->contacts > 0 && $counts->companies > 0 && ($counts->contacts / max($counts->companies, 1)) < 2.0) {
+            $actions[] = new CrmRecommendedActionDto('P1', 'Enrichir les contacts par entreprise', 'Sales', 10);
+        }
+        if ($counts->billings > 0) {
+            $actions[] = new CrmRecommendedActionDto('P1', 'Suivre les factures en retard', 'Finance', 5);
+        }
 
-        return "%PDF-1.4\n1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj\n4 0 obj << /Length {$len} >> stream\n{$stream}\nendstream endobj\n5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj\nxref\n0 6\n0000000000 65535 f \n0000000010 00000 n \n0000000060 00000 n \n0000000117 00000 n \n0000000243 00000 n \n0000000365 00000 n \ntrailer << /Size 6 /Root 1 0 R >>\nstartxref\n435\n%%EOF";
+        if ($actions === []) {
+            $actions[] = new CrmRecommendedActionDto('P2', 'Maintenir la cadence de suivi CRM', 'RevOps', 14);
+        }
+
+        return $actions;
     }
 }

--- a/src/Crm/Application/Service/Report/CrmReportPdfExporter.php
+++ b/src/Crm/Application/Service/Report/CrmReportPdfExporter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service\Report;
+
+use App\Crm\Application\Dto\Report\CrmReportDto;
+
+final class CrmReportPdfExporter
+{
+    public function export(CrmReportDto $report): string
+    {
+        $reportData = $report->toArray();
+        $text = 'CRM REPORT\nPipeline: ' . ($reportData['kpis']['pipeline'] ?? 0) . '\nDeals: ' . ($reportData['kpis']['dealsWon'] ?? 0);
+        $stream = 'BT /F1 18 Tf 40 760 Td (' . str_replace(['\\', '(', ')'], ['\\\\', '\\(', '\\)'], $text) . ') Tj ET';
+        $len = strlen($stream);
+
+        return "%PDF-1.4\n1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj\n4 0 obj << /Length {$len} >> stream\n{$stream}\nendstream endobj\n5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj\nxref\n0 6\n0000000000 65535 f \n0000000010 00000 n \n0000000060 00000 n \n0000000117 00000 n \n0000000243 00000 n \n0000000365 00000 n \ntrailer << /Size 6 /Root 1 0 R >>\nstartxref\n435\n%%EOF";
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Report/ReportsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Report/ReportsController.php
@@ -6,6 +6,7 @@ namespace App\Crm\Transport\Controller\Api\V1\Report;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Application\Service\CrmReportService;
+use App\Crm\Application\Service\Report\CrmReportPdfExporter;
 use App\Role\Domain\Enum\Role;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\HeaderUtils;
@@ -24,6 +25,7 @@ final readonly class ReportsController
     public function __construct(
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmReportService $crmReportService,
+        private CrmReportPdfExporter $pdfExporter,
     ) {
     }
 
@@ -42,12 +44,19 @@ final readonly class ReportsController
         }
 
         if ($format === 'pdf') {
-            return new Response($this->crmReportService->toPdf($report), 200, [
+            return new Response($this->pdfExporter->export($report), 200, [
                 'Content-Type' => 'application/pdf',
                 'Content-Disposition' => HeaderUtils::makeDisposition(HeaderUtils::DISPOSITION_ATTACHMENT, sprintf('crm-report-%s.pdf', $applicationSlug)),
             ]);
         }
 
-        return new JsonResponse($report);
+        if ($format !== 'json') {
+            return new JsonResponse([
+                'message' => sprintf('Unsupported report format "%s".', $format),
+                'supportedFormats' => ['json', 'csv', 'pdf'],
+            ], JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        return new JsonResponse($report->toArray());
     }
 }

--- a/tests/Unit/Crm/Application/Service/CrmReportServiceTest.php
+++ b/tests/Unit/Crm/Application/Service/CrmReportServiceTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Crm\Application\Service;
+
+use App\Crm\Application\Dto\Report\CrmReportContactDto;
+use App\Crm\Application\Dto\Report\CrmReportCountsDto;
+use App\Crm\Application\Dto\Report\CrmReportDto;
+use App\Crm\Application\Dto\Report\CrmReportKpisDto;
+use App\Crm\Application\Dto\Report\CrmReportMetadataDto;
+use App\Crm\Application\Dto\Report\CrmRecommendedActionDto;
+use App\Crm\Application\Service\CrmReportService;
+use App\Crm\Application\Service\Report\CrmReportPdfExporter;
+use App\Crm\Domain\Entity\Billing;
+use App\Crm\Domain\Entity\Company;
+use App\Crm\Domain\Entity\Contact;
+use App\Crm\Domain\Entity\Crm;
+use App\Crm\Domain\Entity\Employee;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Infrastructure\Repository\BillingRepository;
+use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\Crm\Infrastructure\Repository\ContactRepository;
+use App\Crm\Infrastructure\Repository\EmployeeRepository;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use DateTimeImmutable;
+use PHPUnit\Framework\TestCase;
+
+final class CrmReportServiceTest extends TestCase
+{
+    public function testBuildComputesKpisFromRepositoryData(): void
+    {
+        $companyRepository = $this->createMock(CompanyRepository::class);
+        $contactRepository = $this->createMock(ContactRepository::class);
+        $employeeRepository = $this->createMock(EmployeeRepository::class);
+        $billingRepository = $this->createMock(BillingRepository::class);
+        $projectRepository = $this->createMock(ProjectRepository::class);
+        $taskRepository = $this->createMock(TaskRepository::class);
+
+        $crm = $this->createMock(Crm::class);
+        $crm->method('getId')->willReturn('crm-1');
+
+        $companyRepository->method('findScoped')->willReturn([$this->createMock(Company::class)]);
+
+        $contactA = $this->createMock(Contact::class);
+        $contactA->method('getId')->willReturn('c-1');
+        $contactA->method('getFirstName')->willReturn('Alice');
+        $contactA->method('getLastName')->willReturn('Doe');
+        $contactA->method('getEmail')->willReturn('alice@example.test');
+        $contactA->method('getJobTitle')->willReturn('VP Sales');
+        $contactA->method('getCity')->willReturn('Paris');
+        $contactA->method('getScore')->willReturn(50);
+
+        $contactB = $this->createMock(Contact::class);
+        $contactB->method('getId')->willReturn('c-2');
+        $contactB->method('getFirstName')->willReturn('Bob');
+        $contactB->method('getLastName')->willReturn('Doe');
+        $contactB->method('getEmail')->willReturn('bob@example.test');
+        $contactB->method('getJobTitle')->willReturn('CTO');
+        $contactB->method('getCity')->willReturn('Lyon');
+        $contactB->method('getScore')->willReturn(80);
+        $contactRepository->method('findScoped')->willReturn([$contactA, $contactB]);
+
+        $employeeRepository->method('findScoped')->willReturn([$this->createMock(Employee::class)]);
+
+        $billingA = $this->createMock(Billing::class);
+        $billingA->method('getAmount')->willReturn(100.25);
+        $billingB = $this->createMock(Billing::class);
+        $billingB->method('getAmount')->willReturn(49.75);
+        $billingRepository->method('findByCrm')->willReturn([$billingA, $billingB]);
+
+        $projectA = $this->createMock(Project::class);
+        $projectA->method('getStartedAt')->willReturn(new DateTimeImmutable('2024-01-01'));
+        $projectA->method('getDueAt')->willReturn(new DateTimeImmutable('2024-01-11'));
+        $projectB = $this->createMock(Project::class);
+        $projectB->method('getStartedAt')->willReturn(new DateTimeImmutable('2024-02-01'));
+        $projectB->method('getDueAt')->willReturn(new DateTimeImmutable('2024-02-21'));
+        $projectRepository->method('findScoped')->willReturn([$projectA, $projectB]);
+        $projectRepository->method('countProjectsByCrm')->willReturn(2);
+
+        $taskRepository->method('countTasksByCrm')->willReturn(60);
+
+        $service = new CrmReportService(
+            $companyRepository,
+            $contactRepository,
+            $employeeRepository,
+            $billingRepository,
+            $projectRepository,
+            $taskRepository,
+        );
+
+        $report = $service->build($crm)->toArray();
+
+        self::assertSame(150.0, $report['kpis']['pipeline']);
+        self::assertSame(2, $report['kpis']['dealsWon']);
+        self::assertSame(15, $report['kpis']['cycleDays']);
+        self::assertSame(65, $report['kpis']['npsClients']);
+        self::assertSame('rolling-30d', $report['metadata']['period']);
+        self::assertCount(2, $report['recommendedActions']);
+    }
+
+    public function testCsvSnapshotMinimal(): void
+    {
+        $service = new CrmReportService(
+            $this->createMock(CompanyRepository::class),
+            $this->createMock(ContactRepository::class),
+            $this->createMock(EmployeeRepository::class),
+            $this->createMock(BillingRepository::class),
+            $this->createMock(ProjectRepository::class),
+            $this->createMock(TaskRepository::class),
+        );
+
+        $report = new CrmReportDto(
+            new CrmReportMetadataDto('rolling-30d', 'UTC', '2024-05-01T00:00:00+00:00', 'v1'),
+            new CrmReportKpisDto(1200.5, 6, 14, 71),
+            new CrmReportCountsDto(5, 10, 3, 4, 8),
+            [new CrmReportContactDto('id-1', 'Alice Doe', 'alice@example.test', 'VP', 'Paris', 70)],
+            [new CrmRecommendedActionDto('P1', 'Action', 'RevOps', 5)],
+        );
+
+        $csv = $service->toCsv($report);
+
+        self::assertSame(
+            "section,metric,value\n"
+            . "kpis,pipeline,1200.5\n"
+            . "kpis,dealsWon,6\n"
+            . "kpis,cycleDays,14\n"
+            . "kpis,npsClients,71\n"
+            . "counts,companies,5\n"
+            . "counts,contacts,10\n"
+            . "counts,employees,3\n"
+            . "counts,billings,4\n"
+            . "counts,tasks,8\n"
+            . "contact," . '"Alice Doe"' . ",70\n",
+            $csv,
+        );
+    }
+
+    public function testPdfSnapshotMinimal(): void
+    {
+        $exporter = new CrmReportPdfExporter();
+        $report = new CrmReportDto(
+            new CrmReportMetadataDto('rolling-30d', 'UTC', '2024-05-01T00:00:00+00:00', 'v1'),
+            new CrmReportKpisDto(123.45, 3, 9, 55),
+            new CrmReportCountsDto(1, 1, 1, 1, 1),
+            [],
+            [],
+        );
+
+        $pdf = $exporter->export($report);
+
+        self::assertStringStartsWith('%PDF-1.4', $pdf);
+        self::assertStringContainsString('CRM REPORT\\nPipeline: 123.45\\nDeals: 3', $pdf);
+        self::assertStringContainsString('%%EOF', $pdf);
+    }
+}

--- a/tests/Unit/Crm/Transport/Controller/Api/V1/Report/ReportsControllerTest.php
+++ b/tests/Unit/Crm/Transport/Controller/Api/V1/Report/ReportsControllerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Crm\Transport\Controller\Api\V1\Report;
+
+use App\Crm\Application\Dto\Report\CrmReportCountsDto;
+use App\Crm\Application\Dto\Report\CrmReportDto;
+use App\Crm\Application\Dto\Report\CrmReportKpisDto;
+use App\Crm\Application\Dto\Report\CrmReportMetadataDto;
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReportService;
+use App\Crm\Application\Service\Report\CrmReportPdfExporter;
+use App\Crm\Domain\Entity\Crm;
+use App\Crm\Transport\Controller\Api\V1\Report\ReportsController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ReportsControllerTest extends TestCase
+{
+    public function testUnsupportedFormatReturns400(): void
+    {
+        $scopeResolver = $this->createMock(CrmApplicationScopeResolver::class);
+        $reportService = $this->createMock(CrmReportService::class);
+        $pdfExporter = $this->createMock(CrmReportPdfExporter::class);
+        $crm = $this->createMock(Crm::class);
+
+        $scopeResolver->method('resolveOrFail')->willReturn($crm);
+        $reportService->method('build')->willReturn(new CrmReportDto(
+            new CrmReportMetadataDto('rolling-30d', 'UTC', '2024-05-01T00:00:00+00:00', 'v1'),
+            new CrmReportKpisDto(1.0, 1, 1, 1),
+            new CrmReportCountsDto(1, 1, 1, 1, 1),
+            [],
+            [],
+        ));
+
+        $controller = new ReportsController($scopeResolver, $reportService, $pdfExporter);
+        $response = $controller->__invoke('app', new Request(['format' => 'xml']));
+
+        self::assertSame(JsonResponse::HTTP_BAD_REQUEST, $response->getStatusCode());
+    }
+
+    public function testJsonPayloadIncludesMetadata(): void
+    {
+        $scopeResolver = $this->createMock(CrmApplicationScopeResolver::class);
+        $reportService = $this->createMock(CrmReportService::class);
+        $pdfExporter = $this->createMock(CrmReportPdfExporter::class);
+        $crm = $this->createMock(Crm::class);
+
+        $scopeResolver->method('resolveOrFail')->willReturn($crm);
+        $reportService->method('build')->willReturn(new CrmReportDto(
+            new CrmReportMetadataDto('rolling-30d', 'UTC', '2024-05-01T00:00:00+00:00', 'v1'),
+            new CrmReportKpisDto(1.0, 1, 1, 1),
+            new CrmReportCountsDto(1, 1, 1, 1, 1),
+            [],
+            [],
+        ));
+
+        $controller = new ReportsController($scopeResolver, $reportService, $pdfExporter);
+        $response = $controller->__invoke('app', new Request());
+        $payload = json_decode((string)$response->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('rolling-30d', $payload['metadata']['period']);
+        self::assertSame('UTC', $payload['metadata']['timezone']);
+        self::assertSame('v1', $payload['metadata']['version']);
+    }
+}


### PR DESCRIPTION
### Motivation
- Remove hardcoded KPIs and recommended actions so report values reflect real repository data and are easier to evolve. 
- Introduce typed output objects to version and validate report payloads instead of untyped arrays. 
- Extract PDF generation to a dedicated exporter to separate concerns and allow easier integration with other renderers. 
- Make API behavior explicit for unsupported formats and add report metadata for observability/versioning.

### Description
- Compute KPIs from repositories in `CrmReportService::build` (pipeline, `dealsWon`, `cycleDays`, `npsClients`) and generate `recommendedActions` from counts instead of hardcoded values. 
- Add typed DTOs under `src/Crm/Application/Dto/Report`: `CrmReportDto`, `CrmReportMetadataDto`, `CrmReportKpisDto`, `CrmReportCountsDto`, `CrmReportContactDto`, and `CrmRecommendedActionDto`, each exposing `toArray()` for serialization. 
- Replace in-service PDF string builder with `CrmReportPdfExporter` (`src/Crm/Application/Service/Report/CrmReportPdfExporter.php`) and update controller to use it. 
- Update `ReportsController` to return a `400 Bad Request` for unsupported `format` values and to return JSON via the report DTO including `metadata` (period, timezone, generatedAt, version). 
- Update `toCsv` to accept a `CrmReportDto` and produce the CSV snapshot from `toArray()`. 
- Add unit tests: `tests/Unit/Crm/Application/Service/CrmReportServiceTest.php` and `tests/Unit/Crm/Transport/Controller/Api/V1/Report/ReportsControllerTest.php` covering KPI consistency, minimal CSV/PDF snapshots, unsupported format handling and metadata presence.

### Testing
- Static syntax checks passed with `php -l` for all modified and new files (sources and tests). 
- Unit tests were added at `tests/Unit/Crm/Application/Service/CrmReportServiceTest.php` and `tests/Unit/Crm/Transport/Controller/Api/V1/Report/ReportsControllerTest.php` but full PHPUnit run could not be executed in this environment because `vendor/bin/phpunit` (and `bin/phpunit`) is not available. 
- The new files and tests are syntactically valid and ready for CI to run the full test suite once dependencies (`vendor`) are installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8050bf5b8832ba8950ab6ef53786a)