### PR TITLE
Support org repository provisioning and add OpenAPI docs for CRM GitHub API

### DIFF
--- a/src/Crm/Application/Service/CrmGithubService.php
+++ b/src/Crm/Application/Service/CrmGithubService.php
@@ -408,7 +408,7 @@ GRAPHQL, ['projectId' => $projectId, 'perPage' => $perPage, 'after' => null]);
         $this->request($project, 'DELETE', sprintf('/repos/%s', trim($repoFullName)));
     }
 
-    public function createRepository(Project $project, string $name, ?string $description = null, bool $private = true): array
+    public function createRepository(Project $project, string $name, ?string $description = null, bool $private = true, ?string $owner = null): array
     {
         $payload = [
             'name' => trim($name),
@@ -419,7 +419,10 @@ GRAPHQL, ['projectId' => $projectId, 'perPage' => $perPage, 'after' => null]);
             $payload['description'] = trim($description);
         }
 
-        return $this->request($project, 'POST', '/user/repos', ['json' => $payload]);
+        $owner = trim((string)$owner);
+        $path = $owner !== '' ? sprintf('/orgs/%s/repos', $owner) : '/user/repos';
+
+        return $this->request($project, 'POST', $path, ['json' => $payload]);
     }
 
     public function createIssue(Project $project, string $repoFullName, string $title, ?string $body = null): array

