### PR TITLE
feat(crm): migrate GitHub repos from Project JSON to crm_repository entity

### DIFF
--- a/migrations/Version20260322120000.php
+++ b/migrations/Version20260322120000.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260322120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Move CRM project GitHub repositories from JSON column to crm_repository relation table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE crm_repository (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", project_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", provider VARCHAR(30) NOT NULL DEFAULT "github", owner VARCHAR(255) NOT NULL, name VARCHAR(255) NOT NULL, full_name VARCHAR(255) NOT NULL, default_branch VARCHAR(255) DEFAULT NULL, is_private TINYINT(1) NOT NULL DEFAULT 0, html_url VARCHAR(1024) DEFAULT NULL, external_id BIGINT DEFAULT NULL, last_synced_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", sync_status VARCHAR(40) NOT NULL DEFAULT "pending", payload JSON DEFAULT NULL, created_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", INDEX IDX_CRM_REPOSITORY_PROJECT (project_id), INDEX idx_crm_repository_provider (provider), INDEX idx_crm_repository_external_id (external_id), UNIQUE INDEX uq_crm_repository_project_provider_full_name (project_id, provider, full_name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE crm_repository ADD CONSTRAINT FK_CRM_REPOSITORY_PROJECT FOREIGN KEY (project_id) REFERENCES crm_project (id) ON DELETE CASCADE');
+
+        $this->addSql(<<<'SQL'
+            INSERT INTO crm_repository (
+                id,
+                project_id,
+                provider,
+                owner,
+                name,
+                full_name,
+                default_branch,
+                is_private,
+                html_url,
+                external_id,
+                last_synced_at,
+                sync_status,
+                payload,
+                created_at,
+                updated_at
+            )
+            SELECT
+                UUID_TO_BIN(UUID(), 1),
+                project.id,
+                'github',
+                SUBSTRING_INDEX(repository.full_name, '/', 1),
+                SUBSTRING_INDEX(repository.full_name, '/', -1),
+                repository.full_name,
+                NULLIF(repository.default_branch, ''),
+                0,
+                NULL,
+                NULL,
+                NULL,
+                'pending',
+                repository.payload,
+                project.created_at,
+                project.updated_at
+            FROM crm_project project
+            INNER JOIN JSON_TABLE(
+                project.github_repositories,
+                '$[*]' COLUMNS (
+                    full_name VARCHAR(255) PATH '$.fullName',
+                    default_branch VARCHAR(255) PATH '$.defaultBranch' DEFAULT NULL ON EMPTY,
+                    payload JSON PATH '$'
+                )
+            ) repository
+            WHERE JSON_VALID(project.github_repositories)
+              AND repository.full_name IS NOT NULL
+              AND repository.full_name <> ''
+        SQL);
+
+        $this->addSql('ALTER TABLE crm_project DROP github_repositories');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE crm_project ADD github_repositories JSON NOT NULL DEFAULT ('[]')");
+        $this->addSql(<<<'SQL'
+            UPDATE crm_project project
+            LEFT JOIN (
+                SELECT
+                    repository.project_id,
+                    JSON_ARRAYAGG(
+                        JSON_OBJECT(
+                            'fullName', repository.full_name,
+                            'defaultBranch', repository.default_branch
+                        )
+                    ) AS repositories
+                FROM crm_repository repository
+                GROUP BY repository.project_id
+            ) migrated ON migrated.project_id = project.id
+            SET project.github_repositories = COALESCE(migrated.repositories, JSON_ARRAY())
+        SQL);
+
+        $this->addSql('ALTER TABLE crm_repository DROP FOREIGN KEY FK_CRM_REPOSITORY_PROJECT');
+        $this->addSql('DROP TABLE crm_repository');
+    }
+}

--- a/src/Crm/Application/Service/CrmApiNormalizer.php
+++ b/src/Crm/Application/Service/CrmApiNormalizer.php
@@ -89,13 +89,13 @@ final readonly class CrmApiNormalizer
      */
     public function normalizeProjectProjection(array $item): array
     {
-        $repositories = is_array($item['githubRepositories'] ?? null) ? $item['githubRepositories'] : [];
+        $repositoriesCount = (int)($item['githubRepositoriesCount'] ?? 0);
 
         return [
             'id' => (string)($item['id'] ?? ''),
             'name' => (string)($item['name'] ?? ''),
             'status' => ($item['status'] ?? ''),
-            'githubRepositoriesCount' => count($repositories),
+            'githubRepositoriesCount' => $repositoriesCount,
         ];
     }
 

