### PR TITLE
feat(shop): support global shop scope (nullable application + is_global flag)

### DIFF
--- a/migrations/Version20260415103000.php
+++ b/migrations/Version20260415103000.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260415103000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add global shop scope support via nullable application relation and is_global flag.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE shop ADD is_global TINYINT(1) NOT NULL DEFAULT 0');
+        $this->addSql('CREATE INDEX idx_shop_is_global ON shop (is_global)');
+        $this->addSql('ALTER TABLE shop CHANGE application_id application_id BINARY(16) DEFAULT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)"');
+
+        $this->addSql('UPDATE shop SET is_global = 1 WHERE application_id IS NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $globalRows = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM shop WHERE is_global = 1');
+        $this->abortIf($globalRows > 0, 'Cannot revert migration: shop contains at least one global scope row.');
+
+        $rowsWithNullApplication = (int) $this->connection->fetchOne('SELECT COUNT(*) FROM shop WHERE application_id IS NULL');
+        $this->abortIf($rowsWithNullApplication > 0, 'Cannot revert migration: shop contains rows with NULL application_id.');
+
+        $this->addSql('ALTER TABLE shop CHANGE application_id application_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)"');
+        $this->addSql('DROP INDEX idx_shop_is_global ON shop');
+        $this->addSql('ALTER TABLE shop DROP is_global');
+    }
+}

