### PR TITLE
feat(crm): provision GitHub resources during project creation

### DIFF
--- a/src/Crm/Application/Message/ProvisionProjectGithubResources.php
+++ b/src/Crm/Application/Message/ProvisionProjectGithubResources.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Message;
+
+use App\General\Domain\Message\Interfaces\MessageLowInterface;
+
+final readonly class ProvisionProjectGithubResources implements MessageLowInterface
+{
+    public function __construct(
+        public string $projectId,
+    ) {
+    }
+}

--- a/src/Crm/Application/MessageHandler/ProvisionProjectGithubResourcesHandler.php
+++ b/src/Crm/Application/MessageHandler/ProvisionProjectGithubResourcesHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\MessageHandler;
+
+use App\Crm\Application\Message\ProvisionProjectGithubResources;
+use App\Crm\Application\Service\ProjectGithubProvisioningService;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+final readonly class ProvisionProjectGithubResourcesHandler
+{
+    public function __construct(
+        private ProjectRepository $projectRepository,
+        private ProjectGithubProvisioningService $projectGithubProvisioningService,
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function __invoke(ProvisionProjectGithubResources $message): void
+    {
+        $project = $this->projectRepository->find($message->projectId);
+        if ($project === null) {
+            return;
+        }
+
+        $repositoryName = $project->getCode() !== null && $project->getCode() !== '' ? $project->getCode() : $project->getName();
+        $this->projectGithubProvisioningService->provision($project, $repositoryName);
+        $this->entityManager->flush();
+    }
+}

--- a/src/Crm/Application/Service/CrmGithubService.php
+++ b/src/Crm/Application/Service/CrmGithubService.php
@@ -403,6 +403,11 @@ GRAPHQL, ['projectId' => $projectId, 'perPage' => $perPage, 'after' => null]);
         ];
     }
 
