### PR TITLE
Refactor list handling and school reference resolution; introduce request/response helpers

### DIFF
--- a/src/Crm/Application/Service/CompanyApplicationListService.php
+++ b/src/Crm/Application/Service/CompanyApplicationListService.php
@@ -20,6 +20,8 @@ readonly class CompanyApplicationListService
         private CompanyRepository $companyRepository,
         private CacheInterface $cache,
         private CacheKeyConventionService $cacheKeyConventionService,
+        private CrmListRequestHelper $listRequestHelper,
+        private CrmListResponseFactory $listResponseFactory,
     ) {
     }
 
@@ -28,38 +30,24 @@ readonly class CompanyApplicationListService
      * @throws JsonException
      * @throws InvalidArgumentException
      */
-    public function getList(Request $request, string $applicationSlug, Crm $crm): array
+    public function list(Request $request, string $applicationSlug, Crm $crm): array
     {
-        $page = max(1, $request->query->getInt('page', 1));
-        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
-        $filters = [
-            'q' => trim((string)$request->query->get('q', '')),
-        ];
-        $cacheKey = $this->cacheKeyConventionService->buildCrmCompanyApplicationListKey($applicationSlug, $page, $limit, $filters);
+        $queryOptions = $this->listRequestHelper->fromRequest($request, ['q']);
+        $cacheKey = $this->cacheKeyConventionService->buildCrmCompanyApplicationListKey($applicationSlug, $queryOptions->page, $queryOptions->limit, $queryOptions->filters);
 
-        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $filters, $page, $limit): array {
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $queryOptions): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->crmCompanyListByApplicationTag($applicationSlug));
             }
 
-            $items = $this->companyRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, $filters);
-            $totalItems = $this->companyRepository->countScopedByCrm($crm->getId(), $filters);
+            $items = $this->companyRepository->findScopedProjection($crm->getId(), $queryOptions->limit, $queryOptions->offset(), $queryOptions->filters);
+            $totalItems = $this->companyRepository->countScopedByCrm($crm->getId(), $queryOptions->filters);
 
-            return [
-                'items' => $items,
-                'pagination' => [
-                    'page' => $page,
-                    'limit' => $limit,
-                    'totalItems' => $totalItems,
-                    'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
-                ],
-                'meta' => [
-                    'applicationSlug' => $applicationSlug,
-                    'crmId' => $crm->getId(),
-                    'filters' => array_filter($filters),
-                ],
-            ];
+            return $this->listResponseFactory->create($queryOptions, $totalItems, $items, [
+                'applicationSlug' => $applicationSlug,
+                'crmId' => $crm->getId(),
+            ]);
         });
     }
 }

--- a/src/Crm/Application/Service/ContactReadService.php
+++ b/src/Crm/Application/Service/ContactReadService.php
@@ -7,7 +7,6 @@ namespace App\Crm\Application\Service;
 use App\Crm\Infrastructure\Repository\ContactRepository;
 use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
-use JsonException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
@@ -16,11 +15,8 @@ use Throwable;
 
 use function array_filter;
 use function array_map;
-use function ceil;
-use function max;
+use function array_values;
 use function method_exists;
-use function min;
-use function trim;
 
 readonly class ContactReadService
 {
@@ -30,20 +26,21 @@ readonly class ContactReadService
         private CacheInterface $cache,
         private CacheKeyConventionService $cacheKeyConventionService,
         private ElasticsearchServiceInterface $elasticsearchService,
+        private CrmListRequestHelper $listRequestHelper,
+        private CrmListResponseFactory $listResponseFactory,
     ) {
     }
 
     /** @return array<string,mixed> */
-    public function getList(string $applicationSlug, Request $request): array
+    public function list(string $applicationSlug, Request $request): array
     {
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
-        $page = max(1, $request->query->getInt('page', 1));
-        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
-        $filters = ['q' => trim((string)$request->query->get('q', ''))];
+        $queryOptions = $this->listRequestHelper->fromRequest($request, ['q']);
+        $filters = $queryOptions->filters;
 
-        $cacheKey = $this->cacheKeyConventionService->buildCrmContactListKey($applicationSlug, $page, $limit, $filters);
+        $cacheKey = $this->cacheKeyConventionService->buildCrmContactListKey($applicationSlug, $queryOptions->page, $queryOptions->limit, $filters);
 
-        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $page, $limit, $filters): array {
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $crm, $queryOptions, $filters): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->crmContactListTag($applicationSlug));
@@ -51,10 +48,10 @@ readonly class ContactReadService
 
             $esIds = $this->searchIdsFromElastic($filters['q']);
             if ($esIds === []) {
-                return $this->emptyList($page, $limit, $filters);
+                return $this->listResponseFactory->create($queryOptions, 0, []);
             }
 
-            $items = $this->contactRepository->findScopedProjection($crm->getId(), $limit, ($page - 1) * $limit, [
+            $items = $this->contactRepository->findScopedProjection($crm->getId(), $queryOptions->limit, $queryOptions->offset(), [
                 'q' => $esIds === null ? $filters['q'] : '',
                 'ids' => $esIds,
             ]);
@@ -63,18 +60,11 @@ readonly class ContactReadService
                 'ids' => $esIds,
             ]);
 
-            return [
-                'items' => array_map(fn (array $item): array => $this->normalizeProjection($item), $items),
-                'pagination' => [
-                    'page' => $page,
-                    'limit' => $limit,
-                    'totalItems' => $totalItems,
-                    'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
-                ],
-                'meta' => [
-                    'filters' => array_filter($filters, static fn (string $value): bool => $value !== ''),
-                ],
-            ];
+            return $this->listResponseFactory->create(
+                $queryOptions,
+                $totalItems,
+                array_map(fn (array $row): array => $this->normalizeProjection($row), $items),
+            );
         });
     }
 
@@ -131,6 +121,7 @@ readonly class ContactReadService
             ], 0, 500);
 
             $hits = $response['hits']['hits'] ?? [];
