### PR TITLE
test(crm): add prioritized CRM matrix and targeted unit tests

### DIFF
--- a/tests/Application/Crm/CrmPrioritizedMatrixTest.php
+++ b/tests/Application/Crm/CrmPrioritizedMatrixTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Crm;
+
+use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\Crm\Infrastructure\Repository\CrmRepository;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CrmPrioritizedMatrixTest extends WebTestCase
+{
+    private const string PRIMARY_APPLICATION_SLUG = 'crm-sales-hub';
+    private const string FOREIGN_APPLICATION_SLUG = 'crm-pipeline-pro';
+
+    public function testPriorityP0CrossTenantScopeIsStrictOnCreateAndDelete(): void
+    {
+        $foreign = $this->getForeignScopeIds();
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/projects', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode(['name' => 'Cross tenant matrix', 'companyId' => $foreign['companyId']])
+        );
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+
+        $client->request(
+            'DELETE',
+            sprintf('%s/v1/crm/applications/%s/tasks/%s', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG, $foreign['taskId'])
+        );
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+    }
+
+    public function testPriorityP0AclReadVsWriteEndpoints(): void
+    {
+        $readClient = $this->getTestClient('john-crm_viewer', 'password-crm_viewer');
+        $readClient->request('GET', sprintf('%s/v1/crm/applications/%s/tasks', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG));
+        self::assertSame(Response::HTTP_OK, $readClient->getResponse()->getStatusCode());
+
+        $writeClient = $this->getTestClient('john-crm_viewer', 'password-crm_viewer');
+        $writeClient->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/tasks', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode(['title' => 'ACL matrix task', 'projectId' => '00000000-0000-0000-0000-000000000000'])
+        );
+        self::assertSame(Response::HTTP_FORBIDDEN, $writeClient->getResponse()->getStatusCode());
+
+        $managerClient = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $managerClient->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/tasks', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode(['title' => 'ACL matrix task', 'projectId' => '00000000-0000-0000-0000-000000000000'])
+        );
+        self::assertSame(Response::HTTP_NOT_FOUND, $managerClient->getResponse()->getStatusCode());
+    }
+
+    public function testPriorityP1DtoValidationMatrixOnCreateAndPatch(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/companies', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: '{"name":'
+        );
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/companies', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode(['name' => ''])
+        );
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+
+        $client->request(
+            'PATCH',
+            sprintf('%s/v1/crm/applications/%s/companies/%s', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG, '00000000-0000-0000-0000-000000000000'),
+            content: JSON::encode(['name' => 'Updated'])
+        );
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+    }
+
+    public function testPriorityP1TaskListServicePaginationFilteringNonRegression(): void
+    {
+        $companyId = $this->createCompany();
+        $projectId = $this->createProject($companyId);
+        $taskTitle = 'P1 matrix ' . uniqid('', true);
+        $taskId = $this->createTask($projectId, $taskTitle);
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            'GET',
+            sprintf('%s/v1/crm/applications/%s/tasks?page=1&limit=5&title=%s', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG, urlencode($taskTitle))
+        );
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        self::assertCount(1, $payload['items']);
+        self::assertSame($taskId, $payload['items'][0]['id'] ?? null);
+        self::assertSame(1, $payload['pagination']['totalItems'] ?? null);
+        self::assertSame(1, $payload['pagination']['totalPages'] ?? null);
+    }
+
+    /**
+     * @return array{companyId:string,projectId:string,sprintId:string,taskId:string,taskRequestId:string}
+     */
+    private function getForeignScopeIds(): array
+    {
+        static::bootKernel();
+
+        $container = static::getContainer();
+        $crmRepository = $container->get(CrmRepository::class);
+        $companyRepository = $container->get(CompanyRepository::class);
+        $projectRepository = $container->get(ProjectRepository::class);
+        $taskRepository = $container->get(TaskRepository::class);
+
+        $crm = $crmRepository->findOneByApplicationSlug(self::FOREIGN_APPLICATION_SLUG);
+        self::assertNotNull($crm);
+
+        $company = $companyRepository->findScoped($crm->getId(), 1)[0] ?? null;
+        self::assertNotNull($company);
+
+        $project = $projectRepository->findScoped($crm->getId(), 1)[0] ?? null;
+        self::assertNotNull($project);
+
+        $task = $taskRepository->findScoped($crm->getId(), 1)[0] ?? null;
+        self::assertNotNull($task);
+
+        $sprint = $task->getSprint();
+        self::assertNotNull($sprint);
+
+        $taskRequest = $task->getTaskRequests()->first();
+        self::assertInstanceOf(TaskRequest::class, $taskRequest);
+
+        return [
+            'companyId' => $company->getId(),
+            'projectId' => $project->getId(),
+            'sprintId' => $sprint->getId(),
+            'taskId' => $task->getId(),
+            'taskRequestId' => $taskRequest->getId(),
+        ];
+    }
+
+    private function createCompany(): string
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/companies', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode([
+                'name' => 'Matrix Company ' . uniqid('', true),
+                'contactEmail' => 'matrix.company@example.com',
+            ])
+        );
+
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function createProject(string $companyId): string
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/projects', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode([
+                'name' => 'Matrix Project ' . uniqid('', true),
+                'companyId' => $companyId,
+            ])
+        );
+
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function createTask(string $projectId, string $title): string
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/applications/%s/tasks', self::API_URL_PREFIX, self::PRIMARY_APPLICATION_SLUG),
+            content: JSON::encode([
+                'title' => $title,
+                'projectId' => $projectId,
+            ])
+        );
+
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    /** @return array<string, mixed> */
+    private function decodeJsonResponse(string|false $content): array
+    {
+        self::assertNotFalse($content);
+
+        $decoded = JSON::decode($content, true);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/tests/Unit/Crm/Application/Service/CreateTaskHandlerTest.php
+++ b/tests/Unit/Crm/Application/Service/CreateTaskHandlerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Crm\Application\Service;
+
+use App\Crm\Application\Exception\CrmOutOfScopeException;
+use App\Crm\Application\Exception\CrmReferenceNotFoundException;
+use App\Crm\Application\Service\CreateTaskHandler;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Crm\Transport\Request\CreateTaskRequest;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\TestCase;
+
+final class CreateTaskHandlerTest extends TestCase
+{
+    public function testHandleThrowsWhenProjectNotFoundInScope(): void
+    {
+        $projectRepository = $this->createMock(ProjectRepository::class);
+        $projectRepository->method('findOneScopedById')->willReturn(null);
+
+        $handler = new CreateTaskHandler($projectRepository, $this->createMock(SprintRepository::class), $this->createMock(EntityManagerInterface::class));
+        $request = CreateTaskRequest::fromArray(['title' => 'task', 'projectId' => 'p-1']);
+
+        $this->expectException(CrmReferenceNotFoundException::class);
+        $handler->handle($request, 'crm-1', null);
+    }
+
+    public function testHandleThrowsWhenSprintNotFoundInScope(): void
+    {
+        $project = $this->createMock(Project::class);
+        $projectRepository = $this->createMock(ProjectRepository::class);
+        $projectRepository->method('findOneScopedById')->willReturn($project);
+
+        $sprintRepository = $this->createMock(SprintRepository::class);
+        $sprintRepository->method('findOneScopedById')->willReturn(null);
+
+        $handler = new CreateTaskHandler($projectRepository, $sprintRepository, $this->createMock(EntityManagerInterface::class));
+        $request = CreateTaskRequest::fromArray(['title' => 'task', 'projectId' => 'p-1', 'sprintId' => 's-1']);
+
+        $this->expectException(CrmReferenceNotFoundException::class);
+        $handler->handle($request, 'crm-1', null);
+    }
+
+    public function testHandleThrowsWhenSprintDoesNotBelongToProject(): void
+    {
+        $project = $this->createMock(Project::class);
+        $project->method('getId')->willReturn('project-a');
+
+        $otherProject = $this->createMock(Project::class);
+        $otherProject->method('getId')->willReturn('project-b');
+
+        $sprint = $this->createMock(Sprint::class);
+        $sprint->method('getProject')->willReturn($otherProject);
+
+        $projectRepository = $this->createMock(ProjectRepository::class);
+        $projectRepository->method('findOneScopedById')->willReturn($project);
+
+        $sprintRepository = $this->createMock(SprintRepository::class);
+        $sprintRepository->method('findOneScopedById')->willReturn($sprint);
+
+        $handler = new CreateTaskHandler($projectRepository, $sprintRepository, $this->createMock(EntityManagerInterface::class));
+        $request = CreateTaskRequest::fromArray(['title' => 'task', 'projectId' => 'p-1', 'sprintId' => 's-1']);
+
+        $this->expectException(CrmOutOfScopeException::class);
+        $handler->handle($request, 'crm-1', null);
+    }
+
+    public function testHandleThrowsWhenAssigneeIsUnknown(): void
+    {
+        $project = $this->createMock(Project::class);
+
+        $projectRepository = $this->createMock(ProjectRepository::class);
+        $projectRepository->method('findOneScopedById')->willReturn($project);
+
+        $userRepository = $this->createMock(ObjectRepository::class);
+        $userRepository->method('find')->willReturn(null);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->with(User::class)->willReturn($userRepository);
+
+        $handler = new CreateTaskHandler($projectRepository, $this->createMock(SprintRepository::class), $entityManager);
+        $request = CreateTaskRequest::fromArray(['title' => 'task', 'projectId' => 'p-1', 'assigneeIds' => ['u-1']]);
+
+        $this->expectException(CrmReferenceNotFoundException::class);
+        $handler->handle($request, 'crm-1', null);
+    }
+}

--- a/tests/Unit/Crm/Application/Service/CrmReportServiceTest.php
+++ b/tests/Unit/Crm/Application/Service/CrmReportServiceTest.php
@@ -154,4 +154,49 @@ final class CrmReportServiceTest extends TestCase
         self::assertStringContainsString('CRM REPORT\\nPipeline: 123.45\\nDeals: 3', $pdf);
         self::assertStringContainsString('%%EOF', $pdf);
     }
