### PR TITLE
Add CRM repository/issue Elasticsearch projections and cache invalidation support

### DIFF
--- a/src/Crm/Application/MessageHandler/GithubWebhookReceivedHandler.php
+++ b/src/Crm/Application/MessageHandler/GithubWebhookReceivedHandler.php
@@ -68,6 +68,10 @@ final readonly class GithubWebhookReceivedHandler
             $applicationSlug = $project?->getCompany()?->getCrm()?->getApplication()?->getSlug();
             if ($applicationSlug !== null && $applicationSlug !== '') {
                 $this->crmReadCacheInvalidator->invalidateProjectCaches($applicationSlug, $project?->getId());
+                $this->crmReadCacheInvalidator->invalidateRepository($applicationSlug, $repository->getId());
+                if ($message->eventName === 'issues') {
+                    $this->crmReadCacheInvalidator->invalidateIssue($applicationSlug, $webhookEvent->getId());
+                }
             }
         }
 

--- a/src/Crm/Application/Projection/CrmIssueProjection.php
+++ b/src/Crm/Application/Projection/CrmIssueProjection.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Projection;
+
+final class CrmIssueProjection
+{
+    public const string INDEX_NAME = 'crm_issues';
+}

--- a/src/Crm/Application/Projection/CrmRepositoryProjection.php
+++ b/src/Crm/Application/Projection/CrmRepositoryProjection.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Projection;
+
+final class CrmRepositoryProjection
+{
+    public const string INDEX_NAME = 'crm_repositories';
+}

--- a/src/Crm/Application/Service/CrmReadCacheInvalidator.php
+++ b/src/Crm/Application/Service/CrmReadCacheInvalidator.php
@@ -66,6 +66,19 @@ readonly class CrmReadCacheInvalidator
     /**
      * @throws InvalidArgumentException
      */