--- a/src/Crm/Domain/Entity/CrmRepository.php
+++ b/src/Crm/Domain/Entity/CrmRepository.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Throwable;
+
+#[ORM\Entity]
+#[ORM\Table(
+    name: 'crm_repository',
+    uniqueConstraints: [new ORM\UniqueConstraint(name: 'uq_crm_repository_project_provider_full_name', columns: ['project_id', 'provider', 'full_name'])]
+)]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class CrmRepository implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: Project::class, inversedBy: 'repositories')]
+    #[ORM\JoinColumn(name: 'project_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull]
+    private ?Project $project = null;
+
+    #[ORM\Column(name: 'provider', type: Types::STRING, length: 30, options: ['default' => 'github'])]
+    private string $provider = 'github';
+
+    #[ORM\Column(name: 'owner', type: Types::STRING, length: 255)]
+    private string $owner = '';
+
+    #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
+    private string $name = '';
+
+    #[ORM\Column(name: 'full_name', type: Types::STRING, length: 255)]
+    private string $fullName = '';
+
+    #[ORM\Column(name: 'default_branch', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $defaultBranch = null;
+
+    #[ORM\Column(name: 'is_private', type: Types::BOOLEAN, options: ['default' => false])]
+    private bool $isPrivate = false;
+
+    #[ORM\Column(name: 'html_url', type: Types::STRING, length: 1024, nullable: true)]
+    private ?string $htmlUrl = null;
+
+    #[ORM\Column(name: 'external_id', type: Types::BIGINT, nullable: true)]
+    private ?string $externalId = null;
+
+    #[ORM\Column(name: 'last_synced_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $lastSyncedAt = null;
+
+    #[ORM\Column(name: 'sync_status', type: Types::STRING, length: 40, options: ['default' => 'pending'])]
+    private string $syncStatus = 'pending';
+
+    /**
+     * @var array<string,mixed>|null
+     */
+    #[ORM\Column(name: 'payload', type: Types::JSON, nullable: true)]
+    private ?array $payload = null;
+
+    /**
+     * @throws Throwable
+     */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getProject(): ?Project
+    {
+        return $this->project;
+    }
+
+    public function setProject(?Project $project): self
+    {
+        $this->project = $project;
+
+        return $this;
+    }
+
+    public function getProvider(): string
+    {
+        return $this->provider;
+    }
+
+    public function setProvider(string $provider): self
+    {
+        $this->provider = $provider;
+
+        return $this;
+    }
+
+    public function getOwner(): string
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(string $owner): self
+    {
+        $this->owner = $owner;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getFullName(): string
+    {
+        return $this->fullName;
+    }
+
+    public function setFullName(string $fullName): self
+    {
+        $this->fullName = $fullName;
+
+        return $this;
+    }
+
+    public function getDefaultBranch(): ?string
+    {
+        return $this->defaultBranch;
+    }
+
+    public function setDefaultBranch(?string $defaultBranch): self
+    {
+        $this->defaultBranch = $defaultBranch;
+
+        return $this;
+    }
+
+    public function isPrivate(): bool
+    {
+        return $this->isPrivate;
+    }
+
+    public function setIsPrivate(bool $isPrivate): self
+    {
+        $this->isPrivate = $isPrivate;
+
+        return $this;
+    }
+
+    public function getHtmlUrl(): ?string
+    {
+        return $this->htmlUrl;
+    }
+
+    public function setHtmlUrl(?string $htmlUrl): self
+    {
+        $this->htmlUrl = $htmlUrl;
+
+        return $this;
+    }
+
+    public function getExternalId(): ?string
+    {
+        return $this->externalId;
+    }
+
+    public function setExternalId(?string $externalId): self
+    {
+        $this->externalId = $externalId;
+
+        return $this;
+    }
+
+    public function getLastSyncedAt(): ?DateTimeImmutable
+    {
+        return $this->lastSyncedAt;
+    }
+
+    public function setLastSyncedAt(?DateTimeImmutable $lastSyncedAt): self
+    {
+        $this->lastSyncedAt = $lastSyncedAt;
+
+        return $this;
+    }
+
+    public function getSyncStatus(): string
+    {
+        return $this->syncStatus;
+    }
+
+    public function setSyncStatus(string $syncStatus): self
+    {
+        $this->syncStatus = $syncStatus;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function getPayload(): ?array
+    {
+        return $this->payload;
+    }
+
+    /**
+     * @param array<string,mixed>|null $payload
+     */
+    public function setPayload(?array $payload): self
+    {
+        $this->payload = $payload;
+
+        return $this;
+    }
+}

--- a/src/Crm/Domain/Entity/Project.php
+++ b/src/Crm/Domain/Entity/Project.php
@@ -20,6 +20,12 @@ use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Throwable;
 
+use function array_map;
+use function array_pad;
+use function explode;
+use function strtolower;
+use function trim;
+
 #[ORM\Entity]
 #[ORM\Table(name: 'crm_project')]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
@@ -72,11 +78,9 @@ class Project implements EntityInterface
     #[ORM\Column(name: 'github_token', type: Types::STRING, length: 255, nullable: true)]
     private ?string $githubToken = null;
 
-    /**
-     * @var list<array{fullName:string,defaultBranch?:string|null}>
-     */
-    #[ORM\Column(name: 'github_repositories', type: Types::JSON)]
-    private array $githubRepositories = [];
+    /** @var Collection<int, CrmRepository>|ArrayCollection<int, CrmRepository> */
+    #[ORM\OneToMany(targetEntity: CrmRepository::class, mappedBy: 'project', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $repositories;
 
     /** @var Collection<int, Task>|ArrayCollection<int, Task> */
     #[ORM\OneToMany(targetEntity: Task::class, mappedBy: 'project')]
@@ -101,6 +105,7 @@ class Project implements EntityInterface
         $this->id = $this->createUuid();
         $this->tasks = new ArrayCollection();
         $this->sprints = new ArrayCollection();
+        $this->repositories = new ArrayCollection();
         $this->assignees = new ArrayCollection();
     }
 
