### PR TITLE
feat(crm): centralize read-cache invalidation in command handlers

### DIFF
--- a/src/Crm/Application/MessageHandler/CreateBillingCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/CreateBillingCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Application\MessageHandler;
 
 use App\Crm\Application\Message\CreateBillingCommand;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Domain\Entity\Billing;
 use App\Crm\Infrastructure\Repository\BillingRepository;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
@@ -19,6 +20,7 @@ final readonly class CreateBillingCommandHandler
         private CompanyRepository $companyRepository,
         private BillingRepository $billingRepository,
         private MessageBusInterface $messageBus,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -48,5 +50,7 @@ final readonly class CreateBillingCommandHandler
             'crmId' => $command->crmId,
             'companyId' => $command->companyId,
         ]));
+
+        $this->cacheInvalidator->invalidateBilling($command->applicationSlug, $billing->getId());
     }
 }

--- a/src/Crm/Application/MessageHandler/CreateCompanyCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/CreateCompanyCommandHandler.php
@@ -6,6 +6,7 @@ namespace App\Crm\Application\MessageHandler;
 
 use App\Crm\Application\Message\CreateCompanyCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Domain\Entity\Company;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -16,6 +17,7 @@ final readonly class CreateCompanyCommandHandler
     public function __construct(
         private CrmApplicationScopeResolver $scopeResolver,
         private EntityManagerInterface $entityManager,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -34,5 +36,7 @@ final readonly class CreateCompanyCommandHandler
 
         $this->entityManager->persist($company);
         $this->entityManager->flush();
+
+        $this->cacheInvalidator->invalidateCompany($command->applicationSlug, $company->getId());
     }
 }

--- a/src/Crm/Application/MessageHandler/CreateContactCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/CreateContactCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Application\MessageHandler;
 
 use App\Crm\Application\Message\CreateContactCommand;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Domain\Entity\Contact;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Infrastructure\Repository\ContactRepository;
@@ -21,6 +22,7 @@ final readonly class CreateContactCommandHandler
         private CompanyRepository $companyRepository,
         private ContactRepository $contactRepository,
         private MessageBusInterface $messageBus,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -55,5 +57,7 @@ final readonly class CreateContactCommandHandler
             'applicationSlug' => $command->applicationSlug,
             'crmId' => $command->crmId,
         ]));
+
+        $this->cacheInvalidator->invalidateContact($command->applicationSlug, $contact->getId());
     }
 }

--- a/src/Crm/Application/MessageHandler/CreateEmployeeCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/CreateEmployeeCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Application\MessageHandler;
 
 use App\Crm\Application\Message\CreateEmployeeCommand;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Domain\Entity\Employee;
 use App\Crm\Infrastructure\Repository\CrmRepository;
 use App\Crm\Infrastructure\Repository\EmployeeRepository;
@@ -21,6 +22,7 @@ final readonly class CreateEmployeeCommandHandler
         private EmployeeRepository $employeeRepository,
         private UserRepositoryInterface $userRepository,
         private MessageBusInterface $messageBus,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -49,5 +51,7 @@ final readonly class CreateEmployeeCommandHandler
             'applicationSlug' => $command->applicationSlug,
             'crmId' => $command->crmId,
         ]));
+
+        $this->cacheInvalidator->invalidateEmployee($command->applicationSlug, $employee->getId());
     }
 }

--- a/src/Crm/Application/MessageHandler/DeleteCompanyCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/DeleteCompanyCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Crm\Application\MessageHandler;
 use App\Crm\Application\Exception\CrmReferenceNotFoundException;
 use App\Crm\Application\Message\DeleteCompanyCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -18,6 +19,7 @@ final readonly class DeleteCompanyCommandHandler
         private CrmApplicationScopeResolver $scopeResolver,
         private CompanyRepository $companyRepository,
         private EntityManagerInterface $entityManager,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -31,5 +33,7 @@ final readonly class DeleteCompanyCommandHandler
 
         $this->entityManager->remove($company);
         $this->entityManager->flush();
+
+        $this->cacheInvalidator->invalidateCompany($command->applicationSlug, $command->companyId);
     }
 }

--- a/src/Crm/Application/MessageHandler/DeleteContactCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/DeleteContactCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Crm\Application\MessageHandler;
 use App\Crm\Application\Exception\CrmReferenceNotFoundException;
 use App\Crm\Application\Message\DeleteContactCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Infrastructure\Repository\ContactRepository;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -16,6 +17,7 @@ final readonly class DeleteContactCommandHandler
     public function __construct(
         private CrmApplicationScopeResolver $scopeResolver,
         private ContactRepository $contactRepository,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -28,5 +30,7 @@ final readonly class DeleteContactCommandHandler
         }
 
         $this->contactRepository->remove($contact);
+
+        $this->cacheInvalidator->invalidateContact($command->applicationSlug, $command->contactId);
     }
 }