--- a/src/Shop/Application/Message/CheckoutCommand.php
+++ b/src/Shop/Application/Message/CheckoutCommand.php
@@ -10,7 +10,7 @@ final readonly class CheckoutCommand implements MessageHighInterface
 {
     public function __construct(
         public string $operationId,
-        public string $applicationSlug,
+        public ?string $applicationSlug,
         public string $shopId,
         public string $userId,
         public string $billingAddress,

--- a/src/Shop/Application/Service/CheckoutService.php
+++ b/src/Shop/Application/Service/CheckoutService.php
@@ -24,6 +24,8 @@ use Doctrine\ORM\OptimisticLockException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
+use function trim;
+
 final readonly class CheckoutService
 {
     public function __construct(
@@ -49,14 +51,18 @@ final readonly class CheckoutService
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Shop not found.');
         }
 
-        if ($shop->getApplication()?->getSlug() !== $command->applicationSlug) {
+        $requestedScope = $this->normalizeScope($command->applicationSlug);
+        $shopScope = $this->resolveShopScope($shop);
+
+        if ($requestedScope !== $shopScope) {
             $this->monitoringService->logStructured(
                 event: 'shop.checkout.scope_access_denied',
                 message: 'Checkout rejected due to scope access refusal.',
                 context: [
-                    'applicationSlug' => $command->applicationSlug,
+                    'applicationSlug' => $requestedScope,
                     'shopId' => $shop->getId(),
                     'shopApplicationSlug' => $shop->getApplication()?->getSlug(),
+                    'shopIsGlobal' => $shop->isGlobal(),
                     'userId' => $command->userId,
                 ],
             );
@@ -154,5 +160,30 @@ final readonly class CheckoutService
         $this->cartRepository->save($cart, false);
 
         return $order;
+    }
+
+    private function normalizeScope(?string $applicationSlug): ?string
+    {
+        $scope = trim((string) $applicationSlug);
+
+        return $scope === '' ? null : $scope;
+    }
+
+    private function resolveShopScope(\App\Shop\Domain\Entity\Shop $shop): ?string
+    {
+        if ($shop->isGlobal()) {
+            if ($shop->getApplication() !== null) {
+                throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Global shop configuration is invalid.');
+            }
+
+            return null;
+        }
+
+        $applicationSlug = $shop->getApplication()?->getSlug();
+        if (!is_string($applicationSlug) || trim($applicationSlug) === '') {
+            throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Application-scoped shop configuration is invalid.');
+        }
+
+        return trim($applicationSlug);
     }
 }

--- a/src/Shop/Application/Service/PaymentService.php
+++ b/src/Shop/Application/Service/PaymentService.php
@@ -38,7 +38,7 @@ final readonly class PaymentService
      * @throws ORMException
      */
     public function createPaymentIntent(
-        string $applicationSlug,
+        ?string $applicationSlug,
         string $orderId,
         ?string $provider = null,
         ?string $paymentMethod = null,
@@ -85,7 +85,7 @@ final readonly class PaymentService
      * @throws ORMException
      * @throws OptimisticLockException
      */
-    public function confirmPayment(string $applicationSlug, string $orderId, string $providerReference, array $payload = []): PaymentTransaction
+    public function confirmPayment(?string $applicationSlug, string $orderId, string $providerReference, array $payload = []): PaymentTransaction
     {
         $order = $this->orderRepository->find($orderId);
         if ($order === null) {
@@ -230,17 +230,19 @@ final readonly class PaymentService
         return $transaction;
     }
 
-    private function assertOrderAccess(Order $order, string $applicationSlug): void
+    private function assertOrderAccess(Order $order, ?string $applicationSlug): void
     {
-        $orderApplicationSlug = $order->getShop()?->getApplication()?->getSlug();
-        if ($orderApplicationSlug !== trim($applicationSlug)) {
+        $requestedScope = $this->normalizeScope($applicationSlug);
+        $orderScope = $this->resolveOrderScope($order);
+        if ($orderScope !== $requestedScope) {
             $this->monitoringService->logStructured(
                 event: 'shop.payment.scope_access_denied',
                 message: 'Payment access rejected due to scope access refusal.',
                 context: [
-                    'applicationSlug' => trim($applicationSlug),
+                    'applicationSlug' => $requestedScope,
                     'orderId' => $order->getId(),
-                    'orderApplicationSlug' => $orderApplicationSlug,
+                    'orderApplicationSlug' => $order->getShop()?->getApplication()?->getSlug(),
+                    'orderShopIsGlobal' => $order->getShop()?->isGlobal(),
                     'shopId' => $order->getShop()?->getId(),
                 ],
             );
@@ -255,6 +257,36 @@ final readonly class PaymentService
         if (!$user instanceof User || $order->getUser()?->getId() !== $user->getId()) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'This order does not belong to the authenticated user.');
         }
+    }
+
+    private function normalizeScope(?string $applicationSlug): ?string
+    {
+        $scope = trim((string) $applicationSlug);
+
+        return $scope === '' ? null : $scope;
+    }
+
+    private function resolveOrderScope(Order $order): ?string
+    {
+        $shop = $order->getShop();
+        if ($shop === null) {
+            throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Order shop scope is invalid.');
+        }
+
+        if ($shop->isGlobal()) {
+            if ($shop->getApplication() !== null) {
+                throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Global shop configuration is invalid.');
+            }
+
+            return null;
+        }
+
+        $shopApplicationSlug = $shop->getApplication()?->getSlug();
+        if (!is_string($shopApplicationSlug) || trim($shopApplicationSlug) === '') {
+            throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Application-scoped shop configuration is invalid.');
+        }
+
+        return trim($shopApplicationSlug);
     }
 
     private function applyOrderStateFromPayment(Order $order, PaymentStatus $status): void

--- a/src/Shop/Application/Service/ShopApplicationResolverService.php
+++ b/src/Shop/Application/Service/ShopApplicationResolverService.php
@@ -23,8 +23,14 @@ final readonly class ShopApplicationResolverService
 
     public function resolveOrCreateShopByApplicationSlug(string $applicationSlug): Shop
     {
+        $this->assertNoGlobalScopeAmbiguity();
+
         $shop = $this->shopRepository->findOneByApplicationSlug($applicationSlug);
         if ($shop instanceof Shop) {
+            if ($shop->isGlobal()) {
+                throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Application route cannot resolve a global shop.');
+            }
+
             $this->assertApplicationAccess($shop->getApplication(), PlatformKey::SHOP);
 
             return $shop;
@@ -40,6 +46,22 @@ final readonly class ShopApplicationResolverService
         throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Shop root entity not found for this application.');
     }
 
+    public function resolveGlobalShop(): Shop
+    {
+        $this->assertNoGlobalScopeAmbiguity();
+
+        $shop = $this->shopRepository->findGlobalShop();
+        if (!$shop instanceof Shop) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Global shop root entity not found.');
+        }
+
+        if ($shop->getApplication() instanceof Application) {
+            throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Global shop cannot be attached to an application.');
+        }
+
+        return $shop;
+    }
+
     public function assertApplicationAccess(?Application $application, PlatformKey $platformKey): void
     {
         if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== $platformKey) {
@@ -49,6 +71,13 @@ final readonly class ShopApplicationResolverService
         $user = $this->security->getUser();
         if (!$user instanceof User || $application->getUser()?->getId() !== $user->getId()) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot access this application scope.');
+        }
+    }
+
+    private function assertNoGlobalScopeAmbiguity(): void
+    {
+        if ($this->shopRepository->countGlobalShops() > 1) {
+            throw new HttpException(JsonResponse::HTTP_CONFLICT, 'Ambiguous global scope: multiple global shops are configured.');
         }
     }
 }

--- a/src/Shop/Domain/Entity/Shop.php
+++ b/src/Shop/Domain/Entity/Shop.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use DomainException;
 use Override;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
@@ -39,8 +40,13 @@ class Shop implements EntityInterface
     ])]
     private bool $isActive = true;
 
+    #[ORM\Column(name: 'is_global', type: Types::BOOLEAN, options: [
+        'default' => false,
+    ])]
+    private bool $isGlobal = false;
+
     #[ORM\OneToOne(targetEntity: PlatformApplication::class)]
