### PR TITLE
Add multi-provider payment routing and PayPal provider

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -160,10 +160,31 @@ services:
         arguments:
             $monitoringLogger: '@monolog.logger.monitoring'
 
-    App\Shop\Domain\Service\Interfaces\PaymentProviderInterface:
-        class: App\Shop\Infrastructure\Payment\MockPaymentProvider
+    App\Shop\Infrastructure\Payment\StripePaymentProvider:
+        arguments:
+            $secretKey: '%env(default::SHOP_STRIPE_SECRET_KEY)%'
+            $webhookSecret: '%env(default::SHOP_STRIPE_WEBHOOK_SECRET)%'
+        tags:
+            - { name: 'app.shop.payment_provider', key: 'stripe' }
+
+    App\Shop\Infrastructure\Payment\MockPaymentProvider:
         arguments:
             $appSecret: '%kernel.secret%'
+        tags:
+            - { name: 'app.shop.payment_provider', key: 'mock' }
+
+    App\Shop\Infrastructure\Payment\PayPalPaymentProvider:
+        arguments:
+            $clientId: '%env(default::SHOP_PAYPAL_CLIENT_ID)%'
+            $clientSecret: '%env(default::SHOP_PAYPAL_CLIENT_SECRET)%'
+            $webhookSecret: '%env(default::SHOP_PAYPAL_WEBHOOK_SECRET)%'
+            $apiBaseUrl: '%env(default:https://api-m.sandbox.paypal.com:SHOP_PAYPAL_API_BASE_URL)%'
+        tags:
+            - { name: 'app.shop.payment_provider', key: 'paypal' }
+
+    App\Shop\Application\Service\PaymentProviderRouter:
+        arguments:
+            $providers: !tagged_iterator { tag: 'app.shop.payment_provider', index_by: 'key' }
 
     App\Crm\Application\Service\CrmGithubOwnerResolver:
         arguments:

