### PR TITLE
Fix general quiz fixture scenario and categories

### DIFF
--- a/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
+++ b/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
@@ -36,8 +36,9 @@ final class LoadQuizData extends Fixture implements OrderedFixtureInterface
         $applications = $manager->getRepository(Application::class)
             ->createQueryBuilder('application')
             ->innerJoin('application.applicationPlugins', 'applicationPlugin')
-            ->andWhere('applicationPlugin.plugin = :plugin')
+            ->andWhere('applicationPlugin.plugin = :plugin OR application.slug = :generalSlug')
             ->setParameter('plugin', $quizPlugin)
+            ->setParameter('generalSlug', 'general')
             ->orderBy('application.title', 'ASC')
             ->getQuery()
             ->getResult();
@@ -85,7 +86,9 @@ final class LoadQuizData extends Fixture implements OrderedFixtureInterface
                         ? 'General question fixture #' . $questionIndex
                         : 'Question fixture #' . $questionIndex . ' app #' . ($applicationIndex + 1))
                     ->setLevel($questionIndex % 3 === 0 ? QuizLevel::HARD : (QuizLevel::EASY))
-                    ->setCategory($questionIndex % 2 === 0 ? QuizCategory::BACKEND : QuizCategory::FRONTEND)
+                    ->setCategory($isGeneralApplication
+                        ? QuizCategory::GENERAL
+                        : ($questionIndex % 2 === 0 ? QuizCategory::BACKEND : QuizCategory::FRONTEND))
                     ->setPosition($questionIndex)
                     ->setPoints($questionIndex % 3 === 0 ? 3 : 1)
                     ->setExplanation('This explanation helps users understand the expected reasoning.') : new QuizQuestion()
@@ -94,7 +97,9 @@ final class LoadQuizData extends Fixture implements OrderedFixtureInterface
                         ? 'General question fixture #' . $questionIndex
                         : 'Question fixture #' . $questionIndex . ' app #' . ($applicationIndex + 1))
                     ->setLevel($questionIndex % 3 === 0 ? QuizLevel::HARD : (QuizLevel::MEDIUM))
-                    ->setCategory($questionIndex % 2 === 0 ? QuizCategory::BACKEND : QuizCategory::FRONTEND)
+                    ->setCategory($isGeneralApplication
+                        ? QuizCategory::GENERAL
+                        : ($questionIndex % 2 === 0 ? QuizCategory::BACKEND : QuizCategory::FRONTEND))
                     ->setPosition($questionIndex)
                     ->setPoints($questionIndex % 3 === 0 ? 3 : 1)
                     ->setExplanation('This explanation helps users understand the expected reasoning.');


### PR DESCRIPTION
### Motivation

- Ensure the `general` application always receives quiz fixture data even when the scenario lacks a plugin relation so the public general quiz endpoint is populated. 
- Make `general` questions use the `general` category so filtering by `category=general` returns results. 

### Description

- Update `src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php` to include `application.slug = 'general'` in the query by changing the `andWhere` to `applicationPlugin.plugin = :plugin OR application.slug = :generalSlug` and adding `->setParameter('generalSlug', 'general')`. 
- When generating questions, set the category to `QuizCategory::GENERAL` for the `general` application instead of `BACKEND`/`FRONTEND`. 
- Add and persist the created quiz references for the `general` application so `Quiz-general` is present in fixtures. 

### Testing

- Ran `php -l src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php` and there were no syntax errors. 
- Attempted to run `php -d memory_limit=1G vendor/bin/phpunit tests/Application/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationControllerTest.php` but `vendor/bin/phpunit` is unavailable in this environment so PHPUnit tests could not be executed. 
- The fixture file change was committed and is ready for CI/full test execution where `phpunit` is available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd7e54ef40832b8974e9c44545fcb1)