### PR TITLE
refactor(crm): centralize Contact/Project/Employee/TaskRequest GET reads in dedicated services

### DIFF
--- a/src/Crm/Application/Service/ContactReadService.php
+++ b/src/Crm/Application/Service/ContactReadService.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Infrastructure\Repository\ContactRepository;
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use JsonException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function ceil;
+use function max;
+use function method_exists;
+use function min;
+use function trim;
+
+readonly class ContactReadService
+{
+    public function __construct(
+        private ContactRepository $contactRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CacheInterface $cache,
+        private CacheKeyConventionService $cacheKeyConventionService,
+        private ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+    }
+
+    /** @return array<string,mixed> */
+    public function getList(string $applicationSlug, Request $request): array
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = ['q' => trim((string)$request->query->get('q', ''))];
+
+        $cacheKey = $this->cacheKeyConventionService->buildCrmContactListKey($applicationSlug, $page, $limit, $filters);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $page, $limit, $filters): array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->crmContactListTag($applicationSlug));
+            }
+
+            $esIds = $this->searchIdsFromElastic($filters['q']);
+            if ($esIds === []) {
+                return $this->emptyList($page, $limit, $filters);
+            }
+
+            $items = $this->contactRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, [
+                'q' => $esIds === null ? $filters['q'] : '',
+                'ids' => $esIds,
+            ]);
+            $totalItems = $this->contactRepository->countScopedByCrm($crm->getId(), [
+                'q' => $esIds === null ? $filters['q'] : '',
+                'ids' => $esIds,
+            ]);
+
+            return [
+                'items' => array_map(fn (array $item): array => $this->normalizeProjection($item), $items),
+                'pagination' => [
+                    'page' => $page,
+                    'limit' => $limit,
+                    'totalItems' => $totalItems,
+                    'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
+                ],
+                'meta' => [
+                    'filters' => array_filter($filters, static fn (string $value): bool => $value !== ''),
+                ],
+            ];
+        });
+    }
+
+    /** @return array<string,mixed>|null */
+    public function getDetail(string $applicationSlug, string $contactId): ?array
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $cacheKey = $this->cacheKeyConventionService->buildCrmContactDetailKey($applicationSlug, $contactId);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $contactId): ?array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag([
+                    $this->cacheKeyConventionService->crmContactListTag($applicationSlug),
+                    $this->cacheKeyConventionService->crmContactDetailTag($applicationSlug, $contactId),
+                ]);
+            }
+
+            $contact = $this->contactRepository->findOneScopedById($contactId, $crm->getId());
+            if ($contact === null) {
+                return null;
+            }
+
+            return [
+                'id' => $contact->getId(),
+                'companyId' => $contact->getCompany()?->getId(),
+                'firstName' => $contact->getFirstName(),
+                'lastName' => $contact->getLastName(),
+                'email' => $contact->getEmail(),
+                'phone' => $contact->getPhone(),
+                'jobTitle' => $contact->getJobTitle(),
+                'city' => $contact->getCity(),
+                'score' => $contact->getScore(),
+            ];
+        });
+    }
+
+    private function searchIdsFromElastic(string $query): ?array
+    {
+        if ($query === '') {
+            return null;
+        }
+
+        try {
+            $response = $this->elasticsearchService->search('crm_contacts', [
+                'query' => [
+                    'multi_match' => [
+                        'query' => $query,
+                        'type' => 'phrase_prefix',
+                        'fields' => ['firstName^3', 'lastName^3', 'email^2', 'phone', 'jobTitle', 'city'],
+                    ],
+                ],
+                '_source' => ['id'],
+            ], 0, 500);
+
+            $hits = $response['hits']['hits'] ?? [];
+            return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /** @param array<string,mixed> $item */
+    private function normalizeProjection(array $item): array
+    {
+        return [
+            'id' => (string)($item['id'] ?? ''),
+            'companyId' => $item['companyId'] ?? null,
+            'firstName' => (string)($item['firstName'] ?? ''),
+            'lastName' => (string)($item['lastName'] ?? ''),
+            'email' => (string)($item['email'] ?? ''),
+            'phone' => (string)($item['phone'] ?? ''),
+            'jobTitle' => (string)($item['jobTitle'] ?? ''),
+            'city' => (string)($item['city'] ?? ''),
+            'score' => isset($item['score']) ? (int)$item['score'] : null,
+        ];
+    }
+
+    /** @param array{q:string} $filters */
+    private function emptyList(int $page, int $limit, array $filters): array
+    {
+        return [
+            'items' => [],
+            'pagination' => ['page' => $page, 'limit' => $limit, 'totalItems' => 0, 'totalPages' => 0],
+            'meta' => ['filters' => array_filter($filters, static fn (string $value): bool => $value !== '')],
+        ];
+    }
+}

--- a/src/Crm/Application/Service/EmployeeReadService.php
+++ b/src/Crm/Application/Service/EmployeeReadService.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Infrastructure\Repository\EmployeeRepository;
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function ceil;
+use function max;
+use function method_exists;
+use function min;
+use function trim;
+
+readonly class EmployeeReadService
+{
+    public function __construct(
+        private EmployeeRepository $employeeRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CacheInterface $cache,
+        private CacheKeyConventionService $cacheKeyConventionService,
+        private ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+    }
+
+    public function getList(string $applicationSlug, Request $request): array
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = ['q' => trim((string)$request->query->get('q', ''))];
+
+        $cacheKey = $this->cacheKeyConventionService->buildCrmEmployeeListKey($applicationSlug, $page, $limit, $filters);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $page, $limit, $filters): array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->crmEmployeeListTag($applicationSlug));
+            }
+
+            $esIds = $this->searchIdsFromElastic($filters['q']);
+            if ($esIds === []) {
+                return $this->emptyList($page, $limit, $filters);
+            }
+
+            $effectiveFilters = ['q' => $esIds === null ? $filters['q'] : '', 'ids' => $esIds];
+            $items = $this->employeeRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $effectiveFilters);
+            $totalItems = $this->employeeRepository->countScopedByCrm($crm->getId(), $effectiveFilters);
+
+            return [
+                'items' => $items,
+                'pagination' => [
+                    'page' => $page,
+                    'limit' => $limit,
+                    'totalItems' => $totalItems,
+                    'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
+                ],
+                'meta' => ['filters' => array_filter($filters, static fn (string $value): bool => $value !== '')],
+            ];
+        });
+    }
+
+    public function getDetail(string $applicationSlug, string $employeeId): ?array
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $cacheKey = $this->cacheKeyConventionService->buildCrmEmployeeDetailKey($applicationSlug, $employeeId);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $employeeId): ?array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag([
+                    $this->cacheKeyConventionService->crmEmployeeListTag($applicationSlug),
+                    $this->cacheKeyConventionService->crmEmployeeDetailTag($applicationSlug, $employeeId),
+                ]);
+            }
+
+            $employee = $this->employeeRepository->findOneScopedById($employeeId, $crm->getId());
+            if ($employee === null) {
+                return null;
+            }
+
+            return [
+                'id' => $employee->getId(),
+                'firstName' => $employee->getFirstName(),
+                'lastName' => $employee->getLastName(),
+                'email' => $employee->getEmail(),
+                'userId' => $employee->getUserId(),
+                'positionName' => $employee->getPositionName(),
+                'photo' => $employee->getUser()->getPhoto(),
+                'roleName' => $employee->getRoleName(),
+                'createdAt' => $employee->getCreatedAt()->format(DATE_ATOM),
+                'updatedAt' => $employee->getUpdatedAt()->format(DATE_ATOM),
+            ];
+        });
+    }
+
+    private function searchIdsFromElastic(string $query): ?array
+    {
+        if ($query === '') {
+            return null;
+        }
+
+        try {
+            $response = $this->elasticsearchService->search('crm_employees', [
+                'query' => ['multi_match' => [
+                    'query' => $query,
+                    'type' => 'phrase_prefix',
+                    'fields' => ['firstName^3', 'lastName^3', 'email^2', 'positionName', 'roleName'],
+                ]],
+                '_source' => ['id'],
+            ], 0, 500);
+
+            $hits = $response['hits']['hits'] ?? [];
+            return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function emptyList(int $page, int $limit, array $filters): array
+    {
+        return [
+            'items' => [],
+            'pagination' => ['page' => $page, 'limit' => $limit, 'totalItems' => 0, 'totalPages' => 0],
+            'meta' => ['filters' => array_filter($filters, static fn (string $value): bool => $value !== '')],
+        ];
+    }
+}

--- a/src/Crm/Application/Service/ProjectReadService.php
+++ b/src/Crm/Application/Service/ProjectReadService.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function ceil;
+use function max;
+use function method_exists;
+use function min;
+use function trim;
+
+readonly class ProjectReadService
+{
+    public function __construct(
+        private ProjectRepository $projectRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CacheInterface $cache,
+        private CacheKeyConventionService $cacheKeyConventionService,
+        private ElasticsearchServiceInterface $elasticsearchService,
+        private CrmApiNormalizer $crmApiNormalizer,
+    ) {
+    }
+
+    public function getList(string $applicationSlug, Request $request): array
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'q' => trim((string)$request->query->get('q', '')),
+            'status' => trim((string)$request->query->get('status', '')),
+        ];
+
+        $cacheKey = $this->cacheKeyConventionService->buildCrmProjectListKey($applicationSlug, $page, $limit, $filters);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $page, $limit, $filters): array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->crmProjectListTag($applicationSlug));
+            }
+
+            $esIds = $this->searchIdsFromElastic($filters['q']);
+            if ($esIds === []) {
+                return $this->emptyList($page, $limit, $filters);
+            }
+
+            $effectiveFilters = [
+                'q' => $esIds === null ? $filters['q'] : '',
+                'status' => $filters['status'],
+                'ids' => $esIds,
+            ];
+
+            $items = $this->projectRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $effectiveFilters);
+            $totalItems = $this->projectRepository->countScopedByCrm($crm->getId(), $effectiveFilters);
+
+            return [
+                'items' => array_map(fn (array $item): array => $this->crmApiNormalizer->normalizeProjectProjection($item), $items),
+                'pagination' => [
+                    'page' => $page,
+                    'limit' => $limit,
+                    'totalItems' => $totalItems,
+                    'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
+                ],
+                'meta' => ['filters' => array_filter($filters, static fn (string $value): bool => $value !== '')],
+            ];
+        });
+    }
+
+    public function getDetail(string $applicationSlug, string $projectId): ?array
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $cacheKey = $this->cacheKeyConventionService->buildCrmProjectDetailKey($applicationSlug, $projectId);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $projectId): ?array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag([
+                    $this->cacheKeyConventionService->crmProjectListTag($applicationSlug),
+                    $this->cacheKeyConventionService->crmProjectDetailTag($applicationSlug, $projectId),
+                ]);
+            }
+
+            $project = $this->projectRepository->findOneScopedById($projectId, $crm->getId());
+            if ($project === null) {
+                return null;
+            }
+
+            return [
+                'id' => $project->getId(),
+                'companyId' => $project->getCompany()?->getId(),
+                'name' => $project->getName(),
+                'code' => $project->getCode(),
+                'description' => $project->getDescription(),
+                'status' => $project->getStatus()->value,
+                'startedAt' => $project->getStartedAt()?->format(DATE_ATOM),
+                'dueAt' => $project->getDueAt()?->format(DATE_ATOM),
+                'attachments' => $project->getAttachments(),
+                'wikiPages' => $project->getWikiPages(),
+                'tasks' => array_map(static fn (Task $task): array => [
+                    'id' => $task->getId(),
+                    'TITLE' => $task->getTitle(),
+                    'description' => $task->getDescription(),
+                    'status' => $task->getStatus()->value,
+                    'dueAt' => $task->getDueAt()?->format(DATE_ATOM),
+                ], $project->getTasks()->toArray()),
+                'assignees' => array_map(static fn ($assignee): array => [
+                    'id' => $assignee->getId(),
+                    'email' => $assignee->getEmail(),
+                    'firstName' => $assignee->getFirstName(),
+                    'lastName' => $assignee->getLastName(),
+                    'photo' => $assignee->getPhoto(),
+                ], $project->getAssignees()->toArray()),
+            ];
+        });
+    }
+
+    private function searchIdsFromElastic(string $query): ?array
+    {
+        if ($query === '') {
+            return null;
+        }
+
+        try {
+            $response = $this->elasticsearchService->search('crm_projects', [
+                'query' => ['multi_match' => [
+                    'query' => $query,
+                    'type' => 'phrase_prefix',
+                    'fields' => ['name^3', 'code^2', 'description', 'status'],
+                ]],
+                '_source' => ['id'],
+            ], 0, 500);
+
+            $hits = $response['hits']['hits'] ?? [];
+            return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function emptyList(int $page, int $limit, array $filters): array
+    {
+        return [
+            'items' => [],
+            'pagination' => ['page' => $page, 'limit' => $limit, 'totalItems' => 0, 'totalPages' => 0],
+            'meta' => ['filters' => array_filter($filters, static fn (string $value): bool => $value !== '')],
+        ];
+    }
+}

--- a/src/Crm/Application/Service/TaskRequestReadService.php
+++ b/src/Crm/Application/Service/TaskRequestReadService.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Infrastructure\Repository\TaskRequestRepository;
+use App\General\Application\Service\CacheKeyConventionService;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function ceil;
+use function max;
+use function method_exists;
+use function min;
+use function trim;
+
+readonly class TaskRequestReadService
+{
+    public function __construct(
+        private TaskRequestRepository $taskRequestRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CacheInterface $cache,
+        private CacheKeyConventionService $cacheKeyConventionService,
+        private ElasticsearchServiceInterface $elasticsearchService,
+        private CrmApiNormalizer $crmApiNormalizer,
+    ) {
+    }
+
+    public function getList(string $applicationSlug, Request $request): array
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'q' => trim((string)$request->query->get('q', '')),
+            'status' => trim((string)$request->query->get('status', '')),
+        ];
+
+        $cacheKey = $this->cacheKeyConventionService->buildCrmTaskRequestListKey($applicationSlug, $page, $limit, $filters);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $page, $limit, $filters): array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->crmTaskRequestListTag($applicationSlug));
+            }
+
+            $esIds = $this->searchIdsFromElastic($filters['q']);
+            if ($esIds === []) {
+                return $this->emptyList($page, $limit, $filters);
+            }
+
+            $effectiveFilters = [
+                'q' => $esIds === null ? $filters['q'] : '',
+                'status' => $filters['status'],
+                'ids' => $esIds,
+            ];
+
+            $items = $this->taskRequestRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $effectiveFilters);
+            $totalItems = $this->taskRequestRepository->countScopedByCrm($crm->getId(), $effectiveFilters);
+
+            return [
+                'items' => array_map(fn (array $item): array => $this->crmApiNormalizer->normalizeTaskRequestProjection($item), $items),
+                'pagination' => [
+                    'page' => $page,
+                    'limit' => $limit,
+                    'totalItems' => $totalItems,
+                    'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
+                ],
+                'meta' => ['filters' => array_filter($filters, static fn (string $value): bool => $value !== '')],
+            ];
+        });
+    }
+
+    public function getDetail(string $applicationSlug, string $taskRequestId): ?array
+    {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $cacheKey = $this->cacheKeyConventionService->buildCrmTaskRequestDetailKey($applicationSlug, $taskRequestId);
+
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $taskRequestId): ?array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag([
+                    $this->cacheKeyConventionService->crmTaskRequestListTag($applicationSlug),
+                    $this->cacheKeyConventionService->crmTaskRequestDetailTag($applicationSlug, $taskRequestId),
+                ]);
+            }
+
+            $taskRequest = $this->taskRequestRepository->findOneScopedById($taskRequestId, $crm->getId());
+            if ($taskRequest === null) {
+                return null;
+            }
+
+            return $this->crmApiNormalizer->normalizeTaskRequest($taskRequest);
+        });
+    }
+
+    private function searchIdsFromElastic(string $query): ?array
+    {
+        if ($query === '') {
+            return null;
+        }
+
+        try {
+            $response = $this->elasticsearchService->search('crm_task_requests', [
+                'query' => ['multi_match' => [
+                    'query' => $query,
+                    'type' => 'phrase_prefix',
+                    'fields' => ['title^3', 'status', 'taskId'],
+                ]],
+                '_source' => ['id'],
+            ], 0, 500);
+
+            $hits = $response['hits']['hits'] ?? [];
+            return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function emptyList(int $page, int $limit, array $filters): array
+    {
+        return [
+            'items' => [],
+            'pagination' => ['page' => $page, 'limit' => $limit, 'totalItems' => 0, 'totalPages' => 0],
+            'meta' => ['filters' => array_filter($filters, static fn (string $value): bool => $value !== '')],
+        ];
+    }
+}

--- a/src/Crm/Infrastructure/Repository/ContactRepository.php
+++ b/src/Crm/Infrastructure/Repository/ContactRepository.php
@@ -9,6 +9,9 @@ use App\General\Infrastructure\Repository\BaseRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 
+use function array_values;
+use function trim;
+
 class ContactRepository extends BaseRepository
 {
     protected static string $entityName = Entity::class;
@@ -56,7 +59,7 @@ class ContactRepository extends BaseRepository
     }
 
     /**
-     * @param array{q?:string} $filters
+     * @param array{q?:string,ids?:list<string>|null} $filters
      * @return list<array<string,mixed>>
      */
     public function findScopedProjection(string $crmId, int $limit, int $offset, array $filters = []): array
@@ -77,11 +80,21 @@ class ContactRepository extends BaseRepository
                 ->setParameter('space', ' ');
         }
 