--- a/src/Shop/Application/Service/PaymentProviderRouter.php
+++ b/src/Shop/Application/Service/PaymentProviderRouter.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Service;
+
+use App\Shop\Domain\Service\Interfaces\PaymentProviderInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+use function array_keys;
+use function implode;
+use function is_string;
+use function sprintf;
+use function strtolower;
+use function trim;
+
+final readonly class PaymentProviderRouter
+{
+    /**
+     * @var array<string, PaymentProviderInterface>
+     */
+    private array $providers;
+
+    /**
+     * @param iterable<string, PaymentProviderInterface> $providers
+     */
+    public function __construct(iterable $providers)
+    {
+        $normalizedProviders = [];
+        foreach ($providers as $key => $provider) {
+            if (!is_string($key)) {
+                continue;
+            }
+
+            $normalizedProviders[strtolower(trim($key))] = $provider;
+        }
+
+        $this->providers = $normalizedProviders;
+    }
+
+    public function getProvider(string $providerKey): PaymentProviderInterface
+    {
+        $normalizedProviderKey = strtolower(trim($providerKey));
+        $provider = $this->providers[$normalizedProviderKey] ?? null;
+        if ($provider instanceof PaymentProviderInterface) {
+            return $provider;
+        }
+
+        throw new HttpException(
+            JsonResponse::HTTP_BAD_REQUEST,
+            sprintf(
+                'Unsupported payment provider "%s". Supported providers: %s.',
+                $providerKey,
+                implode(', ', $this->getSupportedProviderKeys()),
+            ),
+        );
+    }
+
+    public function resolveProviderKey(?string $provider = null, ?string $paymentMethod = null, string $defaultProvider = 'mock'): string
+    {
+        $resolved = $provider ?? $paymentMethod ?? $defaultProvider;
+
+        return strtolower(trim($resolved));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function getSupportedProviderKeys(): array
+    {
+        return array_keys($this->providers);
+    }
+}

--- a/src/Shop/Application/Service/PaymentService.php
+++ b/src/Shop/Application/Service/PaymentService.php
@@ -9,7 +9,6 @@ use App\Shop\Domain\Entity\Order;
 use App\Shop\Domain\Entity\PaymentTransaction;
 use App\Shop\Domain\Enum\OrderStatus;
 use App\Shop\Domain\Enum\PaymentStatus;
-use App\Shop\Domain\Service\Interfaces\PaymentProviderInterface;
 use App\Shop\Infrastructure\Repository\OrderRepository;
 use App\Shop\Infrastructure\Repository\PaymentTransactionRepository;
 use App\User\Domain\Entity\User;
@@ -27,7 +26,7 @@ final readonly class PaymentService
     public function __construct(
         private OrderRepository $orderRepository,
         private PaymentTransactionRepository $paymentTransactionRepository,
-        private PaymentProviderInterface $paymentProvider,
+        private PaymentProviderRouter $paymentProviderRouter,
         private Security $security,
         private string $environment,
         private ShopMonitoringService $monitoringService,
@@ -38,8 +37,12 @@ final readonly class PaymentService
      * @throws OptimisticLockException
      * @throws ORMException
      */
-    public function createPaymentIntent(string $applicationSlug, string $orderId): PaymentTransaction
-    {
+    public function createPaymentIntent(
+        string $applicationSlug,
+        string $orderId,
+        ?string $provider = null,
+        ?string $paymentMethod = null,
+    ): PaymentTransaction {
         $order = $this->orderRepository->find($orderId);
         if ($order === null) {
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Order not found.');
@@ -51,7 +54,10 @@ final readonly class PaymentService
             throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Order is not in pending_payment status.');
         }
 
-        $providerIntent = $this->paymentProvider->createIntent(
+        $providerKey = $this->paymentProviderRouter->resolveProviderKey($provider, $paymentMethod);
+        $providerClient = $this->paymentProviderRouter->getProvider($providerKey);
+
+        $providerIntent = $providerClient->createIntent(
             orderId: $order->getId(),
             amount: $order->getSubtotal(),
             currency: 'EUR',
@@ -97,7 +103,10 @@ final readonly class PaymentService
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Payment transaction not found.');
         }
 
-        $providerResponse = $this->paymentProvider->confirm($providerReference, $payload);
+        $providerResponse = $this->paymentProviderRouter
+            ->getProvider($transaction->getProvider())
+            ->confirm($providerReference, $payload);
+
         $transaction->setStatus($this->resolvePaymentStatus((string)$providerResponse['status']));
         $transaction->setPayload((array)($providerResponse['payload'] ?? []));
 
@@ -132,7 +141,7 @@ final readonly class PaymentService
      * @throws ORMException
      * @throws OptimisticLockException
      */
-    public function processWebhook(array $payload, ?string $signature = null): ?PaymentTransaction
+    public function processWebhook(array $payload, ?string $signature = null, ?string $provider = null): ?PaymentTransaction
     {
         $normalizedSignature = is_string($signature) ? trim($signature) : '';
         if ($this->environment === 'prod' && $normalizedSignature === '') {
@@ -151,13 +160,21 @@ final readonly class PaymentService
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Webhook signature is required in production.');
         }
 
-        $verifiedPayload = $this->paymentProvider->verifyWebhook($payload, $normalizedSignature !== '' ? $normalizedSignature : null);
+        $providerKey = $this->paymentProviderRouter->resolveProviderKey(
+            $provider,
+            is_string($payload['provider'] ?? null) ? (string) $payload['provider'] : null,
+            'stripe',
+        );
+        $providerClient = $this->paymentProviderRouter->getProvider($providerKey);
+
+        $verifiedPayload = $providerClient->verifyWebhook($payload, $normalizedSignature !== '' ? $normalizedSignature : null);
         if ($verifiedPayload === null) {
             $this->monitoringService->logStructured(
                 event: 'shop.webhook.invalid',
                 message: 'Webhook rejected because signature or payload is invalid.',
                 context: [
                     'reason' => 'invalid_signature_or_payload',
+                    'provider' => $providerKey,
                 ],
             );
             $this->monitoringService->incrementCounter('shop.webhook.invalid_total', [

--- a/src/Shop/Infrastructure/Payment/PayPalPaymentProvider.php
+++ b/src/Shop/Infrastructure/Payment/PayPalPaymentProvider.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Infrastructure\Payment;
+
+use App\Shop\Domain\Service\Interfaces\PaymentProviderInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+use function base64_encode;
+use function hash;
+use function hash_equals;
+use function hash_hmac;
+use function is_array;
+use function is_string;
+use function json_encode;
+use function number_format;
+use function sprintf;
+use function strtolower;
+use function trim;
+
+final readonly class PayPalPaymentProvider implements PaymentProviderInterface
+{
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private string $clientId,
+        private string $clientSecret,
+        private string $webhookSecret,
+        private string $apiBaseUrl,
+    ) {
+    }
+
+    public function createIntent(string $orderId, int $amount, string $currency, array $metadata = []): array
+    {
+        $accessToken = $this->fetchAccessToken();
+
+        try {
+            $response = $this->httpClient->request('POST', $this->buildUrl('/v2/checkout/orders'), [
+                'headers' => [
+                    'Authorization' => sprintf('Bearer %s', $accessToken),
+                    'Content-Type' => 'application/json',
+                ],
+                'json' => [
+                    'intent' => 'CAPTURE',
+                    'purchase_units' => [[
+                        'reference_id' => $orderId,
+                        'amount' => [
+                            'currency_code' => strtoupper(trim($currency)),
+                            'value' => number_format($amount / 100, 2, '.', ''),
+                        ],
+                        'custom_id' => $metadata['orderId'] ?? $orderId,
+                    ]],
+                    'application_context' => [
+                        'shipping_preference' => 'NO_SHIPPING',
+                        'user_action' => 'PAY_NOW',
+                    ],
+                ],
+            ]);
+            $payload = $response->toArray(false);
+        } catch (ExceptionInterface) {
+            return [
+                'provider' => 'paypal',
+                'providerReference' => '',
+                'status' => 'failed',
+                'payload' => [
+                    'error' => 'paypal_create_intent_failed',
+                ],
+            ];
+        }
+
+        $providerReference = is_string($payload['id'] ?? null) ? trim((string) $payload['id']) : '';
+
+        return [
+            'provider' => 'paypal',
+            'providerReference' => $providerReference,
+            'status' => 'requires_confirmation',
+            'payload' => [
+                'paypalOrderId' => $providerReference,
+                'status' => $payload['status'] ?? 'CREATED',
+                'approvalUrl' => $this->extractApprovalUrl($payload),
+                'raw' => $payload,
+            ],
+        ];
+    }
+
+    public function confirm(string $providerReference, array $payload = []): array
+    {
+        $accessToken = $this->fetchAccessToken();
+
+        try {
+            $response = $this->httpClient->request('POST', $this->buildUrl(sprintf('/v2/checkout/orders/%s/capture', trim($providerReference))), [
+                'headers' => [
+                    'Authorization' => sprintf('Bearer %s', $accessToken),
+                    'Content-Type' => 'application/json',
+                ],
+            ]);
+            $responsePayload = $response->toArray(false);
+        } catch (ExceptionInterface) {
+            return [
+                'provider' => 'paypal',
+                'providerReference' => trim($providerReference),
+                'status' => 'failed',
+                'payload' => [
+                    'error' => 'paypal_confirm_failed',
+                ],
+            ];
+        }
+
+        return [
+            'provider' => 'paypal',
+            'providerReference' => trim($providerReference),
+            'status' => $this->mapPayPalStatus((string) ($responsePayload['status'] ?? '')),
+            'payload' => $responsePayload,
+        ];
+    }
+
+    public function verifyWebhook(array $payload, ?string $signature = null): ?array
+    {
+        if (trim($this->webhookSecret) !== '') {
+            if (!is_string($signature) || trim($signature) === '') {
+                return null;
+            }
+
+            $encodedPayload = json_encode($payload);
+            if (!is_string($encodedPayload)) {
+                return null;
+            }
+
+            $expectedSignature = hash_hmac('sha256', $encodedPayload, $this->webhookSecret);
+            if (!hash_equals($expectedSignature, strtolower(trim($signature)))) {
+                return null;
+            }
+        }
+
+        $resource = $payload['resource'] ?? null;
+        if (!is_array($resource)) {
+            return null;
+        }
+
+        $providerReference = $resource['id'] ?? ($resource['supplementary_data']['related_ids']['order_id'] ?? null);
+        $eventId = $payload['id'] ?? null;
+
+        if (!is_string($providerReference) || !is_string($eventId)) {
+            return null;
+        }
+
+        $eventType = is_string($payload['event_type'] ?? null) ? (string) $payload['event_type'] : '';
+
+        return [
+            'provider' => 'paypal',
+            'providerReference' => trim($providerReference),
+            'status' => $this->mapWebhookStatus($eventType, $resource),
+            'webhookKey' => $this->buildWebhookKey(trim($eventId)),
+            'payload' => $payload,
+        ];
+    }
+
+    private function fetchAccessToken(): string
+    {
+        try {
+            $response = $this->httpClient->request('POST', $this->buildUrl('/v1/oauth2/token'), [
+                'headers' => [
+                    'Authorization' => sprintf('Basic %s', base64_encode(sprintf('%s:%s', $this->clientId, $this->clientSecret))),
+                    'Content-Type' => 'application/x-www-form-urlencoded',
+                ],
+                'body' => [
+                    'grant_type' => 'client_credentials',
+                ],
+            ]);
+            $payload = $response->toArray(false);
+        } catch (ExceptionInterface) {
+            return '';
+        }
+
+        return is_string($payload['access_token'] ?? null) ? (string) $payload['access_token'] : '';
+    }
+
+    /**
+     * @param array<string,mixed> $payload
+     */
+    private function extractApprovalUrl(array $payload): ?string
+    {
+        $links = $payload['links'] ?? null;
+        if (!is_array($links)) {
+            return null;
+        }
+
+        foreach ($links as $link) {
+            if (!is_array($link)) {
+                continue;
+            }
+
+            if (($link['rel'] ?? null) === 'approve' && is_string($link['href'] ?? null)) {
+                return (string) $link['href'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string,mixed> $resource
+     */
+    private function mapWebhookStatus(string $eventType, array $resource): string
+    {
+        return match ($eventType) {
+            'PAYMENT.CAPTURE.COMPLETED', 'CHECKOUT.ORDER.APPROVED', 'CHECKOUT.ORDER.COMPLETED' => 'succeeded',
+            'PAYMENT.CAPTURE.DENIED', 'PAYMENT.CAPTURE.DECLINED', 'CHECKOUT.ORDER.VOIDED' => 'failed',
+            default => $this->mapPayPalStatus((string) ($resource['status'] ?? '')),
+        };
+    }
+
+    private function mapPayPalStatus(string $status): string
+    {
+        $normalizedStatus = strtoupper(trim($status));
+
+        return match ($normalizedStatus) {
+            'COMPLETED' => 'succeeded',
+            'FAILED', 'DENIED', 'VOIDED' => 'failed',
+            'CREATED', 'APPROVED', 'PAYER_ACTION_REQUIRED', 'SAVED', 'PENDING' => 'requires_confirmation',
+            default => 'created',
+        };
+    }
+
+    private function buildWebhookKey(string $eventId): string
+    {
+        return hash('sha256', 'paypal_' . $eventId);
+    }
+
+    private function buildUrl(string $path): string
+    {
+        $baseUrl = trim($this->apiBaseUrl);
+
+        return sprintf('%s%s', rtrim($baseUrl, '/'), $path);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Payment/CreatePaymentIntentInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Payment/CreatePaymentIntentInput.php
@@ -6,11 +6,8 @@ namespace App\Shop\Transport\Controller\Api\V1\Input\Payment;
 
 use Symfony\Component\Validator\Constraints as Assert;
 
-final class ConfirmPaymentInput
+final class CreatePaymentIntentInput
 {
-    #[Assert\NotBlank(message: 'providerReference is required.')]
-    public string $providerReference = '';
-
     #[Assert\Choice(choices: ['paypal', 'stripe', 'mock'], message: 'provider must be one of: paypal, stripe, mock.')]
     public ?string $provider = null;
 
@@ -23,7 +20,6 @@ final class ConfirmPaymentInput
     public static function fromArray(array $payload): self
     {
         $input = new self();
-        $input->providerReference = trim((string)($payload['providerReference'] ?? ''));
 
         $provider = isset($payload['provider']) ? trim((string) $payload['provider']) : null;
         $paymentMethod = isset($payload['paymentMethod']) ? trim((string) $payload['paymentMethod']) : null;

--- a/src/Shop/Transport/Controller/Api/V1/Input/Payment/PaymentInputValidator.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Payment/PaymentInputValidator.php
@@ -15,7 +15,7 @@ final readonly class PaymentInputValidator
     ) {
     }
 
-    public function validate(ConfirmPaymentInput $input): ?JsonResponse
+    public function validate(CreatePaymentIntentInput|ConfirmPaymentInput $input): ?JsonResponse
     {
         $violations = $this->validator->validate($input);
         if ($violations->count() === 0) {

--- a/src/Shop/Transport/Controller/Api/V1/Payment/ConfirmPaymentController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/ConfirmPaymentController.php
@@ -41,6 +41,18 @@ final readonly class ConfirmPaymentController
         security: [[
             'Bearer' => [],
         ]],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                type: 'object',
+                required: ['providerReference'],
+                properties: [
+                    new OA\Property(property: 'providerReference', type: 'string', example: 'pi_3Nxx...'),
+                    new OA\Property(property: 'provider', type: 'string', enum: ['paypal', 'stripe', 'mock'], nullable: true),
+                    new OA\Property(property: 'paymentMethod', type: 'string', enum: ['paypal', 'stripe', 'mock'], nullable: true),
+                ],
+            ),
+        ),
     )]
     #[OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Forbidden. The order does not belong to the authenticated user or requested application.')]
     public function __invoke(string $applicationSlug, string $orderId, Request $request): JsonResponse

--- a/src/Shop/Transport/Controller/Api/V1/Payment/CreatePaymentIntentController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/CreatePaymentIntentController.php
@@ -6,8 +6,12 @@ namespace App\Shop\Transport\Controller\Api\V1\Payment;
 
 use App\Shop\Application\Service\MoneyFormatter;
 use App\Shop\Application\Service\PaymentService;
+use App\Shop\Transport\Controller\Api\V1\Input\Payment\CreatePaymentIntentInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Payment\PaymentInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -16,6 +20,8 @@ use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
+use function trim;
+
 #[AsController]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[OA\Tag(name: 'Shop')]
@@ -23,6 +29,7 @@ final readonly class CreatePaymentIntentController
 {
     public function __construct(
         private PaymentService $paymentService,
+        private PaymentInputValidator $paymentInputValidator,
     ) {
     }
 
@@ -37,11 +44,45 @@ final readonly class CreatePaymentIntentController
         security: [[
             'Bearer' => [],
         ]],
+        requestBody: new OA\RequestBody(
+            required: false,
+            content: new OA\JsonContent(
+                properties: [
+                    new OA\Property(property: 'provider', type: 'string', enum: ['paypal', 'stripe', 'mock'], example: 'stripe'),
+                    new OA\Property(property: 'paymentMethod', type: 'string', enum: ['paypal', 'stripe', 'mock'], example: 'paypal'),
+                ],
+                type: 'object',
+            ),
+        ),
     )]
     #[OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Forbidden. The order does not belong to the authenticated user or requested application.')]
-    public function __invoke(string $applicationSlug, string $orderId): JsonResponse
+    public function __invoke(string $applicationSlug, string $orderId, Request $request): JsonResponse
     {
-        $transaction = $this->paymentService->createPaymentIntent($applicationSlug, $orderId);
+        $request->attributes->set('applicationSlug', $applicationSlug);
+
+        $rawContent = (string)$request->getContent();
+        if (trim($rawContent) === '') {
+            $payload = [];
+        } else {
+            try {
+                $payload = (array)json_decode($rawContent, true, 512, JSON_THROW_ON_ERROR);
+            } catch (JsonException) {
+                return ValidationResponseFactory::invalidJson();
+            }
+        }
+
+        $input = CreatePaymentIntentInput::fromArray($payload);
+        $validationResponse = $this->paymentInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $transaction = $this->paymentService->createPaymentIntent(
+            $applicationSlug,
+            $orderId,
+            $input->provider,
+            $input->paymentMethod,
+        );
 
         return new JsonResponse([
             'id' => $transaction->getId(),

--- a/src/Shop/Transport/Controller/Api/V1/Payment/PaymentWebhookController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Payment/PaymentWebhookController.php
@@ -31,9 +31,17 @@ final readonly class PaymentWebhookController
      */
     #[Route('/v1/shop/applications/{applicationSlug}/payments/webhook', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'provider', in: 'query', required: false, schema: new OA\Schema(type: 'string', enum: ['paypal', 'stripe', 'mock']))]
     #[OA\Post(
         summary: 'Handle payment provider webhook (public endpoint with strict signature verification).',
         security: [],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                type: 'object',
+                description: 'Webhook payload from the selected provider. Optionally include provider in body as fallback.',
+            ),
+        ),
     )]
     #[OA\Response(response: JsonResponse::HTTP_BAD_REQUEST, description: 'Webhook signature is required in production.')]
     #[OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Invalid webhook signature or payload.')]
@@ -47,8 +55,9 @@ final readonly class PaymentWebhookController
             return ValidationResponseFactory::invalidJson();
         }
         $signature = $request->headers->get('x-signature');
+        $provider = $request->query->get('provider');
 
-        $transaction = $this->paymentService->processWebhook($payload, $signature);
+        $transaction = $this->paymentService->processWebhook($payload, $signature, is_string($provider) ? $provider : null);
 
         if ($transaction === null) {
             return new JsonResponse([


### PR DESCRIPTION
### Motivation
- Support multiple payment providers (paypal, stripe, mock) and allow selecting the provider per request or via payment method.
- Centralize provider resolution to avoid a single hardwired provider and make provider wiring pluggable via service tags.
- Add PayPal support (order creation, capture, webhook verification) to broaden supported payment flows.

### Description
- Add `PayPalPaymentProvider` (`src/Shop/Infrastructure/Payment/PayPalPaymentProvider.php`) implementing `PaymentProviderInterface` with `createIntent`, `confirm`, and `verifyWebhook` using the HTTP client and PayPal APIs.
- Introduce `PaymentProviderRouter` (`src/Shop/Application/Service/PaymentProviderRouter.php`) that receives providers via a tagged iterator and resolves/returns the provider by key, exposing `resolveProviderKey` and `getProvider`.
- Refactor `PaymentService` to use the router (`PaymentProviderRouter`) instead of a single `PaymentProviderInterface`, and update `createPaymentIntent`, `confirmPayment`, and `processWebhook` to route calls to the correct provider.
- Extend payment inputs and controllers to accept provider selection: add `CreatePaymentIntentInput`, extend `ConfirmPaymentInput`, update `PaymentInputValidator`, and adjust `CreatePaymentIntentController`, `ConfirmPaymentController`, and `PaymentWebhookController` with OpenAPI annotations and request handling to surface `provider`/`paymentMethod` and an optional webhook `provider` query param.
- Update `config/services.yaml` to register `StripePaymentProvider`, `MockPaymentProvider`, and `PayPalPaymentProvider` with tag `app.shop.payment_provider` keyed by provider name, add env var bindings for Stripe/PayPal secrets, and wire `PaymentProviderRouter` using `!tagged_iterator`.

### Testing
- Ran `php -l` syntax checks on the modified/new payment-related files (`PaymentProviderRouter`, `PayPalPaymentProvider`, `PaymentService`, `CreatePaymentIntentController`, `ConfirmPaymentController`, `PaymentWebhookController`, `CreatePaymentIntentInput`, `ConfirmPaymentInput`, `PaymentInputValidator`) and they reported no syntax errors.
- Attempted `php bin/console lint:yaml config/services.yaml` but the command could not run in this environment because project dependencies are missing (message: `Dependencies are missing. Try running "composer install"`).
- No other automated test suites were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df902c65d083268e1354313a61d03a)