### PR TITLE
feat(shop): add V1 global-scope shop endpoints

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -99,6 +99,17 @@ shop-controllers:
     resource:
         path: ../src/Shop/Transport/Controller/Api/
         namespace: App\Shop\Transport\Controller\Api
+        exclude:
+            - ../src/Shop/Transport/Controller/Api/V1/General/
+    type: attribute
+    prefix: /api
+    defaults:
+        _format: json
+
+shop-general-controllers:
+    resource:
+        path: ../src/Shop/Transport/Controller/Api/V1/General/
+        namespace: App\Shop\Transport\Controller\Api\V1\General
     type: attribute
     prefix: /api
     defaults:

--- a/src/Shop/Application/Service/ProductListService.php
+++ b/src/Shop/Application/Service/ProductListService.php
@@ -128,6 +128,113 @@ readonly class ProductListService
     }
 
     /**
+     * @return array<string, mixed>
+     * @throws \JsonException
+     * @throws InvalidArgumentException
+     */
+    public function getGlobalList(Request $request): array
+    {
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'q' => trim((string)$request->query->get('q', '')),
+            'name' => trim((string)$request->query->get('name', '')),
+            'category' => trim((string)$request->query->get('category', '')),
+            'status' => trim((string)$request->query->get('status', '')),
+        ];
+
+        $cacheKey = $this->cacheKeyConventionService->buildShopProductListKey($page, $limit, array_merge($filters, ['scope' => 'global']));
+
+        /** @var array<string,mixed> $result */
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($filters, $page, $limit): array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->shopProductListTag());
+            }
+
+            $esIds = $this->searchIdsFromElastic($filters);
+            if ($esIds === []) {
+                return [
+                    'items' => [],
+                    'pagination' => [
+                        'page' => $page,
+                        'limit' => $limit,
+                        'totalItems' => 0,
+                        'totalPages' => 0,
+                    ],
+                ];
+            }
+
+            $qb = $this->productRepository->createQueryBuilder('product')
+                ->leftJoin('product.shop', 'shop')
+                ->leftJoin('product.category', 'category')
+                ->leftJoin('product.tags', 'tag')
+                ->addSelect('category', 'tag')
+                ->andWhere('shop.isGlobal = true')
+                ->setFirstResult(($page - 1) * $limit)
+                ->setMaxResults($limit)
+                ->orderBy('product.createdAt', 'DESC');
+
+            if ($filters['name'] !== '') {
+                $qb->andWhere('LOWER(product.name) LIKE LOWER(:name)')->setParameter('name', '%' . $filters['name'] . '%');
+            }
+
+            if ($filters['category'] !== '') {
+                $qb->andWhere('LOWER(category.name) LIKE LOWER(:category)')->setParameter('category', '%' . $filters['category'] . '%');
+            }
+
+            if ($filters['status'] !== '') {
+                $qb->andWhere('product.status = :status')->setParameter('status', $filters['status']);
+            }
+
+            if ($esIds !== null) {
+                $qb->andWhere('product.id IN (:ids)')->setParameter('ids', $esIds);
+            }
+
+            $items = array_map(static fn (Product $product): array => self::serializeProduct($product), $qb->getQuery()->getResult());
+
+            $countQb = $this->productRepository->createQueryBuilder('product')
+                ->select('COUNT(product.id)')
+                ->leftJoin('product.shop', 'shop')
+                ->leftJoin('product.category', 'category')
+                ->andWhere('shop.isGlobal = true');
+
+            if ($filters['name'] !== '') {
+                $countQb->andWhere('LOWER(product.name) LIKE LOWER(:name)')->setParameter('name', '%' . $filters['name'] . '%');
+            }
+            if ($filters['category'] !== '') {
+                $countQb->andWhere('LOWER(category.name) LIKE LOWER(:category)')->setParameter('category', '%' . $filters['category'] . '%');
+            }
+            if ($filters['status'] !== '') {
+                $countQb->andWhere('product.status = :status')->setParameter('status', $filters['status']);
+            }
+            if ($esIds !== null) {
+                $countQb->andWhere('product.id IN (:ids)')->setParameter('ids', $esIds);
+            }
+
+            $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
+
+            return [
+                'items' => $items,
+                'pagination' => [
+                    'page' => $page,
+                    'limit' => $limit,
+                    'totalItems' => $totalItems,
+                    'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
+                ],
+                'meta' => [
+                    'module' => 'shop',
+                    'scope' => 'global',
+                ],
+            ];
+        });
+
+        $result['meta']['filters'] = array_filter($filters, static fn (string $value): bool => $value !== '');
+
+        return $result;
+    }
+
+    /**
      * @return array<string,mixed>
      */
     public static function serializeProduct(Product $product): array

