### PR TITLE
fix(crm): remove unused GraphQL $page variable for repository projects

### DIFF
--- a/src/Crm/Application/Service/CrmGithubService.php
+++ b/src/Crm/Application/Service/CrmGithubService.php
@@ -318,7 +318,7 @@ readonly class CrmGithubService
         $owner = (string)($repository['owner']['login'] ?? '');
 
         $graphql = $this->graphql($project, <<<'GRAPHQL'
-query($owner:String!, $page:Int!, $perPage:Int!) {
+query($owner:String!, $perPage:Int!) {
   user(login: $owner) {
     projectsV2(first: $perPage, orderBy: {field: UPDATED_AT, direction: DESC}) {
       nodes { id title number url closed updatedAt }
@@ -334,7 +334,7 @@ query($owner:String!, $page:Int!, $perPage:Int!) {
     }
   }
 }
-GRAPHQL, ['owner' => $owner, 'page' => $page, 'perPage' => $perPage]);
+GRAPHQL, ['owner' => $owner, 'perPage' => $perPage]);
 
         $projectBlock = $graphql['data']['user']['projectsV2'] ?? $graphql['data']['organization']['projectsV2'] ?? null;
         $nodes = is_array($projectBlock['nodes'] ?? null) ? $projectBlock['nodes'] : [];


### PR DESCRIPTION
### Motivation
- Fix GitHub GraphQL validation error (`variableNotUsed`) triggered by the CRM endpoint that lists repository projects. 
- Prevent GitHub rejecting queries that declare variables which are not referenced in the query.

### Description
- Removed the unused `$page` variable from the GraphQL query in `CrmGithubService::listRepositoryProjects` (`src/Crm/Application/Service/CrmGithubService.php`).
- Stopped sending the `page` variable in the GraphQL variables payload so the variables match the query signature.

### Testing
- Ran `php -l src/Crm/Application/Service/CrmGithubService.php` and it reported no syntax errors (succeeded).
- No automated unit/integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0337a8ed0832bb99ffd254a63cf5a)