### PR TITLE
feat(crm): add GitHub issues/projects endpoints with unified API errors

### DIFF
--- a/src/Crm/Application/Exception/CrmGithubApiException.php
+++ b/src/Crm/Application/Exception/CrmGithubApiException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Exception;
+
+use RuntimeException;
+
+final class CrmGithubApiException extends RuntimeException
+{
+    public function __construct(
+        string $message,
+        private readonly int $statusCode = 502,
+        private readonly array $errors = [],
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    /**
+     * @return array<int|string,mixed>
+     */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Crm/Application/Service/CrmGithubService.php
+++ b/src/Crm/Application/Service/CrmGithubService.php
@@ -4,21 +4,26 @@ declare(strict_types=1);
 
 namespace App\Crm\Application\Service;
 
+use App\Crm\Application\Exception\CrmGithubApiException;
 use App\Crm\Domain\Entity\Project;
-use RuntimeException;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 use function array_filter;
+use function array_key_exists;
 use function array_map;
 use function array_values;
 use function count;
 use function is_array;
+use function is_int;
 use function is_string;
+use function parse_str;
+use function preg_match;
 use function sprintf;
 use function str_contains;
 use function strtolower;
 use function trim;
+use function urldecode;
 
 readonly class CrmGithubService
 {
@@ -81,9 +86,27 @@ readonly class CrmGithubService
         }, $configured)));
     }
 
+    public function getRepository(Project $project, string $repoFullName): array
+    {
+        $repository = $this->request($project, 'GET', sprintf('/repos/%s', trim($repoFullName)));
+
+        return [
+            'id' => (int)($repository['id'] ?? 0),
+            'name' => (string)($repository['name'] ?? ''),
+            'fullName' => (string)($repository['full_name'] ?? ''),
+            'private' => (bool)($repository['private'] ?? false),
+            'defaultBranch' => isset($repository['default_branch']) && is_string($repository['default_branch']) && $repository['default_branch'] !== ''
+                ? $repository['default_branch']
+                : null,
+            'description' => isset($repository['description']) ? (string)$repository['description'] : null,
+            'owner' => (string)($repository['owner']['login'] ?? ''),
+            'htmlUrl' => (string)($repository['html_url'] ?? ''),
+        ];
+    }
+
     public function listAccountRepositories(Project $project, int $page = 1, int $perPage = 30, string $search = ''): array
     {
-        $response = $this->request($project, 'GET', '/user/repos', [
+        $response = $this->requestWithMeta($project, 'GET', '/user/repos', [
             'query' => [
                 'sort' => 'updated',
                 'direction' => 'desc',
@@ -108,7 +131,7 @@ readonly class CrmGithubService
                 'htmlUrl' => (string)($repository['html_url'] ?? ''),
                 'owner' => (string)($repository['owner']['login'] ?? ''),
             ];
-        }, $response)));
+        }, $response['data'])));
 
         if ($search !== '') {
             $normalizedSearch = strtolower($search);
@@ -118,12 +141,7 @@ readonly class CrmGithubService
 
         return [
             'items' => $items,
-            'pagination' => [
-                'page' => $page,
-                'limit' => $perPage,
-                'totalItems' => count($items),
-                'totalPages' => 1,
-            ],
+            'pagination' => $this->buildPagination($response['meta']['link'], $page, $perPage, count($items)),
         ];
     }
 
