### PR TITLE
Add GitHub integration for CRM projects (fields, service, and API endpoints)

### DIFF
--- a/migrations/Version20260321103000.php
+++ b/migrations/Version20260321103000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260321103000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add GitHub configuration fields for CRM projects.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE crm_project ADD github_token VARCHAR(255) DEFAULT NULL, ADD github_repositories JSON NOT NULL DEFAULT ('[]')");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_project DROP github_token, DROP github_repositories');
+    }
+}

--- a/src/Crm/Application/Service/CrmApiNormalizer.php
+++ b/src/Crm/Application/Service/CrmApiNormalizer.php
@@ -89,10 +89,13 @@ final readonly class CrmApiNormalizer
      */
     public function normalizeProjectProjection(array $item): array
     {
+        $repositories = is_array($item['githubRepositories'] ?? null) ? $item['githubRepositories'] : [];
+
         return [
             'id' => (string)($item['id'] ?? ''),
             'name' => (string)($item['name'] ?? ''),
             'status' => ($item['status'] ?? ''),
+            'githubRepositoriesCount' => count($repositories),
         ];
     }
 

--- a/src/Crm/Application/Service/CrmGithubService.php
+++ b/src/Crm/Application/Service/CrmGithubService.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Domain\Entity\Project;
+use RuntimeException;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function count;
+use function is_array;
+use function is_string;
+use function sprintf;
+use function str_contains;
+use function strtolower;
+
+readonly class CrmGithubService
+{
+    private const string BASE_URL = 'https://api.github.com';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+    ) {
+    }
+
+    public function getDashboard(Project $project): array
+    {
+        $repositories = $this->listRepositories($project);
+        $stats = ['open' => 0, 'closed' => 0, 'merged' => 0];
+
+        foreach ($repositories as $repository) {
+            $pulls = $this->listPullRequests($project, $repository['fullName'], state: 'all', page: 1, perPage: 100);
+            foreach ($pulls['items'] as $pullRequest) {
+                $state = (string)($pullRequest['state'] ?? '');
+                if ($state === 'open') {
+                    $stats['open']++;
+                    continue;
+                }
+
+                $mergedAt = $pullRequest['mergedAt'] ?? null;
+                if (is_string($mergedAt) && $mergedAt !== '') {
+                    $stats['merged']++;
+                    continue;
+                }
+
+                $stats['closed']++;
+            }
+        }
+
+        return [
+            'repositories' => $repositories,
+            'pullRequests' => $stats,
+        ];
+    }
+
+    /**
+     * @return list<array{fullName:string,defaultBranch:string|null}>
+     */
+    public function listRepositories(Project $project): array
+    {
+        $configured = $project->getGithubRepositories();
+
+        return array_values(array_filter(array_map(static function (array $repository): ?array {
+            $fullName = $repository['fullName'] ?? null;
+            if (!is_string($fullName) || $fullName === '') {
+                return null;
+            }
+
+            $defaultBranch = $repository['defaultBranch'] ?? null;
+
+            return [
+                'fullName' => $fullName,
+                'defaultBranch' => is_string($defaultBranch) && $defaultBranch !== '' ? $defaultBranch : null,
+            ];
+        }, $configured)));
+    }
+
+    public function listBranches(Project $project, string $repoFullName, int $page = 1, int $perPage = 30, string $search = ''): array
+    {
+        $response = $this->request($project, 'GET', sprintf('/repos/%s/branches', $repoFullName), [
+            'query' => ['page' => $page, 'per_page' => $perPage],
+        ]);
+
+        $items = array_map(static fn (array $branch): array => [
+            'name' => $branch['name'] ?? '',
+            'protected' => (bool)($branch['protected'] ?? false),
+            'sha' => $branch['commit']['sha'] ?? null,
+        ], $response);
+
+        if ($search !== '') {
+            $items = array_values(array_filter($items, static fn (array $item): bool => str_contains(strtolower((string)$item['name']), strtolower($search))));
+        }
+
+        return [
+            'items' => $items,
+            'pagination' => [
+                'page' => $page,
+                'limit' => $perPage,
+                'totalItems' => count($items),
+                'totalPages' => 1,
+            ],
+        ];
+    }
+
+    public function listPullRequests(Project $project, string $repoFullName, string $state = 'open', ?string $author = null, string $search = '', int $page = 1, int $perPage = 30): array
+    {
+        $response = $this->request($project, 'GET', sprintf('/repos/%s/pulls', $repoFullName), [
+            'query' => [
+                'state' => $state,
+                'page' => $page,
+                'per_page' => $perPage,
+            ],
+        ]);
+
+        $items = array_values(array_filter(array_map(static function (array $pull): ?array {
+            $user = $pull['user'] ?? [];
+            $head = $pull['head'] ?? [];
+            $base = $pull['base'] ?? [];
+
+            return [
+                'number' => (int)($pull['number'] ?? 0),
+                'title' => (string)($pull['title'] ?? ''),
+                'state' => (string)($pull['state'] ?? ''),
+                'mergedAt' => $pull['merged_at'] ?? null,
+                'author' => (string)($user['login'] ?? ''),
+                'head' => (string)($head['ref'] ?? ''),
+                'base' => (string)($base['ref'] ?? ''),
+                'draft' => (bool)($pull['draft'] ?? false),
+                'htmlUrl' => (string)($pull['html_url'] ?? ''),
+            ];
+        }, $response)));
+
+        if (is_string($author) && $author !== '') {
+            $items = array_values(array_filter($items, static fn (array $item): bool => strtolower((string)$item['author']) === strtolower($author)));
+        }
+
+        if ($search !== '') {
+            $items = array_values(array_filter($items, static fn (array $item): bool => str_contains(strtolower((string)$item['title']), strtolower($search))));
+        }
+
+        return [
+            'items' => $items,
+            'pagination' => [
+                'page' => $page,
+                'limit' => $perPage,
+                'totalItems' => count($items),
+                'totalPages' => 1,
+            ],
+        ];
+    }
+
+    public function getPullRequest(Project $project, string $repoFullName, int $number): array
+    {
+        $pull = $this->request($project, 'GET', sprintf('/repos/%s/pulls/%d', $repoFullName, $number));
+
+        return [
+            'number' => (int)($pull['number'] ?? 0),
+            'title' => (string)($pull['title'] ?? ''),
+            'state' => (string)($pull['state'] ?? ''),
+            'author' => (string)($pull['user']['login'] ?? ''),
+            'commits' => (int)($pull['commits'] ?? 0),
+            'changedFiles' => (int)($pull['changed_files'] ?? 0),
+            'additions' => (int)($pull['additions'] ?? 0),
+            'deletions' => (int)($pull['deletions'] ?? 0),
+            'mergedAt' => $pull['merged_at'] ?? null,
+            'mergeable' => $pull['mergeable'] ?? null,
+            'statusesUrl' => (string)($pull['statuses_url'] ?? ''),
+            'head' => (string)($pull['head']['ref'] ?? ''),
+            'base' => (string)($pull['base']['ref'] ?? ''),
+            'htmlUrl' => (string)($pull['html_url'] ?? ''),
+        ];
+    }
+
+    public function mergePullRequest(Project $project, string $repoFullName, int $number, string $method = 'merge'): array
+    {
+        return $this->request($project, 'PUT', sprintf('/repos/%s/pulls/%d/merge', $repoFullName, $number), [
+            'json' => [
+                'merge_method' => $method,
+            ],
+        ]);
+    }
+
+    public function closePullRequest(Project $project, string $repoFullName, int $number): array
+    {
+        return $this->request($project, 'PATCH', sprintf('/repos/%s/pulls/%d', $repoFullName, $number), [
+            'json' => ['state' => 'closed'],
+        ]);
+    }
+
+    /**
+     * @param array<string,mixed> $options
+     * @return array<mixed>
+     */
+    private function request(Project $project, string $method, string $path, array $options = []): array
+    {
+        $token = $project->getGithubToken();
+        if (!is_string($token) || $token === '') {
+            throw new RuntimeException('GitHub token is not configured on this project.');
+        }
+
+        try {
+            $response = $this->httpClient->request($method, self::BASE_URL . $path, $options + [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $token,
+                    'Accept' => 'application/vnd.github+json',
+                    'X-GitHub-Api-Version' => '2022-11-28',
+                ],
+            ]);
+
+            return $response->toArray(false);
+        } catch (ExceptionInterface $exception) {
+            throw new RuntimeException('GitHub API request failed: ' . $exception->getMessage(), previous: $exception);
+        }
+    }
+}