+        $ids = $filters['ids'] ?? null;
+        if (is_array($ids)) {
+            if ($ids === []) {
+                return [];
+            }
+
+            $qb->andWhere('contact.id IN (:ids)')
+                ->setParameter('ids', array_values($ids), UuidBinaryOrderedTimeType::NAME);
+        }
+
         return $qb->getQuery()->getArrayResult();
     }
 
     /**
-     * @param array{q?:string} $filters
+     * @param array{q?:string,ids?:list<string>|null} $filters
      */
     public function countScopedByCrm(string $crmId, array $filters = []): int
     {
@@ -96,6 +109,16 @@ class ContactRepository extends BaseRepository
                 ->andWhere('LOWER(CONCAT(contact.firstName, :space, contact.lastName)) LIKE LOWER(:q) OR LOWER(contact.email) LIKE LOWER(:q)')
                 ->setParameter('q', '%' . $query . '%')
                 ->setParameter('space', ' ');
+        }
+
+        $ids = $filters['ids'] ?? null;
+        if (is_array($ids)) {
+            if ($ids === []) {
+                return 0;
+            }
+
+            $qb->andWhere('contact.id IN (:ids)')
+                ->setParameter('ids', array_values($ids), UuidBinaryOrderedTimeType::NAME);
         }
 
         return (int)$qb->getQuery()->getSingleScalarResult();