@@ -134,7 +152,7 @@ readonly class CrmGithubService
     {
         $normalizedFullName = trim($fullName);
         if ($normalizedFullName === '') {
-            throw new RuntimeException('Repository full name cannot be empty.');
+            throw new CrmGithubApiException('Repository full name cannot be empty.', 422);
         }
 
         $repository = $this->request($project, 'GET', sprintf('/repos/%s', $normalizedFullName));
@@ -160,7 +178,7 @@ readonly class CrmGithubService
 
     public function listBranches(Project $project, string $repoFullName, int $page = 1, int $perPage = 30, string $search = ''): array
     {
-        $response = $this->request($project, 'GET', sprintf('/repos/%s/branches', $repoFullName), [
+        $response = $this->requestWithMeta($project, 'GET', sprintf('/repos/%s/branches', $repoFullName), [
             'query' => ['page' => $page, 'per_page' => $perPage],
         ]);
 
@@ -168,7 +186,7 @@ readonly class CrmGithubService
             'name' => $branch['name'] ?? '',
             'protected' => (bool)($branch['protected'] ?? false),
             'sha' => $branch['commit']['sha'] ?? null,
-        ], $response);
+        ], $response['data']);
 
         if ($search !== '') {
             $items = array_values(array_filter($items, static fn (array $item): bool => str_contains(strtolower((string)$item['name']), strtolower($search))));
@@ -176,18 +194,13 @@ readonly class CrmGithubService
 
         return [
             'items' => $items,
-            'pagination' => [
-                'page' => $page,
-                'limit' => $perPage,
-                'totalItems' => count($items),
-                'totalPages' => 1,
-            ],
+            'pagination' => $this->buildPagination($response['meta']['link'], $page, $perPage, count($items)),
         ];
     }
 
     public function listPullRequests(Project $project, string $repoFullName, string $state = 'open', ?string $author = null, string $search = '', int $page = 1, int $perPage = 30): array
     {
-        $response = $this->request($project, 'GET', sprintf('/repos/%s/pulls', $repoFullName), [
+        $response = $this->requestWithMeta($project, 'GET', sprintf('/repos/%s/pulls', $repoFullName), [
             'query' => [
                 'state' => $state,
                 'page' => $page,
@@ -211,7 +224,7 @@ readonly class CrmGithubService
                 'draft' => (bool)($pull['draft'] ?? false),
                 'htmlUrl' => (string)($pull['html_url'] ?? ''),
             ];
-        }, $response)));
+        }, $response['data'])));
 
         if (is_string($author) && $author !== '') {
             $items = array_values(array_filter($items, static fn (array $item): bool => strtolower((string)$item['author']) === strtolower($author)));
@@ -223,12 +236,7 @@ readonly class CrmGithubService
 
         return [
             'items' => $items,
-            'pagination' => [
-                'page' => $page,
-                'limit' => $perPage,
-                'totalItems' => count($items),
-                'totalPages' => 1,
-            ],
+            'pagination' => $this->buildPagination($response['meta']['link'], $page, $perPage, count($items)),
         ];
     }
 
@@ -254,6 +262,211 @@ readonly class CrmGithubService
         ];
     }
 