--- a/src/Crm/Application/MessageHandler/PatchCompanyCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/PatchCompanyCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Crm\Application\MessageHandler;
 use App\Crm\Application\Exception\CrmReferenceNotFoundException;
 use App\Crm\Application\Message\PatchCompanyCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -16,6 +17,7 @@ final readonly class PatchCompanyCommandHandler
     public function __construct(
         private CrmApplicationScopeResolver $scopeResolver,
         private CompanyRepository $companyRepository,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -44,5 +46,7 @@ final readonly class PatchCompanyCommandHandler
         }
 
         $this->companyRepository->save($company);
+
+        $this->cacheInvalidator->invalidateCompany($command->applicationSlug, $company->getId());
     }
 }

--- a/src/Crm/Application/MessageHandler/PatchContactCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/PatchContactCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Crm\Application\MessageHandler;
 use App\Crm\Application\Exception\CrmReferenceNotFoundException;
 use App\Crm\Application\Message\PatchContactCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Infrastructure\Repository\ContactRepository;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -18,6 +19,7 @@ final readonly class PatchContactCommandHandler
         private CrmApplicationScopeResolver $scopeResolver,
         private ContactRepository $contactRepository,
         private CompanyRepository $companyRepository,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -66,5 +68,7 @@ final readonly class PatchContactCommandHandler
         }
 
         $this->contactRepository->save($contact);
+
+        $this->cacheInvalidator->invalidateContact($command->applicationSlug, $contact->getId());
     }
 }

--- a/src/Crm/Application/MessageHandler/PutCompanyCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/PutCompanyCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Crm\Application\MessageHandler;
 use App\Crm\Application\Exception\CrmReferenceNotFoundException;
 use App\Crm\Application\Message\PutCompanyCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
@@ -16,6 +17,7 @@ final readonly class PutCompanyCommandHandler
     public function __construct(
         private CrmApplicationScopeResolver $scopeResolver,
         private CompanyRepository $companyRepository,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -35,5 +37,7 @@ final readonly class PutCompanyCommandHandler
             ->setPhone($command->phone);
 
         $this->companyRepository->save($company);
+
+        $this->cacheInvalidator->invalidateCompany($command->applicationSlug, $company->getId());
     }
 }

--- a/src/Crm/Application/MessageHandler/PutContactCommandHandler.php
+++ b/src/Crm/Application/MessageHandler/PutContactCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Crm\Application\MessageHandler;
 use App\Crm\Application\Exception\CrmReferenceNotFoundException;
 use App\Crm\Application\Message\PutContactCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Infrastructure\Repository\ContactRepository;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -18,6 +19,7 @@ final readonly class PutContactCommandHandler
         private CrmApplicationScopeResolver $scopeResolver,
         private ContactRepository $contactRepository,
         private CompanyRepository $companyRepository,
+        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -49,5 +51,7 @@ final readonly class PutContactCommandHandler
         }
 
         $this->contactRepository->save($contact);
+
+        $this->cacheInvalidator->invalidateContact($command->applicationSlug, $contact->getId());
     }
 }