+    public function deleteRepository(Project $project, string $repoFullName): void
+    {
+        $this->request($project, 'DELETE', sprintf('/repos/%s', trim($repoFullName)));
+    }
+
     public function createRepository(Project $project, string $name, ?string $description = null, bool $private = true): array
     {
         $payload = [

--- a/src/Crm/Application/Service/ProjectGithubProvisioningService.php
+++ b/src/Crm/Application/Service/ProjectGithubProvisioningService.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Application\Exception\CrmGithubApiException;
+use App\Crm\Domain\Entity\Project;
+use DateTimeImmutable;
+
+use function explode;
+use function is_array;
+use function is_numeric;
+use function is_string;
+use function str_contains;
+use function preg_replace;
+use function strtolower;
+use function trim;
+
+final readonly class ProjectGithubProvisioningService
+{
+    public function __construct(private CrmGithubService $crmGithubService)
+    {
+    }
+
+    /**
+     * @return array{provisioningStatus:string,githubResourceIds:array<string,mixed>}
+     */
+    public function provision(Project $project, string $repositoryName): array
+    {
+        $provisionedRepository = null;
+        $normalizedRepositoryName = $this->normalizeRepositoryName($repositoryName);
+
+        try {
+            $repository = $this->crmGithubService->createRepository($project, $normalizedRepositoryName, $project->getDescription(), true);
+            $provisionedRepository = $repository;
+
+            $board = $this->crmGithubService->createProjectBoard($project, (string)($repository['owner']['node_id'] ?? ''), $project->getName());
+
+            $repositoryRecord = [
+                'provider' => 'github',
+                'owner' => (string)($repository['owner']['login'] ?? ''),
+                'name' => (string)($repository['name'] ?? $normalizedRepositoryName),
+                'fullName' => (string)($repository['full_name'] ?? ''),
+                'defaultBranch' => is_string($repository['default_branch'] ?? null) ? $repository['default_branch'] : null,
+                'isPrivate' => (bool)($repository['private'] ?? true),
+                'htmlUrl' => is_string($repository['html_url'] ?? null) ? $repository['html_url'] : null,
+                'externalId' => is_numeric($repository['id'] ?? null) ? (string)$repository['id'] : null,
+                'syncStatus' => 'synced',
+                'payload' => [
+                    'nodeId' => is_string($repository['node_id'] ?? null) ? $repository['node_id'] : null,
+                    'url' => is_string($repository['url'] ?? null) ? $repository['url'] : null,
+                    'projectBoard' => [
+                        'id' => (string)($board['id'] ?? ''),
+                        'url' => (string)($board['url'] ?? ''),
+                    ],
+                ],
+            ];
+
+            $project->setGithubRepositories([$repositoryRecord]);
+            $project->setGithubResourceIds($this->buildGithubResourceIds($repository, is_array($board) ? $board : []));
+            $project->setProvisioningStatus('provisioned');
+
+            foreach ($project->getRepositories() as $storedRepository) {
+                $storedRepository->setLastSyncedAt(new DateTimeImmutable());
+            }
+
+            return [
+                'provisioningStatus' => $project->getProvisioningStatus(),
+                'githubResourceIds' => $project->getGithubResourceIds(),
+            ];
+        } catch (CrmGithubApiException $exception) {
+            $this->rollbackProvisioning($project, $provisionedRepository);
+
+            return [
+                'provisioningStatus' => $project->getProvisioningStatus(),
+                'githubResourceIds' => $project->getGithubResourceIds(),
+            ];
+        }
+    }
+
+    /**
+     * @param array<string,mixed>|null $provisionedRepository
+     */
+    private function rollbackProvisioning(Project $project, ?array $provisionedRepository): void
+    {
+        if (is_array($provisionedRepository) && is_string($provisionedRepository['full_name'] ?? null) && $provisionedRepository['full_name'] !== '') {
+            try {
+                $this->crmGithubService->deleteRepository($project, (string)$provisionedRepository['full_name']);
+            } catch (CrmGithubApiException) {
+                // Best-effort compensating action.
+            }
+        }
+
+        $project->setGithubRepositories([]);
+        $project->setProvisioningStatus('failed');
+        $project->setGithubResourceIds([]);
+    }
+
+    /**
+     * @param array<string,mixed> $repository
+     * @param array<string,mixed> $board
+     * @return array<string,mixed>
+     */
+    private function buildGithubResourceIds(array $repository, array $board): array
+    {
+        return [
+            'repository' => [
+                'externalId' => is_numeric($repository['id'] ?? null) ? (string)$repository['id'] : null,
+                'nodeId' => is_string($repository['node_id'] ?? null) ? $repository['node_id'] : null,
+                'url' => is_string($repository['html_url'] ?? null) ? $repository['html_url'] : null,
+            ],
+            'project' => [
+                'externalId' => $this->extractProjectExternalId((string)($board['url'] ?? '')),
+                'nodeId' => (string)($board['id'] ?? ''),
+                'url' => (string)($board['url'] ?? ''),
+            ],
+        ];
+    }
+
+    private function normalizeRepositoryName(string $repositoryName): string
+    {
+        $normalized = strtolower(trim((string)preg_replace('/[^a-z0-9._-]+/i', '-', $repositoryName), '-'));
+
+        return $normalized !== '' ? $normalized : 'project';
+    }
+
+    private function extractProjectExternalId(string $boardUrl): ?string
+    {
+        if (!str_contains($boardUrl, '/projects/')) {
+            return null;
+        }
+
+        $parts = explode('/projects/', trim($boardUrl, '/'));
+        if (!isset($parts[1])) {
+            return null;
+        }
+
+        $id = trim($parts[1]);
+
+        return $id !== '' ? $id : null;
+    }
+}

--- a/src/Crm/Domain/Entity/Project.php
+++ b/src/Crm/Domain/Entity/Project.php
@@ -23,6 +23,7 @@ use Throwable;
 use function array_map;
 use function array_pad;
 use function explode;
+use function is_array;
 use function strtolower;
 use function trim;
 
@@ -77,6 +78,15 @@ class Project implements EntityInterface
 
     #[ORM\Column(name: 'github_token', type: Types::STRING, length: 255, nullable: true)]
     private ?string $githubToken = null;
+
+    #[ORM\Column(name: 'provisioning_status', type: Types::STRING, length: 40, options: ['default' => 'pending'])]
+    private string $provisioningStatus = 'pending';
+
+    /**
+     * @var array<string,mixed>
+     */
+    #[ORM\Column(name: 'github_resource_ids', type: Types::JSON, nullable: true)]
+    private ?array $githubResourceIds = null;
 
     /** @var Collection<int, CrmRepository>|ArrayCollection<int, CrmRepository> */
     #[ORM\OneToMany(targetEntity: CrmRepository::class, mappedBy: 'project', cascade: ['persist', 'remove'], orphanRemoval: true)]
@@ -267,6 +277,36 @@ class Project implements EntityInterface
         return $this;
     }
 
+    public function getProvisioningStatus(): string
+    {
+        return $this->provisioningStatus;
+    }
+
+    public function setProvisioningStatus(string $provisioningStatus): self
+    {
+        $this->provisioningStatus = $provisioningStatus;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getGithubResourceIds(): array
+    {
+        return is_array($this->githubResourceIds) ? $this->githubResourceIds : [];
+    }
+
+    /**
+     * @param array<string,mixed>|null $githubResourceIds
+     */
+    public function setGithubResourceIds(?array $githubResourceIds): self
+    {
+        $this->githubResourceIds = $githubResourceIds;
+
+        return $this;
+    }
+
     /**
      * @return Collection<int, CrmRepository>|ArrayCollection<int, CrmRepository>
      */
@@ -292,6 +332,7 @@ class Project implements EntityInterface
             'isPrivate' => $repository->isPrivate(),
             'htmlUrl' => $repository->getHtmlUrl(),
             'externalId' => $repository->getExternalId(),
+            'nodeId' => $repository->getPayload()['nodeId'] ?? null,
             'lastSyncedAt' => $repository->getLastSyncedAt()?->format(DATE_ATOM),
             'syncStatus' => $repository->getSyncStatus(),
             'payload' => $repository->getPayload(),

--- a/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\Project;
 
+use App\Crm\Application\Message\ProvisionProjectGithubResources;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\ProjectGithubProvisioningService;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Domain\Enum\ProjectStatus;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
@@ -26,10 +28,6 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
-use function preg_replace;
-use function strtolower;
-use function trim;
-
 #[AsController]
 #[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_MANAGER->value)]
@@ -42,6 +40,7 @@ final readonly class CreateProjectController
         private ValidatorInterface $validator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
+        private ProjectGithubProvisioningService $projectGithubProvisioningService,
     ) {
     }
 
@@ -64,6 +63,7 @@ final readonly class CreateProjectController
                     new OA\Property(property: 'startedAt', type: 'string', format: 'date-time', example: '2026-01-15T09:00:00+00:00', nullable: true),
                     new OA\Property(property: 'dueAt', type: 'string', format: 'date-time', example: '2026-06-30T18:00:00+00:00', nullable: true),
                     new OA\Property(property: 'companyId', type: 'string', format: 'uuid', example: '4db7f53d-cf31-4b36-9b9b-78e914c36a39'),
+                    new OA\Property(property: 'asyncProvisioning', type: 'boolean', example: true, nullable: true),
                 ],
             ),
         ),
