### PR TITLE
Ajout de packs de coins globaux et champ `coins_amount` sur Product

### DIFF
--- a/migrations/Version20260415120000.php
+++ b/migrations/Version20260415120000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260415120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add coins_amount to shop_product to store delivered virtual currency quantity per product.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE shop_product ADD coins_amount INT NOT NULL DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE shop_product DROP coins_amount');
+    }
+}

--- a/src/Shop/Application/Service/ProductHydratorService.php
+++ b/src/Shop/Application/Service/ProductHydratorService.php
@@ -48,6 +48,9 @@ final readonly class ProductHydratorService
         if (!$partial || array_key_exists('stock', $payload)) {
             $product->setStock((int)($payload['stock'] ?? 0));
         }
+        if (!$partial || array_key_exists('coinsAmount', $payload)) {
+            $product->setCoinsAmount((int)($payload['coinsAmount'] ?? 0));
+        }
         if (!$partial || array_key_exists('isFeatured', $payload)) {
             $product->setIsFeatured((bool)($payload['isFeatured'] ?? false));
         }

--- a/src/Shop/Application/Service/ProductListService.php
+++ b/src/Shop/Application/Service/ProductListService.php
@@ -140,6 +140,7 @@ readonly class ProductListService
             'price' => MoneyFormatter::toApiAmount($product->getPrice()),
             'currencyCode' => $product->getCurrencyCode(),
             'stock' => $product->getStock(),
+            'coinsAmount' => $product->getCoinsAmount(),
             'isFeatured' => $product->isFeatured(),
             'status' => $product->getStatus()->value,
             'categoryId' => $product->getCategory()?->getId(),

--- a/src/Shop/Domain/Entity/Product.php
+++ b/src/Shop/Domain/Entity/Product.php
@@ -60,6 +60,11 @@ class Product implements EntityInterface
     ])]
     private int $stock = 0;
 
+    #[ORM\Column(name: 'coins_amount', type: Types::INTEGER, options: [
+        'default' => 0,
+    ])]
+    private int $coinsAmount = 0;
+
     #[ORM\Column(name: 'is_featured', type: Types::BOOLEAN, options: [
         'default' => false,
     ])]
@@ -177,6 +182,18 @@ class Product implements EntityInterface
     public function setStock(int $stock): self
     {
         $this->stock = max(0, $stock);
+
+        return $this;
+    }
+
+    public function getCoinsAmount(): int
+    {
+        return $this->coinsAmount;
+    }
+
+    public function setCoinsAmount(int $coinsAmount): self
+    {
+        $this->coinsAmount = max(0, $coinsAmount);
 
         return $this;
     }