+
             return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
         } catch (Throwable) {
             return null;
@@ -150,16 +141,6 @@ readonly class ContactReadService
             'jobTitle' => (string)($item['jobTitle'] ?? ''),
             'city' => (string)($item['city'] ?? ''),
             'score' => isset($item['score']) ? (int)$item['score'] : null,
-        ];
-    }
-
-    /** @param array{q:string} $filters */
-    private function emptyList(int $page, int $limit, array $filters): array
-    {
-        return [
-            'items' => [],
-            'pagination' => ['page' => $page, 'limit' => $limit, 'totalItems' => 0, 'totalPages' => 0],
-            'meta' => ['filters' => array_filter($filters, static fn (string $value): bool => $value !== '')],
         ];
     }
 }

--- a/src/Crm/Application/Service/CrmListQueryOptions.php
+++ b/src/Crm/Application/Service/CrmListQueryOptions.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+final readonly class CrmListQueryOptions
+{
+    /** @param array<string,string> $filters */
+    public function __construct(
+        public int $page,
+        public int $limit,
+        public array $filters,
+    ) {
+    }
+
+    public function offset(): int
+    {
+        return ($this->page - 1) * $this->limit;
+    }
+
+    /** @return array{page:int,limit:int,totalItems:int,totalPages:int} */
+    public function toPaginationMeta(int $totalItems): array
+    {
+        return [
+            'page' => $this->page,
+            'limit' => $this->limit,
+            'totalItems' => $totalItems,
+            'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $this->limit) : 0,
+        ];
+    }
+}

--- a/src/Crm/Application/Service/CrmListRequestHelper.php
+++ b/src/Crm/Application/Service/CrmListRequestHelper.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final readonly class CrmListRequestHelper
+{
+    /** @param array<int,string> $filterKeys */
+    public function fromRequest(Request $request, array $filterKeys = ['q']): CrmListQueryOptions
+    {
+        $filters = [];
+        foreach ($filterKeys as $key) {
+            $filters[$key] = trim((string)$request->query->get($key, ''));
+        }
+
+        return new CrmListQueryOptions(
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 20))),
+            $filters,
+        );
+    }
+
+    /** @param array<string,string> $filters
+     *  @return array<string,string>
+     */
+    public function activeFilters(array $filters): array
+    {
+        return array_filter($filters, static fn (string $value): bool => $value !== '');
+    }
+}

--- a/src/Crm/Application/Service/CrmListResponseFactory.php
+++ b/src/Crm/Application/Service/CrmListResponseFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+final readonly class CrmListResponseFactory
+{
+    public function __construct(
+        private CrmListRequestHelper $crmListRequestHelper,
+    ) {
+    }
+
+    /**
+     * @param array<int,mixed> $items
+     * @param array<string,mixed> $meta
+     * @return array<string,mixed>
+     */
+    public function create(CrmListQueryOptions $queryOptions, int $totalItems, array $items, array $meta = []): array
+    {
+        return [
+            'items' => $items,
+            'pagination' => $queryOptions->toPaginationMeta($totalItems),
+            'meta' => [
+                ...$meta,
+                'filters' => $this->crmListRequestHelper->activeFilters($queryOptions->filters),
+            ],
+        ];
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Company/ListCompaniesByApplicationController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Company/ListCompaniesByApplicationController.php
@@ -39,6 +39,6 @@ final readonly class ListCompaniesByApplicationController
         $request->attributes->set('applicationSlug', $applicationSlug);
         $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
 
-        return new JsonResponse($this->companyApplicationListService->getList($request, $applicationSlug, $crm));
+        return new JsonResponse($this->companyApplicationListService->list($request, $applicationSlug, $crm));
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Contact/ListContactsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Contact/ListContactsController.php
@@ -26,6 +26,6 @@ final readonly class ListContactsController
     #[Route('/v1/crm/applications/{applicationSlug}/contacts', methods: [Request::METHOD_GET])]
     public function __invoke(string $applicationSlug, Request $request): JsonResponse
     {
-        return new JsonResponse($this->contactReadService->getList($applicationSlug, $request));
+        return new JsonResponse($this->contactReadService->list($applicationSlug, $request));
     }
 }

--- a/src/School/Application/Service/ClassApplicationListService.php
+++ b/src/School/Application/Service/ClassApplicationListService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\School\Application\Service;
 
 use App\General\Application\Service\CacheKeyConventionService;
-use App\School\Application\Serializer\SchoolApiResponseSerializer;
 use App\School\Application\Serializer\SchoolViewMapper;
 use App\School\Domain\Entity\School;
 use App\School\Infrastructure\Repository\SchoolClassRepository;
@@ -22,7 +21,8 @@ readonly class ClassApplicationListService
         private CacheInterface $cache,
         private CacheKeyConventionService $cacheKeyConventionService,
         private SchoolViewMapper $viewMapper,
-        private SchoolApiResponseSerializer $responseSerializer,
+        private SchoolListRequestHelper $listRequestHelper,
+        private SchoolListResponseFactory $listResponseFactory,
     ) {
     }
 
@@ -31,16 +31,12 @@ readonly class ClassApplicationListService
      * @throws \JsonException
      * @throws InvalidArgumentException
      */
-    public function getList(Request $request, string $applicationSlug, School $school): array
+    public function list(Request $request, string $applicationSlug, School $school): array
     {
-        $page = max(1, $request->query->getInt('page', 1));
-        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
-        $filters = [
-            'q' => trim((string)$request->query->get('q', '')),
-        ];
-        $cacheKey = $this->cacheKeyConventionService->buildSchoolClassApplicationListKey($applicationSlug, $page, $limit, $filters);
+        $queryOptions = $this->listRequestHelper->fromRequest($request, ['q']);
+        $cacheKey = $this->cacheKeyConventionService->buildSchoolClassApplicationListKey($applicationSlug, $queryOptions->page, $queryOptions->limit, $queryOptions->filters);
 
-        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $school, $filters, $page, $limit): array {
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $school, $queryOptions): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->schoolClassListByApplicationTag($applicationSlug));
@@ -49,33 +45,28 @@ readonly class ClassApplicationListService
             $qb = $this->classRepository->createQueryBuilder('class')
                 ->andWhere('class.school = :school')->setParameter('school', $school)
                 ->orderBy('class.createdAt', 'DESC')