+
+    public function testBuildClampsNpsAndProvidesFallbackActionWhenNoCountsTrigger(): void
+    {
+        $companyRepository = $this->createMock(CompanyRepository::class);
+        $contactRepository = $this->createMock(ContactRepository::class);
+        $employeeRepository = $this->createMock(EmployeeRepository::class);
+        $billingRepository = $this->createMock(BillingRepository::class);
+        $projectRepository = $this->createMock(ProjectRepository::class);
+        $taskRepository = $this->createMock(TaskRepository::class);
+
+        $crm = $this->createMock(Crm::class);
+        $crm->method('getId')->willReturn('crm-clamp');
+
+        $companyRepository->method('findScoped')->willReturn([]);
+        $employeeRepository->method('findScoped')->willReturn([]);
+        $billingRepository->method('findByCrm')->willReturn([]);
+        $projectRepository->method('findScoped')->willReturn([]);
+        $projectRepository->method('countProjectsByCrm')->willReturn(0);
+        $taskRepository->method('countTasksByCrm')->willReturn(0);
+
+        $contact = $this->createMock(Contact::class);
+        $contact->method('getId')->willReturn('contact-high-score');
+        $contact->method('getFirstName')->willReturn('Alice');
+        $contact->method('getLastName')->willReturn('High');
+        $contact->method('getEmail')->willReturn('alice.high@example.test');
+        $contact->method('getJobTitle')->willReturn('Head of CRM');
+        $contact->method('getCity')->willReturn('Paris');
+        $contact->method('getScore')->willReturn(999);
+        $contactRepository->method('findScoped')->willReturn([$contact]);
+
+        $service = new CrmReportService(
+            $companyRepository,
+            $contactRepository,
+            $employeeRepository,
+            $billingRepository,
+            $projectRepository,
+            $taskRepository,
+        );
+
+        $report = $service->build($crm)->toArray();
+
+        self::assertSame(100, $report['kpis']['npsClients']);
+        self::assertCount(1, $report['recommendedActions']);
+        self::assertSame('Maintenir la cadence de suivi CRM', $report['recommendedActions'][0]['title']);
+    }
 }