--- a/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
+++ b/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
@@ -33,6 +33,14 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
     #[Override]
     public function load(ObjectManager $manager): void
     {
+        $globalShop = $this->findOrCreateGlobalShop($manager);
+        $coinsCategory = $this->findOrCreateCategory($manager, $globalShop, 'Coins', 'coins', 'Pièces virtuelles à créditer sur le solde utilisateur.');
+        $coinsPackCategory = $this->findOrCreateCategory($manager, $globalShop, 'Packs coins', 'packs-coins', 'Packs de coins prêts à être achetés et crédités automatiquement.');
+
+        $this->findOrCreateCoinProduct($manager, $globalShop, $coinsCategory, 'Pack 200 coins', 'COINS-200', 300, 200);
+        $this->findOrCreateCoinProduct($manager, $globalShop, $coinsPackCategory, 'Pack 500 coins', 'COINS-500', 500, 500);
+        $this->findOrCreateCoinProduct($manager, $globalShop, $coinsPackCategory, 'Pack 1000 coins', 'COINS-1000', 800, 1000);
+
         foreach ($this->getApplicationsByPlatform(PlatformKey::SHOP) as $application) {
             $existingCatalog = $manager->getRepository(Shop::class)->findOneBy([
                 'application' => $application,
@@ -87,6 +95,87 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
     public function getOrder(): int
     {
         return 10;
+    }
+
+    private function findOrCreateGlobalShop(ObjectManager $manager): Shop
+    {
+        $shop = $manager->getRepository(Shop::class)->findOneBy(['isGlobal' => true]);
+        if ($shop instanceof Shop) {
+            return $shop
+                ->setName('Global Coins Shop')
+                ->setDescription('Catalogue global pour les achats de coins.')
+                ->setIsActive(true)
+                ->setIsGlobal(true)
+                ->setApplication(null);
+        }
+
+        $shop = (new Shop())
+            ->setName('Global Coins Shop')
+            ->setDescription('Catalogue global pour les achats de coins.')
+            ->setIsActive(true)
+            ->setIsGlobal(true)
+            ->setApplication(null);
+        $manager->persist($shop);
+
+        return $shop;
+    }
+
+    private function findOrCreateCategory(ObjectManager $manager, Shop $shop, string $name, string $slug, string $description): Category
+    {
+        $category = $manager->getRepository(Category::class)->findOneBy([
+            'shop' => $shop,
+            'slug' => $slug,
+        ]);
+
+        if ($category instanceof Category) {
+            return $category
+                ->setName($name)
+                ->setDescription($description);
+        }
+
+        $category = (new Category())
+            ->setShop($shop)
+            ->setName($name)
+            ->setSlug($slug)
+            ->setDescription($description);
+        $manager->persist($category);
+
+        return $category;
+    }
+
+    private function findOrCreateCoinProduct(ObjectManager $manager, Shop $shop, Category $category, string $name, string $sku, int $price, int $coinsAmount): Product
+    {
+        $product = $manager->getRepository(Product::class)->findOneBy(['sku' => $sku]);
+
+        if ($product instanceof Product) {
+            return $product
+                ->setShop($shop)
+                ->setCategory($category)
+                ->setName($name)
+                ->setDescription(sprintf('Crédite %d coins sur le compte utilisateur après paiement validé.', $coinsAmount))
+                ->setPrice($price)
+                ->setCurrencyCode('EUR')
+                ->setStock(999999)
+                ->setCoinsAmount($coinsAmount)
+                ->setStatus(ProductStatus::ACTIVE)
+                ->setIsFeatured(true);
+        }
+
+        $product = (new Product())
+            ->setShop($shop)
+            ->setCategory($category)
+            ->setName($name)
+            ->setSku($sku)
+            ->setDescription(sprintf('Crédite %d coins sur le compte utilisateur après paiement validé.', $coinsAmount))
+            ->setPrice($price)
+            ->setCurrencyCode('EUR')
+            ->setStock(999999)
+            ->setCoinsAmount($coinsAmount)
+            ->setStatus(ProductStatus::ACTIVE)
+            ->setIsFeatured(true);
+        $manager->persist($product);
+
+        return $product;
     }
 
     /**

--- a/src/Shop/Transport/Controller/Api/V1/Input/Product/CreateProductInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Product/CreateProductInput.php
@@ -21,6 +21,9 @@ final class CreateProductInput
     #[Assert\GreaterThanOrEqual(value: 0, message: 'stock must be greater than or equal to 0.')]
     public int $stock = 0;
 
+    #[Assert\GreaterThanOrEqual(value: 0, message: 'coinsAmount must be greater than or equal to 0.')]
+    public int $coinsAmount = 0;
+
     public ?string $description = null;
     public ?string $currencyCode = null;
     public ?string $categoryId = null;
@@ -45,6 +48,7 @@ final class CreateProductInput
         $input->sku = strtoupper(trim((string)($payload['sku'] ?? '')));
         $input->price = (float)($payload['price'] ?? 0);
         $input->stock = (int)($payload['stock'] ?? 0);
+        $input->coinsAmount = (int)($payload['coinsAmount'] ?? 0);
         $input->description = ($payload['description'] ?? null) !== null ? (string)$payload['description'] : null;
         $input->currencyCode = is_string($payload['currencyCode'] ?? null) ? trim((string)$payload['currencyCode']) : null;
         $input->categoryId = is_string($payload['categoryId'] ?? null) ? trim((string)$payload['categoryId']) : null;

--- a/src/Shop/Transport/Controller/Api/V1/Input/Product/PatchProductInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Product/PatchProductInput.php
@@ -10,6 +10,7 @@ final class PatchProductInput
     public ?string $sku = null;
     public ?float $price = null;
     public ?int $stock = null;
+    public ?int $coinsAmount = null;
     public ?string $description = null;
     public ?string $currencyCode = null;
     public ?string $categoryId = null;
@@ -32,6 +33,7 @@ final class PatchProductInput
         $input->sku = array_key_exists('sku', $payload) ? strtoupper(trim((string)$payload['sku'])) : null;
         $input->price = array_key_exists('price', $payload) ? (float)$payload['price'] : null;
         $input->stock = array_key_exists('stock', $payload) ? (int)$payload['stock'] : null;
+        $input->coinsAmount = array_key_exists('coinsAmount', $payload) ? (int)$payload['coinsAmount'] : null;
         $input->description = array_key_exists('description', $payload) ? (($payload['description'] ?? null) !== null ? (string)$payload['description'] : null) : null;
         $input->currencyCode = array_key_exists('currencyCode', $payload) ? (($payload['currencyCode'] ?? null) !== null ? (string)$payload['currencyCode'] : null) : null;
         $input->categoryId = array_key_exists('categoryId', $payload) ? (($payload['categoryId'] ?? null) !== null ? (string)$payload['categoryId'] : null) : null;

--- a/src/Shop/Transport/Controller/Api/V1/Input/Product/ProductInputValidator.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Product/ProductInputValidator.php
@@ -55,6 +55,13 @@ final readonly class ProductInputValidator
                 'code' => 'STOCK_INVALID',
             ];
         }
+        if ($input->coinsAmount !== null && $input->coinsAmount < 0) {
+            $errors[] = [
+                'field' => 'coinsAmount',
+                'message' => 'coinsAmount must be greater than or equal to 0.',
+                'code' => 'COINS_AMOUNT_INVALID',
+            ];
+        }
 
         if ($errors === []) {
             return null;

--- a/src/Shop/Transport/Controller/Api/V1/Support/ProductPayloadHydrator.php
+++ b/src/Shop/Transport/Controller/Api/V1/Support/ProductPayloadHydrator.php
@@ -48,6 +48,9 @@ final readonly class ProductPayloadHydrator
         if (!$partial || array_key_exists('stock', $payload)) {
             $product->setStock((int)($payload['stock'] ?? 0));
         }
+        if (!$partial || array_key_exists('coinsAmount', $payload)) {
+            $product->setCoinsAmount((int)($payload['coinsAmount'] ?? 0));
+        }
         if (!$partial || array_key_exists('isFeatured', $payload)) {
             $product->setIsFeatured((bool)($payload['isFeatured'] ?? false));
         }


### PR DESCRIPTION
### Motivation
- Fournir un catalogue global stable pour l’achat de coins et porter explicitement la quantité de monnaie virtuelle livrée sur le produit pour faciliter le crédit du solde utilisateur après paiement. 
- Éviter d’utiliser des metadata implicites en stockant le nombre de coins directement dans le modèle produit.

### Description
- Ajout d’une colonne `coins_amount` au modèle `Product` avec getter/setter borné (`>= 0`) dans `src/Shop/Domain/Entity/Product.php` et ajout d’une migration Doctrine `migrations/Version20260415120000.php` qui exécute `ALTER TABLE shop_product ADD coins_amount INT NOT NULL DEFAULT 0`.
- Propagation de `coinsAmount` dans l’hydratation, la sérialisation et la validation produit (`src/Shop/Application/Service/ProductHydratorService.php`, `src/Shop/Transport/Controller/Api/V1/Support/ProductPayloadHydrator.php`, `src/Shop/Application/Service/ProductListService.php`, `src/Shop/Transport/Controller/Api/V1/Input/Product/*.php`).
- Mise à jour de la fixture `LoadShopData` (`src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php`) pour créer/récupérer un `Shop` global unique (`isGlobal = true`) et créer/réutiliser les catégories `Coins` et `Packs coins`, puis ajouter 3 produits actifs EUR avec SKU explicites, prix demandé et stock élevé (`999999`): `COINS-200` (3 EUR, 200 coins), `COINS-500` (5 EUR, 500 coins), `COINS-1000` (8 EUR, 1000 coins).

### Testing
- J’ai exécuté la vérification de syntaxe PHP avec `php -l` sur tous les fichiers modifiés et sur la migration (`php -l ...`), et toutes les vérifications sont passées avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df93510d988326a483e56a9a88c946)