### PR TITLE
Add support for 'general' application quizzes: fixtures, alias endpoints, and tests

### DIFF
--- a/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
+++ b/src/Quiz/Infrastructure/DataFixtures/ORM/LoadQuizData.php
@@ -36,8 +36,9 @@ final class LoadQuizData extends Fixture implements OrderedFixtureInterface
         $applications = $manager->getRepository(Application::class)
             ->createQueryBuilder('application')
             ->innerJoin('application.applicationPlugins', 'applicationPlugin')
-            ->andWhere('applicationPlugin.plugin = :plugin')
+            ->andWhere('applicationPlugin.plugin = :plugin OR application.slug = :generalSlug')
             ->setParameter('plugin', $quizPlugin)
+            ->setParameter('generalSlug', 'general')
             ->orderBy('application.title', 'ASC')
             ->getQuery()
             ->getResult();
@@ -74,9 +75,6 @@ final class LoadQuizData extends Fixture implements OrderedFixtureInterface
             $manager->persist($quiz);
             $this->addReference('Quiz-' . $application->getSlug(), $quiz);
 
-            if ($isGeneralApplication) {
-                $this->addReference('Quiz-general', $quiz);
-            }
 
             for ($questionIndex = 1; $questionIndex <= 12; $questionIndex++) {
                 $question = (0 !== $questionIndex % 2) ? new QuizQuestion()
@@ -85,7 +83,9 @@ final class LoadQuizData extends Fixture implements OrderedFixtureInterface
                         ? 'General question fixture #' . $questionIndex
                         : 'Question fixture #' . $questionIndex . ' app #' . ($applicationIndex + 1))
                     ->setLevel($questionIndex % 3 === 0 ? QuizLevel::HARD : (QuizLevel::EASY))
-                    ->setCategory($questionIndex % 2 === 0 ? QuizCategory::BACKEND : QuizCategory::FRONTEND)
+                    ->setCategory($isGeneralApplication
+                        ? QuizCategory::GENERAL
+                        : ($questionIndex % 2 === 0 ? QuizCategory::BACKEND : QuizCategory::FRONTEND))
                     ->setPosition($questionIndex)
                     ->setPoints($questionIndex % 3 === 0 ? 3 : 1)
                     ->setExplanation('This explanation helps users understand the expected reasoning.') : new QuizQuestion()
@@ -94,7 +94,9 @@ final class LoadQuizData extends Fixture implements OrderedFixtureInterface
                         ? 'General question fixture #' . $questionIndex
                         : 'Question fixture #' . $questionIndex . ' app #' . ($applicationIndex + 1))
                     ->setLevel($questionIndex % 3 === 0 ? QuizLevel::HARD : (QuizLevel::MEDIUM))
-                    ->setCategory($questionIndex % 2 === 0 ? QuizCategory::BACKEND : QuizCategory::FRONTEND)
+                    ->setCategory($isGeneralApplication
+                        ? QuizCategory::GENERAL
+                        : ($questionIndex % 2 === 0 ? QuizCategory::BACKEND : QuizCategory::FRONTEND))
                     ->setPosition($questionIndex)
                     ->setPoints($questionIndex % 3 === 0 ? 3 : 1)
                     ->setExplanation('This explanation helps users understand the expected reasoning.');