-                ->setFirstResult(($page - 1) * $limit)
-                ->setMaxResults($limit);
-            if ($filters['q'] !== '') {
-                $qb->andWhere('LOWER(class.name) LIKE LOWER(:q)')->setParameter('q', '%' . $filters['q'] . '%');
+                ->setFirstResult($queryOptions->offset())
+                ->setMaxResults($queryOptions->limit);
+            if ($queryOptions->filters['q'] !== '') {
+                $qb->andWhere('LOWER(class.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
             }
 
             $items = $this->viewMapper->mapClassCollection($qb->getQuery()->getResult());
 
             $countQb = $this->classRepository->createQueryBuilder('class')->select('COUNT(class.id)')
                 ->andWhere('class.school = :school')->setParameter('school', $school);
-            if ($filters['q'] !== '') {
-                $countQb->andWhere('LOWER(class.name) LIKE LOWER(:q)')->setParameter('q', '%' . $filters['q'] . '%');
+            if ($queryOptions->filters['q'] !== '') {
+                $countQb->andWhere('LOWER(class.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
             }
             $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
 
-            return $this->responseSerializer->list(
+            return $this->listResponseFactory->create(
+                $queryOptions,
+                $totalItems,
                 $items,
-                [
-                    'page' => $page,
-                    'limit' => $limit,
-                    'totalItems' => $totalItems,
-                    'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
-                ],
                 [
                     'applicationSlug' => $applicationSlug,
                     'schoolId' => $school->getId(),
-                    'filters' => array_filter($filters),
                 ],
             );
         });

--- a/src/School/Application/Service/ClassTeacherAssignmentService.php
+++ b/src/School/Application/Service/ClassTeacherAssignmentService.php
@@ -4,25 +4,20 @@ declare(strict_types=1);
 
 namespace App\School\Application\Service;
 
-use App\School\Domain\Entity\SchoolClass;
-use App\School\Domain\Entity\Teacher;
-use App\School\Infrastructure\Repository\SchoolClassRepository;
+use App\School\Domain\Entity\School;
 use App\School\Infrastructure\Repository\TeacherRepository;
-use Ramsey\Uuid\Uuid;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 final readonly class ClassTeacherAssignmentService
 {
     public function __construct(
-        private SchoolClassRepository $classRepository,
+        private SchoolReferenceResolver $referenceResolver,
         private TeacherRepository $teacherRepository,
     ) {
     }
 
-    public function assign(string $classId, string $teacherId): void
+    public function assign(School $school, string $classId, string $teacherId): void
     {
-        [$class, $teacher] = $this->resolve($classId, $teacherId);
+        [$class, $teacher] = $this->resolve($school, $classId, $teacherId);
 
         if (!$teacher->getClasses()->contains($class)) {
             $teacher->getClasses()->add($class);
@@ -30,9 +25,9 @@ final readonly class ClassTeacherAssignmentService
         }
     }
 
-    public function unassign(string $classId, string $teacherId): void
+    public function unassign(School $school, string $classId, string $teacherId): void
     {
-        [$class, $teacher] = $this->resolve($classId, $teacherId);
+        [$class, $teacher] = $this->resolve($school, $classId, $teacherId);
 
         if ($teacher->getClasses()->contains($class)) {
             $teacher->getClasses()->removeElement($class);
@@ -41,24 +36,16 @@ final readonly class ClassTeacherAssignmentService
     }
 
     /**
-     * @return array{0:SchoolClass,1:Teacher}
+     * @return array{0:\App\School\Domain\Entity\SchoolClass,1:\App\School\Domain\Entity\Teacher}
      */
-    private function resolve(string $classId, string $teacherId): array
+    private function resolve(School $school, string $classId, string $teacherId): array
     {
-        if (!Uuid::isValid($classId) || !Uuid::isValid($teacherId)) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid identifier format.');
-        }
+        $this->referenceResolver->assertValidIdentifier($classId, 'classId');
+        $this->referenceResolver->assertValidIdentifier($teacherId, 'teacherId');
 
-        $class = $this->classRepository->find($classId);
-        if (!$class instanceof SchoolClass) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Class not found.');
-        }
-
-        $teacher = $this->teacherRepository->find($teacherId);
-        if (!$teacher instanceof Teacher) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Teacher not found.');
-        }
-
-        return [$class, $teacher];
+        return [
+            $this->referenceResolver->resolveClassInSchool($school, $classId),
+            $this->referenceResolver->resolveTeacherInSchool($school, $teacherId),
+        ];
     }
 }

--- a/src/School/Application/Service/CreateExamService.php
+++ b/src/School/Application/Service/CreateExamService.php
@@ -8,21 +8,16 @@ use App\General\Application\Message\EntityCreated;
 use App\School\Application\Exception\SchoolRelationException;
 use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\School;
-use App\School\Domain\Entity\SchoolClass;
-use App\School\Domain\Entity\Teacher;
 use App\School\Domain\Enum\ExamStatus;
 use App\School\Domain\Enum\ExamType;
 use App\School\Domain\Enum\Term;
-use App\School\Infrastructure\Repository\SchoolClassRepository;
-use App\School\Infrastructure\Repository\TeacherRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 final readonly class CreateExamService
 {
     public function __construct(
-        private SchoolClassRepository $classRepository,
-        private TeacherRepository $teacherRepository,
+        private SchoolReferenceResolver $referenceResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -37,35 +32,8 @@ final readonly class CreateExamService
         ExamStatus $status,
         Term $term,
     ): Exam {
-        if (!is_string($classId)) {
-            throw SchoolRelationException::unprocessable('classId is required');
-        }
-
-        if (!is_string($teacherId)) {
-            throw SchoolRelationException::unprocessable('teacherId is required');
-        }
-
-        $class = $this->classRepository->find($classId);
-        if (!$class instanceof SchoolClass || $class->getSchool()?->getId() !== $school->getId()) {
-            throw SchoolRelationException::notFound('classId');
-        }
-
-        $teacher = $this->teacherRepository->find($teacherId);
-        if (!$teacher instanceof Teacher) {
-            throw SchoolRelationException::notFound('teacherId');
-        }
-
-        $teacherBelongsToSchool = false;
-        foreach ($teacher->getClasses() as $teacherClass) {
-            if ($teacherClass->getSchool()?->getId() === $school->getId()) {
-                $teacherBelongsToSchool = true;
-                break;
-            }
-        }
-
-        if (!$teacherBelongsToSchool) {
-            throw SchoolRelationException::notFound('teacherId');
-        }
+        $class = $this->referenceResolver->resolveClassInSchool($school, $classId);
+        $teacher = $this->referenceResolver->resolveTeacherInSchool($school, $teacherId);
 
         if (!$teacher->getClasses()->contains($class)) {
             throw SchoolRelationException::unprocessable('teacherId is not assigned to classId');

--- a/src/School/Application/Service/CreateGradeService.php
+++ b/src/School/Application/Service/CreateGradeService.php
@@ -6,20 +6,15 @@ namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityCreated;
 use App\School\Application\Exception\SchoolRelationException;
-use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\Grade;
 use App\School\Domain\Entity\School;
-use App\School\Domain\Entity\Student;
-use App\School\Infrastructure\Repository\ExamRepository;
-use App\School\Infrastructure\Repository\StudentRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 final readonly class CreateGradeService
 {
     public function __construct(
-        private StudentRepository $studentRepository,
-        private ExamRepository $examRepository,
+        private SchoolReferenceResolver $referenceResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -27,23 +22,8 @@ final readonly class CreateGradeService
 
     public function create(School $school, float $score, ?string $studentId, ?string $examId): Grade
     {
-        if (!is_string($studentId)) {
-            throw SchoolRelationException::unprocessable('studentId is required');
-        }
-
-        if (!is_string($examId)) {
-            throw SchoolRelationException::unprocessable('examId is required');
-        }
-
-        $student = $this->studentRepository->find($studentId);
-        if (!$student instanceof Student || $student->getSchoolClass()?->getSchool()?->getId() !== $school->getId()) {
-            throw SchoolRelationException::notFound('studentId');
-        }
-
-        $exam = $this->examRepository->find($examId);
-        if (!$exam instanceof Exam || $exam->getSchoolClass()?->getSchool()?->getId() !== $school->getId()) {
-            throw SchoolRelationException::notFound('examId');
-        }
+        $student = $this->referenceResolver->resolveStudentInSchool($school, $studentId);
+        $exam = $this->referenceResolver->resolveExamInSchool($school, $examId);
 
         if ($student->getSchoolClass()?->getId() !== $exam->getSchoolClass()?->getId()) {
             throw SchoolRelationException::unprocessable('studentId and examId must belong to the same class');

--- a/src/School/Application/Service/CreateStudentService.php
+++ b/src/School/Application/Service/CreateStudentService.php
@@ -5,18 +5,15 @@ declare(strict_types=1);
 namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityCreated;
-use App\School\Application\Exception\SchoolRelationException;
 use App\School\Domain\Entity\School;
-use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Student;
-use App\School\Infrastructure\Repository\SchoolClassRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 final readonly class CreateStudentService
 {
     public function __construct(
-        private SchoolClassRepository $classRepository,
+        private SchoolReferenceResolver $referenceResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -24,14 +21,7 @@ final readonly class CreateStudentService
 
     public function create(School $school, string $name, ?string $classId): Student
     {
-        if (!is_string($classId)) {
-            throw SchoolRelationException::unprocessable('classId is required');
-        }
-
-        $class = $this->classRepository->find($classId);
-        if (!$class instanceof SchoolClass || $class->getSchool()?->getId() !== $school->getId()) {
-            throw SchoolRelationException::notFound('classId');
-        }
+        $class = $this->referenceResolver->resolveClassInSchool($school, $classId);
 
         $student = (new Student())->setName($name);
         $student->setSchoolClass($class);

--- a/src/School/Application/Service/ExamListService.php
+++ b/src/School/Application/Service/ExamListService.php
@@ -7,7 +7,6 @@ namespace App\School\Application\Service;
 use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\School\Application\Projection\SchoolExamProjection;
-use App\School\Application\Serializer\SchoolApiResponseSerializer;
 use App\School\Application\Serializer\SchoolViewMapper;
 use App\School\Infrastructure\Repository\ExamRepository;
 use Symfony\Component\HttpFoundation\Request;
@@ -24,29 +23,25 @@ readonly class ExamListService
         private ElasticsearchServiceInterface $elasticsearchService,
         private CacheKeyConventionService $cacheKeyConventionService,
         private SchoolViewMapper $viewMapper,
-        private SchoolApiResponseSerializer $responseSerializer,
+        private SchoolListRequestHelper $listRequestHelper,
+        private SchoolListResponseFactory $listResponseFactory,
     ) {
     }
 
     /**
      * @return array<string,mixed>
      */
-    public function getList(Request $request, string $schoolId): array
+    public function list(Request $request, string $schoolId): array
     {
-        $page = max(1, $request->query->getInt('page', 1));
-        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
-        $filters = [
-            'q' => trim((string)$request->query->get('q', '')),
-            'title' => trim((string)$request->query->get('title', '')),
-        ];
+        $queryOptions = $this->listRequestHelper->fromRequest($request, ['q', 'title']);
         $applicationSlug = (string)$request->attributes->get('applicationSlug', 'default');
-        $cacheKey = $this->cacheKeyConventionService->buildSchoolExamListKey($applicationSlug, $page, $limit, [
-            ...$filters,
+        $cacheKey = $this->cacheKeyConventionService->buildSchoolExamListKey($applicationSlug, $queryOptions->page, $queryOptions->limit, [
+            ...$queryOptions->filters,
             'schoolId' => $schoolId,
         ]);
 
         /** @var array<string,mixed> $result */
-        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit, $schoolId, $applicationSlug): array {
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($queryOptions, $schoolId, $applicationSlug): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag([
@@ -55,23 +50,18 @@ readonly class ExamListService
                 ]);
             }
 
-            $esIds = $this->searchIdsFromElastic($filters);
+            $esIds = $this->searchIdsFromElastic($queryOptions->filters);
             if ($esIds === []) {
-                return $this->responseSerializer->list([], [
-                    'page' => $page,
-                    'limit' => $limit,
-                    'totalItems' => 0,
-                    'totalPages' => 0,
-                ]);
+                return $this->listResponseFactory->create($queryOptions, 0, []);
             }
 
             $qb = $this->examRepository->createQueryBuilder('exam')->leftJoin('exam.schoolClass', 'class')->leftJoin('exam.teacher', 'teacher')
                 ->innerJoin('class.school', 'school')
                 ->andWhere('school.id = :schoolId')
                 ->setParameter('schoolId', $schoolId)
-                ->setFirstResult(($page - 1) * $limit)->setMaxResults($limit)->orderBy('exam.createdAt', 'DESC');
-            if ($filters['title'] !== '') {
-                $qb->andWhere('LOWER(exam.title) LIKE LOWER(:title)')->setParameter('title', '%' . $filters['title'] . '%');
+                ->setFirstResult($queryOptions->offset())->setMaxResults($queryOptions->limit)->orderBy('exam.createdAt', 'DESC');
+            if ($queryOptions->filters['title'] !== '') {
+                $qb->andWhere('LOWER(exam.title) LIKE LOWER(:title)')->setParameter('title', '%' . $queryOptions->filters['title'] . '%');
             }
             if ($esIds !== null) {
                 $qb->andWhere('exam.id IN (:ids)')->setParameter('ids', $esIds);
@@ -84,8 +74,8 @@ readonly class ExamListService
                 ->innerJoin('class.school', 'school')
                 ->andWhere('school.id = :schoolId')
                 ->setParameter('schoolId', $schoolId);
-            if ($filters['title'] !== '') {
-                $countQb->andWhere('LOWER(exam.title) LIKE LOWER(:title)')->setParameter('title', '%' . $filters['title'] . '%');
+            if ($queryOptions->filters['title'] !== '') {
+                $countQb->andWhere('LOWER(exam.title) LIKE LOWER(:title)')->setParameter('title', '%' . $queryOptions->filters['title'] . '%');
             }
             if ($esIds !== null) {
                 $countQb->andWhere('exam.id IN (:ids)')->setParameter('ids', $esIds);
@@ -93,21 +83,15 @@ readonly class ExamListService
 
             $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
 
-            return $this->responseSerializer->list(
+            return $this->listResponseFactory->create(
+                $queryOptions,
+                $totalItems,
                 $items,
-                [
-                    'page' => $page,
-                    'limit' => $limit,
-                    'totalItems' => $totalItems,
-                    'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
-                ],
                 [
                     'module' => 'school',
                 ],
             );
         });
-
-        $result['meta']['filters'] = array_filter($filters, static fn (string $value): bool => $value !== '');
 
         return $result;
     }

--- a/src/School/Application/Service/ListGradesService.php
+++ b/src/School/Application/Service/ListGradesService.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Domain\Entity\School;
+use App\School\Infrastructure\Repository\GradeRepository;
+use Symfony\Component\HttpFoundation\Request;
+
+final readonly class ListGradesService
+{
+    public function __construct(
+        private GradeRepository $gradeRepository,
+        private SchoolViewMapper $viewMapper,
+        private SchoolListRequestHelper $listRequestHelper,
+        private SchoolListResponseFactory $listResponseFactory,
+    ) {
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function list(Request $request, School $school): array
+    {
+        $queryOptions = $this->listRequestHelper->fromRequest($request, ['q']);
+
+        $qb = $this->gradeRepository->createQueryBuilder('grade')
+            ->innerJoin('grade.exam', 'exam')
+            ->innerJoin('grade.student', 'student')
+            ->innerJoin('exam.schoolClass', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $school->getId())
+            ->orderBy('grade.createdAt', 'DESC')
+            ->setFirstResult($queryOptions->offset())
+            ->setMaxResults($queryOptions->limit);
+        if ($queryOptions->filters['q'] !== '') {
+            $qb->andWhere('LOWER(exam.title) LIKE LOWER(:q) OR LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+        }
+
+        $items = $this->viewMapper->mapGradeCollection($qb->getQuery()->getResult());
+
+        $countQb = $this->gradeRepository->createQueryBuilder('grade')->select('COUNT(grade.id)')
+            ->innerJoin('grade.exam', 'exam')
+            ->innerJoin('grade.student', 'student')
+            ->innerJoin('exam.schoolClass', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $school->getId());
+        if ($queryOptions->filters['q'] !== '') {
+            $countQb->andWhere('LOWER(exam.title) LIKE LOWER(:q) OR LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+        }
+        $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
+
+        return $this->listResponseFactory->create($queryOptions, $totalItems, $items, [
+            'schoolId' => $school->getId(),
+        ]);
+    }
+}

--- a/src/School/Application/Service/ListStudentsService.php
+++ b/src/School/Application/Service/ListStudentsService.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Domain\Entity\School;
+use App\School\Infrastructure\Repository\StudentRepository;
+use Symfony\Component\HttpFoundation\Request;
+
+final readonly class ListStudentsService
+{
+    public function __construct(
+        private StudentRepository $studentRepository,
+        private SchoolViewMapper $viewMapper,
+        private SchoolListRequestHelper $listRequestHelper,
+        private SchoolListResponseFactory $listResponseFactory,
+    ) {
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function list(Request $request, School $school): array
+    {
+        $queryOptions = $this->listRequestHelper->fromRequest($request, ['q']);
+
+        $qb = $this->studentRepository->createQueryBuilder('student')
+            ->innerJoin('student.schoolClass', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $school->getId())
+            ->orderBy('student.createdAt', 'DESC')
+            ->setFirstResult($queryOptions->offset())
+            ->setMaxResults($queryOptions->limit);
+        if ($queryOptions->filters['q'] !== '') {
+            $qb->andWhere('LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+        }
+
+        $items = $this->viewMapper->mapStudentCollection($qb->getQuery()->getResult());
+
+        $countQb = $this->studentRepository->createQueryBuilder('student')->select('COUNT(student.id)')
+            ->innerJoin('student.schoolClass', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $school->getId());
+        if ($queryOptions->filters['q'] !== '') {
+            $countQb->andWhere('LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+        }
+        $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
+
+        return $this->listResponseFactory->create($queryOptions, $totalItems, $items, [
+            'schoolId' => $school->getId(),
+        ]);
+    }
+}

--- a/src/School/Application/Service/ListTeachersService.php
+++ b/src/School/Application/Service/ListTeachersService.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Domain\Entity\School;
+use App\School\Infrastructure\Repository\TeacherRepository;
+use Symfony\Component\HttpFoundation\Request;
+
+final readonly class ListTeachersService
+{
+    public function __construct(
+        private TeacherRepository $teacherRepository,
+        private SchoolViewMapper $viewMapper,
+        private SchoolListRequestHelper $listRequestHelper,
+        private SchoolListResponseFactory $listResponseFactory,
+    ) {
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function list(Request $request, School $school): array
+    {
+        $queryOptions = $this->listRequestHelper->fromRequest($request, ['q']);
+
+        $qb = $this->teacherRepository->createQueryBuilder('teacher')
+            ->innerJoin('teacher.classes', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $school->getId())
+            ->orderBy('teacher.createdAt', 'DESC')
+            ->distinct()
+            ->setFirstResult($queryOptions->offset())
+            ->setMaxResults($queryOptions->limit);
+        if ($queryOptions->filters['q'] !== '') {
+            $qb->andWhere('LOWER(teacher.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+        }
+
+        $items = $this->viewMapper->mapTeacherCollection($qb->getQuery()->getResult());
+
+        $countQb = $this->teacherRepository->createQueryBuilder('teacher')->select('COUNT(DISTINCT teacher.id)')
+            ->innerJoin('teacher.classes', 'class')
+            ->innerJoin('class.school', 'school')
+            ->andWhere('school.id = :schoolId')
+            ->setParameter('schoolId', $school->getId());
+        if ($queryOptions->filters['q'] !== '') {
+            $countQb->andWhere('LOWER(teacher.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+        }
+        $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
+
+        return $this->listResponseFactory->create($queryOptions, $totalItems, $items, [
+            'schoolId' => $school->getId(),
+        ]);
+    }
+}

--- a/src/School/Application/Service/SchoolListQueryOptions.php
+++ b/src/School/Application/Service/SchoolListQueryOptions.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+final readonly class SchoolListQueryOptions
+{
+    /**
+     * @param array<string,string> $filters
+     */
+    public function __construct(
+        public int $page,
+        public int $limit,
+        public array $filters,
+    ) {
+    }
+
+    public function offset(): int
+    {
+        return ($this->page - 1) * $this->limit;
+    }
+
+    /**
+     * @return array{page:int,limit:int,totalItems:int,totalPages:int}
+     */
+    public function toPaginationMeta(int $totalItems): array
+    {
+        return [
+            'page' => $this->page,
+            'limit' => $this->limit,
+            'totalItems' => $totalItems,
+            'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $this->limit) : 0,
+        ];
+    }
+}

--- a/src/School/Application/Service/SchoolListRequestHelper.php
+++ b/src/School/Application/Service/SchoolListRequestHelper.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use Symfony\Component\HttpFoundation\Request;
+
+final readonly class SchoolListRequestHelper
+{
+    /**
+     * @param array<int,string> $filterKeys
+     */
+    public function fromRequest(Request $request, array $filterKeys = ['q']): SchoolListQueryOptions
+    {
+        $filters = [];
+        foreach ($filterKeys as $key) {
+            $filters[$key] = trim((string)$request->query->get($key, ''));
+        }
+
+        return new SchoolListQueryOptions(
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 20))),
+            $filters,
+        );
+    }
+
+    /**
+     * @param array<string,string> $filters
+     *
+     * @return array<string,string>
+     */
+    public function activeFilters(array $filters): array
+    {
+        return array_filter($filters, static fn (string $value): bool => $value !== '');
+    }
+}

--- a/src/School/Application/Service/SchoolListResponseFactory.php
+++ b/src/School/Application/Service/SchoolListResponseFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use App\School\Application\Serializer\SchoolApiResponseSerializer;
+
+final readonly class SchoolListResponseFactory
+{
+    public function __construct(
+        private SchoolApiResponseSerializer $responseSerializer,
+        private SchoolListRequestHelper $listRequestHelper,
+    ) {
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $items
+     * @param array<string,mixed> $context
+     *
+     * @return array<string,mixed>
+     */
+    public function create(SchoolListQueryOptions $queryOptions, int $totalItems, array $items, array $context = []): array
+    {
+        return $this->responseSerializer->list(
+            $items,
+            $queryOptions->toPaginationMeta($totalItems),
+            [
+                ...$context,
+                'filters' => $this->listRequestHelper->activeFilters($queryOptions->filters),
+            ],
+        );
+    }
+}

--- a/src/School/Application/Service/SchoolReferenceResolver.php
+++ b/src/School/Application/Service/SchoolReferenceResolver.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use App\School\Application\Exception\SchoolRelationException;
+use App\School\Domain\Entity\Exam;
+use App\School\Domain\Entity\School;
+use App\School\Domain\Entity\SchoolClass;
+use App\School\Domain\Entity\Student;
+use App\School\Domain\Entity\Teacher;
+use App\School\Infrastructure\Repository\ExamRepository;
+use App\School\Infrastructure\Repository\SchoolClassRepository;
+use App\School\Infrastructure\Repository\StudentRepository;
+use App\School\Infrastructure\Repository\TeacherRepository;
+use Ramsey\Uuid\Uuid;
+
+final readonly class SchoolReferenceResolver
+{
+    public function __construct(
+        private SchoolClassRepository $classRepository,
+        private TeacherRepository $teacherRepository,
+        private StudentRepository $studentRepository,
+        private ExamRepository $examRepository,
+    ) {
+    }
+
+    public function resolveClassInSchool(School $school, ?string $classId, string $reference = 'classId'): SchoolClass
+    {
+        if (!is_string($classId) || $classId === '') {
+            throw SchoolRelationException::unprocessable($reference . ' is required');
+        }
+
+        $class = $this->classRepository->find($classId);
+        if (!$class instanceof SchoolClass || $class->getSchool()?->getId() !== $school->getId()) {
+            throw SchoolRelationException::notFound($reference);
+        }
+
+        return $class;
+    }
+
+    public function resolveTeacherInSchool(School $school, ?string $teacherId, string $reference = 'teacherId'): Teacher
+    {
+        if (!is_string($teacherId) || $teacherId === '') {
+            throw SchoolRelationException::unprocessable($reference . ' is required');
+        }
+
+        $teacher = $this->teacherRepository->find($teacherId);
+        if (!$teacher instanceof Teacher) {
+            throw SchoolRelationException::notFound($reference);
+        }
+
+        foreach ($teacher->getClasses() as $teacherClass) {
+            if ($teacherClass->getSchool()?->getId() === $school->getId()) {
+                return $teacher;
+            }
+        }
+
+        throw SchoolRelationException::notFound($reference);
+    }
+
+    public function resolveStudentInSchool(School $school, ?string $studentId, string $reference = 'studentId'): Student
+    {
+        if (!is_string($studentId) || $studentId === '') {
+            throw SchoolRelationException::unprocessable($reference . ' is required');
+        }
+
+        $student = $this->studentRepository->find($studentId);
+        if (!$student instanceof Student || $student->getSchoolClass()?->getSchool()?->getId() !== $school->getId()) {
+            throw SchoolRelationException::notFound($reference);
+        }
+
+        return $student;
+    }
+
+    public function resolveExamInSchool(School $school, ?string $examId, string $reference = 'examId'): Exam
+    {
+        if (!is_string($examId) || $examId === '') {
+            throw SchoolRelationException::unprocessable($reference . ' is required');
+        }
+
+        $exam = $this->examRepository->find($examId);
+        if (!$exam instanceof Exam || $exam->getSchoolClass()?->getSchool()?->getId() !== $school->getId()) {
+            throw SchoolRelationException::notFound($reference);
+        }
+
+        return $exam;
+    }
+
+    public function assertValidIdentifier(string $identifier, string $reference): void
+    {
+        if (!Uuid::isValid($identifier)) {
+            throw SchoolRelationException::unprocessable($reference . ' has invalid format');
+        }
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/Class/AssignClassTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/AssignClassTeacherController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\School\Transport\Controller\Api\V1\Class;
 
 use App\School\Application\Service\ClassTeacherAssignmentService;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,14 +21,16 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class AssignClassTeacherController
 {
     public function __construct(
-        private ClassTeacherAssignmentService $assignmentService
+        private ClassTeacherAssignmentService $assignmentService,
+        private SchoolApplicationScopeResolver $scopeResolver,
     ) {
     }
     #[Route('/v1/school/applications/{applicationSlug}/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $id, string $teacherId): JsonResponse
+    public function __invoke(string $applicationSlug, string $id, string $teacherId, ?User $loggedInUser): JsonResponse
     {
-        $this->assignmentService->assign($id, $teacherId);
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+        $this->assignmentService->assign($school, $id, $teacherId);
 
         return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
     }

--- a/src/School/Transport/Controller/Api/V1/Class/ListClassesByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/ListClassesByApplicationController.php
@@ -69,6 +69,6 @@ final readonly class ListClassesByApplicationController
         $request->attributes->set('applicationSlug', $applicationSlug);
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
 
-        return new JsonResponse($this->classApplicationListService->getList($request, $applicationSlug, $school));
+        return new JsonResponse($this->classApplicationListService->list($request, $applicationSlug, $school));
     }
 }

--- a/src/School/Transport/Controller/Api/V1/Class/UnassignClassTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/UnassignClassTeacherController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\School\Transport\Controller\Api\V1\Class;
 
 use App\School\Application\Service\ClassTeacherAssignmentService;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,14 +21,16 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class UnassignClassTeacherController
 {
     public function __construct(
-        private ClassTeacherAssignmentService $assignmentService
+        private ClassTeacherAssignmentService $assignmentService,
+        private SchoolApplicationScopeResolver $scopeResolver,
     ) {
     }
     #[Route('/v1/school/applications/{applicationSlug}/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_DELETE])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $id, string $teacherId): JsonResponse
+    public function __invoke(string $applicationSlug, string $id, string $teacherId, ?User $loggedInUser): JsonResponse
     {
-        $this->assignmentService->unassign($id, $teacherId);
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+        $this->assignmentService->unassign($school, $id, $teacherId);
 
         return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
     }

--- a/src/School/Transport/Controller/Api/V1/Exam/ListExamsController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/ListExamsController.php
@@ -33,6 +33,6 @@ final readonly class ListExamsController
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
         $request->attributes->set('applicationSlug', $applicationSlug);
 
-        return new JsonResponse($this->examListService->getList($request, $school->getId()));
+        return new JsonResponse($this->examListService->list($request, $school->getId()));
     }
 }

--- a/src/School/Transport/Controller/Api/V1/Grade/ListGradesController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/ListGradesController.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace App\School\Transport\Controller\Api\V1\Grade;
 
-use App\School\Application\Serializer\SchoolApiResponseSerializer;
-use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Application\Service\ListGradesService;
 use App\School\Application\Service\SchoolApplicationScopeResolver;
-use App\School\Infrastructure\Repository\GradeRepository;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -24,29 +22,16 @@ final readonly class ListGradesController
 {
     public function __construct(
         private SchoolApplicationScopeResolver $scopeResolver,
-        private GradeRepository $gradeRepository,
-        private SchoolViewMapper $viewMapper,
-        private SchoolApiResponseSerializer $responseSerializer,
+        private ListGradesService $listGradesService,
     ) {
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/grades', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, ?User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
 
-        $items = $this->viewMapper->mapGradeCollection($this->gradeRepository->createQueryBuilder('grade')
-            ->innerJoin('grade.exam', 'exam')
-            ->innerJoin('exam.schoolClass', 'class')
-            ->innerJoin('class.school', 'school')
-            ->andWhere('school.id = :schoolId')
-            ->setParameter('schoolId', $school->getId())
-            ->orderBy('grade.createdAt', 'DESC')
-            ->setMaxResults(200)
-            ->getQuery()
-            ->getResult());
-
-        return new JsonResponse($this->responseSerializer->list($items));
+        return new JsonResponse($this->listGradesService->list($request, $school));
     }
 }

--- a/src/School/Transport/Controller/Api/V1/Student/ListStudentsController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/ListStudentsController.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace App\School\Transport\Controller\Api\V1\Student;
 
-use App\School\Application\Serializer\SchoolApiResponseSerializer;
-use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Application\Service\ListStudentsService;
 use App\School\Application\Service\SchoolApplicationScopeResolver;
-use App\School\Infrastructure\Repository\StudentRepository;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -24,27 +22,16 @@ final readonly class ListStudentsController
 {
     public function __construct(
         private SchoolApplicationScopeResolver $scopeResolver,
-        private StudentRepository $studentRepository,
-        private SchoolViewMapper $viewMapper,
-        private SchoolApiResponseSerializer $responseSerializer,
+        private ListStudentsService $listStudentsService,
     ) {
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/students', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, ?User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
-        $items = $this->viewMapper->mapStudentCollection($this->studentRepository->createQueryBuilder('student')
-            ->innerJoin('student.schoolClass', 'class')
-            ->innerJoin('class.school', 'school')
-            ->andWhere('school.id = :schoolId')
-            ->setParameter('schoolId', $school->getId())
-            ->orderBy('student.createdAt', 'DESC')
-            ->setMaxResults(200)
-            ->getQuery()
-            ->getResult());
 
-        return new JsonResponse($this->responseSerializer->list($items));
+        return new JsonResponse($this->listStudentsService->list($request, $school));
     }
 }

--- a/src/School/Transport/Controller/Api/V1/Teacher/ListTeachersController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/ListTeachersController.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace App\School\Transport\Controller\Api\V1\Teacher;
 
-use App\School\Application\Serializer\SchoolApiResponseSerializer;
-use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Application\Service\ListTeachersService;
 use App\School\Application\Service\SchoolApplicationScopeResolver;
-use App\School\Infrastructure\Repository\TeacherRepository;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -24,29 +22,16 @@ final readonly class ListTeachersController
 {
     public function __construct(
         private SchoolApplicationScopeResolver $scopeResolver,
-        private TeacherRepository $teacherRepository,
-        private SchoolViewMapper $viewMapper,
-        private SchoolApiResponseSerializer $responseSerializer,
+        private ListTeachersService $listTeachersService,
     ) {
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/teachers', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, ?User $loggedInUser): JsonResponse
+    public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
 
-        $items = $this->viewMapper->mapTeacherCollection($this->teacherRepository->createQueryBuilder('teacher')
-            ->innerJoin('teacher.classes', 'class')
-            ->innerJoin('class.school', 'school')
-            ->andWhere('school.id = :schoolId')
-            ->setParameter('schoolId', $school->getId())
-            ->orderBy('teacher.createdAt', 'DESC')
-            ->distinct()
-            ->setMaxResults(200)
-            ->getQuery()
-            ->getResult());
-
-        return new JsonResponse($this->responseSerializer->list($items));
+        return new JsonResponse($this->listTeachersService->list($request, $school));
     }
 }


### PR DESCRIPTION
### Motivation
- Centralize list query parsing, pagination and response shaping to remove duplicated logic across CRM and School modules.
- Consolidate and standardize list endpoints and controllers to use the same `list` contract and response format.
- Centralize validation and resolution of school-scoped references to avoid repetitive repository checks and error handling.

### Description
- Introduced `CrmListQueryOptions`, `CrmListRequestHelper`, and `CrmListResponseFactory` and their `School*` equivalents to parse request pagination/filters and to build list responses, and updated services to consume them.
- Replaced many `getList` methods with `list` and updated controllers to call `list`, migrating pagination/filtering/caching logic to the new helpers in `CompanyApplicationListService`, `ContactReadService`, `ClassApplicationListService`, `ExamListService` and others.
- Added new list services `ListStudentsService`, `ListTeachersService`, and `ListGradesService` and refactored controllers to use them and the unified response factory.
- Implemented `SchoolReferenceResolver` to centralize resolving and validating `class`, `teacher`, `student`, and `exam` references and updated `CreateExamService`, `CreateGradeService`, `CreateStudentService`, and `ClassTeacherAssignmentService` to use it; also tightened controller flows to resolve or create `School` scope before performing assignments.
- Improved Elasticsearch id extraction in `ContactReadService` to use `array_values` and compacted response normalization flow.

### Testing
- Ran the project's automated test suite including unit and integration tests and static analysis checks; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b862d483bc832b81c95d68e23dc97a)