+    public function listIssues(Project $project, string $repoFullName, string $state = 'open', int $page = 1, int $perPage = 30): array
+    {
+        $response = $this->requestWithMeta($project, 'GET', sprintf('/repos/%s/issues', $repoFullName), [
+            'query' => [
+                'state' => $state,
+                'page' => $page,
+                'per_page' => $perPage,
+            ],
+        ]);
+
+        $items = array_values(array_filter(array_map(static function (array $issue): ?array {
+            if (array_key_exists('pull_request', $issue)) {
+                return null;
+            }
+
+            return [
+                'number' => (int)($issue['number'] ?? 0),
+                'title' => (string)($issue['title'] ?? ''),
+                'state' => (string)($issue['state'] ?? ''),
+                'author' => (string)($issue['user']['login'] ?? ''),
+                'comments' => (int)($issue['comments'] ?? 0),
+                'htmlUrl' => (string)($issue['html_url'] ?? ''),
+                'createdAt' => (string)($issue['created_at'] ?? ''),
+                'updatedAt' => (string)($issue['updated_at'] ?? ''),
+            ];
+        }, $response['data'])));
+
+        return [
+            'items' => $items,
+            'pagination' => $this->buildPagination($response['meta']['link'], $page, $perPage, count($items)),
+        ];
+    }
+
+    public function getIssue(Project $project, string $repoFullName, int $number): array
+    {
+        $issue = $this->request($project, 'GET', sprintf('/repos/%s/issues/%d', $repoFullName, $number));
+
+        return [
+            'number' => (int)($issue['number'] ?? 0),
+            'title' => (string)($issue['title'] ?? ''),
+            'state' => (string)($issue['state'] ?? ''),
+            'body' => isset($issue['body']) ? (string)$issue['body'] : null,
+            'author' => (string)($issue['user']['login'] ?? ''),
+            'comments' => (int)($issue['comments'] ?? 0),
+            'htmlUrl' => (string)($issue['html_url'] ?? ''),
+            'createdAt' => (string)($issue['created_at'] ?? ''),
+            'updatedAt' => (string)($issue['updated_at'] ?? ''),
+        ];
+    }
+
+    public function listRepositoryProjects(Project $project, string $repoFullName, int $page = 1, int $perPage = 20): array
+    {
+        $repository = $this->request($project, 'GET', sprintf('/repos/%s', $repoFullName));
+        $owner = (string)($repository['owner']['login'] ?? '');
+
+        $graphql = $this->graphql($project, <<<'GRAPHQL'
+query($owner:String!, $page:Int!, $perPage:Int!) {
+  user(login: $owner) {
+    projectsV2(first: $perPage, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes { id title number url closed updatedAt }
+      pageInfo { hasNextPage endCursor }
+      totalCount
+    }
+  }
+  organization(login: $owner) {
+    projectsV2(first: $perPage, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      nodes { id title number url closed updatedAt }
+      pageInfo { hasNextPage endCursor }
+      totalCount
+    }
+  }
+}
+GRAPHQL, ['owner' => $owner, 'page' => $page, 'perPage' => $perPage]);
+
+        $projectBlock = $graphql['data']['user']['projectsV2'] ?? $graphql['data']['organization']['projectsV2'] ?? null;
+        $nodes = is_array($projectBlock['nodes'] ?? null) ? $projectBlock['nodes'] : [];
+        $totalCount = (int)($projectBlock['totalCount'] ?? count($nodes));
+
+        return [
+            'items' => array_values(array_map(static fn (array $item): array => [
+                'id' => (string)($item['id'] ?? ''),
+                'title' => (string)($item['title'] ?? ''),
+                'number' => (int)($item['number'] ?? 0),
+                'url' => (string)($item['url'] ?? ''),
+                'closed' => (bool)($item['closed'] ?? false),
+                'updatedAt' => (string)($item['updatedAt'] ?? ''),
+            ], $nodes)),
+            'pagination' => [
+                'page' => $page,
+                'limit' => $perPage,
+                'totalItems' => $totalCount,
+                'totalPages' => (int)max(1, (int)ceil($totalCount / $perPage)),
+            ],
+        ];
+    }
+
+    public function getProjectItems(Project $project, string $projectId, int $page = 1, int $perPage = 20): array
+    {
+        $graphql = $this->graphql($project, <<<'GRAPHQL'
+query($projectId:ID!, $perPage:Int!, $after:String) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: $perPage, after: $after) {
+        nodes {
+          id
+          content {
+            ... on Issue { id number title url state }
+          }
+        }
+        totalCount
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+GRAPHQL, ['projectId' => $projectId, 'perPage' => $perPage, 'after' => null]);
+
+        $itemsBlock = $graphql['data']['node']['items'] ?? [];
+        $nodes = is_array($itemsBlock['nodes'] ?? null) ? $itemsBlock['nodes'] : [];
+        $totalCount = (int)($itemsBlock['totalCount'] ?? count($nodes));
+
+        return [
+            'items' => array_values(array_map(static fn (array $item): array => [
+                'id' => (string)($item['id'] ?? ''),
+                'issue' => [
+                    'id' => (string)($item['content']['id'] ?? ''),
+                    'number' => (int)($item['content']['number'] ?? 0),
+                    'title' => (string)($item['content']['title'] ?? ''),
+                    'url' => (string)($item['content']['url'] ?? ''),
+                    'state' => (string)($item['content']['state'] ?? ''),
+                ],
+            ], $nodes)),
+            'pagination' => [
+                'page' => $page,
+                'limit' => $perPage,
+                'totalItems' => $totalCount,
+                'totalPages' => (int)max(1, (int)ceil($totalCount / $perPage)),
+            ],
+        ];
+    }
+
+    public function createRepository(Project $project, string $name, ?string $description = null, bool $private = true): array
+    {
+        $payload = [
+            'name' => trim($name),
+            'private' => $private,
+        ];
+
+        if (is_string($description) && trim($description) !== '') {
+            $payload['description'] = trim($description);
+        }
+
+        return $this->request($project, 'POST', '/user/repos', ['json' => $payload]);
+    }
+
+    public function createIssue(Project $project, string $repoFullName, string $title, ?string $body = null): array
+    {
+        $payload = ['title' => trim($title)];
+        if (is_string($body) && trim($body) !== '') {
+            $payload['body'] = trim($body);
+        }
+
+        return $this->request($project, 'POST', sprintf('/repos/%s/issues', $repoFullName), ['json' => $payload]);
+    }
+
+    public function updateIssueState(Project $project, string $repoFullName, int $number, string $state): array
+    {
+        return $this->request($project, 'PATCH', sprintf('/repos/%s/issues/%d', $repoFullName, $number), [
+            'json' => ['state' => strtolower(trim($state))],
+        ]);
+    }
+
+    public function addIssueComment(Project $project, string $repoFullName, int $number, string $body): array
+    {
+        return $this->request($project, 'POST', sprintf('/repos/%s/issues/%d/comments', $repoFullName, $number), [
+            'json' => ['body' => trim($body)],
+        ]);
+    }
+
+    public function createProjectBoard(Project $project, string $ownerLogin, string $title): array
+    {
+        $graphql = $this->graphql($project, <<<'GRAPHQL'
+mutation($owner:String!, $title:String!) {
+  createProjectV2(input:{ownerId:$owner, title:$title}) {
+    projectV2 { id title number url }
+  }
+}
+GRAPHQL, ['owner' => $ownerLogin, 'title' => $title]);
+
+        return $graphql['data']['createProjectV2']['projectV2'] ?? [];
+    }
+
+    public function moveIssueToProjectColumn(Project $project, string $projectId, string $itemId, ?string $afterItemId = null): array
+    {
+        $graphql = $this->graphql($project, <<<'GRAPHQL'
+mutation($projectId:ID!, $itemId:ID!, $afterId:ID) {
+  updateProjectV2ItemPosition(input:{projectId:$projectId, itemId:$itemId, afterId:$afterId}) {
+    items { totalCount }
+  }
+}
+GRAPHQL, ['projectId' => $projectId, 'itemId' => $itemId, 'afterId' => $afterItemId]);
+
+        return $graphql['data']['updateProjectV2ItemPosition']['items'] ?? [];
+    }
+
     public function mergePullRequest(Project $project, string $repoFullName, int $number, string $method = 'merge'): array
     {
         return $this->request($project, 'PUT', sprintf('/repos/%s/pulls/%d/merge', $repoFullName, $number), [
@@ -272,14 +485,15 @@ readonly class CrmGithubService
 
     /**
      * @param array<string,mixed> $options
-     * @return array<mixed>
+     * @return array{data:array<mixed>,meta:array<string,mixed>}
      */
-    private function request(Project $project, string $method, string $path, array $options = []): array
+    private function requestWithMeta(Project $project, string $method, string $path, array $options = []): array
     {
         $token = $project->getGithubToken();
         if (!is_string($token) || $token === '') {
-            throw new RuntimeException('GitHub token is not configured on this project.');
+            throw new CrmGithubApiException('GitHub token is not configured on this project.', 400);
         }
+
         try {
             $response = $this->httpClient->request($method, self::BASE_URL . $path, $options + [
                 'headers' => [
@@ -289,9 +503,111 @@ readonly class CrmGithubService
                 ],
             ]);
 
-            return $response->toArray(false);
+            $statusCode = $response->getStatusCode();
+            $data = $response->toArray(false);
+
+            if ($statusCode >= 400) {
+                throw $this->mapToCrmException($statusCode, is_array($data) ? $data : []);
+            }
+
+            return [
+                'data' => is_array($data) ? $data : [],
+                'meta' => [
+                    'link' => $response->getHeaders(false)['link'][0] ?? null,
+                ],
+            ];
+        } catch (CrmGithubApiException $exception) {
+            throw $exception;
         } catch (ExceptionInterface $exception) {
-            throw new RuntimeException('GitHub API request failed: ' . $exception->getMessage(), previous: $exception);
+            throw new CrmGithubApiException('Unable to reach GitHub API.', 502, previous: $exception);
         }
+    }
+
+    /**
+     * @param array<string,mixed> $options
+     * @return array<mixed>
+     */
+    private function request(Project $project, string $method, string $path, array $options = []): array
+    {
+        $response = $this->requestWithMeta($project, $method, $path, $options);
+
+        return $response['data'];
+    }
+
+    /**
+     * @param array<string,mixed> $variables
+     */
+    private function graphql(Project $project, string $query, array $variables = []): array
+    {
+        $data = $this->request($project, 'POST', '/graphql', ['json' => ['query' => $query, 'variables' => $variables]]);
+        if (is_array($data['errors'] ?? null) && $data['errors'] !== []) {
+            throw new CrmGithubApiException('GitHub project operation failed.', 422, $data['errors']);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     */
+    private function mapToCrmException(int $statusCode, array $payload): CrmGithubApiException
+    {
+        $message = (string)($payload['message'] ?? 'GitHub API request failed.');
+        $errors = is_array($payload['errors'] ?? null) ? $payload['errors'] : [];
+
+        return match ($statusCode) {
+            401, 403 => new CrmGithubApiException('GitHub authentication failed for this project token.', 401, $errors),
+            404 => new CrmGithubApiException('GitHub resource not found or inaccessible.', 404, $errors),
+            422 => new CrmGithubApiException('GitHub validation failed for this request.', 422, $errors),
+            default => new CrmGithubApiException($message, 502, $errors),
+        };
+    }
+
+    private function buildPagination(?string $linkHeader, int $page, int $limit, int $itemsCount): array
+    {
+        $parsed = $this->parseLinkHeader($linkHeader);
+        $lastPage = $parsed['last'] ?? null;
+        $nextPage = $parsed['next'] ?? null;
+
+        return [
+            'page' => $page,
+            'limit' => $limit,
+            'totalItems' => $lastPage !== null ? $lastPage * $limit : $itemsCount,
+            'totalPages' => $lastPage ?? ($nextPage !== null ? $page + 1 : max(1, $page)),
+            'hasNextPage' => $nextPage !== null,
+        ];
+    }
+
+    /**
+     * @return array{next?:int,last?:int}
+     */
+    private function parseLinkHeader(?string $linkHeader): array
+    {
+        if (!is_string($linkHeader) || trim($linkHeader) === '') {
+            return [];
+        }
+
+        $pages = [];
+        foreach (explode(',', $linkHeader) as $linkPart) {
+            if (!preg_match('/<([^>]+)>;\s*rel="([a-z]+)"/i', trim($linkPart), $matches)) {
+                continue;
+            }
+
+            $url = $matches[1];
+            $rel = strtolower($matches[2]);
+
+            $query = [];
+            parse_str((string)parse_url($url, PHP_URL_QUERY), $query);
+            $page = $query['page'] ?? null;
+            if (is_string($page)) {
+                $page = (int)urldecode($page);
+            }
+
+            if (is_int($page) && $page > 0) {
+                $pages[$rel] = $page;
+            }
+        }
+
+        return $pages;
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubIssueCommentController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubIssueCommentController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\AddGithubIssueCommentRequest;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class AddProjectGithubIssueCommentController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(private CrmGithubService $crmGithubService, private CrmRequestHandler $crmRequestHandler, private CrmGithubApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}/comments', methods: [Request::METHOD_POST])]
+    public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
+    {
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $input = $this->crmRequestHandler->mapAndValidate($payload, AddGithubIssueCommentRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
+        }
+
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->addIssueComment($project, (string)$input->repository, $number, (string)$input->body),
+            JsonResponse::HTTP_CREATED,
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubRepositoryController.php
@@ -8,12 +8,12 @@ use App\Crm\Application\Service\CrmGithubService;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
 use App\Crm\Transport\Request\AddProjectGithubRepositoryRequest;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Crm\Transport\Request\CrmRequestHandler;
 use App\Role\Domain\Enum\Role;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use OpenApi\Attributes as OA;
-use RuntimeException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -25,10 +25,12 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_ADMIN->value)]
 final readonly class AddProjectGithubRepositoryController
 {
+    use HandlesGithubApiExceptions;
     public function __construct(
         private CrmGithubService $crmGithubService,
         private CrmRequestHandler $crmRequestHandler,
         private ProjectRepository $projectRepository,
+        private CrmGithubApiErrorResponseFactory $errorResponseFactory,
     ) {
     }
 
@@ -136,7 +138,7 @@ final readonly class AddProjectGithubRepositoryController
             return $input;
         }
 
-        try {
+        return $this->withGithubApiErrors(function () use ($project, $input): JsonResponse {
             $repository = $this->crmGithubService->attachRepository($project, (string)$input->fullName);
             $this->projectRepository->save($project);
 
@@ -145,11 +147,6 @@ final readonly class AddProjectGithubRepositoryController
                 'repository' => $repository,
                 'repositories' => $this->crmGithubService->listRepositories($project),
             ], JsonResponse::HTTP_CREATED);
-        } catch (RuntimeException $exception) {
-            return new JsonResponse([
-                'message' => $exception->getMessage(),
-                'errors' => [],
-            ], JsonResponse::HTTP_BAD_GATEWAY);
-        }
+        }, $this->errorResponseFactory);
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubIssueController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CreateGithubIssueRequest;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class CreateProjectGithubIssueController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(private CrmGithubService $crmGithubService, private CrmRequestHandler $crmRequestHandler, private CrmGithubApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues', methods: [Request::METHOD_POST])]
+    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    {
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $input = $this->crmRequestHandler->mapAndValidate($payload, CreateGithubIssueRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
+        }
+
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->createIssue($project, (string)$input->repository, (string)$input->title, $input->body),
+            JsonResponse::HTTP_CREATED,
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubProjectBoardController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubProjectBoardController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CreateGithubProjectBoardRequest;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class CreateProjectGithubProjectBoardController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(private CrmGithubService $crmGithubService, private CrmRequestHandler $crmRequestHandler, private CrmGithubApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects', methods: [Request::METHOD_POST])]
+    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    {
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $input = $this->crmRequestHandler->mapAndValidate($payload, CreateGithubProjectBoardRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
+        }
+
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->createProjectBoard($project, (string)$input->owner, (string)$input->title),
+            JsonResponse::HTTP_CREATED,
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubRepositoryController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CreateGithubRepositoryRequest;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class CreateProjectGithubRepositoryController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(private CrmGithubService $crmGithubService, private CrmRequestHandler $crmRequestHandler, private CrmGithubApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/create', methods: [Request::METHOD_POST])]
+    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    {
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $input = $this->crmRequestHandler->mapAndValidate($payload, CreateGithubRepositoryRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
+        }
+
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->createRepository($project, (string)$input->name, $input->description, $input->private),
+            JsonResponse::HTTP_CREATED,
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubIssueController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class GetProjectGithubIssueController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(private CrmGithubService $crmGithubService, private CrmGithubApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
+    {
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->getIssue($project, (string)$request->query->get('repo', ''), $number),
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubRepositoryController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class GetProjectGithubRepositoryController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(private CrmGithubService $crmGithubService, private CrmGithubApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/{repository}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Project $project, string $repository): JsonResponse
+    {
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->getRepository($project, $repository),
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/HandlesGithubApiExceptions.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/HandlesGithubApiExceptions.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Exception\CrmGithubApiException;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use Closure;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+trait HandlesGithubApiExceptions
+{
+    protected function withGithubApiErrors(Closure $operation, CrmGithubApiErrorResponseFactory $errorResponseFactory): JsonResponse
+    {
+        try {
+            return $operation();
+        } catch (CrmGithubApiException $exception) {
+            return $errorResponseFactory->fromException($exception);
+        }
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubIssuesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubIssuesController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class ListProjectGithubIssuesController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(private CrmGithubService $crmGithubService, private CrmGithubApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    {
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse($this->crmGithubService->listIssues(
+            $project,
+            (string)$request->query->get('repo', ''),
+            (string)$request->query->get('state', 'open'),
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+        )), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectItemsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectItemsController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class ListProjectGithubProjectItemsController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(private CrmGithubService $crmGithubService, private CrmGithubApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects/{projectId}/items', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Project $project, string $projectId, Request $request): JsonResponse
+    {
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse($this->crmGithubService->getProjectItems(
+            $project,
+            $projectId,
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 20))),
+        )), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectsController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class ListProjectGithubProjectsController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(private CrmGithubService $crmGithubService, private CrmGithubApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects', methods: [Request::METHOD_GET])]
+    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    {
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse($this->crmGithubService->listRepositoryProjects(
+            $project,
+            (string)$request->query->get('repo', ''),
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 20))),
+        )), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/MoveProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/MoveProjectGithubIssueController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use App\Crm\Transport\Request\MoveGithubProjectItemRequest;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class MoveProjectGithubIssueController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(private CrmGithubService $crmGithubService, private CrmRequestHandler $crmRequestHandler, private CrmGithubApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects/{projectId}/items/{itemId}/move', methods: [Request::METHOD_POST])]
+    public function __invoke(string $applicationSlug, Project $project, string $projectId, string $itemId, Request $request): JsonResponse
+    {
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $input = $this->crmRequestHandler->mapAndValidate($payload, MoveGithubProjectItemRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
+        }
+
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->moveIssueToProjectColumn($project, $projectId, $itemId, $input->afterItemId),
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubIssueStateController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubIssueStateController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use App\Crm\Transport\Request\UpdateGithubIssueStateRequest;
+use App\Role\Domain\Enum\Role;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class UpdateProjectGithubIssueStateController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(private CrmGithubService $crmGithubService, private CrmRequestHandler $crmRequestHandler, private CrmGithubApiErrorResponseFactory $errorResponseFactory)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}', methods: [Request::METHOD_PATCH])]
+    public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
+    {
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $input = $this->crmRequestHandler->mapAndValidate($payload, UpdateGithubIssueStateRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
+        }
+
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->updateIssueState($project, (string)$input->repository, $number, (string)$input->state),
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Request/AddGithubIssueCommentRequest.php
+++ b/src/Crm/Transport/Request/AddGithubIssueCommentRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class AddGithubIssueCommentRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Regex(pattern: '/^[^\s\/]+\/[^\s\/]+$/', message: 'Repository must be in the "owner/name" format.')]
+    public ?string $repository = null;
+
+    #[Assert\NotBlank]
+    public ?string $body = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->repository = isset($payload['repository']) ? trim((string)$payload['repository']) : null;
+        $request->body = isset($payload['body']) ? trim((string)$payload['body']) : null;
+
+        return $request;
+    }
+}

--- a/src/Crm/Transport/Request/CreateGithubIssueRequest.php
+++ b/src/Crm/Transport/Request/CreateGithubIssueRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateGithubIssueRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Regex(pattern: '/^[^\s\/]+\/[^\s\/]+$/', message: 'Repository must be in the "owner/name" format.')]
+    public ?string $repository = null;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    public ?string $title = null;
+
+    public ?string $body = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->repository = isset($payload['repository']) ? trim((string)$payload['repository']) : null;
+        $request->title = isset($payload['title']) ? trim((string)$payload['title']) : null;
+        $request->body = isset($payload['body']) ? (string)$payload['body'] : null;
+
+        return $request;
+    }
+}

--- a/src/Crm/Transport/Request/CreateGithubProjectBoardRequest.php
+++ b/src/Crm/Transport/Request/CreateGithubProjectBoardRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateGithubProjectBoardRequest
+{
+    #[Assert\NotBlank]
+    public ?string $owner = null;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    public ?string $title = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->owner = isset($payload['owner']) ? trim((string)$payload['owner']) : null;
+        $request->title = isset($payload['title']) ? trim((string)$payload['title']) : null;
+
+        return $request;
+    }
+}

--- a/src/Crm/Transport/Request/CreateGithubRepositoryRequest.php
+++ b/src/Crm/Transport/Request/CreateGithubRepositoryRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateGithubRepositoryRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 100)]
+    public ?string $name = null;
+
+    #[Assert\Length(max: 500)]
+    public ?string $description = null;
+
+    public bool $private = true;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->name = isset($payload['name']) ? trim((string)$payload['name']) : null;
+        $request->description = isset($payload['description']) ? trim((string)$payload['description']) : null;
+        $request->private = (bool)($payload['private'] ?? true);
+
+        return $request;
+    }
+}

--- a/src/Crm/Transport/Request/CrmGithubApiErrorResponseFactory.php
+++ b/src/Crm/Transport/Request/CrmGithubApiErrorResponseFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use App\Crm\Application\Exception\CrmGithubApiException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+final class CrmGithubApiErrorResponseFactory
+{
+    public function fromException(CrmGithubApiException $exception): JsonResponse
+    {
+        return new JsonResponse([
+            'message' => $exception->getMessage(),
+            'errors' => $exception->getErrors(),
+        ], $exception->getStatusCode());
+    }
+}

--- a/src/Crm/Transport/Request/MoveGithubProjectItemRequest.php
+++ b/src/Crm/Transport/Request/MoveGithubProjectItemRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+final class MoveGithubProjectItemRequest
+{
+    public ?string $afterItemId = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->afterItemId = isset($payload['afterItemId']) ? trim((string)$payload['afterItemId']) : null;
+
+        return $request;
+    }
+}

--- a/src/Crm/Transport/Request/UpdateGithubIssueStateRequest.php
+++ b/src/Crm/Transport/Request/UpdateGithubIssueStateRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class UpdateGithubIssueStateRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Regex(pattern: '/^[^\s\/]+\/[^\s\/]+$/', message: 'Repository must be in the "owner/name" format.')]
+    public ?string $repository = null;
+
+    #[Assert\NotBlank]
+    #[Assert\Choice(choices: ['open', 'closed'])]
+    public ?string $state = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->repository = isset($payload['repository']) ? trim((string)$payload['repository']) : null;
+        $request->state = isset($payload['state']) ? strtolower(trim((string)$payload['state'])) : null;
+
+        return $request;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide CRM-level read and write access to GitHub resources (repositories, issues, projects) from the project scope. 
- Replace the previous stubbed pagination and ad-hoc error responses with real GitHub `Link`-based pagination and a unified error mapping for clearer API semantics.

### Description
- Extended `CrmGithubService` with new read methods `getRepository`, `listIssues`, `getIssue`, `listRepositoryProjects` (ProjectsV2 via GraphQL), and `getProjectItems`, and action methods `createRepository`, `createIssue`, `updateIssueState`, `addIssueComment`, `createProjectBoard`, `moveIssueToProjectColumn` (ProjectsV2 item position).
- Replaced fixed pagination (`totalPages = 1`) for REST list endpoints by parsing GitHub `Link` headers and returning full pagination metadata via `buildPagination`/`parseLinkHeader`, and introduced `requestWithMeta` to expose response meta.
- Introduced `CrmGithubApiException` and `CrmGithubApiErrorResponseFactory` to map GitHub HTTP errors into CRM-friendly messages and HTTP status codes, and added `HandlesGithubApiExceptions` trait used by controllers to convert exceptions to JSON responses.
- Added dedicated REST controllers and request DTOs under `src/Crm/Transport/Controller/Api/V1/Project/Github/` and `src/Crm/Transport/Request/` with explicit routes and intended permissions (`ROLE_CRM_MANAGER` for reads, `ROLE_CRM_ADMIN` for actions), and updated the existing attach-repository controller to use the unified error handling.

### Testing
- Ran a PHP syntax check across modified/new files with `for f in $(git status --short | awk '{print $2}'); do php -l "$f" || exit 1; done`, which reported `No syntax errors detected` for all changed files.
- Created and validated new PHP files and controllers (syntax-only automated validation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c018c306d4832b83795b60df700770)