--- a/src/Shop/Application/Service/ShopApiSerializer.php
+++ b/src/Shop/Application/Service/ShopApiSerializer.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Application\Service;
+
+use App\Shop\Domain\Entity\Category;
+use App\Shop\Domain\Entity\Shop;
+
+final class ShopApiSerializer
+{
+    /**
+     * @return array<string,mixed>
+     */
+    public static function serializeShop(Shop $shop): array
+    {
+        return [
+            'id' => $shop->getId(),
+            'name' => $shop->getName(),
+            'description' => $shop->getDescription(),
+            'isActive' => $shop->isActive(),
+            'isGlobal' => $shop->isGlobal(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public static function serializeCategory(Category $category): array
+    {
+        return [
+            'id' => $category->getId(),
+            'name' => $category->getName(),
+            'slug' => $category->getSlug(),
+            'description' => $category->getDescription(),
+            'shopId' => $category->getShop()?->getId(),
+        ];
+    }
+}

--- a/src/Shop/Infrastructure/Repository/CategoryRepository.php
+++ b/src/Shop/Infrastructure/Repository/CategoryRepository.php
@@ -57,4 +57,21 @@ class CategoryRepository extends BaseRepository
 
         return $category;
     }
+
+    /**
+     * @return array<int, Entity>
+     */
+    public function findGlobalCategories(int $limit = 200): array
+    {
+        /** @var array<int, Entity> $categories */
+        $categories = $this->createQueryBuilder('category')
+            ->innerJoin('category.shop', 'shop')
+            ->andWhere('shop.isGlobal = true')
+            ->orderBy('category.createdAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return $categories;
+    }
 }

--- a/src/Shop/Infrastructure/Repository/ProductRepository.php
+++ b/src/Shop/Infrastructure/Repository/ProductRepository.php
@@ -78,4 +78,18 @@ class ProductRepository extends BaseRepository
 
         return $product;
     }
+
+    public function findOneGlobalById(string $id): ?Entity
+    {
+        /** @var Entity|null $product */
+        $product = $this->createQueryBuilder('product')
+            ->innerJoin('product.shop', 'shop')
+            ->andWhere('product.id = :id')
+            ->andWhere('shop.isGlobal = true')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $product;
+    }
 }