@@ -263,19 +268,85 @@ class Project implements EntityInterface
     }
 
     /**
-     * @return list<array{fullName:string,defaultBranch?:string|null}>
+     * @return Collection<int, CrmRepository>|ArrayCollection<int, CrmRepository>
      */
-    public function getGithubRepositories(): array
+    public function getRepositories(): Collection|ArrayCollection
     {
-        return $this->githubRepositories;
+        return $this->repositories;
     }
 
     /**
-     * @param list<array{fullName:string,defaultBranch?:string|null}> $githubRepositories
+     * Backward-compatible accessor used by read/services and controllers.
+     *
+     * @return list<array<string,mixed>>
+     */
+    public function getGithubRepositories(): array
+    {
+        return array_map(static fn (CrmRepository $repository): array => [
+            'id' => $repository->getId(),
+            'provider' => $repository->getProvider(),
+            'owner' => $repository->getOwner(),
+            'name' => $repository->getName(),
+            'fullName' => $repository->getFullName(),
+            'defaultBranch' => $repository->getDefaultBranch(),
+            'isPrivate' => $repository->isPrivate(),
+            'htmlUrl' => $repository->getHtmlUrl(),
+            'externalId' => $repository->getExternalId(),
+            'lastSyncedAt' => $repository->getLastSyncedAt()?->format(DATE_ATOM),
+            'syncStatus' => $repository->getSyncStatus(),
+            'payload' => $repository->getPayload(),
+        ], $this->repositories->toArray());
+    }
+
+    /**
+     * @param list<array{fullName:string,defaultBranch?:string|null,provider?:string,owner?:string,name?:string,isPrivate?:bool,htmlUrl?:string|null,externalId?:string|int|null,syncStatus?:string,payload?:array<string,mixed>|null}> $githubRepositories
      */
     public function setGithubRepositories(array $githubRepositories): self
     {
-        $this->githubRepositories = $githubRepositories;
+        $this->repositories->clear();
+
+        foreach ($githubRepositories as $githubRepository) {
+            $fullName = trim((string)($githubRepository['fullName'] ?? ''));
+            if ($fullName === '') {
+                continue;
+            }
+
+            [$fallbackOwner, $fallbackName] = array_pad(explode('/', $fullName, 2), 2, '');
+
+            $repository = (new CrmRepository())
+                ->setProject($this)
+                ->setProvider(strtolower(trim((string)($githubRepository['provider'] ?? 'github'))))
+                ->setOwner(trim((string)($githubRepository['owner'] ?? $fallbackOwner)))
+                ->setName(trim((string)($githubRepository['name'] ?? $fallbackName)))
+                ->setFullName($fullName)
+                ->setDefaultBranch(($githubRepository['defaultBranch'] ?? null) !== '' ? ($githubRepository['defaultBranch'] ?? null) : null)
+                ->setIsPrivate((bool)($githubRepository['isPrivate'] ?? false))
+                ->setHtmlUrl(isset($githubRepository['htmlUrl']) ? (string)$githubRepository['htmlUrl'] : null)
+                ->setExternalId(isset($githubRepository['externalId']) ? (string)$githubRepository['externalId'] : null)
+                ->setSyncStatus(trim((string)($githubRepository['syncStatus'] ?? 'pending')))
+                ->setPayload(isset($githubRepository['payload']) && is_array($githubRepository['payload']) ? $githubRepository['payload'] : null);
+
+            $this->addRepository($repository);
+        }
+
+        return $this;
+    }
+
+    public function addRepository(CrmRepository $repository): self
+    {
+        if (!$this->repositories->contains($repository)) {
+            $this->repositories->add($repository);
+            $repository->setProject($this);
+        }
+
+        return $this;
+    }
+
+    public function removeRepository(CrmRepository $repository): self
+    {
+        if ($this->repositories->removeElement($repository) && $repository->getProject() === $this) {
+            $repository->setProject(null);
+        }
 
         return $this;
     }