--- a/src/Crm/Application/Service/ProjectReadService.php
+++ b/src/Crm/Application/Service/ProjectReadService.php
@@ -107,6 +107,8 @@ readonly class ProjectReadService
                 'dueAt' => $project->getDueAt()?->format(DATE_ATOM),
                 'attachments' => $project->getAttachments(),
                 'wikiPages' => $project->getWikiPages(),
+                'githubRepositories' => $project->getGithubRepositories(),
+                'githubConfigured' => $project->getGithubToken() !== null && $project->getGithubToken() !== '',
                 'tasks' => array_map(static fn (Task $task): array => [
                     'id' => $task->getId(),
                     'TITLE' => $task->getTitle(),

--- a/src/Crm/Domain/Entity/Project.php
+++ b/src/Crm/Domain/Entity/Project.php
@@ -69,6 +69,15 @@ class Project implements EntityInterface
     #[ORM\Column(name: 'wiki_pages', type: Types::JSON)]
     private array $wikiPages = [];
 
+    #[ORM\Column(name: 'github_token', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $githubToken = null;
+
+    /**
+     * @var list<array{fullName:string,defaultBranch?:string|null}>
+     */
+    #[ORM\Column(name: 'github_repositories', type: Types::JSON)]
+    private array $githubRepositories = [];
+
     /** @var Collection<int, Task>|ArrayCollection<int, Task> */
     #[ORM\OneToMany(targetEntity: Task::class, mappedBy: 'project')]
     private Collection|ArrayCollection $tasks;
@@ -237,6 +246,36 @@ class Project implements EntityInterface
     public function addWikiPage(array $wikiPage): self
     {
         $this->wikiPages[] = $wikiPage;
+
+        return $this;
+    }
+
+    public function getGithubToken(): ?string
+    {
+        return $this->githubToken;
+    }
+
+    public function setGithubToken(?string $githubToken): self
+    {
+        $this->githubToken = $githubToken;
+
+        return $this;
+    }
+
+    /**
+     * @return list<array{fullName:string,defaultBranch?:string|null}>
+     */
+    public function getGithubRepositories(): array
+    {
+        return $this->githubRepositories;
+    }
+
+    /**
+     * @param list<array{fullName:string,defaultBranch?:string|null}> $githubRepositories
+     */
+    public function setGithubRepositories(array $githubRepositories): self
+    {
+        $this->githubRepositories = $githubRepositories;
 
         return $this;
     }

--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -298,6 +298,10 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
         for ($index = 0; $index < $projectCount; $index++) {
             $startedAt = $faker->dateTimeBetween('-3 months', '-2 weeks');
             $dueAt = $faker->dateTimeBetween($startedAt, '+4 months');
+            $projectSlug = trim(strtolower((string)preg_replace('/[^a-z0-9]+/i', '-', $faker->words(2, true))), '-');
+            if ($projectSlug === '') {
+                $projectSlug = sprintf('project-%d-%d', $companyIndex + 1, $index + 1);
+            }
 
             $project = (new Project())
                 ->setCompany($company)
@@ -306,7 +310,18 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                 ->setDescription($faker->paragraph(2))
                 ->setStatus($faker->randomElement(ProjectStatus::cases()))
                 ->setStartedAt(DateTimeImmutable::createFromMutable($startedAt))
-                ->setDueAt(DateTimeImmutable::createFromMutable($dueAt));
+                ->setDueAt(DateTimeImmutable::createFromMutable($dueAt))
+                ->setGithubToken('ghp_john_root_fake_token')
+                ->setGithubRepositories([
+                    [
+                        'fullName' => sprintf('john-root/%s-api', $projectSlug),
+                        'defaultBranch' => 'main',
+                    ],
+                    [
+                        'fullName' => sprintf('john-root/%s-web', $projectSlug),
+                        'defaultBranch' => 'develop',
+                    ],
+                ]);
 
             for ($attachmentIndex = 0; $attachmentIndex < $attachmentCount; $attachmentIndex++) {
                 $project->addAttachment($this->generateAttachment($faker, '/uploads/crm/projects/', $project->getId()));

--- a/src/Crm/Infrastructure/Repository/ProjectRepository.php
+++ b/src/Crm/Infrastructure/Repository/ProjectRepository.php
@@ -79,7 +79,7 @@ class ProjectRepository extends BaseRepository
     public function findScopedProjection(string $crmId, int $limit, int $offset, array $filters = []): array
     {
         $qb = $this->createQueryBuilder('project')
-            ->select('project.id, project.name, project.status')
+            ->select('project.id, project.name, project.status, project.githubRepositories')
             ->leftJoin('project.company', 'company')
             ->andWhere('company.crm = :crmId')
             ->setParameter('crmId', $crmId, UuidBinaryOrderedTimeType::NAME)

--- a/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
@@ -26,6 +26,10 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
+use function preg_replace;
+use function strtolower;
+use function trim;
+
 #[AsController]
 #[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_MANAGER->value)]
@@ -157,12 +161,19 @@ final readonly class CreateProjectController
         }
 
         $project = new Project();
+        $githubRepositories = $this->normalizeGithubRepositories($input->githubRepositories);
+        if ($githubRepositories === []) {
+            $githubRepositories = $this->buildDefaultGithubRepositories((string)$input->name, $input->code);
+        }
+
         $project->setName((string)$input->name)
             ->setCode($input->code)
             ->setDescription($input->description)
             ->setStatus(ProjectStatus::tryFrom((string)$input->status) ?? ProjectStatus::PLANNED)
             ->setStartedAt($startedAt)
-            ->setDueAt($dueAt);
+            ->setDueAt($dueAt)
+            ->setGithubToken($input->githubToken !== null && $input->githubToken !== '' ? $input->githubToken : 'ghp_john_root_fake_token')
+            ->setGithubRepositories($githubRepositories);
 
         if (is_string($input->companyId)) {
             $company = $this->companyRepository->findOneScopedById($input->companyId, $crm->getId());
@@ -197,5 +208,56 @@ final readonly class CreateProjectController
         }
 
         return $date;
+    }
+
+    /**
+     * @param array<mixed> $repositories
+     * @return list<array{fullName:string,defaultBranch?:string|null}>
+     */
+    private function normalizeGithubRepositories(array $repositories): array
+    {
+        $normalized = [];
+
+        foreach ($repositories as $repository) {
+            if (!is_array($repository)) {
+                continue;
+            }
+
+            $fullName = isset($repository['fullName']) ? trim((string)$repository['fullName']) : '';
+            if ($fullName === '') {
+                continue;
+            }
+
+            $defaultBranch = isset($repository['defaultBranch']) ? trim((string)$repository['defaultBranch']) : null;
+
+            $normalized[] = [
+                'fullName' => $fullName,
+                'defaultBranch' => $defaultBranch !== '' ? $defaultBranch : null,
+            ];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return list<array{fullName:string,defaultBranch:string|null}>
+     */
+    private function buildDefaultGithubRepositories(string $projectName, ?string $projectCode): array
+    {
+        $base = strtolower(trim((string)preg_replace('/[^a-z0-9]+/i', '-', $projectCode ?? $projectName), '-'));
+        if ($base === '') {
+            $base = 'project';
+        }
+
+        return [
+            [
+                'fullName' => sprintf('john-root/%s-api', $base),
+                'defaultBranch' => 'main',
+            ],
+            [
+                'fullName' => sprintf('john-root/%s-web', $base),
+                'defaultBranch' => 'develop',
+            ],
+        ];
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubDashboardController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubDashboardController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_VIEWER->value)]
+final readonly class GetProjectGithubDashboardController
+{
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/dashboard', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Project $project): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->getDashboard($project));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubPullRequestDetailController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubPullRequestDetailController.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_VIEWER->value)]
+final readonly class GetProjectGithubPullRequestDetailController
+{
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests/{number}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->getPullRequest($project, (string)$request->query->get('repo', ''), $number));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubBranchesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubBranchesController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_VIEWER->value)]
+final readonly class ListProjectGithubBranchesController
+{
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/branches', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    {
+        $repo = (string)$request->query->get('repo', '');
+
+        return new JsonResponse($this->crmGithubService->listBranches(
+            $project,
+            $repo,
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+            trim((string)$request->query->get('q', '')),
+        ));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestsController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_VIEWER->value)]
+final readonly class ListProjectGithubPullRequestsController
+{
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->listPullRequests(
+            $project,
+            (string)$request->query->get('repo', ''),
+            (string)$request->query->get('state', 'open'),
+            $request->query->get('author') !== null ? (string)$request->query->get('author') : null,
+            trim((string)$request->query->get('q', '')),
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+        ));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubRepositoriesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubRepositoriesController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_VIEWER->value)]
+final readonly class ListProjectGithubRepositoriesController
+{
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Project $project): JsonResponse
+    {
+        return new JsonResponse([
+            'items' => $this->crmGithubService->listRepositories($project),
+        ]);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ProjectGithubPullRequestActionController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ProjectGithubPullRequestActionController.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Role\Domain\Enum\Role;
+use JsonException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class ProjectGithubPullRequestActionController
+{
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+    ) {
+    }
+
+    /**
+     * @throws JsonException
+     */
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests/{number}/action', methods: [Request::METHOD_POST])]
+    public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
+    {
+        $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        $repo = isset($payload['repo']) ? (string)$payload['repo'] : '';
+        $action = isset($payload['action']) ? (string)$payload['action'] : '';
+
+        if ($action === 'merge') {
+            return new JsonResponse($this->crmGithubService->mergePullRequest(
+                $project,
+                $repo,
+                $number,
+                isset($payload['mergeMethod']) ? (string)$payload['mergeMethod'] : 'merge',
+            ));
+        }
+
+        if ($action === 'close') {
+            return new JsonResponse($this->crmGithubService->closePullRequest($project, $repo, $number));
+        }
+
+        return new JsonResponse(['message' => 'Unknown action.'], JsonResponse::HTTP_BAD_REQUEST);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/PatchProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/PatchProjectController.php
@@ -70,6 +70,15 @@ final readonly class PatchProjectController
         if (array_key_exists('dueAt', $payload)) {
             $project->setDueAt($this->parseDate($payload['dueAt']));
         }
+        if (array_key_exists('githubToken', $payload)) {
+            $project->setGithubToken($payload['githubToken'] !== null ? (string)$payload['githubToken'] : null);
+        }
+        if (array_key_exists('githubRepositories', $payload) && is_array($payload['githubRepositories'])) {
+            $repositories = $this->normalizeGithubRepositories($payload['githubRepositories']);
+            if ($repositories !== []) {
+                $project->setGithubRepositories($repositories);
+            }
+        }
 
         $this->projectRepository->save($project);
 
@@ -91,5 +100,33 @@ final readonly class PatchProjectController
         $parsed = DateTimeImmutable::createFromFormat(DateTimeInterface::ATOM, $value);
 
         return $parsed === false ? null : $parsed;
+    }
+
+    /**
+     * @param array<mixed> $repositories
+     * @return list<array{fullName:string,defaultBranch?:string|null}>
+     */
+    private function normalizeGithubRepositories(array $repositories): array
+    {
+        $normalized = [];
+        foreach ($repositories as $repository) {
+            if (!is_array($repository)) {
+                continue;
+            }
+
+            $fullName = isset($repository['fullName']) ? trim((string)$repository['fullName']) : '';
+            if ($fullName === '') {
+                continue;
+            }
+
+            $defaultBranch = isset($repository['defaultBranch']) ? trim((string)$repository['defaultBranch']) : null;
+
+            $normalized[] = [
+                'fullName' => $fullName,
+                'defaultBranch' => $defaultBranch !== '' ? $defaultBranch : null,
+            ];
+        }
+
+        return $normalized;
     }
 }