--- a/src/Quiz/Transport/Controller/Api/V1/QuizMutationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/QuizMutationController.php
@@ -37,6 +37,8 @@ use function is_string;
 #[OA\Tag(name: 'Quiz')]
 final readonly class QuizMutationController
 {
+    private const string GENERAL_APPLICATION_SLUG = 'general';
+
     public function __construct(
         private QuizRepository $quizRepository,
         private QuizQuestionRepository $questionRepository,
@@ -80,6 +82,16 @@ final readonly class QuizMutationController
     /**
      * @throws JsonException
      */
+    #[Route('/v1/quiz/general', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Create quiz for general application', tags: ['Quiz'])]
+    public function createGeneralQuiz(Request $request, User $loggedInUser): JsonResponse
+    {
+        return $this->createQuiz(self::GENERAL_APPLICATION_SLUG, $request, $loggedInUser);
+    }
+
+    /**
+     * @throws JsonException
+     */
     #[Route('/v1/quiz/applications/{applicationSlug}', methods: [Request::METHOD_PUT])]
     #[OA\Put(summary: 'Update quiz metadata', tags: ['Quiz'])]
     public function updateQuiz(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
@@ -113,6 +125,37 @@ final readonly class QuizMutationController
     public function unpublishQuiz(string $applicationSlug, User $loggedInUser): JsonResponse
     {
         return $this->toggleQuizPublication($applicationSlug, $loggedInUser, false);
+    }
+
+    /**
+     * @throws JsonException
+     */
+    #[Route('/v1/quiz/general', methods: [Request::METHOD_PUT])]
+    #[OA\Put(summary: 'Update general quiz metadata', tags: ['Quiz'])]
+    public function updateGeneralQuiz(Request $request, User $loggedInUser): JsonResponse
+    {
+        return $this->updateQuiz(self::GENERAL_APPLICATION_SLUG, $request, $loggedInUser);
+    }
+
+    #[Route('/v1/quiz/general/publish', methods: [Request::METHOD_PATCH])]
+    #[OA\Patch(summary: 'Publish general quiz', tags: ['Quiz'])]
+    public function publishGeneralQuiz(User $loggedInUser): JsonResponse
+    {
+        return $this->toggleQuizPublication(self::GENERAL_APPLICATION_SLUG, $loggedInUser, true);
+    }
+
+    #[Route('/v1/quiz/general/unpublish', methods: [Request::METHOD_PATCH])]
+    #[OA\Patch(summary: 'Unpublish general quiz', tags: ['Quiz'])]
+    public function unpublishGeneralQuiz(User $loggedInUser): JsonResponse
+    {
+        return $this->toggleQuizPublication(self::GENERAL_APPLICATION_SLUG, $loggedInUser, false);
+    }
+
+    #[Route('/v1/quiz/general', methods: [Request::METHOD_DELETE])]
+    #[OA\Delete(summary: 'Delete general quiz', tags: ['Quiz'])]
+    public function deleteGeneralQuiz(User $loggedInUser): JsonResponse
+    {
+        return $this->deleteQuiz(self::GENERAL_APPLICATION_SLUG, $loggedInUser);
     }
 
     #[Route('/v1/quiz/applications/{applicationSlug}', methods: [Request::METHOD_DELETE])]

--- a/src/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationController.php
@@ -20,6 +20,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[OA\Tag(name: 'Quiz')]
 final class SubmitQuizByApplicationController
 {
+    private const string GENERAL_APPLICATION_SLUG = 'general';
+
     /**
      * @throws JsonException
      */
@@ -30,5 +32,17 @@ final class SubmitQuizByApplicationController
         $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
 
         return new JsonResponse($quizSubmissionService->submitByApplicationSlug($applicationSlug, $payload, $loggedInUser));
+    }
+
+    /**
+     * @throws JsonException
+     */
+    #[Route('/v1/quiz/general/submit', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'POST /v1/quiz/general/submit', tags: ['Quiz'])]
+    public function submitGeneral(Request $request, QuizSubmissionService $quizSubmissionService, User $loggedInUser): JsonResponse
+    {
+        $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        return new JsonResponse($quizSubmissionService->submitByApplicationSlug(self::GENERAL_APPLICATION_SLUG, $payload, $loggedInUser));
     }
 }

--- a/tests/Application/Quiz/Transport/Controller/Api/V1/QuizManagementControllerTest.php
+++ b/tests/Application/Quiz/Transport/Controller/Api/V1/QuizManagementControllerTest.php
@@ -138,6 +138,64 @@ final class QuizManagementControllerTest extends WebTestCase
         self::assertSame(Response::HTTP_NO_CONTENT, $ownerClient->getResponse()->getStatusCode());
     }
 
+
+    #[TestDox('General quiz endpoints for put/publish/unpublish/submit are functional.')]
+    public function testGeneralQuizSpecificEndpointsFlow(): void
+    {
+        self::bootKernel();
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $generalQuiz = $entityManager->getRepository(Quiz::class)
+            ->createQueryBuilder('quiz')
+            ->innerJoin('quiz.application', 'application')
+            ->andWhere('application.slug = :slug')
+            ->setParameter('slug', 'general')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+        self::assertInstanceOf(Quiz::class, $generalQuiz);
+
+        $adminClient = $this->getTestClient('john-admin', 'password-admin');
+        $adminClient->request('PUT', self::API_URL_PREFIX . '/v1/quiz/general', content: JSON::encode([
+            'title' => 'General quiz updated from alias endpoint',
+            'description' => 'Alias endpoint update',
+            'passScore' => 65,
+        ]));
+        self::assertSame(Response::HTTP_OK, $adminClient->getResponse()->getStatusCode());
+
+        $adminClient->request('PATCH', self::API_URL_PREFIX . '/v1/quiz/general/publish');
+        self::assertSame(Response::HTTP_OK, $adminClient->getResponse()->getStatusCode());
+
+        $entityManager->clear();
+        $generalQuiz = $entityManager->getRepository(Quiz::class)->findOneBy([
+            'title' => 'General quiz updated from alias endpoint',
+        ]);
+        self::assertInstanceOf(Quiz::class, $generalQuiz);
+
+        $question = $entityManager->getRepository(QuizQuestion::class)->findOneBy([
+            'quiz' => $generalQuiz,
+        ]);
+        self::assertInstanceOf(QuizQuestion::class, $question);
+
+        $answer = $entityManager->getRepository(QuizAnswer::class)->findOneBy([
+            'question' => $question,
+            'isCorrect' => true,
+        ]);
+        self::assertInstanceOf(QuizAnswer::class, $answer);
+
+        $userClient = $this->getTestClient('john-user', 'password-user');
+        $userClient->request('POST', self::API_URL_PREFIX . '/v1/quiz/general/submit', content: JSON::encode([
+            'answers' => [[
+                'questionId' => $question->getId(),
+                'answerId' => $answer->getId(),
+            ]],
+        ]));
+        self::assertSame(Response::HTTP_OK, $userClient->getResponse()->getStatusCode());
+
+        $adminClient->request('PATCH', self::API_URL_PREFIX . '/v1/quiz/general/unpublish');
+        self::assertSame(Response::HTTP_OK, $adminClient->getResponse()->getStatusCode());
+    }
+
     #[TestDox('Non owner cannot mutate quiz content while admin can.')]
     public function testQuizMutationSecurity(): void
     {


### PR DESCRIPTION
### Motivation

- Provide first-class support for a shared "general" application quiz that can be managed via dedicated alias endpoints and seeded by fixtures.
- Ensure questions created for the general application are categorized as `QuizCategory::GENERAL` instead of application-specific categories.

### Description

- Updated `LoadQuizData` to include the `general` application in the application query and detect `isGeneralApplication` by slug, and set question categories to `QuizCategory::GENERAL` when appropriate.
- Added `GENERAL_APPLICATION_SLUG` constant and alias controller actions in `QuizMutationController` for create/update/publish/unpublish/delete operations that delegate to the application-specific implementations using the `general` slug.
- Added a `submitGeneral` endpoint in `SubmitQuizByApplicationController` that submits answers using the `general` application slug.
- Added `testGeneralQuizSpecificEndpointsFlow` to `tests/.../QuizManagementControllerTest.php` to exercise the alias endpoints (PUT/publish/unpublish/submit) against the seeded general quiz.

### Testing

- Ran the new PHPUnit test `QuizManagementControllerTest::testGeneralQuizSpecificEndpointsFlow` which passed.
- Executed the project's PHPUnit test suite after the changes and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd7e54ef40832b8974e9c44545fcb1)