--- a/src/Crm/Infrastructure/Repository/EmployeeRepository.php
+++ b/src/Crm/Infrastructure/Repository/EmployeeRepository.php
@@ -9,6 +9,9 @@ use App\General\Infrastructure\Repository\BaseRepository;
 use Doctrine\Persistence\ManagerRegistry;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 
+use function array_values;
+use function trim;
+
 class EmployeeRepository extends BaseRepository
 {
     protected static string $entityName = Entity::class;
@@ -52,5 +55,70 @@ class EmployeeRepository extends BaseRepository
             ->andWhere('employee.crm = :crmId')
             ->setParameter('crmId', $crmId, UuidBinaryOrderedTimeType::NAME)
             ->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @param array{q?:string,ids?:list<string>|null} $filters
+     * @return list<array<string,mixed>>
+     */
+    public function findScopedProjection(string $crmId, int $limit, int $offset, array $filters = []): array
+    {
+        $qb = $this->createQueryBuilder('employee')
+            ->select('employee.id, employee.firstName, employee.lastName, employee.email, employee.userId, employee.positionName, employee.roleName, employee.createdAt, employee.updatedAt, user.photo AS photo')
+            ->leftJoin('employee.user', 'user')
+            ->andWhere('employee.crm = :crmId')
+            ->setParameter('crmId', $crmId, UuidBinaryOrderedTimeType::NAME)
+            ->orderBy('employee.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->setFirstResult($offset);
+
+        $query = trim((string)($filters['q'] ?? ''));
+        if ($query !== '') {
+            $qb->andWhere('LOWER(CONCAT(employee.firstName, :space, employee.lastName)) LIKE LOWER(:q) OR LOWER(employee.email) LIKE LOWER(:q)')
+                ->setParameter('q', '%' . $query . '%')
+                ->setParameter('space', ' ');
+        }
+
+        $ids = $filters['ids'] ?? null;
+        if (is_array($ids)) {
+            if ($ids === []) {
+                return [];
+            }
+
+            $qb->andWhere('employee.id IN (:ids)')
+                ->setParameter('ids', array_values($ids), UuidBinaryOrderedTimeType::NAME);
+        }
+
+        return $qb->getQuery()->getArrayResult();
+    }
+
+    /**
+     * @param array{q?:string,ids?:list<string>|null} $filters
+     */
+    public function countScopedByCrm(string $crmId, array $filters = []): int
+    {
+        $qb = $this->createQueryBuilder('employee')
+            ->select('COUNT(employee.id)')
+            ->andWhere('employee.crm = :crmId')
+            ->setParameter('crmId', $crmId, UuidBinaryOrderedTimeType::NAME);
+
+        $query = trim((string)($filters['q'] ?? ''));
+        if ($query !== '') {
+            $qb->andWhere('LOWER(CONCAT(employee.firstName, :space, employee.lastName)) LIKE LOWER(:q) OR LOWER(employee.email) LIKE LOWER(:q)')
+                ->setParameter('q', '%' . $query . '%')
+                ->setParameter('space', ' ');
+        }
+
+        $ids = $filters['ids'] ?? null;
+        if (is_array($ids)) {
+            if ($ids === []) {
+                return 0;
+            }
+
+            $qb->andWhere('employee.id IN (:ids)')
+                ->setParameter('ids', array_values($ids), UuidBinaryOrderedTimeType::NAME);
+        }
+
+        return (int)$qb->getQuery()->getSingleScalarResult();
     }
 }

--- a/src/Crm/Infrastructure/Repository/ProjectRepository.php
+++ b/src/Crm/Infrastructure/Repository/ProjectRepository.php
@@ -10,6 +10,9 @@ use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 
+use function array_values;
+use function trim;
+
 /**
  * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
  * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
@@ -70,7 +73,7 @@ class ProjectRepository extends BaseRepository
     }
 
     /**
-     * @param array{q?:string,status?:string} $filters
+     * @param array{q?:string,status?:string,ids?:list<string>|null} $filters
      * @return list<array<string,mixed>>
      */
     public function findScopedProjection(string $crmId, int $limit, int $offset, array $filters = []): array
@@ -94,11 +97,21 @@ class ProjectRepository extends BaseRepository
             $qb->andWhere('project.status = :status')->setParameter('status', $status);
         }
 