--- a/src/Crm/Application/Service/CrmReadCacheInvalidator.php
+++ b/src/Crm/Application/Service/CrmReadCacheInvalidator.php
@@ -18,13 +18,83 @@ readonly class CrmReadCacheInvalidator
 
     public function invalidateBilling(string $applicationSlug, string $billingId): void
     {
+        $this->invalidateTags([
+            $this->cacheKeyConventionService->crmBillingListTag($applicationSlug),
+            $this->cacheKeyConventionService->crmBillingDetailTag($applicationSlug, $billingId),
+        ]);
+    }
+
+    public function invalidateCompany(string $applicationSlug, ?string $companyId = null): void
+    {
+        $tags = [$this->cacheKeyConventionService->crmCompanyListByApplicationTag($applicationSlug)];
+        if ($companyId !== null) {
+            $tags[] = $this->cacheKeyConventionService->crmCompanyDetailTag($applicationSlug, $companyId);
+        }
+
+        $this->invalidateTags($tags);
+    }
+
+    public function invalidateContact(string $applicationSlug, string $contactId): void
+    {
+        $this->invalidateTags([
+            $this->cacheKeyConventionService->crmContactListTag($applicationSlug),
+            $this->cacheKeyConventionService->crmContactDetailTag($applicationSlug, $contactId),
+        ]);
+    }
+
+    public function invalidateProject(string $applicationSlug, string $projectId): void
+    {
+        $this->invalidateTags([
+            $this->cacheKeyConventionService->crmProjectListTag($applicationSlug),
+            $this->cacheKeyConventionService->crmProjectDetailTag($applicationSlug, $projectId),
+        ]);
+    }
+
+    public function invalidateEmployee(string $applicationSlug, string $employeeId): void
+    {
+        $this->invalidateTags([
+            $this->cacheKeyConventionService->crmEmployeeListTag($applicationSlug),
+            $this->cacheKeyConventionService->crmEmployeeDetailTag($applicationSlug, $employeeId),
+        ]);
+    }
+
+    public function invalidateTaskRequest(string $applicationSlug, string $taskRequestId): void
+    {
+        $this->invalidateTags([
+            $this->cacheKeyConventionService->crmTaskRequestListTag($applicationSlug),
+            $this->cacheKeyConventionService->crmTaskRequestDetailTag($applicationSlug, $taskRequestId),
+        ]);
+    }
+
+    public function invalidateTask(string $applicationSlug, ?string $taskId = null): void
+    {
+        $tags = [$this->cacheKeyConventionService->crmTaskListTag($applicationSlug)];
+        if ($taskId !== null) {
+            $tags[] = $this->cacheKeyConventionService->crmTaskDetailTag($applicationSlug, $taskId);
+        }
+
+        $this->invalidateTags($tags);
+    }
+
+    public function invalidateSprint(string $applicationSlug, ?string $sprintId = null): void
+    {
+        $tags = [$this->cacheKeyConventionService->crmSprintListTag($applicationSlug)];
+        if ($sprintId !== null) {
+            $tags[] = $this->cacheKeyConventionService->crmSprintDetailTag($applicationSlug, $sprintId);
+        }
+
+        $this->invalidateTags($tags);
+    }
+
+    /**
+     * @param list<string> $tags
+     */
+    private function invalidateTags(array $tags): void
+    {
         if (!$this->cache instanceof TagAwareCacheInterface) {
             return;
         }
 
-        $this->cache->invalidateTags([
-            $this->cacheKeyConventionService->crmBillingListTag($applicationSlug),
-            $this->cacheKeyConventionService->crmBillingDetailTag($applicationSlug, $billingId),
-        ]);
+        $this->cache->invalidateTags($tags);
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Billing/CreateBillingController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Billing/CreateBillingController.php
@@ -6,7 +6,6 @@ namespace App\Crm\Transport\Controller\Api\V1\Billing;
 
 use App\Crm\Application\Message\CreateBillingCommand;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
-use App\Crm\Application\Service\CrmReadCacheInvalidator;
 use App\Crm\Domain\Entity\Billing;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
 use App\Crm\Application\Dto\Command\CreateBillingCommandDto;
@@ -34,7 +33,6 @@ final readonly class CreateBillingController
         private CrmApiErrorResponseFactory $errorResponseFactory,
         private CrmRequestHandler $crmRequestHandler,
         private MessageBusInterface $messageBus,
-        private CrmReadCacheInvalidator $cacheInvalidator,
     ) {
     }
 
@@ -83,7 +81,6 @@ final readonly class CreateBillingController
             crmId: $crm->getId(),
         ));
 
-        $this->cacheInvalidator->invalidateBilling($applicationSlug, $billing->getId());
 
         return new JsonResponse((new EntityIdResponseDto($billing->getId(), ['companyId' => $company->getId()]))->toArray(), JsonResponse::HTTP_CREATED);
     }

--- a/src/Crm/Transport/Controller/Api/V1/Company/GetCompanyController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/GetCompanyController.php
@@ -4,38 +4,78 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Company;
 
-use App\Crm\Domain\Entity\Company;
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\Project;
+use App\Crm\Infrastructure\Repository\CompanyRepository;
+use App\General\Application\Service\CacheKeyConventionService;
 use App\Role\Domain\Enum\Role;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+
+use function method_exists;
 
 #[AsController]
 #[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_VIEWER->value)]
 final readonly class GetCompanyController
 {
+    public function __construct(
+        private CompanyRepository $companyRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CacheInterface $cache,
+        private CacheKeyConventionService $cacheKeyConventionService,
+    ) {
+    }
+
     #[Route('/v1/crm/applications/{applicationSlug}/companies/{id}', methods: [Request::METHOD_GET])]
-    public function __invoke(string $applicationSlug, Company $company): JsonResponse
+    public function __invoke(string $applicationSlug, string $id): JsonResponse
     {
-        return new JsonResponse([
-            'id' => $company->getId(),
-            'name' => $company->getName(),
-            'industry' => $company->getIndustry(),
-            'website' => $company->getWebsite(),
-            'contactEmail' => $company->getContactEmail(),
-            'phone' => $company->getPhone(),
-            'projects' => array_map(
-                static fn (Project $project) =>
-                [
-                    'id' => $project->getId(),
-                    'name' => $project->getName(),
-                ],
-                $company->getProjects()->toArray())
-        ]);
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+        $cacheKey = $this->cacheKeyConventionService->buildCrmCompanyDetailKey($applicationSlug, $id);
+
+        $payload = $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $id): ?array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag([
+                    $this->cacheKeyConventionService->crmCompanyListByApplicationTag($applicationSlug),
+                    $this->cacheKeyConventionService->crmCompanyDetailTag($applicationSlug, $id),
+                ]);
+            }
+
+            $company = $this->companyRepository->findOneScopedById($id, $crm->getId());
+            if ($company === null) {
+                return null;
+            }
+
+            return [
+                'id' => $company->getId(),
+                'name' => $company->getName(),
+                'industry' => $company->getIndustry(),
+                'website' => $company->getWebsite(),
+                'contactEmail' => $company->getContactEmail(),
+                'phone' => $company->getPhone(),
+                'projects' => array_map(
+                    static fn (Project $project) =>
+                    [
+                        'id' => $project->getId(),
+                        'name' => $project->getName(),
+                    ],
+                    $company->getProjects()->toArray())
+            ];
+        });
+
+        if ($payload === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Company not found for this CRM scope.');
+        }
+
+        return new JsonResponse($payload);
     }
 }

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -172,6 +172,12 @@ class CacheKeyConventionService
         ], JSON_THROW_ON_ERROR));
     }
 