-    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: false, unique: true, onDelete: 'CASCADE')]
+    #[ORM\JoinColumn(name: 'application_id', referencedColumnName: 'id', nullable: true, unique: true, onDelete: 'CASCADE')]
     private ?PlatformApplication $application = null;
 
     /** @var Collection<int, Category>|ArrayCollection<int, Category> */
@@ -107,7 +113,27 @@ class Shop implements EntityInterface
 
     public function setApplication(?PlatformApplication $application): self
     {
+        if ($this->isGlobal && $application instanceof PlatformApplication) {
+            throw new DomainException('Global shop cannot be attached to an application.');
+        }
+
         $this->application = $application;
+
+        return $this;
+    }
+
+    public function isGlobal(): bool
+    {
+        return $this->isGlobal;
+    }
+
+    public function setIsGlobal(bool $isGlobal): self
+    {
+        if ($isGlobal && $this->application instanceof PlatformApplication) {
+            throw new DomainException('Application-scoped shop cannot be marked as global.');
+        }
+
+        $this->isGlobal = $isGlobal;
 
         return $this;
     }

--- a/src/Shop/Infrastructure/Repository/ShopRepository.php
+++ b/src/Shop/Infrastructure/Repository/ShopRepository.php
@@ -9,6 +9,7 @@ use App\Platform\Domain\Entity\Application;
 use App\Shop\Domain\Entity\Shop as Entity;
 use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
+use function trim;
 
 /**
  * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
@@ -29,15 +30,40 @@ class ShopRepository extends BaseRepository
 
     public function findOneByApplicationSlug(string $applicationSlug): ?Entity
     {
+        $scope = trim($applicationSlug);
+        if ($scope === '') {
+            return null;
+        }
+
         $entity = $this->createQueryBuilder('module')
             ->innerJoin('module.application', 'application')
             ->addSelect('application')
             ->where('application.slug = :applicationSlug')
-            ->setParameter('applicationSlug', $applicationSlug)
+            ->andWhere('module.isGlobal = false')
+            ->setParameter('applicationSlug', $scope)
             ->getQuery()
             ->getOneOrNullResult();
 
         return $entity instanceof Entity ? $entity : null;
+    }
+
+    public function findGlobalShop(): ?Entity
+    {
+        $entity = $this->createQueryBuilder('shop')
+            ->where('shop.isGlobal = true')
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $entity instanceof Entity ? $entity : null;
+    }
+
+    public function countGlobalShops(): int
+    {
+        return (int) $this->createQueryBuilder('shop')
+            ->select('COUNT(shop.id)')
+            ->where('shop.isGlobal = true')
+            ->getQuery()
+            ->getSingleScalarResult();
     }
 
     public function findApplicationBySlug(string $applicationSlug): ?Application


### PR DESCRIPTION
### Motivation
- Permettre la configuration d’un shop « global » non lié à une application spécifique pour exposer un endpoint unique ou fallback global.
- Refléter la nouvelle sémantique au niveau base de données en rendant `application_id` nullable et en ajoutant un flag `is_global`.
- Éviter les ambiguïtés et les régressions d’accès en ajoutant des garde‑fous métier et des vérifications côté résolution/accès.

### Description
- Adaptation de l’entité `Shop` pour rendre `application` nullable, ajout du champ `isGlobal` et de validations dans les setters pour empêcher des états ambigus (`global + application`).
- Nouvelle migration Doctrine `Version20260415103000` qui ajoute `is_global`, crée un index, rend `shop.application_id` nullable et backfill `is_global = 1` pour les lignes sans `application_id`, avec protections `abortIf` au rollback.
- Extensions du repository `ShopRepository` avec `findGlobalShop()` et `countGlobalShops()` et durcissement de `findOneByApplicationSlug()` (trim + exclure les shops globaux).
- Evolution de `ShopApplicationResolverService` (résolution globale via `resolveGlobalShop()`, détection d’ambiguïté si plusieurs shops globaux) et refactor des contrôles d’accès dans `CheckoutService` et `PaymentService` pour accepter un `applicationSlug` nullable et résoudre/valider proprement scope global vs application-scoped.
- `CheckoutCommand` modifié pour accepter `applicationSlug` nullable et divers garde‑fous runtime ajoutés pour détecter des configurations de shop incohérentes.

### Testing
- Validation de syntaxe PHP par `php -l` sur les fichiers modifiés: `src/Shop/Domain/Entity/Shop.php`, `src/Shop/Infrastructure/Repository/ShopRepository.php`, `src/Shop/Application/Service/ShopApplicationResolverService.php`, `src/Shop/Application/Service/CheckoutService.php`, `src/Shop/Application/Service/PaymentService.php`, `src/Shop/Application/Message/CheckoutCommand.php` et `migrations/Version20260415103000.php`, tous sans erreurs.
- La migration inclut des vérifications (`abortIf`) en `down()` pour empêcher un revert dangereux si des shops globaux existent, et la commit a été créé avec ces changements.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df920cfe848326b71186cdd4eae2f5)