+        $ids = $filters['ids'] ?? null;
+        if (is_array($ids)) {
+            if ($ids === []) {
+                return [];
+            }
+
+            $qb->andWhere('project.id IN (:ids)')
+                ->setParameter('ids', array_values($ids), UuidBinaryOrderedTimeType::NAME);
+        }
+
         return $qb->getQuery()->getArrayResult();
     }
 
     /**
-     * @param array{q?:string,status?:string} $filters
+     * @param array{q?:string,status?:string,ids?:list<string>|null} $filters
      */
     public function countScopedByCrm(string $crmId, array $filters = []): int
     {
@@ -116,6 +129,16 @@ class ProjectRepository extends BaseRepository
         $status = trim((string)($filters['status'] ?? ''));
         if ($status !== '') {
             $qb->andWhere('project.status = :status')->setParameter('status', $status);
+        }
+
+        $ids = $filters['ids'] ?? null;
+        if (is_array($ids)) {
+            if ($ids === []) {
+                return 0;
+            }
+
+            $qb->andWhere('project.id IN (:ids)')
+                ->setParameter('ids', array_values($ids), UuidBinaryOrderedTimeType::NAME);
         }
 
         return (int)$qb->getQuery()->getSingleScalarResult();

--- a/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
+++ b/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
@@ -79,7 +79,7 @@ class TaskRequestRepository extends BaseRepository
     }
 
     /**
-     * @param array{q?:string,status?:string} $filters
+     * @param array{q?:string,status?:string,ids?:list<string>|null} $filters
      *
      * @return list<array<string,mixed>>
      */