--- a/src/Crm/Infrastructure/Repository/ProjectRepository.php
+++ b/src/Crm/Infrastructure/Repository/ProjectRepository.php
@@ -79,11 +79,13 @@ class ProjectRepository extends BaseRepository
     public function findScopedProjection(string $crmId, int $limit, int $offset, array $filters = []): array
     {
         $qb = $this->createQueryBuilder('project')
-            ->select('project.id, project.name, project.status, project.githubRepositories')
+            ->select('project.id, project.name, project.status, COUNT(repository.id) AS githubRepositoriesCount')
             ->leftJoin('project.company', 'company')
+            ->leftJoin('project.repositories', 'repository')
             ->andWhere('company.crm = :crmId')
             ->setParameter('crmId', $crmId, UuidBinaryOrderedTimeType::NAME)
             ->orderBy('project.createdAt', 'DESC')
+            ->groupBy('project.id')
             ->setMaxResults($limit)
             ->setFirstResult($offset);
 


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc JSON storage of GitHub repositories on `crm_project.github_repositories` with a first-class relational entity to store per-repo metadata and sync state.
- Allow richer metadata (external id, last synced, sync status, raw payload) and efficient DB queries (counts, joins) while keeping existing service code working.
- Prepare the model for future sync and provider-agnostic handling while avoiding collisions with generic `Repository` names by introducing `CrmRepository`.

### Description
- Add new entity `App\Crm\Domain\Entity\CrmRepository` mapped to table `crm_repository` with fields `id`, `project` (ManyToOne), `provider`, `owner`, `name`, `fullName`, `defaultBranch`, `isPrivate`, `htmlUrl`, `externalId`, `lastSyncedAt`, `syncStatus`, `payload`, and timestamps in `src/Crm/Domain/Entity/CrmRepository.php`.
- Refactor `Project` (`src/Crm/Domain/Entity/Project.php`) to remove the JSON array storage and add a `OneToMany` `repositories` relation to `CrmRepository`, including compatibility helpers `getGithubRepositories()` and `setGithubRepositories()` which map the legacy array format to the new relation.
- Update `ProjectRepository::findScopedProjection()` (`src/Crm/Infrastructure/Repository/ProjectRepository.php`) to `LEFT JOIN` the new relation and return `COUNT(repository.id) AS githubRepositoriesCount` grouped by `project.id` for projection queries.
- Update `CrmApiNormalizer::normalizeProjectProjection()` (`src/Crm/Application/Service/CrmApiNormalizer.php`) to use the scalar `githubRepositoriesCount` instead of decoding a JSON column.
- Add Doctrine migration `migrations/Version20260322120000.php` that creates `crm_repository`, migrates data from `crm_project.github_repositories` using `JSON_TABLE` into `crm_repository`, drops the JSON column, and includes a `down` path that reinserts JSON from `crm_repository` and drops the table.

### Testing
- `php -l` syntax checks were run for `src/Crm/Domain/Entity/CrmRepository.php`, `src/Crm/Domain/Entity/Project.php`, `src/Crm/Infrastructure/Repository/ProjectRepository.php`, `src/Crm/Application/Service/CrmApiNormalizer.php`, and `migrations/Version20260322120000.php` and all returned no syntax errors.
- `php bin/console doctrine:schema:validate --skip-sync` was attempted but failed in the environment due to missing Composer dependencies with the message `Dependencies are missing. Try running "composer install".`
- Changes were committed (commit `1f1cca2`) and prepared for PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c016582d2c832bb4e738e974fb8fbb)