--- a/src/Shop/Transport/Controller/Api/V1/General/GetGeneralProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/GetGeneralProductController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\Shop\Application\Service\ProductListService;
+use App\Shop\Application\Service\SimilarProductService;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class GetGeneralProductController
+{
+    public function __construct(
+        private ProductRepository $productRepository,
+        private SimilarProductService $similarProductService,
+    ) {
+    }
+
+    #[Route('/v1/shop/general/products/{id}', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Get one product in global shop scope')]
+    #[OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    public function __invoke(string $id): JsonResponse
+    {
+        $product = $this->productRepository->findOneGlobalById($id);
+        if (!$product instanceof Product) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $similarProducts = array_map(
+            static fn (Product $similarProduct): array => ProductListService::serializeProduct($similarProduct),
+            $this->similarProductService->getSimilarProducts($product),
+        );
+
+        return new JsonResponse([
+            'product' => ProductListService::serializeProduct($product),
+            'similarProducts' => $similarProducts,
+        ]);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/General/GetGeneralShopController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/GetGeneralShopController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\Shop\Application\Service\ProductListService;
+use App\Shop\Application\Service\ShopApiSerializer;
+use App\Shop\Application\Service\ShopApplicationResolverService;
+use App\Shop\Domain\Entity\Category;
+use App\Shop\Infrastructure\Repository\CategoryRepository;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class GetGeneralShopController
+{
+    public function __construct(
+        private ShopApplicationResolverService $shopApplicationResolverService,
+        private CategoryRepository $categoryRepository,
+        private ProductListService $productListService,
+    ) {
+    }
+
+    /**
+     * @throws JsonException
+     * @throws InvalidArgumentException
+     */
+    #[Route('/v1/shop/general', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Get global shop overview')]
+    #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 1, minimum: 1))]
+    #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 20, minimum: 1, maximum: 100))]
+    #[OA\Parameter(name: 'q', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'name', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'category', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'status', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $shop = $this->shopApplicationResolverService->resolveGlobalShop();
+        $categories = array_map(
+            static fn (Category $category): array => ShopApiSerializer::serializeCategory($category),
+            $this->categoryRepository->findGlobalCategories(),
+        );
+
+        return new JsonResponse([
+            'shop' => ShopApiSerializer::serializeShop($shop),
+            'categories' => $categories,
+            'products' => $this->productListService->getGlobalList($request),
+        ]);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/General/ListGeneralCategoriesController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/ListGeneralCategoriesController.php
@@ -2,10 +2,9 @@
 
 declare(strict_types=1);
 
-namespace App\Shop\Transport\Controller\Api\V1\Category;
+namespace App\Shop\Transport\Controller\Api\V1\General;
 
 use App\Shop\Application\Service\ShopApiSerializer;
-use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Category;
 use App\Shop\Infrastructure\Repository\CategoryRepository;
 use OpenApi\Attributes as OA;
@@ -19,21 +18,21 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[AsController]
 #[OA\Tag(name: 'Shop')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
-final readonly class ListCategoriesController
+final readonly class ListGeneralCategoriesController
 {
     public function __construct(
-        private ShopApplicationResolverService $shopApplicationResolverService,
         private CategoryRepository $categoryRepository,
     ) {
     }
 
-    #[Route('/v1/shop/applications/{applicationSlug}/categories', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug): JsonResponse
+    #[Route('/v1/shop/general/categories', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'List categories for global shop scope')]
+    public function __invoke(): JsonResponse
     {
-        $shop = $this->shopApplicationResolverService->resolveOrCreateShopByApplicationSlug($applicationSlug);
-
-        $items = array_map(static fn (Category $category): array => ShopApiSerializer::serializeCategory($category), $this->categoryRepository->findByShop($shop));
+        $items = array_map(
+            static fn (Category $category): array => ShopApiSerializer::serializeCategory($category),
+            $this->categoryRepository->findGlobalCategories(),
+        );
 
         return new JsonResponse([
             'items' => $items,

--- a/src/Shop/Transport/Controller/Api/V1/General/ListGeneralProductsController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/ListGeneralProductsController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\Shop\Application\Service\ProductListService;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ListGeneralProductsController
+{
+    public function __construct(
+        private ProductListService $productListService,
+    ) {
+    }
+
+    /**
+     * @throws JsonException
+     * @throws InvalidArgumentException
+     */
+    #[Route('/v1/shop/general/products', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'List products for global shop scope')]
+    #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 1, minimum: 1))]
+    #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 20, minimum: 1, maximum: 100))]
+    #[OA\Parameter(name: 'q', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'name', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'category', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'status', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse($this->productListService->getGlobalList($request));
+    }
+}


### PR DESCRIPTION
### Motivation
- Exposer un scope global pour le module Shop avec des endpoints dédiés pour permettre la consultation centralisée des données globales (shop, categories, products) et réutiliser la logique existante de listing.
- Garantir une sortie cohérente entre endpoints applicatifs et globaux en réutilisant les services de sérialisation et le modèle de pagination/filtrage existant.

### Description
- Ajout de contrôleurs V1 globaux pour `GET /v1/shop/general`, `GET /v1/shop/general/categories`, `GET /v1/shop/general/products` et `GET /v1/shop/general/products/{id}` sous `src/Shop/Transport/Controller/Api/V1/General` et annotations OpenAPI associées.
- Implémentation de `ProductListService::getGlobalList(Request $request)` qui reprend les mêmes paramètres de pagination/filtrage (`page`, `limit`, `q`, `name`, `category`, `status`) avec le filtre Doctrine `shop.isGlobal = true` pour scope global.
- Ajout de helpers repository `CategoryRepository::findGlobalCategories()` et `ProductRepository::findOneGlobalById()` pour résolution/listing côté BDD.
- Ajout de `ShopApiSerializer` pour standardiser la sérialisation `shop`/`category`, réutilisation de `ProductListService::serializeProduct()` pour les produits, et harmonisation de l’endpoint applicatif de catégories pour utiliser le serializer partagé.
- Mise à jour de `config/routes.yaml` pour exclure les controllers généraux de l’import shop générique et les charger via une ressource dédiée `shop-general-controllers`.

### Testing
- Exécution de `php -l` sur tous les fichiers modifiés/ajoutés (compilation/syntaxe PHP) : succès.
- Tentative de `php bin/console debug:router` pour valider l’enregistrement des routes : échec dans cet environnement car les dépendances ne sont pas installées (message : `Try running "composer install"`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df947260cc8326aada9061bc129666)