### PR TITLE
feat(crm): enforce repository relation on task requests

### DIFF
--- a/migrations/Version20260322143000.php
+++ b/migrations/Version20260322143000.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use RuntimeException;
+
+final class Version20260322143000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Attach CRM task requests to a CRM repository and add repository/status index.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE crm_task_request ADD repository_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+
+        $this->addSql(
+            'UPDATE crm_task_request task_request
+            INNER JOIN crm_task task ON task_request.task_id = task.id
+            INNER JOIN crm_project project ON task.project_id = project.id
+            SET task_request.repository_id = (
+                SELECT repository.id
+                FROM crm_repository repository
+                WHERE repository.project_id = project.id
+                ORDER BY repository.created_at ASC, repository.id ASC
+                LIMIT 1
+            )
+            WHERE task_request.repository_id IS NULL'
+        );
+
+        $nullCount = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM crm_task_request WHERE repository_id IS NULL');
+        if (0 !== $nullCount) {
+            throw new RuntimeException('Cannot migrate crm_task_request.repository_id to NOT NULL: at least one task request has no repository candidate.');
+        }
+
+        $this->addSql("ALTER TABLE crm_task_request CHANGE repository_id repository_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)'");
+        $this->addSql('ALTER TABLE crm_task_request ADD CONSTRAINT FK_CRM_TASK_REQUEST_REPOSITORY FOREIGN KEY (repository_id) REFERENCES crm_repository (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX idx_crm_task_request_repository_status ON crm_task_request (repository_id, status)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_task_request DROP FOREIGN KEY FK_CRM_TASK_REQUEST_REPOSITORY');
+        $this->addSql('DROP INDEX idx_crm_task_request_repository_status ON crm_task_request');
+        $this->addSql('ALTER TABLE crm_task_request DROP repository_id');
+    }
+}