--- a/src/Crm/Transport/Request/CreateProjectRequest.php
+++ b/src/Crm/Transport/Request/CreateProjectRequest.php
@@ -33,6 +33,12 @@ final class CreateProjectRequest
     #[Assert\Uuid]
     public ?string $companyId = null;
 
+    #[Assert\Length(max: 255)]
+    public ?string $githubToken = null;
+
+    /** @var list<array{fullName?:mixed,defaultBranch?:mixed}> */
+    public array $githubRepositories = [];
+
     public static function fromArray(array $payload): self
     {
         $request = new self();
@@ -43,6 +49,8 @@ final class CreateProjectRequest
         $request->startedAt = isset($payload['startedAt']) ? (string)$payload['startedAt'] : null;
         $request->dueAt = isset($payload['dueAt']) ? (string)$payload['dueAt'] : null;
         $request->companyId = isset($payload['companyId']) ? (string)$payload['companyId'] : null;
+        $request->githubToken = isset($payload['githubToken']) ? (string)$payload['githubToken'] : null;
+        $request->githubRepositories = isset($payload['githubRepositories']) && is_array($payload['githubRepositories']) ? $payload['githubRepositories'] : [];
 
         return $request;
     }


### PR DESCRIPTION
### Motivation

- Enable per-project GitHub configuration so the CRM can surface repository and pull request data for projects. 
- Provide programmatic access to GitHub data and actions (list repos/branches/PRs, PR detail, merge/close, dashboard) through the API. 
- Populate fixtures and default values so example data and newly created projects include GitHub config.

### Description

- Add database columns via migration `Version20260321103000` to store `github_token` and `github_repositories` and wire them into the `Project` entity with getters/setters (`getGithubToken`, `setGithubToken`, `getGithubRepositories`, `setGithubRepositories`).
- Implement `CrmGithubService` to call the GitHub API (`request`, `listRepositories`, `listBranches`, `listPullRequests`, `getPullRequest`, `mergePullRequest`, `closePullRequest`, `getDashboard`) using the configured project token. 
- Add API controllers for GitHub endpoints under `Crm/Transport/Controller/Api/V1/Project/Github` to list repositories, branches, pull requests, get PR detail, perform PR actions, and return a dashboard summary. 
- Update project creation and patch flows to accept and normalize `githubToken` and `githubRepositories` (`CreateProjectRequest`, `CreateProjectController`, `PatchProjectController`), add default repo naming when none supplied, update `ProjectReadService` and `CrmApiNormalizer` to expose repository data and a repo count, include `project.githubRepositories` in repository projections, and populate fixtures in `LoadCrmData` with example GitHub data.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1bba7b88832bb99e214e8d872c88)