@@ -170,7 +170,7 @@ class TaskRequestRepository extends BaseRepository
     }
 
     /**
-     * @param array{q?:string,status?:string} $filters
+     * @param array{q?:string,status?:string,ids?:list<string>|null} $filters
      */
     public function countScopedByCrm(string $crmId, array $filters = []): int
     {
@@ -214,7 +214,7 @@ class TaskRequestRepository extends BaseRepository
     }
 
     /**
-     * @param array{q?:string,status?:string} $filters
+     * @param array{q?:string,status?:string,ids?:list<string>|null} $filters
      */
     private function applyProjectionFilters(QueryBuilder $qb, array $filters): void
     {
@@ -229,6 +229,8 @@ class TaskRequestRepository extends BaseRepository
             $qb->andWhere('taskRequest.status = :status')
                 ->setParameter('status', $status);
         }
+
+        $this->applyBinaryUuidIdsFilter($qb, 'taskRequest.id', $filters['ids'] ?? null, 'projection_task_request_id_');
     }
 
     /**

--- a/src/Crm/Transport/Controller/Api/V1/Contact/GetContactController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Contact/GetContactController.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Contact;
 
+use App\Crm\Application\Service\ContactReadService;
 use App\Crm\Domain\Entity\Contact;
 use App\Role\Domain\Enum\Role;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -18,19 +20,19 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_VIEWER->value)]
 final readonly class GetContactController
 {
+    public function __construct(
+        private ContactReadService $contactReadService,
+    ) {
+    }
+
     #[Route('/v1/crm/applications/{applicationSlug}/contacts/{contact}', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug, Contact $contact): JsonResponse
     {
-        return new JsonResponse([
-            'id' => $contact->getId(),
-            'companyId' => $contact->getCompany()?->getId(),
-            'firstName' => $contact->getFirstName(),
-            'lastName' => $contact->getLastName(),
-            'email' => $contact->getEmail(),
-            'phone' => $contact->getPhone(),
-            'jobTitle' => $contact->getJobTitle(),
-            'city' => $contact->getCity(),
-            'score' => $contact->getScore(),
-        ]);
+        $payload = $this->contactReadService->getDetail($applicationSlug, $contact->getId());
+        if ($payload === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Contact not found for this CRM scope.');
+        }
+
+        return new JsonResponse($payload);
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Contact/ListContactsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Contact/ListContactsController.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Contact;
 
-use App\Crm\Application\Service\CrmApplicationScopeResolver;
-use App\Crm\Infrastructure\Repository\ContactRepository;
+use App\Crm\Application\Service\ContactReadService;
 use App\Role\Domain\Enum\Role;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -20,35 +19,13 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListContactsController
 {
     public function __construct(
-        private ContactRepository $contactRepository,
-        private CrmApplicationScopeResolver $scopeResolver,
+        private ContactReadService $contactReadService,
     ) {
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/contacts', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
-        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $page = max(1, $request->query->getInt('page', 1));
-        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
-        $filters = [
-            'q' => trim((string)$request->query->get('q', '')),
-        ];
-
-        $items = $this->contactRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $filters);
-        $totalItems = $this->contactRepository->countScopedByCrm($crm->getId(), $filters);
-
-        return new JsonResponse([
-            'items' => $items,
-            'pagination' => [
-                'page' => $page,
-                'limit' => $limit,
-                'totalItems' => $totalItems,
-                'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
-            ],
-            'meta' => [
-                'filters' => array_filter($filters),
-            ],
-        ]);
+        return new JsonResponse($this->contactReadService->getList($applicationSlug, $request));
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Employee/GetEmployeeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Employee/GetEmployeeController.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Employee;
 
+use App\Crm\Application\Service\EmployeeReadService;
 use App\Crm\Domain\Entity\Employee;
 use App\Role\Domain\Enum\Role;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -18,20 +20,19 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_VIEWER->value)]
 final readonly class GetEmployeeController
 {
+    public function __construct(
+        private EmployeeReadService $employeeReadService,
+    ) {
+    }
+
     #[Route('/v1/crm/applications/{applicationSlug}/employees/{employee}', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug, Employee $employee): JsonResponse
     {
-        return new JsonResponse([
-            'id' => $employee->getId(),
-            'firstName' => $employee->getFirstName(),
-            'lastName' => $employee->getLastName(),
-            'email' => $employee->getEmail(),
-            'userId' => $employee->getUserId(),
-            'positionName' => $employee->getPositionName(),
-            'photo' => $employee->getUser()->getPhoto(),
-            'roleName' => $employee->getRoleName(),
-            'createdAt' => $employee->getCreatedAt()->format(DATE_ATOM),
-            'updatedAt' => $employee->getUpdatedAt()->format(DATE_ATOM),
-        ]);
+        $payload = $this->employeeReadService->getDetail($applicationSlug, $employee->getId());
+        if ($payload === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Employee not found for this CRM scope.');
+        }
+
+        return new JsonResponse($payload);
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Employee/ListEmployeesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Employee/ListEmployeesController.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Employee;
 
-use App\Crm\Application\Service\CrmApplicationScopeResolver;
-use App\Crm\Domain\Entity\Employee;
-use App\Crm\Infrastructure\Repository\EmployeeRepository;
+use App\Crm\Application\Service\EmployeeReadService;
 use App\Role\Domain\Enum\Role;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -21,43 +19,13 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListEmployeesController
 {
     public function __construct(
-        private CrmApplicationScopeResolver $scopeResolver,
-        private EmployeeRepository $employeeRepository,
+        private EmployeeReadService $employeeReadService,
     ) {
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/employees', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
-        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $page = max(1, $request->query->getInt('page', 1));
-        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
-
-        $items = array_map(
-            static fn (Employee $employee): array => [
-                'id' => $employee->getId(),
-                'firstName' => $employee->getFirstName(),
-                'lastName' => $employee->getLastName(),
-                'email' => $employee->getEmail(),
-                'userId' => $employee->getUserId(),
-                'positionName' => $employee->getPositionName(),
-                'photo' => $employee->getUser()->getPhoto(),
-                'roleName' => $employee->getRoleName(),
-                'createdAt' => $employee->getCreatedAt()->format(DATE_ATOM),
-                'updatedAt' => $employee->getUpdatedAt()->format(DATE_ATOM),
-            ],
-            $this->employeeRepository->findScoped($crm->getId(), $limit, ($page - 1) * $limit)
-        );
-        $totalItems = $this->employeeRepository->countByCrm($crm->getId());
-
-        return new JsonResponse([
-            'items' => $items,
-            'pagination' => [
-                'page' => $page,
-                'limit' => $limit,
-                'totalItems' => $totalItems,
-                'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
-            ],
-        ]);
+        return new JsonResponse($this->employeeReadService->getList($applicationSlug, $request));
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Project/GetProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/GetProjectController.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Project;
 
-use App\Crm\Application\Security\CrmPermissions;
+use App\Crm\Application\Service\ProjectReadService;
 use App\Crm\Domain\Entity\Project;
-use App\Crm\Domain\Entity\Task;
 use App\Role\Domain\Enum\Role;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -20,38 +20,19 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class GetProjectController
 {
+    public function __construct(
+        private ProjectReadService $projectReadService,
+    ) {
+    }
+
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug, Project $project): JsonResponse
     {
-        return new JsonResponse([
-            'id' => $project->getId(),
-            'companyId' => $project->getCompany()?->getId(),
-            'name' => $project->getName(),
-            'code' => $project->getCode(),
-            'description' => $project->getDescription(),
-            'status' => $project->getStatus()->value,
-            'startedAt' => $project->getStartedAt()?->format(DATE_ATOM),
-            'dueAt' => $project->getDueAt()?->format(DATE_ATOM),
-            'attachments' => $project->getAttachments(),
-            'wikiPages' => $project->getWikiPages(),
-            'tasks' => array_map(
-                static fn (Task $task) => [
-                    'id' => $task->getId(),
-                    'TITLE' => $task->getTitle(),
-                    'description' => $task->getDescription(),
-                    'status' => $task->getStatus()->value,
-                    'dueAt' => $task->getDueAt()?->format(DATE_ATOM),
-                ],
-                $project->getTasks()->toArray()),
-            'assignees' => array_map(
-                static fn ($assignee) => [
-                    'id' => $assignee->getId(),
-                    'email' => $assignee->getEmail(),
-                    'firstName' => $assignee->getFirstName(),
-                    'lastName' => $assignee->getLastName(),
-                    'photo' => $assignee->getPhoto(),
-                ],
-                $project->getAssignees()->toArray())
-        ]);
+        $payload = $this->projectReadService->getDetail($applicationSlug, $project->getId());
+        if ($payload === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Project not found for this CRM scope.');
+        }
+
+        return new JsonResponse($payload);
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Project/ListProjectsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/ListProjectsController.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Project;
 
-use App\Crm\Application\Service\CrmApiNormalizer;
-use App\Crm\Application\Service\CrmApplicationScopeResolver;
-use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Application\Service\ProjectReadService;
 use App\Role\Domain\Enum\Role;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -21,40 +19,13 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListProjectsController
 {
     public function __construct(
-        private ProjectRepository $projectRepository,
-        private CrmApplicationScopeResolver $scopeResolver,
-        private CrmApiNormalizer $crmApiNormalizer,
+        private ProjectReadService $projectReadService,
     ) {
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    #[OA\Response(response: 200, description: 'Projects list with normalized name field.')]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
-        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $page = max(1, $request->query->getInt('page', 1));
-        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
-        $filters = [
-            'q' => trim((string)$request->query->get('q', '')),
-            'status' => trim((string)$request->query->get('status', '')),
-        ];
-
-        $items = array_map(fn (array $item): array => $this->crmApiNormalizer->normalizeProjectProjection($item), $this->projectRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $filters));
-
-        $totalItems = $this->projectRepository->countScopedByCrm($crm->getId(), $filters);
-
-        return new JsonResponse([
-            'items' => $items,
-            'pagination' => [
-                'page' => $page,
-                'limit' => $limit,
-                'totalItems' => $totalItems,
-                'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
-            ],
-            'meta' => [
-                'filters' => array_filter($filters),
-            ],
-        ]);
+        return new JsonResponse($this->projectReadService->getList($applicationSlug, $request));
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/GetTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/GetTaskRequestController.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
 
-use App\Crm\Application\Service\CrmApiNormalizer;
+use App\Crm\Application\Service\TaskRequestReadService;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Role\Domain\Enum\Role;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -20,13 +21,18 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class GetTaskRequestController
 {
     public function __construct(
-        private CrmApiNormalizer $normalizer
+        private TaskRequestReadService $taskRequestReadService,
     ) {
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/task-requests/{taskRequest}', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug, TaskRequest $taskRequest): JsonResponse
     {
-        return new JsonResponse($this->normalizer->normalizeTaskRequest($taskRequest));
+        $payload = $this->taskRequestReadService->getDetail($applicationSlug, $taskRequest->getId());
+        if ($payload === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Task request not found for this CRM scope.');
+        }
+
+        return new JsonResponse($payload);
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestsController.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
 
-use App\Crm\Application\Service\CrmApiNormalizer;
-use App\Crm\Application\Service\CrmApplicationScopeResolver;
-use App\Crm\Infrastructure\Repository\TaskRequestRepository;
+use App\Crm\Application\Service\TaskRequestReadService;
 use App\Role\Domain\Enum\Role;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -21,38 +19,13 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListTaskRequestsController
 {
     public function __construct(
-        private TaskRequestRepository $taskRequestRepository,
-        private CrmApplicationScopeResolver $scopeResolver,
-        private CrmApiNormalizer $crmApiNormalizer,
+        private TaskRequestReadService $taskRequestReadService,
     ) {
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/task-requests', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
-        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $page = max(1, $request->query->getInt('page', 1));
-        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
-        $filters = [
-            'q' => trim((string)$request->query->get('q', '')),
-            'status' => trim((string)$request->query->get('status', '')),
-        ];
-
-        $items = array_map(fn (array $item): array => $this->crmApiNormalizer->normalizeTaskRequestProjection($item), $this->taskRequestRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $filters));
-        $totalItems = $this->taskRequestRepository->countScopedByCrm($crm->getId(), $filters);
-
-        return new JsonResponse([
-            'items' => $items,
-            'pagination' => [
-                'page' => $page,
-                'limit' => $limit,
-                'totalItems' => $totalItems,
-                'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
-            ],
-            'meta' => [
-                'filters' => array_filter($filters),
-            ],
-        ]);
+        return new JsonResponse($this->taskRequestReadService->getList($applicationSlug, $request));
     }
 }

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -195,6 +195,82 @@ class CacheKeyConventionService
      * @param array<string, mixed> $filters
      * @throws JsonException
      */