@@ -74,6 +74,8 @@ final readonly class CreateProjectController
                 content: new OA\JsonContent(
                     properties: [
                         new OA\Property(property: 'id', type: 'string', format: 'uuid', example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12'),
+                        new OA\Property(property: 'provisioningStatus', type: 'string', example: 'pending'),
+                        new OA\Property(property: 'githubResourceIds', type: 'object'),
                     ],
                 ),
             ),
@@ -161,19 +163,15 @@ final readonly class CreateProjectController
         }
 
         $project = new Project();
-        $githubRepositories = $this->normalizeGithubRepositories($input->githubRepositories);
-        if ($githubRepositories === []) {
-            $githubRepositories = $this->buildDefaultGithubRepositories((string)$input->name, $input->code);
-        }
-
         $project->setName((string)$input->name)
             ->setCode($input->code)
             ->setDescription($input->description)
             ->setStatus(ProjectStatus::tryFrom((string)$input->status) ?? ProjectStatus::PLANNED)
             ->setStartedAt($startedAt)
             ->setDueAt($dueAt)
-            ->setGithubToken($input->githubToken !== null && $input->githubToken !== '' ? $input->githubToken : 'ghp_john_root_fake_token')
-            ->setGithubRepositories($githubRepositories);
+            ->setGithubToken($input->githubToken)
+            ->setProvisioningStatus('pending')
+            ->setGithubResourceIds([]);
 
         if (is_string($input->companyId)) {
             $company = $this->companyRepository->findOneScopedById($input->companyId, $crm->getId());
@@ -186,13 +184,25 @@ final readonly class CreateProjectController
 
         $this->entityManager->persist($project);
         $this->entityManager->flush();
+
+        if ($input->asyncProvisioning) {
+            $this->messageBus->dispatch(new ProvisionProjectGithubResources($project->getId()));
+        } else {
+            $repositoryName = $input->code !== null && $input->code !== '' ? $input->code : (string)$input->name;
+            $this->projectGithubProvisioningService->provision($project, $repositoryName);
+            $this->entityManager->flush();
+        }
+
         $this->messageBus->dispatch(new EntityCreated('crm_project', $project->getId(), context: [
             'applicationSlug' => $applicationSlug,
             'crmId' => $crm->getId(),
+            'provisioningStatus' => $project->getProvisioningStatus(),
         ]));
 
         return new JsonResponse([
             'id' => $project->getId(),
+            'provisioningStatus' => $project->getProvisioningStatus(),
+            'githubResourceIds' => $project->getGithubResourceIds(),
         ], JsonResponse::HTTP_CREATED);
     }
 
@@ -208,56 +218,5 @@ final readonly class CreateProjectController
         }
 
         return $date;
