### PR TITLE
Support creating repos under a specific owner/org and update provisioning/fixtures to use default owner

### DIFF
--- a/src/Crm/Application/Service/CrmGithubService.php
+++ b/src/Crm/Application/Service/CrmGithubService.php
@@ -408,7 +408,7 @@ GRAPHQL, ['projectId' => $projectId, 'perPage' => $perPage, 'after' => null]);
         $this->request($project, 'DELETE', sprintf('/repos/%s', trim($repoFullName)));
     }
 
-    public function createRepository(Project $project, string $name, ?string $description = null, bool $private = true): array
+    public function createRepository(Project $project, string $name, ?string $description = null, bool $private = true, ?string $owner = null): array
     {
         $payload = [
             'name' => trim($name),
@@ -419,7 +419,10 @@ GRAPHQL, ['projectId' => $projectId, 'perPage' => $perPage, 'after' => null]);
             $payload['description'] = trim($description);
         }
 
-        return $this->request($project, 'POST', '/user/repos', ['json' => $payload]);
+        $owner = trim((string)$owner);
+        $path = $owner !== '' ? sprintf('/orgs/%s/repos', $owner) : '/user/repos';
+
+        return $this->request($project, 'POST', $path, ['json' => $payload]);
     }
 
     public function createIssue(Project $project, string $repoFullName, string $title, ?string $body = null): array

--- a/src/Crm/Application/Service/ProjectGithubProvisioningService.php
+++ b/src/Crm/Application/Service/ProjectGithubProvisioningService.php
@@ -19,6 +19,8 @@ use function trim;
 
 final readonly class ProjectGithubProvisioningService
 {
+    private const string DEFAULT_REPOSITORY_OWNER = 'rami-aouinti';
+
     public function __construct(private CrmGithubService $crmGithubService)
     {
     }
@@ -32,7 +34,13 @@ final readonly class ProjectGithubProvisioningService
         $normalizedRepositoryName = $this->normalizeRepositoryName($repositoryName);
 
         try {
-            $repository = $this->crmGithubService->createRepository($project, $normalizedRepositoryName, $project->getDescription(), true);
+            $repository = $this->crmGithubService->createRepository(
+                $project,
+                $normalizedRepositoryName,
+                $project->getDescription(),
+                true,
+                self::DEFAULT_REPOSITORY_OWNER,
+            );
             $provisionedRepository = $repository;
 
             $board = $this->crmGithubService->createProjectBoard($project, (string)($repository['owner']['node_id'] ?? ''), $project->getName());

--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -315,11 +315,11 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                 ->setGithubToken('ghp_john_root_fake_token')
                 ->setGithubRepositories([
                     [
-                        'fullName' => sprintf('john-root/%s-api', $projectSlug),
+                        'fullName' => sprintf('rami-aouinti/%s-api', $projectSlug),
                         'defaultBranch' => 'main',
                     ],
                     [
-                        'fullName' => sprintf('john-root/%s-web', $projectSlug),
+                        'fullName' => sprintf('rami-aouinti/%s-web', $projectSlug),
                         'defaultBranch' => 'develop',
                     ],
                 ]);


### PR DESCRIPTION
### Motivation

- Allow creating GitHub repositories under a specific organization or owner instead of always using the authenticated user when provisioning projects and in sample data.

### Description

- Added an optional `$owner` parameter to `CrmGithubService::createRepository` and select the API path `/orgs/{owner}/repos` when a non-empty owner is provided, keeping `/user/repos` as the default.
- Trim the provided owner value before building the request path to avoid malformed routes.
- Introduced `DEFAULT_REPOSITORY_OWNER` in `ProjectGithubProvisioningService` and pass it to `createRepository` during provisioning so created repos are owned by the configured default.
- Updated `LoadCrmData` fixtures to use the new default owner (`rami-aouinti`) for generated sample repository `fullName` values.

### Testing

- Ran the test suite with `phpunit` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0159670d4832bb34ecee8189ce2ac)