+    public function invalidateProjectCaches(string $applicationSlug, ?string $projectId = null): void
+    {
+        $tags = [$this->cacheKeyConventionService->crmProjectListTag($applicationSlug)];
+        if ($projectId !== null) {
+            $tags[] = $this->cacheKeyConventionService->crmProjectDetailTag($applicationSlug, $projectId);
+        }
+
+        $this->invalidateTags($tags);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
     public function invalidateEmployee(string $applicationSlug, string $employeeId): void
     {
         $this->invalidateTags([
@@ -83,6 +96,32 @@ readonly class CrmReadCacheInvalidator
             $this->cacheKeyConventionService->crmTaskRequestListTag($applicationSlug),
             $this->cacheKeyConventionService->crmTaskRequestDetailTag($applicationSlug, $taskRequestId),
         ]);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function invalidateRepository(string $applicationSlug, ?string $repositoryId = null): void
+    {
+        $tags = [$this->cacheKeyConventionService->crmRepositoryListTag($applicationSlug)];
+        if ($repositoryId !== null) {
+            $tags[] = $this->cacheKeyConventionService->crmRepositoryDetailTag($applicationSlug, $repositoryId);
+        }
+
+        $this->invalidateTags($tags);
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function invalidateIssue(string $applicationSlug, ?string $issueId = null): void
+    {
+        $tags = [$this->cacheKeyConventionService->crmIssueListTag($applicationSlug)];
+        if ($issueId !== null) {
+            $tags[] = $this->cacheKeyConventionService->crmIssueDetailTag($applicationSlug, $issueId);
+        }
+
+        $this->invalidateTags($tags);
     }
 
     /**

--- a/src/Crm/Application/Service/ProjectReadService.php
+++ b/src/Crm/Application/Service/ProjectReadService.php
@@ -19,6 +19,7 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use function ceil;
+use function is_array;
 use function max;
 use function method_exists;
 use function min;
@@ -145,7 +146,10 @@ readonly class ProjectReadService
                 '_source' => ['id'],
             ], 0, 500);
 
-            $hits = $response['hits']['hits'] ?? [];
+            $hits = $response['hits']['hits'] ?? null;
+            if (!is_array($hits)) {
+                return null;
+            }
 
             return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
         } catch (Throwable) {

--- a/src/Crm/Application/Service/TaskRequestReadService.php
+++ b/src/Crm/Application/Service/TaskRequestReadService.php
@@ -19,6 +19,7 @@ use function array_filter;
 use function array_map;
 use function array_values;
 use function ceil;
+use function is_array;
 use function max;
 use function method_exists;
 use function min;
@@ -128,7 +129,10 @@ readonly class TaskRequestReadService
                 '_source' => ['id'],
             ], 0, 500);
 
-            $hits = $response['hits']['hits'] ?? [];
+            $hits = $response['hits']['hits'] ?? null;
+            if (!is_array($hits)) {
+                return null;
+            }
 
             return array_values(array_filter(array_map(static fn (array $hit): ?string => $hit['_source']['id'] ?? $hit['_id'] ?? null, $hits)));
         } catch (Throwable) {

--- a/src/General/Application/MessageHandler/EntityProjectionHandler.php
+++ b/src/General/Application/MessageHandler/EntityProjectionHandler.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 namespace App\General\Application\MessageHandler;
 
 use App\Crm\Application\Projection\CrmTaskProjection;
+use App\Crm\Application\Projection\CrmIssueProjection;
+use App\Crm\Application\Projection\CrmRepositoryProjection;
+use App\Crm\Infrastructure\Repository\CrmGithubWebhookEventRepository;
+use App\Crm\Infrastructure\Repository\CrmProjectRepositoryRepository;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\General\Application\Message\EntityCreated;
 use App\General\Application\Message\EntityDeleted;
@@ -25,6 +29,7 @@ use App\Shop\Infrastructure\Repository\ProductRepository;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 use function array_map;
+use function is_array;
 
 #[AsMessageHandler]
 final readonly class EntityProjectionHandler
@@ -37,6 +42,8 @@ final readonly class EntityProjectionHandler
     private const string CRM_PROJECT = 'crm_project';
     private const string CRM_TASK_REQUEST = 'crm_task_request';
     private const string CRM_SPRINT = 'crm_sprint';
+    private const string CRM_REPOSITORY = 'crm_repository';
+    private const string CRM_ISSUE = 'crm_issue';
     private const string SCHOOL_EXAM = 'school_exam';
     private const string SCHOOL_CLASS = 'school_class';
     private const string SCHOOL_TEACHER = 'school_teacher';
@@ -50,6 +57,8 @@ final readonly class EntityProjectionHandler
         private JobRepository $jobRepository,
         private ProductRepository $productRepository,
         private TaskRepository $taskRepository,
+        private CrmProjectRepositoryRepository $crmProjectRepositoryRepository,
+        private CrmGithubWebhookEventRepository $crmGithubWebhookEventRepository,
         private ExamRepository $examRepository,
         private CacheInvalidationService $cacheInvalidationService,
         private CriticalViewWarmer $criticalViewWarmer,
@@ -90,6 +99,18 @@ final readonly class EntityProjectionHandler
 
         if ($message->entityType === self::CRM_TASK) {
             $this->projectCrmTask($message);
+
+            return;
+        }
+
+        if ($message->entityType === self::CRM_REPOSITORY) {
+            $this->projectCrmRepository($message);
+
+            return;
+        }
+
+        if ($message->entityType === self::CRM_ISSUE) {
+            $this->projectCrmIssue($message);
 
             return;
         }
@@ -303,5 +324,83 @@ final readonly class EntityProjectionHandler
     private function projectSchoolSupportEntities(): void
     {
         $this->cacheInvalidationService->invalidateSchoolExamListCaches(null);
+    }
+
+    private function projectCrmRepository(EntityMutationMessage $message): void
+    {
+        $applicationSlug = (string)($message->context['applicationSlug'] ?? '');
+
+        if ($message instanceof EntityDeleted) {
+            $this->elasticsearchService->delete(CrmRepositoryProjection::INDEX_NAME, $message->entityId);
+            if ($applicationSlug !== '') {
+                $this->cacheInvalidationService->invalidateCrmTaskListCaches($applicationSlug);
+            }
+
+            return;
+        }
+
+        $repository = $this->crmProjectRepositoryRepository->find($message->entityId);
+        if ($repository === null) {
+            return;
+        }
+
+        $this->elasticsearchService->index(CrmRepositoryProjection::INDEX_NAME, $repository->getId(), [
+            'id' => $repository->getId(),
+            'projectId' => $repository->getProject()?->getId(),
+            'projectName' => $repository->getProject()?->getName(),
+            'provider' => $repository->getProvider(),
+            'owner' => $repository->getOwner(),
+            'name' => $repository->getName(),
+            'fullName' => $repository->getFullName(),
+            'defaultBranch' => $repository->getDefaultBranch(),
+            'isPrivate' => $repository->isPrivate(),
+            'htmlUrl' => $repository->getHtmlUrl(),
+            'externalId' => $repository->getExternalId(),
+            'syncStatus' => $repository->getSyncStatus(),
+            'lastSyncedAt' => $repository->getLastSyncedAt()?->format(DATE_ATOM),
+            'updatedAt' => $repository->getUpdatedAt()?->format(DATE_ATOM),
+        ]);
+
+        $applicationSlug = $repository->getProject()?->getCompany()?->getCrm()?->getApplication()?->getSlug() ?? $applicationSlug;
+        if ($applicationSlug !== '') {
+            $this->cacheInvalidationService->invalidateCrmTaskListCaches($applicationSlug);
+        }
+    }
+
+    private function projectCrmIssue(EntityMutationMessage $message): void
+    {
+        $applicationSlug = (string)($message->context['applicationSlug'] ?? '');
+
+        if ($message instanceof EntityDeleted) {
+            $this->elasticsearchService->delete(CrmIssueProjection::INDEX_NAME, $message->entityId);
+            if ($applicationSlug !== '') {
+                $this->cacheInvalidationService->invalidateCrmTaskListCaches($applicationSlug);
+            }
+
+            return;
+        }
+
+        $event = $this->crmGithubWebhookEventRepository->find($message->entityId);
+        if ($event === null) {
+            return;
+        }
+
+        $payload = $event->getPayload();
+        $issuePayload = isset($payload['issue']) && is_array($payload['issue']) ? $payload['issue'] : [];
+
+        $this->elasticsearchService->index(CrmIssueProjection::INDEX_NAME, $event->getId(), [
+            'id' => $event->getId(),
+            'deliveryId' => $event->getDeliveryId(),
+            'repositoryFullName' => $event->getRepositoryFullName(),
+            'eventAction' => $event->getEventAction(),
+            'issueNumber' => $issuePayload['number'] ?? null,
+            'issueTitle' => $issuePayload['title'] ?? null,
+            'issueState' => $issuePayload['state'] ?? null,
+            'updatedAt' => $event->getUpdatedAt()?->format(DATE_ATOM),
+        ]);
+
+        if ($applicationSlug !== '') {
+            $this->cacheInvalidationService->invalidateCrmTaskListCaches($applicationSlug);
+        }
     }
 }

--- a/src/General/Application/Service/CacheKeyConventionService.php
+++ b/src/General/Application/Service/CacheKeyConventionService.php
@@ -238,6 +238,44 @@ class CacheKeyConventionService
      * @param array<string, mixed> $filters
      * @throws JsonException
      */
+    public function buildCrmRepositoryListKey(string $applicationSlug, int $page, int $limit, array $filters): string
+    {
+        return 'crm_repository_list_' . md5((string)json_encode([
+            'applicationSlug' => $applicationSlug,
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function buildCrmRepositoryDetailKey(string $applicationSlug, string $repositoryId): string
+    {
+        return 'crm_repository_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($repositoryId);
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     * @throws JsonException
+     */
+    public function buildCrmIssueListKey(string $applicationSlug, int $page, int $limit, array $filters): string
+    {
+        return 'crm_issue_list_' . md5((string)json_encode([
+            'applicationSlug' => $applicationSlug,
+            'page' => $page,
+            'limit' => $limit,
+            'filters' => $filters,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    public function buildCrmIssueDetailKey(string $applicationSlug, string $issueId): string
+    {
+        return 'crm_issue_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($issueId);
+    }
+
+    /**
+     * @param array<string, mixed> $filters
+     * @throws JsonException
+     */
     public function buildCrmEmployeeListKey(string $applicationSlug, int $page, int $limit, array $filters): string
     {
         return 'crm_employee_list_' . md5((string)json_encode([
@@ -453,6 +491,26 @@ class CacheKeyConventionService
     public function crmTaskRequestDetailTag(string $applicationSlug, string $taskRequestId): string
     {
         return 'cache_crm_task_request_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($taskRequestId);
+    }
+
+    public function crmRepositoryListTag(string $applicationSlug): string
+    {
+        return 'cache_crm_repository_list_' . $this->sanitizeSegment($applicationSlug);
+    }
+
+    public function crmRepositoryDetailTag(string $applicationSlug, string $repositoryId): string
+    {
+        return 'cache_crm_repository_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($repositoryId);
+    }
+
+    public function crmIssueListTag(string $applicationSlug): string
+    {
+        return 'cache_crm_issue_list_' . $this->sanitizeSegment($applicationSlug);
+    }
+
+    public function crmIssueDetailTag(string $applicationSlug, string $issueId): string
+    {
+        return 'cache_crm_issue_detail_' . $this->sanitizeSegment($applicationSlug) . '_' . $this->sanitizeSegment($issueId);
     }
 
     public function crmTaskDetailTag(string $applicationSlug, string $taskId): string

--- a/src/Tool/Transport/Command/Elastic/ReindexAllDomainsCommand.php
+++ b/src/Tool/Transport/Command/Elastic/ReindexAllDomainsCommand.php
@@ -20,6 +20,8 @@ final class ReindexAllDomainsCommand extends Command
     public function __construct(
         private readonly ReindexBlogsCommand $reindexBlogsCommand,
         private readonly ReindexCrmTasksCommand $reindexCrmTasksCommand,
+        private readonly ReindexCrmRepositoriesCommand $reindexCrmRepositoriesCommand,
+        private readonly ReindexCrmIssuesCommand $reindexCrmIssuesCommand,
         private readonly ReindexShopProductsCommand $reindexShopProductsCommand,
         private readonly ReindexPlatformsCommand $reindexPlatformsCommand,
         private readonly ReindexNotificationsCommand $reindexNotificationsCommand,
@@ -31,6 +33,8 @@ final class ReindexAllDomainsCommand extends Command
     {
         $this->reindexBlogsCommand->run($input, $output);
         $this->reindexCrmTasksCommand->run($input, $output);
+        $this->reindexCrmRepositoriesCommand->run($input, $output);
+        $this->reindexCrmIssuesCommand->run($input, $output);
         $this->reindexShopProductsCommand->run($input, $output);
         $this->reindexPlatformsCommand->run($input, $output);
         $this->reindexNotificationsCommand->run($input, $output);

--- a/src/Tool/Transport/Command/Elastic/ReindexCrmIssuesCommand.php
+++ b/src/Tool/Transport/Command/Elastic/ReindexCrmIssuesCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Command\Elastic;
+
+use App\Crm\Application\Projection\CrmIssueProjection;
+use App\Crm\Domain\Entity\CrmGithubWebhookEvent;
+use App\Crm\Infrastructure\Repository\CrmGithubWebhookEventRepository;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function is_array;
+use function is_int;
+use function is_string;
+use function trim;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Index CRM GitHub issues in Elasticsearch.',
+)]
+final class ReindexCrmIssuesCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'elastic:reindex:crm-issues';
+
+    public function __construct(
+        private readonly CrmGithubWebhookEventRepository $webhookEventRepository,
+        private readonly ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $indexed = 0;
+
+        /** @var CrmGithubWebhookEvent $event */
+        foreach ($this->webhookEventRepository->findBy(['eventName' => 'issues'], ['createdAt' => 'DESC']) as $event) {
+            $payload = $event->getPayload();
+            $issue = is_array($payload['issue'] ?? null) ? $payload['issue'] : [];
+
+            $issueNumber = $issue['number'] ?? null;
+            $issueTitle = $issue['title'] ?? null;
+            $issueState = $issue['state'] ?? null;
+
+            $this->elasticsearchService->index(CrmIssueProjection::INDEX_NAME, $event->getId(), [
+                'id' => $event->getId(),
+                'deliveryId' => $event->getDeliveryId(),
+                'repositoryFullName' => $event->getRepositoryFullName(),
+                'eventAction' => $event->getEventAction(),
+                'issueNumber' => is_int($issueNumber) ? $issueNumber : null,
+                'issueTitle' => is_string($issueTitle) ? trim($issueTitle) : null,
+                'issueState' => is_string($issueState) ? trim($issueState) : null,
+                'updatedAt' => $event->getUpdatedAt()?->format(DATE_ATOM),
+            ]);
+            $indexed++;
+        }
+
+        if ($input->isInteractive()) {
+            $this->getSymfonyStyle($input, $output)->success('CRM issues indexed: ' . $indexed);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Tool/Transport/Command/Elastic/ReindexCrmRepositoriesCommand.php
+++ b/src/Tool/Transport/Command/Elastic/ReindexCrmRepositoriesCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Command\Elastic;
+
+use App\Crm\Application\Projection\CrmRepositoryProjection;
+use App\Crm\Domain\Entity\CrmRepository;
+use App\Crm\Infrastructure\Repository\CrmProjectRepositoryRepository;
+use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Index CRM repositories in Elasticsearch.',
+)]
+final class ReindexCrmRepositoriesCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'elastic:reindex:crm-repositories';
+
+    public function __construct(
+        private readonly CrmProjectRepositoryRepository $crmRepository,
+        private readonly ElasticsearchServiceInterface $elasticsearchService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $indexed = 0;
+
+        /** @var CrmRepository $repository */
+        foreach ($this->crmRepository->findBy([], ['createdAt' => 'DESC']) as $repository) {
+            $this->elasticsearchService->index(CrmRepositoryProjection::INDEX_NAME, $repository->getId(), [
+                'id' => $repository->getId(),
+                'projectId' => $repository->getProject()?->getId(),
+                'projectName' => $repository->getProject()?->getName(),
+                'provider' => $repository->getProvider(),
+                'owner' => $repository->getOwner(),
+                'name' => $repository->getName(),
+                'fullName' => $repository->getFullName(),
+                'defaultBranch' => $repository->getDefaultBranch(),
+                'isPrivate' => $repository->isPrivate(),
+                'htmlUrl' => $repository->getHtmlUrl(),
+                'externalId' => $repository->getExternalId(),
+                'syncStatus' => $repository->getSyncStatus(),
+                'lastSyncedAt' => $repository->getLastSyncedAt()?->format(DATE_ATOM),
+                'updatedAt' => $repository->getUpdatedAt()?->format(DATE_ATOM),
+            ]);
+            $indexed++;
+        }
+
+        if ($input->isInteractive()) {
+            $this->getSymfonyStyle($input, $output)->success('CRM repositories indexed: ' . $indexed);
+        }
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduire l'indexation et l'invalidation cache pour les dépôts et issues GitHub liés au CRM afin d'améliorer les recherches et la cohérence des caches applicatifs.
- Rendre le flux de réindex Elasticsearch global robuste en ajoutant des commandes dédiées pour les repositories et issues.

### Description
- Ajout des projections `CrmRepositoryProjection` et `CrmIssueProjection` avec constantes d'index et création des commandes `elastic:reindex:crm-repositories` et `elastic:reindex:crm-issues` pour (re)peupler Elasticsearch à partir des entités persistées.
- Extension de `EntityProjectionHandler` pour gérer les nouveaux `entityType` `crm_repository` et `crm_issue` avec flux d'indexation/suppression Elasticsearch et invalidation cache via `CacheInvalidationService`.
- Ajout des clés/tags cache pour repository/issue dans `CacheKeyConventionService` et nouvelles méthodes d'invalidation `invalidateRepository`, `invalidateIssue` et `invalidateProjectCaches` dans `CrmReadCacheInvalidator`, utilisées notamment par le handler webhook.
- Durcissement des services de lecture `TaskRequestReadService` et `ProjectReadService` pour retomber proprement sur la requête SQL si la recherche Elasticsearch est indisponible ou retourne un payload malformé, et intégration des nouvelles commandes au `ReindexAllDomainsCommand`.

### Testing
- Exécuté un contrôle de syntaxe PHP (`php -l`) sur tous les fichiers modifiés/ajoutés (incluant `ReindexCrmRepositoriesCommand`, `ReindexCrmIssuesCommand`, nouvelles projections et handlers) et toutes les vérifications sont passées avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c01c9d89c0832b8cd75ac0a0ba327b)