--- a/tests/Unit/Crm/Transport/Request/CrmRequestHandlerTest.php
+++ b/tests/Unit/Crm/Transport/Request/CrmRequestHandlerTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Crm\Transport\Request;
+
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmDateParser;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+final class CrmRequestHandlerTest extends TestCase
+{
+    public function testDecodeJsonReturnsErrorForInvalidPayload(): void
+    {
+        $handler = $this->buildHandler($this->createMock(ValidatorInterface::class));
+
+        $response = $handler->decodeJson(new Request(content: '{"invalid":'));
+
+        self::assertInstanceOf(JsonResponse::class, $response);
+        self::assertSame(JsonResponse::HTTP_BAD_REQUEST, $response->getStatusCode());
+    }
+
+    public function testMapAndValidateThrowsWhenMapperMethodDoesNotExist(): void
+    {
+        $handler = $this->buildHandler($this->createMock(ValidatorInterface::class));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $handler->mapAndValidate(['name' => 'x'], DummyDto::class, mapperMethod: 'missing');
+    }
+
+    public function testMapAndValidateReturnsValidationErrorResponseWhenViolationsExist(): void
+    {
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->method('validate')->willReturn(new ConstraintViolationList([
+            new ConstraintViolation('msg', null, [], null, 'name', null),
+        ]));
+
+        $handler = $this->buildHandler($validator);
+        $result = $handler->mapAndValidate(['name' => ''], DummyDto::class);
+
+        self::assertInstanceOf(JsonResponse::class, $result);
+        self::assertSame(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, $result->getStatusCode());
+    }
+
+    public function testMapAndValidateReturnsDtoWhenValidationPasses(): void
+    {
+        $validator = $this->createMock(ValidatorInterface::class);
+        $validator->method('validate')->willReturn(new ConstraintViolationList());
+
+        $handler = $this->buildHandler($validator);
+        $result = $handler->mapAndValidate(['name' => 'ok'], DummyDto::class);
+
+        self::assertInstanceOf(DummyDto::class, $result);
+        self::assertSame('ok', $result->name);
+    }
+
+    private function buildHandler(ValidatorInterface $validator): CrmRequestHandler
+    {
+        $errorFactory = new CrmApiErrorResponseFactory();
+
+        return new CrmRequestHandler($validator, $errorFactory, new CrmDateParser($errorFactory));
+    }
+}
+
+final class DummyDto
+{
+    public string $name = '';
+
+    public static function fromArray(array $payload): self
+    {
+        $dto = new self();
+        $dto->name = (string) ($payload['name'] ?? '');
+
+        return $dto;
+    }
+}