-    }
-
-    /**
-     * @param array<mixed> $repositories
-     * @return list<array{fullName:string,defaultBranch?:string|null}>
-     */
-    private function normalizeGithubRepositories(array $repositories): array
-    {
-        $normalized = [];
-
-        foreach ($repositories as $repository) {
-            if (!is_array($repository)) {
-                continue;
-            }
-
-            $fullName = isset($repository['fullName']) ? trim((string)$repository['fullName']) : '';
-            if ($fullName === '') {
-                continue;
-            }
-
-            $defaultBranch = isset($repository['defaultBranch']) ? trim((string)$repository['defaultBranch']) : null;
-
-            $normalized[] = [
-                'fullName' => $fullName,
-                'defaultBranch' => $defaultBranch !== '' ? $defaultBranch : null,
-            ];
-        }
-
-        return $normalized;
-    }
-
-    /**
-     * @return list<array{fullName:string,defaultBranch:string|null}>
-     */
-    private function buildDefaultGithubRepositories(string $projectName, ?string $projectCode): array
-    {
-        $base = strtolower(trim((string)preg_replace('/[^a-z0-9]+/i', '-', $projectCode ?? $projectName), '-'));
-        if ($base === '') {
-            $base = 'project';
-        }
-
-        return [
-            [
-                'fullName' => sprintf('john-root/%s-api', $base),
-                'defaultBranch' => 'main',
-            ],
-            [
-                'fullName' => sprintf('john-root/%s-web', $base),
-                'defaultBranch' => 'develop',
-            ],
-        ];
     }
 }

--- a/src/Crm/Transport/Request/CreateProjectRequest.php
+++ b/src/Crm/Transport/Request/CreateProjectRequest.php
@@ -36,8 +36,8 @@ final class CreateProjectRequest
     #[Assert\Length(max: 255)]
     public ?string $githubToken = null;
 
-    /** @var list<array{fullName?:mixed,defaultBranch?:mixed}> */
-    public array $githubRepositories = [];
+    #[Assert\Type(type: 'bool')]
+    public bool $asyncProvisioning = false;
 
     public static function fromArray(array $payload): self
     {
@@ -50,7 +50,7 @@ final class CreateProjectRequest
         $request->dueAt = isset($payload['dueAt']) ? (string)$payload['dueAt'] : null;
         $request->companyId = isset($payload['companyId']) ? (string)$payload['companyId'] : null;
         $request->githubToken = isset($payload['githubToken']) ? (string)$payload['githubToken'] : null;
-        $request->githubRepositories = isset($payload['githubRepositories']) && is_array($payload['githubRepositories']) ? $payload['githubRepositories'] : [];
+        $request->asyncProvisioning = isset($payload['asyncProvisioning']) ? (bool)$payload['asyncProvisioning'] : false;
 
         return $request;
     }


### PR DESCRIPTION
### Motivation

- Replace the previous fake/default GitHub repository wiring with a real provisioning use-case that creates remote GitHub resources and persists their identifiers. 
- Avoid blocking HTTP requests on slow GitHub calls by adding an optional async provisioning path that delegates to a worker. 
- Ensure partial failures are handled with a compensating rollback so local state does not remain inconsistent with remote GitHub resources.

### Description

- Add `ProjectGithubProvisioningService` which orchestrates creating a GitHub repository and project board, persisting `externalId`, `nodeId` and URLs, setting `provisioningStatus`, and performing a best-effort rollback (remote repo deletion + local cleanup) on failures. 
- Introduce an async message and handler `ProvisionProjectGithubResources` / `ProvisionProjectGithubResourcesHandler` to enqueue provisioning to a low-priority worker when `asyncProvisioning=true`. 
- Extend `CrmGithubService` with `deleteRepository()` to support compensating deletion of remote repos. 
- Extend the `Project` entity to store `provisioningStatus` and `githubResourceIds`, and expose repository `nodeId` in the `getGithubRepositories()` projection. 
- Update `CreateProjectRequest` to accept `asyncProvisioning` (bool) and modify `CreateProjectController` to: persist the CRM project first, then either call the provisioning service synchronously or dispatch the provisioning message, and include `provisioningStatus` and `githubResourceIds` in the `201` response and `EntityCreated` context.

### Testing

- Ran `php -l` syntax checks on modified files and they all passed: `src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php` (OK). 
- Ran `php -l` on `src/Crm/Application/Service/ProjectGithubProvisioningService.php` (OK). 
- Ran `php -l` on `src/Crm/Application/Message/ProvisionProjectGithubResources.php` and `src/Crm/Application/MessageHandler/ProvisionProjectGithubResourcesHandler.php` (OK). 
- Ran `php -l` on `src/Crm/Domain/Entity/Project.php`, `src/Crm/Transport/Request/CreateProjectRequest.php`, and `src/Crm/Application/Service/CrmGithubService.php` (OK).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c01dec5290832b8f70fafbe2bcdb88)