### PR TITLE
Blog: include createdAt in post and comment read payloads

### DIFF
--- a/src/Blog/Application/Service/BlogReadService.php
+++ b/src/Blog/Application/Service/BlogReadService.php
@@ -181,6 +181,7 @@ final readonly class BlogReadService
             'author' => $this->normalizeAuthor($post->getAuthor()),
             'title' => $post->getTitle(),
             'content' => $post->getContent(),
+            'createdAt' => $post->getCreatedAt()?->format(DATE_ATOM),
             'sharedUrl' => $post->getSharedUrl(),
             'isPinned' => $post->isPinned(),
             'filePath' => $post->getFilePath(),
@@ -256,6 +257,7 @@ final readonly class BlogReadService
                 'isAuthor' => $this->isAuthor($comment->getAuthor(), $currentUser),
                 'author' => $this->normalizeAuthor($comment->getAuthor()),
                 'content' => $comment->getContent(),
+                'createdAt' => $comment->getCreatedAt()?->format(DATE_ATOM),
                 'filePath' => $comment->getFilePath(),
                 'reactions' => array_map(fn ($reaction): array => [
                     'id' => $reaction->getId(),

--- a/tests/Unit/Blog/Application/Service/BlogReadServiceTest.php
+++ b/tests/Unit/Blog/Application/Service/BlogReadServiceTest.php
@@ -18,6 +18,7 @@ use App\Blog\Infrastructure\Repository\BlogRepository;
 use App\General\Application\Service\CacheInvalidationService;
 use App\General\Application\Service\CacheKeyConventionService;
 use App\User\Domain\Entity\User;
+use DateTimeImmutable;
 use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -88,6 +89,7 @@ final class BlogReadServiceTest extends TestCase
         $post->method('getAuthor')->willReturn($currentUser);
         $post->method('getTitle')->willReturn('Post title');
         $post->method('getContent')->willReturn('Post content');
+        $post->method('getCreatedAt')->willReturn(new DateTimeImmutable('2026-01-01T10:00:00+00:00'));
         $post->method('getSharedUrl')->willReturn(null);
         $post->method('getParentPost')->willReturn(null);
         $post->method('isPinned')->willReturn(true);
@@ -130,9 +132,11 @@ final class BlogReadServiceTest extends TestCase
         self::assertSame(8, $normalized['pagination']['totalItems']);
         self::assertSame(2, $normalized['pagination']['totalPages']);
         self::assertSame('p-1', $normalized['posts'][0]['id']);
+        self::assertSame('2026-01-01T10:00:00+00:00', $normalized['posts'][0]['createdAt']);
         self::assertSame(1, $normalized['posts'][0]['children']['count']);
         self::assertSame('alice-user', $normalized['posts'][0]['children']['authors'][0]['username']);
         self::assertSame('c-root', $normalized['posts'][0]['comments'][0]['id']);
+        self::assertSame('2026-01-01T12:00:00+00:00', $normalized['posts'][0]['comments'][0]['createdAt']);
     }
 
     public function testPrivateBlogCacheIsRefreshedAfterBlogMutationInvalidation(): void
@@ -206,6 +210,7 @@ final class BlogReadServiceTest extends TestCase
         $comment->method('getAuthor')->willReturn($author);
         $comment->method('getParent')->willReturn($parent);
         $comment->method('getContent')->willReturn('Comment ' . $id);
+        $comment->method('getCreatedAt')->willReturn(new DateTimeImmutable('2026-01-01T12:00:00+00:00'));
         $comment->method('getFilePath')->willReturn(null);
         $comment->method('getReactions')->willReturn(new ArrayCollection($reactions));
 


### PR DESCRIPTION
### Motivation
- Ensure all Blog read endpoints that return posts, a single post, comments and nested comments include the creation timestamp so clients can display and sort by creation date.

### Description
- Add `createdAt` to the normalized post payload in `BlogReadService::normalizePost` using `->getCreatedAt()?->format(DATE_ATOM)` so all post read endpoints expose the ISO timestamp.
- Add `createdAt` to the normalized comment payload in `BlogReadService::normalizeComments` so comments and nested sub-comments include their creation timestamp.
- Update unit test `tests/Unit/Blog/Application/Service/BlogReadServiceTest.php` to mock `getCreatedAt()` for posts and comments and assert the new `createdAt` fields are present and correctly formatted.
- Files modified: `src/Blog/Application/Service/BlogReadService.php` and `tests/Unit/Blog/Application/Service/BlogReadServiceTest.php`.

### Testing
- Ran PHP lint on the modified files with `php -l src/Blog/Application/Service/BlogReadService.php` and `php -l tests/Unit/Blog/Application/Service/BlogReadServiceTest.php`, both returned no syntax errors.
- Attempted to run PHPUnit for the updated unit test but the standard PHPUnit entrypoint was not available in this environment so tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d5543fb580832b9c1f3e91b6481dad)