+
+    public function buildCrmCompanyDetailKey(string $applicationSlug, string $companyId): string
+    {
+        return 'crm_company_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($companyId);
+    }
+
     /**
      * @param array<string, mixed> $filters
      * @throws JsonException
@@ -395,6 +401,12 @@ class CacheKeyConventionService
         return 'cache_crm_company_list_' . $this->sanitizeSegment($applicationSlug);
     }
 
+
+    public function crmCompanyDetailTag(string $applicationSlug, string $companyId): string
+    {
+        return 'cache_crm_company_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($companyId);
+    }
+
     public function crmBillingListTag(string $applicationSlug): string
     {
         return 'cache_crm_billing_list_' . $this->sanitizeSegment($applicationSlug);
@@ -443,6 +455,22 @@ class CacheKeyConventionService
     public function crmTaskRequestDetailTag(string $applicationSlug, string $taskRequestId): string
     {
         return 'cache_crm_task_request_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($taskRequestId);
+    }
+
+
+    public function crmTaskDetailTag(string $applicationSlug, string $taskId): string
+    {
+        return 'cache_crm_task_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($taskId);
+    }
+
+    public function crmSprintListTag(string $applicationSlug): string
+    {
+        return 'cache_crm_sprint_list_' . $this->sanitizeSegment($applicationSlug);
+    }
+
+    public function crmSprintDetailTag(string $applicationSlug, string $sprintId): string
+    {
+        return 'cache_crm_sprint_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($sprintId);
     }
 
     public function schoolExamListTag(): string


### PR DESCRIPTION
### Motivation

- Centraliser l'invalidation du cache de lecture CRM dans les handlers Messenger pour garantir la cohérence entre écritures et lectures et éviter les invalidations côté contrôleur.
- Ajouter les conventions de clés/tags manquantes pour couvrir listes et détails CRM afin de pouvoir tagger/invalider correctement les entrées mises en cache.

### Description

- Ajout de méthodes dédiées d'invalidation dans `CrmReadCacheInvalidator` : `invalidateCompany`, `invalidateContact`, `invalidateProject`, `invalidateEmployee`, `invalidateTaskRequest`, `invalidateTask`, `invalidateSprint` et factorisation via une méthode privée `invalidateTags`.
- Ajout des clés/tags manquants dans `CacheKeyConventionService`: `buildCrmCompanyDetailKey`, `crmCompanyDetailTag`, `crmTaskDetailTag`, `crmSprintListTag` et `crmSprintDetailTag` pour aligner conventions clé/tag CRM.
- Déplacement de l'appel d'invalidation de création de facture du contrôleur vers le handler Messenger `CreateBillingCommandHandler` et suppression de l'appel côté contrôleur (`CreateBillingController`).
- Branchement des invalidations dans les handlers Messenger pour les mutations CRM (Create/Patch/Put/Delete company, Create/Patch/Put/Delete contact, Create employee, Create billing) et mise en cache alignée du endpoint GET company via `GetCompanyController` (utilise désormais `buildCrmCompanyDetailKey` et tagge list + detail).

### Testing

- ✅ Vérification de syntaxe PHP sur les fichiers modifiés via `php -l` pour tous les fichiers touchés, tous passés sans erreur.
- ✅ Recherche/inspection automatisée pour confirmer l'utilisation de `CrmReadCacheInvalidator` et des méthodes `invalidate*` dans les handlers via `rg` (matching usages trouvés dans les handlers, appel retiré du contrôleur de billing).
- ✅ Les modifications ont été committées; les contrôles automatisés effectués dans cette PR (lint PHP + grep) ont tous réussi.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b86130db88832bbca2b7325939716a)