--- a/src/Crm/Application/Service/CrmApiNormalizer.php
+++ b/src/Crm/Application/Service/CrmApiNormalizer.php
@@ -60,6 +60,7 @@ final readonly class CrmApiNormalizer
         return [
             'id' => $taskRequest->getId(),
             'taskId' => $taskRequest->getTask()?->getId(),
+            'repositoryId' => $taskRequest->getRepository()?->getId(),
             'title' => $taskRequest->getTitle(),
             'status' => $taskRequest->getStatus()->value,
             'requestedAt' => $this->normalizeDate($taskRequest->getRequestedAt()),
@@ -107,6 +108,7 @@ final readonly class CrmApiNormalizer
         return [
             'id' => (string)($item['id'] ?? ''),
             'taskId' => $item['taskId'] ?? null,
+            'repositoryId' => $item['repositoryId'] ?? null,
             'title' => (string)($item['title'] ?? ''),
             'status' => ($item['status'] ?? ''),
             'requestedAt' => $this->normalizeDateValue($item['requestedAt'] ?? null),

--- a/src/Crm/Domain/Entity/TaskRequest.php
+++ b/src/Crm/Domain/Entity/TaskRequest.php
@@ -22,7 +22,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Throwable;
 
 #[ORM\Entity]
-#[ORM\Table(name: 'crm_task_request')]
+#[ORM\Table(
+    name: 'crm_task_request',
+    indexes: [new ORM\Index(name: 'idx_crm_task_request_repository_status', columns: ['repository_id', 'status'])]
+)]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class TaskRequest implements EntityInterface
 {
@@ -37,6 +40,11 @@ class TaskRequest implements EntityInterface
     #[ORM\JoinColumn(name: 'task_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     #[Assert\NotNull]
     private ?Task $task = null;
+
+    #[ORM\ManyToOne(targetEntity: CrmRepository::class)]
+    #[ORM\JoinColumn(name: 'repository_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull]
+    private ?CrmRepository $repository = null;
 
     #[ORM\OneToOne(targetEntity: Blog::class, cascade: ['persist'])]
     #[ORM\JoinColumn(name: 'blog_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
@@ -103,6 +111,18 @@ class TaskRequest implements EntityInterface
     public function getBlog(): ?Blog
     {
         return $this->blog;
+    }
+
+    public function getRepository(): ?CrmRepository
+    {
+        return $this->repository;
+    }
+
+    public function setRepository(?CrmRepository $repository): self
+    {
+        $this->repository = $repository;
+
+        return $this;
     }
 
     public function setBlog(?Blog $blog): self
@@ -230,6 +250,7 @@ class TaskRequest implements EntityInterface
     {
         return [
             'id' => $this->getId(),
+            'repository_id' => $this->getRepository()?->getId(),
             'title' => $this->getTitle(),
             'description' => $this->getDescription(),
             'status' => $this->getStatus(),

--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -12,6 +12,7 @@ use App\Crm\Domain\Entity\Billing;
 use App\Crm\Domain\Entity\Company;
 use App\Crm\Domain\Entity\Contact;
 use App\Crm\Domain\Entity\Crm;
+use App\Crm\Domain\Entity\CrmRepository;
 use App\Crm\Domain\Entity\Employee;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Domain\Entity\Sprint;
@@ -416,10 +417,32 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
         int $countByTask,
     ): void {
         foreach ($tasks as $task) {
+            $repository = $task->getProject()?->getRepositories()->first();
+            if (!$repository instanceof CrmRepository) {
+                $project = $task->getProject();
+                if (!$project instanceof Project) {
+                    continue;
+                }
+
+                $repository = (new CrmRepository())
+                    ->setProject($project)
+                    ->setProvider('github')
+                    ->setOwner('fixtures')
+                    ->setName($project->getCode() !== null ? strtolower($project->getCode()) : 'project-' . substr($project->getId(), 0, 8))
+                    ->setFullName(sprintf('fixtures/%s', $project->getCode() !== null ? strtolower($project->getCode()) : 'project-' . substr($project->getId(), 0, 8)))
+                    ->setDefaultBranch('main')
+                    ->setIsPrivate(false)
+                    ->setSyncStatus('synced');
+
+                $project->addRepository($repository);
+                $manager->persist($repository);
+            }
+
             for ($index = 0; $index < $countByTask; $index++) {
                 $status = $faker->randomElement(TaskRequestStatus::cases());
                 $taskRequest = (new TaskRequest())
                     ->setTask($task)
+                    ->setRepository($repository)
                     ->setTitle($faker->sentence(6))
                     ->setDescription($faker->paragraph())
                     ->setStatus($status);

--- a/src/Crm/Infrastructure/Repository/CrmProjectRepositoryRepository.php
+++ b/src/Crm/Infrastructure/Repository/CrmProjectRepositoryRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Infrastructure\Repository;
+
+use App\Crm\Domain\Entity\CrmRepository as Entity;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class CrmProjectRepositoryRepository extends BaseRepository
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+        'fullName',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+
+    public function findOneScopedById(string $id, string $crmId): ?Entity
+    {
+        $entity = $this->createQueryBuilder('repository')
+            ->leftJoin('repository.project', 'project')
+            ->leftJoin('project.company', 'company')
+            ->andWhere('repository.id = :id')
+            ->andWhere('IDENTITY(company.crm) = :crmId')
+            ->setParameter('id', $id, UuidBinaryOrderedTimeType::NAME)
+            ->setParameter('crmId', $crmId, UuidBinaryOrderedTimeType::NAME)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $entity instanceof Entity ? $entity : null;
+    }
+}

--- a/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
+++ b/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
@@ -111,7 +111,7 @@ class TaskRequestRepository extends BaseRepository
         }
 
         $itemsQb = $this->createQueryBuilder('taskRequest')
-            ->select('taskRequest.id, taskRequest.title, taskRequest.status, taskRequest.requestedAt, taskRequest.resolvedAt, IDENTITY(taskRequest.task) AS taskId');
+            ->select('taskRequest.id, taskRequest.title, taskRequest.status, taskRequest.requestedAt, taskRequest.resolvedAt, IDENTITY(taskRequest.task) AS taskId, IDENTITY(taskRequest.repository) AS repositoryId');
 
         $this->applyBinaryUuidIdsFilter($itemsQb, 'taskRequest.id', $taskRequestIds, 'task_request_id_');
 

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
@@ -8,6 +8,7 @@ use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Application\Service\CrmTaskBlogProvisioningService;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Crm\Domain\Enum\TaskRequestStatus;
+use App\Crm\Infrastructure\Repository\CrmProjectRepositoryRepository;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\Crm\Transport\Request\CreateTaskRequestEntryRequest;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
@@ -33,6 +34,7 @@ final readonly class CreateTaskRequestController
 {
     public function __construct(
         private TaskRepository $taskRepository,
+        private CrmProjectRepositoryRepository $crmProjectRepositoryRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
         private CrmTaskBlogProvisioningService $crmTaskBlogProvisioningService,
@@ -53,13 +55,14 @@ final readonly class CreateTaskRequestController
         requestBody: new OA\RequestBody(
             required: true,
             content: new OA\JsonContent(
-                required: ['title', 'taskId'],
+                required: ['title', 'taskId', 'repositoryId'],
                 properties: [
                     new OA\Property(property: 'title', type: 'string', maxLength: 255, example: 'Demande de revue produit'),
                     new OA\Property(property: 'description', type: 'string', maxLength: 5000, example: 'Valider les nouveaux critères de qualification.', nullable: true),
                     new OA\Property(property: 'status', type: 'string', enum: ['pending', 'approved', 'rejected'], example: 'pending', nullable: true),
                     new OA\Property(property: 'resolvedAt', type: 'string', format: 'date-time', example: '2026-03-20T16:30:00+00:00', nullable: true),
                     new OA\Property(property: 'taskId', type: 'string', format: 'uuid', example: '8f6a3550-9a07-4f69-9f75-0089f7d83e7f'),
+                    new OA\Property(property: 'repositoryId', type: 'string', format: 'uuid', example: '03463358-2e8f-4f63-a893-69d5313b05d2'),
                     new OA\Property(property: 'assigneeIds', type: 'array', items: new OA\Items(type: 'string', format: 'uuid'), example: ['7d3c919e-5d4e-406a-a615-ffaf6dddbd85'], nullable: true),
                 ],
             ),
@@ -151,6 +154,14 @@ final readonly class CreateTaskRequestController
             }
 
             $taskRequest->setTask($task);
+        }
+        if (is_string($input->repositoryId)) {
+            $repository = $this->crmProjectRepositoryRepository->findOneScopedById($input->repositoryId, $crm->getId());
+            if ($repository === null) {
+                return $this->errorResponseFactory->notFoundReference('repositoryId');
+            }
+
+            $taskRequest->setRepository($repository);
         }
 
         if (is_array($input->assigneeIds)) {

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/PatchTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/PatchTaskRequestController.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
 
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Crm\Domain\Enum\TaskRequestStatus;
+use App\Crm\Infrastructure\Repository\CrmProjectRepositoryRepository;
 use App\Crm\Infrastructure\Repository\TaskRequestRepository;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
@@ -28,6 +30,8 @@ final readonly class PatchTaskRequestController
 {
     public function __construct(
         private TaskRequestRepository $taskRequestRepository,
+        private CrmProjectRepositoryRepository $crmProjectRepositoryRepository,
+        private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
     ) {
     }
@@ -39,6 +43,8 @@ final readonly class PatchTaskRequestController
     #[Route('/v1/crm/applications/{applicationSlug}/task-requests/{taskRequest}', methods: [Request::METHOD_PATCH])]
     public function __invoke(string $applicationSlug, TaskRequest $taskRequest, Request $request): JsonResponse
     {
+        $crm = $this->scopeResolver->resolveOrFail($applicationSlug);
+
         try {
             $payload = json_decode(
                 (string)$request->getContent(),
@@ -67,6 +73,14 @@ final readonly class PatchTaskRequestController
         }
         if (array_key_exists('resolvedAt', $payload)) {
             $taskRequest->setResolvedAt($this->parseDate($payload['resolvedAt']));
+        }
+        if (isset($payload['repositoryId']) && is_string($payload['repositoryId'])) {
+            $repository = $this->crmProjectRepositoryRepository->findOneScopedById($payload['repositoryId'], $crm->getId());
+            if ($repository === null) {
+                return $this->errorResponseFactory->notFoundReference('repositoryId');
+            }
+
+            $taskRequest->setRepository($repository);
         }
 
         $this->taskRequestRepository->save($taskRequest);

--- a/src/Crm/Transport/Request/CreateTaskRequestEntryRequest.php
+++ b/src/Crm/Transport/Request/CreateTaskRequestEntryRequest.php
@@ -27,6 +27,11 @@ final class CreateTaskRequestEntryRequest
     #[Assert\Uuid]
     public ?string $taskId = null;
 
+    #[Assert\NotBlank]
+    #[Assert\NotNull]
+    #[Assert\Uuid]
+    public ?string $repositoryId = null;
+
     #[Assert\Type(type: 'array')]
     #[Assert\All([
         new Assert\Uuid(),
@@ -41,6 +46,7 @@ final class CreateTaskRequestEntryRequest
         $request->status = isset($payload['status']) ? (string)$payload['status'] : null;
         $request->resolvedAt = isset($payload['resolvedAt']) ? (string)$payload['resolvedAt'] : null;
         $request->taskId = isset($payload['taskId']) ? (string)$payload['taskId'] : null;
+        $request->repositoryId = isset($payload['repositoryId']) ? (string)$payload['repositoryId'] : null;
         $request->assigneeIds = isset($payload['assigneeIds']) && is_array($payload['assigneeIds']) ? $payload['assigneeIds'] : $payload['assigneeIds'] ?? null;
 
         return $request;


### PR DESCRIPTION
### Motivation
- Ensure every `TaskRequest` is attached to a `CrmRepository` so requests can be filtered/boarded by repository and to enforce CRM/application scope consistency.
- Provide a scoped validation path for incoming payloads so clients cannot link task requests to repositories outside the same CRM/application.

### Description
- Add a mandatory `ManyToOne` relation from `TaskRequest` to `CrmRepository` with `JoinColumn(nullable=false)` and a Doctrine index on `(repository_id, status)` in `src/Crm/Domain/Entity/TaskRequest.php` and expose `repository_id` in the entity `toArray()`.
- Require `repositoryId` in the create DTO `src/Crm/Transport/Request/CreateTaskRequestEntryRequest.php` and hydrate/validate it in `CreateTaskRequestController` using a scoped lookup.
- Introduce `CrmProjectRepositoryRepository` with `findOneScopedById()` to validate repository ownership within the same CRM/application and use it in `CreateTaskRequestController` and `PatchTaskRequestController` when `repositoryId` is provided.
- Include `repositoryId` in task request projections/normalization (`TaskRequestRepository` and `CrmApiNormalizer`) and update fixtures to ensure generated task requests have a repository.
- Add a DB migration to add `repository_id`, backfill values from the task's project repositories, enforce `NOT NULL` + FK constraint, and create the `(repository_id, status)` index (migration file `migrations/Version20260322143000.php`).

### Testing
- Performed PHP syntax checks with `php -l` on modified files and the migration and all returned no syntax errors for `src/Crm/Domain/Entity/TaskRequest.php`, `src/Crm/Transport/Request/CreateTaskRequestEntryRequest.php`, `src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php`, `src/Crm/Transport/Controller/Api/V1/TaskRequest/PatchTaskRequestController.php`, `src/Crm/Infrastructure/Repository/CrmProjectRepositoryRepository.php`, `src/Crm/Infrastructure/Repository/TaskRequestRepository.php`, `src/Crm/Application/Service/CrmApiNormalizer.php`, `src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php`, and `migrations/Version20260322143000.php`.
- All automated checks executed in this rollout succeeded (no syntax errors reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0179dc06c832bb1bbd9929a3e71a1)