+    public function buildCrmContactListKey(string $applicationSlug, int $page, int $limit, array $filters): string
+    {
+        return 'crm_contact_list_' . md5((string)json_encode([
+            'applicationSlug' => $applicationSlug,
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function buildCrmContactDetailKey(string $applicationSlug, string $contactId): string
+    {
+        return 'crm_contact_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($contactId);
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     * @throws JsonException
+     */
+    public function buildCrmProjectListKey(string $applicationSlug, int $page, int $limit, array $filters): string
+    {
+        return 'crm_project_list_' . md5((string)json_encode([
+            'applicationSlug' => $applicationSlug,
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function buildCrmProjectDetailKey(string $applicationSlug, string $projectId): string
+    {
+        return 'crm_project_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($projectId);
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     * @throws JsonException
+     */
+    public function buildCrmEmployeeListKey(string $applicationSlug, int $page, int $limit, array $filters): string
+    {
+        return 'crm_employee_list_' . md5((string)json_encode([
+            'applicationSlug' => $applicationSlug,
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function buildCrmEmployeeDetailKey(string $applicationSlug, string $employeeId): string
+    {
+        return 'crm_employee_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($employeeId);
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     * @throws JsonException
+     */
+    public function buildCrmTaskRequestListKey(string $applicationSlug, int $page, int $limit, array $filters): string
+    {
+        return 'crm_task_request_list_' . md5((string)json_encode([
+            'applicationSlug' => $applicationSlug,
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function buildCrmTaskRequestDetailKey(string $applicationSlug, string $taskRequestId): string
+    {
+        return 'crm_task_request_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($taskRequestId);
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     * @throws JsonException
+     */
     public function buildSchoolExamListKey(string $applicationSlug, int $page, int $limit, array $filters): string
     {
         return 'school_exam_list_' . md5((string)json_encode([
@@ -327,6 +403,46 @@ class CacheKeyConventionService
     public function crmBillingDetailTag(string $applicationSlug, string $billingId): string
     {
         return 'cache_crm_billing_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($billingId);
+    }
+
+    public function crmContactListTag(string $applicationSlug): string
+    {
+        return 'cache_crm_contact_list_' . $this->sanitizeSegment($applicationSlug);
+    }
+
+    public function crmContactDetailTag(string $applicationSlug, string $contactId): string
+    {
+        return 'cache_crm_contact_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($contactId);
+    }
+
+    public function crmProjectListTag(string $applicationSlug): string
+    {
+        return 'cache_crm_project_list_' . $this->sanitizeSegment($applicationSlug);
+    }
+
+    public function crmProjectDetailTag(string $applicationSlug, string $projectId): string
+    {
+        return 'cache_crm_project_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($projectId);
+    }
+
+    public function crmEmployeeListTag(string $applicationSlug): string
+    {
+        return 'cache_crm_employee_list_' . $this->sanitizeSegment($applicationSlug);
+    }
+
+    public function crmEmployeeDetailTag(string $applicationSlug, string $employeeId): string
+    {
+        return 'cache_crm_employee_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($employeeId);
+    }
+
+    public function crmTaskRequestListTag(string $applicationSlug): string
+    {
+        return 'cache_crm_task_request_list_' . $this->sanitizeSegment($applicationSlug);
+    }
+
+    public function crmTaskRequestDetailTag(string $applicationSlug, string $taskRequestId): string
+    {
+        return 'cache_crm_task_request_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($taskRequestId);
     }
 
     public function schoolExamListTag(): string


### PR DESCRIPTION
### Motivation
- Centralize GET list/detail logic for CRM resources to reduce duplication and align with existing patterns like `TaskListService` and `BillingReadService`.
- Provide consistent caching (keys + tags) and targeted invalidation for read endpoints.
- Support full-text search via Elasticsearch by resolving IDs first and hydrating database projections to keep SQL queries efficient and ordered.
- Harmonize list response shape across endpoints to always return `items`, `pagination`, and `meta.filters`.

### Description
- Added dedicated read services: `ContactReadService`, `ProjectReadService`, `EmployeeReadService`, and `TaskRequestReadService` that implement caching (TTL + tags), build cache keys via `CacheKeyConventionService`, optionally call Elasticsearch to fetch matching IDs, and hydrate SQL projections for results and counts.
- Refactored relevant GET controllers under `src/Crm/Transport/Controller/Api/V1/**` to delegate list/detail responsibilities to the new read services and to return the standardized response shape (`items`, `pagination`, `meta.filters`).
- Extended repositories (`ContactRepository`, `ProjectRepository`, `EmployeeRepository`, `TaskRequestRepository`) to accept optional `ids` filters for projection and counting so results can be restricted to Elasticsearch-returned IDs, and added projection helpers where needed.
- Extended `CacheKeyConventionService` with new list/detail key builders and cache tag functions for `Contact`, `Project`, `Employee`, and `TaskRequest` to support consistent cache key generation and tag-based invalidation.

### Testing
- Ran PHP syntax checks with `php -l` on all modified/added service, repository, controller, and cache convention files and they all passed without syntax errors.
- Specific checks executed include `php -l` over the new services, updated repositories and controllers, and `src/General/Application/Service/CacheKeyConventionService.php`, all returning no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b85b8ae358832ba13fd0f16ff4b751)