### PR TITLE
feat(crm): list GitHub account repositories and attach repository to project

### DIFF
--- a/src/Crm/Application/Service/CrmGithubService.php
+++ b/src/Crm/Application/Service/CrmGithubService.php
@@ -18,6 +18,7 @@ use function is_string;
 use function sprintf;
 use function str_contains;
 use function strtolower;
+use function trim;
 
 readonly class CrmGithubService
 {
@@ -78,6 +79,83 @@ readonly class CrmGithubService
                 'defaultBranch' => is_string($defaultBranch) && $defaultBranch !== '' ? $defaultBranch : null,
             ];
         }, $configured)));
+    }
+
+    public function listAccountRepositories(Project $project, int $page = 1, int $perPage = 30, string $search = ''): array
+    {
+        $response = $this->request($project, 'GET', '/user/repos', [
+            'query' => [
+                'sort' => 'updated',
+                'direction' => 'desc',
+                'page' => $page,
+                'per_page' => $perPage,
+            ],
+        ]);
+
+        $items = array_values(array_filter(array_map(static function (array $repository): ?array {
+            $fullName = $repository['full_name'] ?? null;
+            if (!is_string($fullName) || $fullName === '') {
+                return null;
+            }
+
+            return [
+                'name' => (string)($repository['name'] ?? ''),
+                'fullName' => $fullName,
+                'private' => (bool)($repository['private'] ?? false),
+                'defaultBranch' => isset($repository['default_branch']) && is_string($repository['default_branch']) && $repository['default_branch'] !== ''
+                    ? $repository['default_branch']
+                    : null,
+                'htmlUrl' => (string)($repository['html_url'] ?? ''),
+                'owner' => (string)($repository['owner']['login'] ?? ''),
+            ];
+        }, $response)));
+
+        if ($search !== '') {
+            $normalizedSearch = strtolower($search);
+            $items = array_values(array_filter($items, static fn (array $item): bool => str_contains(strtolower((string)$item['name']), $normalizedSearch)
+                || str_contains(strtolower((string)$item['fullName']), $normalizedSearch)));
+        }
+
+        return [
+            'items' => $items,
+            'pagination' => [
+                'page' => $page,
+                'limit' => $perPage,
+                'totalItems' => count($items),
+                'totalPages' => 1,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{fullName:string,defaultBranch:string|null}
+     */
+    public function attachRepository(Project $project, string $fullName): array
+    {
+        $normalizedFullName = trim($fullName);
+        if ($normalizedFullName === '') {
+            throw new RuntimeException('Repository full name cannot be empty.');
+        }
+
+        $repository = $this->request($project, 'GET', sprintf('/repos/%s', $normalizedFullName));
+        $normalizedRepository = [
+            'fullName' => (string)($repository['full_name'] ?? $normalizedFullName),
+            'defaultBranch' => isset($repository['default_branch']) && is_string($repository['default_branch']) && $repository['default_branch'] !== ''
+                ? $repository['default_branch']
+                : null,
+        ];
+
+        $repositories = $this->listRepositories($project);
+        foreach ($repositories as $configuredRepository) {
+            if (strtolower($configuredRepository['fullName']) === strtolower($normalizedRepository['fullName'])) {
+                return $configuredRepository;
+            }
+        }
+
+        $repositories[] = $normalizedRepository;
+        $project->setGithubRepositories($repositories);
+
+        return $normalizedRepository;
     }
 
     public function listBranches(Project $project, string $repoFullName, int $page = 1, int $perPage = 30, string $search = ''): array

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubRepositoryController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Crm\Transport\Request\AddProjectGithubRepositoryRequest;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class AddProjectGithubRepositoryController
+{
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+        private CrmRequestHandler $crmRequestHandler,
+        private ProjectRepository $projectRepository,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories', methods: [Request::METHOD_POST])]
+    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    {
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $input = $this->crmRequestHandler->mapAndValidate($payload, AddProjectGithubRepositoryRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
+        }
+
+        try {
+            $repository = $this->crmGithubService->attachRepository($project, (string)$input->fullName);
+            $this->projectRepository->save($project);
+
+            return new JsonResponse([
+                'id' => $project->getId(),
+                'repository' => $repository,
+                'repositories' => $this->crmGithubService->listRepositories($project),
+            ], JsonResponse::HTTP_CREATED);
+        } catch (RuntimeException $exception) {
+            return new JsonResponse([
+                'message' => $exception->getMessage(),
+                'errors' => [],
+            ], JsonResponse::HTTP_BAD_GATEWAY);
+        }
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListGithubAccountRepositoriesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListGithubAccountRepositoriesController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_VIEWER->value)]
+final readonly class ListGithubAccountRepositoriesController
+{
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/account/repositories', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->listAccountRepositories(
+            $project,
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+            trim((string)$request->query->get('q', '')),
+        ));
+    }
+}

--- a/src/Crm/Transport/Request/AddProjectGithubRepositoryRequest.php
+++ b/src/Crm/Transport/Request/AddProjectGithubRepositoryRequest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class AddProjectGithubRepositoryRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    #[Assert\Regex(pattern: '/^[^\s\/]+\/[^\s\/]+$/', message: 'Repository must be in the "owner/name" format.')]
+    public ?string $fullName = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->fullName = isset($payload['fullName']) ? trim((string)$payload['fullName']) : null;
+
+        return $request;
+    }
+}


### PR DESCRIPTION
### Motivation
- Allow CRM projects to discover repositories available to the GitHub account associated with the project token. 
- Provide a safe way to attach a chosen GitHub repository to a CRM project with server-side validation against the GitHub API.

### Description
- Added `listAccountRepositories` and `attachRepository` implementations to `CrmGithubService` to call `/user/repos` and `/repos/{owner}/{repo}` respectively and to normalize results. 
- Introduced `ListGithubAccountRepositoriesController` exposing `GET /v1/crm/applications/{applicationSlug}/projects/{project}/github/account/repositories` with `page`, `limit` and `q` query params. 
- Introduced `AddProjectGithubRepositoryRequest` request DTO and `AddProjectGithubRepositoryController` exposing `POST /v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories` which validates payload, verifies repository existence on GitHub, appends it to `project.githubRepositories` and persists the project. 
- Error handling returns CRM validation errors for bad payloads and `502` with upstream message when GitHub API calls fail, and duplicate repositories are ignored via case-insensitive comparison.

### Testing
- Ran `php -l` syntax checks on changed files with no errors for `src/Crm/Application/Service/CrmGithubService.php`, `src/Crm/Transport/Request/AddProjectGithubRepositoryRequest.php`, `src/Crm/Transport/Controller/Api/V1/Project/Github/ListGithubAccountRepositoriesController.php`, and `src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubRepositoryController.php`. 
- Verified files were staged and committed successfully (commit message: `feat(crm): add github account repos listing and attach endpoint`). 
- No unit or integration tests were added or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bffa2d4ee4832bb2ce5a8f102c3b0a)