### PR DESCRIPTION
### Motivation

- Centralize high-priority acceptance checks for CRM flows (cross-tenant scope, ACL, DTO validation, pagination regression) into a single application-level matrix. 
- Provide targeted unit coverage for request handling, mutation error paths and KPI/reporting edge-cases to prevent regressions.
- Make the expected behavior explicit for cross-application scope checks and role-based read vs write restrictions.

### Description

- Add an application-level prioritized test matrix in `tests/Application/Crm/CrmPrioritizedMatrixTest.php` covering cross-tenant scope, ACL read/write, DTO 400/422/404 cases and a non-regression for `TaskListService` pagination/filtering. 
- Add unit tests for the request pipeline in `tests/Unit/Crm/Transport/Request/CrmRequestHandlerTest.php` covering invalid JSON, mapper-method guard, validation failure response and successful DTO mapping. 
- Add unit tests for mutation error handling in `tests/Unit/Crm/Application/Service/CreateTaskHandlerTest.php` covering missing references, out-of-scope sprint/project mismatch and missing assignee references. 
- Extend `CrmReportService` unit coverage in `tests/Unit/Crm/Application/Service/CrmReportServiceTest.php` with a test that clamps `npsClients` and verifies fallback recommended action behavior when no count-based triggers apply.

### Testing

- Syntax checks with `php -l` were executed on the touched test files (`tests/Application/Crm/CrmPrioritizedMatrixTest.php`, `tests/Unit/Crm/Transport/Request/CrmRequestHandlerTest.php`, `tests/Unit/Crm/Application/Service/CreateTaskHandlerTest.php`, and the updated `CrmReportService` test) and returned no syntax errors. 
- An attempt to run the targeted suites with `./vendor/bin/phpunit` failed because the local `vendor/bin/phpunit` binary is not present in this environment, so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b806915d20832b897e221dea68748b)