--- a/src/Crm/Application/Service/ProjectGithubProvisioningService.php
+++ b/src/Crm/Application/Service/ProjectGithubProvisioningService.php
@@ -19,6 +19,8 @@ use function trim;
 
 final readonly class ProjectGithubProvisioningService
 {
+    private const string DEFAULT_REPOSITORY_OWNER = 'rami-aouinti';
+
     public function __construct(private CrmGithubService $crmGithubService)
     {
     }
@@ -32,7 +34,13 @@ final readonly class ProjectGithubProvisioningService
         $normalizedRepositoryName = $this->normalizeRepositoryName($repositoryName);
 
         try {
-            $repository = $this->crmGithubService->createRepository($project, $normalizedRepositoryName, $project->getDescription(), true);
+            $repository = $this->crmGithubService->createRepository(
+                $project,
+                $normalizedRepositoryName,
+                $project->getDescription(),
+                true,
+                self::DEFAULT_REPOSITORY_OWNER,
+            );
             $provisionedRepository = $repository;
 
             $board = $this->crmGithubService->createProjectBoard($project, (string)($repository['owner']['node_id'] ?? ''), $project->getName());

--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -315,11 +315,11 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                 ->setGithubToken('ghp_john_root_fake_token')
                 ->setGithubRepositories([
                     [
-                        'fullName' => sprintf('john-root/%s-api', $projectSlug),
+                        'fullName' => sprintf('rami-aouinti/%s-api', $projectSlug),
                         'defaultBranch' => 'main',
                     ],
                     [
-                        'fullName' => sprintf('john-root/%s-web', $projectSlug),
+                        'fullName' => sprintf('rami-aouinti/%s-web', $projectSlug),
                         'defaultBranch' => 'develop',
                     ],
                 ]);

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubIssueCommentController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubIssueCommentController.php
@@ -10,6 +10,7 @@ use App\Crm\Transport\Request\AddGithubIssueCommentRequest;
 use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Crm\Transport\Request\CrmRequestHandler;
 use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -17,6 +18,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_ADMIN->value)]
 final readonly class AddProjectGithubIssueCommentController
 {
@@ -27,6 +29,27 @@ final readonly class AddProjectGithubIssueCommentController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}/comments', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
+    #[OA\Post(
+        summary: 'Add a comment to a GitHub issue.',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['repository', 'body'],
+                properties: [
+                    new OA\Property(property: 'repository', type: 'string', example: 'rami-aouinti/bro-world-api'),
+                    new OA\Property(property: 'body', type: 'string', example: 'On valide cette issue côté CRM.'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_CREATED, description: 'Issue comment created on GitHub.'),
+            new OA\Response(response: JsonResponse::HTTP_BAD_REQUEST, description: 'Invalid payload or GitHub validation error.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error while commenting issue.'),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubIssueController.php
@@ -10,6 +10,7 @@ use App\Crm\Transport\Request\CreateGithubIssueRequest;
 use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Crm\Transport\Request\CrmRequestHandler;
 use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -17,6 +18,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_ADMIN->value)]
 final readonly class CreateProjectGithubIssueController
 {
@@ -27,6 +29,27 @@ final readonly class CreateProjectGithubIssueController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Post(
+        summary: 'Create a GitHub issue from CRM.',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['repository', 'title'],
+                properties: [
+                    new OA\Property(property: 'repository', type: 'string', example: 'rami-aouinti/bro-world-api'),
+                    new OA\Property(property: 'title', type: 'string', example: 'Créer endpoint de synchronisation webhook'),
+                    new OA\Property(property: 'body', type: 'string', nullable: true, example: 'Description détaillée générée depuis CRM.'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_CREATED, description: 'Issue created.'),
+            new OA\Response(response: JsonResponse::HTTP_BAD_REQUEST, description: 'Invalid payload.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubProjectBoardController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubProjectBoardController.php
@@ -10,6 +10,7 @@ use App\Crm\Transport\Request\CreateGithubProjectBoardRequest;
 use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Crm\Transport\Request\CrmRequestHandler;
 use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -17,6 +18,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_ADMIN->value)]
 final readonly class CreateProjectGithubProjectBoardController
 {
@@ -27,6 +29,25 @@ final readonly class CreateProjectGithubProjectBoardController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Post(
+        summary: 'Create a GitHub Project board (Projects v2).',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['owner', 'title'],
+                properties: [
+                    new OA\Property(property: 'owner', type: 'string', description: 'GitHub owner node id', example: 'O_kgDOBfke3Q'),
+                    new OA\Property(property: 'title', type: 'string', example: 'CRM Project Board'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_CREATED, description: 'Project board created.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubRepositoryController.php
@@ -10,6 +10,7 @@ use App\Crm\Transport\Request\CreateGithubRepositoryRequest;
 use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Crm\Transport\Request\CrmRequestHandler;
 use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -17,6 +18,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_ADMIN->value)]
 final readonly class CreateProjectGithubRepositoryController
 {
@@ -27,6 +29,26 @@ final readonly class CreateProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/create', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Post(
+        summary: 'Create a GitHub repository.',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['name'],
+                properties: [
+                    new OA\Property(property: 'name', type: 'string', example: 'crm-sync-service'),
+                    new OA\Property(property: 'description', type: 'string', nullable: true, example: 'Repository provisionné depuis CRM.'),
+                    new OA\Property(property: 'private', type: 'boolean', example: true),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_CREATED, description: 'Repository created on GitHub.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubIssueController.php
@@ -8,6 +8,7 @@ use App\Crm\Application\Service\CrmGithubService;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -15,6 +16,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class GetProjectGithubIssueController
 {
@@ -25,6 +27,17 @@ final readonly class GetProjectGithubIssueController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
+    #[OA\Parameter(name: 'repo', in: 'query', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
+    #[OA\Get(
+        summary: 'Get a GitHub issue by number.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'Issue details.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
     {
         return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubRepositoryController.php
@@ -8,6 +8,7 @@ use App\Crm\Application\Service\CrmGithubService;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -15,6 +16,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class GetProjectGithubRepositoryController
 {
@@ -25,6 +27,16 @@ final readonly class GetProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/{repository}', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'repository', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
+    #[OA\Get(
+        summary: 'Get repository details from GitHub.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'Repository details.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Project $project, string $repository): JsonResponse
     {
         return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GithubWebhookController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GithubWebhookController.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[AsController]
-#[OA\Tag(name: 'CRM')]
+#[OA\Tag(name: 'Crm')]
 final readonly class GithubWebhookController
 {
     public function __construct(
@@ -27,7 +27,42 @@ final readonly class GithubWebhookController
      * @throws JsonException
      */
     #[Route('/v1/crm/github/webhook', methods: [Request::METHOD_POST])]
-    #[OA\Post(summary: 'Public GitHub webhook endpoint with HMAC signature validation + idempotence guard.', security: [])]
+    #[OA\Post(
+        summary: 'Public GitHub webhook endpoint with HMAC signature validation + idempotence guard.',
+        description: 'Use this endpoint as GitHub webhook URL. In /api/doc, click "Try it out", set required headers and paste the raw GitHub payload JSON.',
+        security: [],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                example: [
+                    'action' => 'opened',
+                    'repository' => [
+                        'full_name' => 'rami-aouinti/bro-world-api',
+                    ],
+                    'issue' => [
+                        'number' => 42,
+                        'title' => 'Bug webhook CRM',
+                    ],
+                ],
+            ),
+        ),
+    )]
+    #[OA\Parameter(name: 'x-github-delivery', in: 'header', required: true, schema: new OA\Schema(type: 'string'), example: '7f5baf30-6402-11ef-8946-3f95d8cf7f6c')]
+    #[OA\Parameter(name: 'x-github-event', in: 'header', required: true, schema: new OA\Schema(type: 'string'), example: 'issues')]
+    #[OA\Parameter(name: 'x-hub-signature-256', in: 'header', required: true, schema: new OA\Schema(type: 'string'), example: 'sha256=4f7f2e11f2f6c477f2c5f8cf227f4e5b2e02691a1f4a5e80ccfe84fc8c3fd6c2')]
+    #[OA\Response(
+        response: JsonResponse::HTTP_ACCEPTED,
+        description: 'Webhook accepted and queued/processed.',
+        content: new OA\JsonContent(
+            example: [
+                'processed' => true,
+                'eventId' => 'f53d5a41-9f56-4f2c-a9f3-f8a2fd17f12e',
+                'deliveryId' => '7f5baf30-6402-11ef-8946-3f95d8cf7f6c',
+                'event' => 'issues',
+                'status' => 'processed',
+            ],
+        ),
+    )]
     #[OA\Response(response: JsonResponse::HTTP_BAD_REQUEST, description: 'Invalid payload or missing required headers.')]
     #[OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Invalid HMAC signature.')]
     public function __invoke(Request $request): JsonResponse

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubIssuesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubIssuesController.php
@@ -8,6 +8,7 @@ use App\Crm\Application\Service\CrmGithubService;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -15,6 +16,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class ListProjectGithubIssuesController
 {
@@ -25,6 +27,19 @@ final readonly class ListProjectGithubIssuesController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'repo', in: 'query', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
+    #[OA\Parameter(name: 'state', in: 'query', required: false, schema: new OA\Schema(type: 'string', enum: ['open', 'closed', 'all']), example: 'open')]
+    #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]
+    #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100), example: 30)]
+    #[OA\Get(
+        summary: 'List GitHub issues for a repository linked to a CRM project.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'Issues fetched from GitHub.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
     {
         return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse($this->crmGithubService->listIssues(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectItemsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectItemsController.php
@@ -8,6 +8,7 @@ use App\Crm\Application\Service\CrmGithubService;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -15,6 +16,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class ListProjectGithubProjectItemsController
 {
@@ -25,6 +27,18 @@ final readonly class ListProjectGithubProjectItemsController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects/{projectId}/items', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'projectId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'PVT_kwDOBfke3c4A9v0F')]
+    #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]
+    #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100), example: 20)]
+    #[OA\Get(
+        summary: 'List items in a GitHub Project (Projects v2).',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'Project items fetched.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Project $project, string $projectId, Request $request): JsonResponse
     {
         return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse($this->crmGithubService->getProjectItems(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectsController.php
@@ -8,6 +8,7 @@ use App\Crm\Application\Service\CrmGithubService;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -15,6 +16,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class ListProjectGithubProjectsController
 {
@@ -25,6 +27,18 @@ final readonly class ListProjectGithubProjectsController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'repo', in: 'query', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
+    #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]
+    #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100), example: 20)]
+    #[OA\Get(
+        summary: 'List GitHub Projects (Projects v2) for repository owner.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'Projects fetched.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
     {
         return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse($this->crmGithubService->listRepositoryProjects(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/MoveProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/MoveProjectGithubIssueController.php
@@ -10,6 +10,7 @@ use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Crm\Transport\Request\CrmRequestHandler;
 use App\Crm\Transport\Request\MoveGithubProjectItemRequest;
 use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -17,6 +18,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_ADMIN->value)]
 final readonly class MoveProjectGithubIssueController
 {
@@ -27,6 +29,25 @@ final readonly class MoveProjectGithubIssueController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects/{projectId}/items/{itemId}/move', methods: [Request::METHOD_POST])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'projectId', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'itemId', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Post(
+        summary: 'Move an issue item in GitHub Project board.',
+        requestBody: new OA\RequestBody(
+            required: false,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'afterItemId', type: 'string', nullable: true, example: 'PVTI_lADO...'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'Item moved.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Project $project, string $projectId, string $itemId, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubIssueStateController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubIssueStateController.php
@@ -10,6 +10,7 @@ use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
 use App\Crm\Transport\Request\CrmRequestHandler;
 use App\Crm\Transport\Request\UpdateGithubIssueStateRequest;
 use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -17,6 +18,7 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
+#[OA\Tag(name: 'Crm')]
 #[IsGranted(Role::CRM_ADMIN->value)]
 final readonly class UpdateProjectGithubIssueStateController
 {
@@ -27,6 +29,26 @@ final readonly class UpdateProjectGithubIssueStateController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
+    #[OA\Patch(
+        summary: 'Update GitHub issue state.',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['repository', 'state'],
+                properties: [
+                    new OA\Property(property: 'repository', type: 'string', example: 'rami-aouinti/bro-world-api'),
+                    new OA\Property(property: 'state', type: 'string', enum: ['open', 'closed'], example: 'closed'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'Issue state updated.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
+        ],
+    )]
     public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);


### PR DESCRIPTION
### Motivation

- Allow provisioning repositories under a specific GitHub organization instead of only the authenticated user. 
- Improve API discoverability and documentation for CRM GitHub endpoints with OpenAPI attributes and examples. 
- Ensure test/demo fixtures reference the intended GitHub owner used during provisioning. 

### Description

- Extended `CrmGithubService::createRepository` to accept an optional `owner` parameter and choose the request path between `/user/repos` and `/orgs/{owner}/repos` accordingly. 
- Added `DEFAULT_REPOSITORY_OWNER` to `ProjectGithubProvisioningService` and pass it when creating repositories during provisioning. 
- Updated data fixtures in `LoadCrmData` to use `rami-aouinti` as the repository owner in `fullName` values. 
- Added OpenAPI (`OpenApi\\Attributes as OA`) annotations to many CRM GitHub controllers to document tags, path/query/header parameters, request bodies, responses and examples, and improved the webhook controller documentation and examples. 

### Testing

- Ran the project test suite with `composer test` locally and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0159670d4832bb34ecee8189ce2ac)