### PR TITLE
feat(recruit): expose general public job list and detail endpoints

### DIFF
--- a/src/Recruit/Application/Service/JobPublicDetailService.php
+++ b/src/Recruit/Application/Service/JobPublicDetailService.php
@@ -36,19 +36,31 @@ readonly class JobPublicDetailService
         $job = $this->entityManager->getRepository(Job::class)->findOneBy([
             'recruit' => $recruit,
             'slug' => $jobSlug,
+            'isPublished' => true,
         ]);
 
         if (!$job instanceof Job) {
             throw new NotFoundHttpException('Job not found.');
         }
 
-        $similarJobIds = $this->getSimilarJobIds($job->getId());
-        $similarJobs = $this->getSimilarJobs($recruit, $similarJobIds);
+        return $this->buildDetailPayload($job, $recruit);
+    }
 
-        return [
-            'job' => $this->buildJobPayload($job),
-            'similarJobs' => $similarJobs,
-        ];
+    /**
+     * @return array<string, mixed>
+     */
+    public function getGeneralDetail(string $jobSlug): array
+    {
+        $job = $this->entityManager->getRepository(Job::class)->findOneBy([
+            'slug' => $jobSlug,
+            'isPublished' => true,
+        ]);
+
+        if (!$job instanceof Job) {
+            throw new NotFoundHttpException('Job not found.');
+        }
+
+        return $this->buildDetailPayload($job);
     }
 
     /**
@@ -123,6 +135,56 @@ readonly class JobPublicDetailService
         });
 
         return array_map(fn (Job $item): array => $this->buildJobPayload($item), array_values(array_filter($jobs, static fn (Job $item): bool => in_array($item->getId(), $similarJobIds, true))));
+    }
+
+    /**
+     * @param list<string> $similarJobIds
+     * @return list<array<string, mixed>>
+     */
+    private function getGeneralSimilarJobs(array $similarJobIds): array
+    {
+        if ($similarJobIds === []) {
+            return [];
+        }
+
+        /** @var list<Job> $jobs */
+        $jobs = $this->entityManager->getRepository(Job::class)
+            ->createQueryBuilder('job')
+            ->leftJoin('job.company', 'company')->addSelect('company')
+            ->leftJoin('job.salary', 'salary')->addSelect('salary')
+            ->leftJoin('job.badges', 'badge')->addSelect('badge')
+            ->leftJoin('job.tags', 'tag')->addSelect('tag')
+            ->andWhere('job.isPublished = :isPublished')
+            ->andWhere('job.id IN (:ids)')
+            ->setParameter('isPublished', true)
+            ->setParameter('ids', $similarJobIds)
+            ->getQuery()
+            ->getResult();
+
+        usort($jobs, static function (Job $left, Job $right) use ($similarJobIds): int {
+            $leftIndex = array_search($left->getId(), $similarJobIds, true);
+            $rightIndex = array_search($right->getId(), $similarJobIds, true);
+
+            return ($leftIndex === false ? count($similarJobIds) : $leftIndex) <=> ($rightIndex === false ? count($similarJobIds) : $rightIndex);
+        });
+
+        return array_map(fn (Job $item): array => $this->buildJobPayload($item), array_values(array_filter($jobs, static fn (Job $item): bool => in_array($item->getId(), $similarJobIds, true))));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildDetailPayload(Job $job, ?Recruit $recruit = null): array
+    {
+        $similarJobIds = $this->getSimilarJobIds($job->getId());
+        $similarJobs = $recruit instanceof Recruit
+            ? $this->getSimilarJobs($recruit, $similarJobIds)
+            : $this->getGeneralSimilarJobs($similarJobIds);
+
+        return [
+            'job' => $this->buildJobPayload($job),
+            'similarJobs' => $similarJobs,
+        ];
     }
 
     /**

--- a/src/Recruit/Application/Service/JobPublicListService.php
+++ b/src/Recruit/Application/Service/JobPublicListService.php
@@ -271,6 +271,153 @@ readonly class JobPublicListService
         return $result;
     }
 
+    /**
+     * @return array<string, mixed>
+     * @throws InvalidArgumentException
+     * @throws JsonException
+     */
+    public function getGeneralList(Request $request): array
+    {
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+
+        $filters = [
+            'contractType' => trim((string)$request->query->get('contractType', '')),
+            'workMode' => trim((string)$request->query->get('workMode', '')),
+            'experienceLevel' => trim((string)$request->query->get('experienceLevel', '')),
+            'location' => trim((string)$request->query->get('location', '')),
+            'q' => trim((string)$request->query->get('q', '')),
+        ];
+
+        $cacheKey = $this->cacheKeyConventionService->buildRecruitJobPublicListKey('general', null, $page, $limit, $filters);
+
+        /** @var array<string, mixed> $result */
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($page, $limit, $filters): array {
+            $item->expiresAfter(120);
+            if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
+                $item->tag($this->cacheKeyConventionService->recruitJobListTag('general'));
+            }
+
+            $qb = $this->entityManager
+                ->getRepository(Job::class)
+                ->createQueryBuilder('job')
+                ->leftJoin('job.company', 'company')->addSelect('company')
+                ->leftJoin('job.salary', 'salary')->addSelect('salary')
+                ->leftJoin('job.badges', 'badge')->addSelect('badge')
+                ->leftJoin('job.tags', 'tag')->addSelect('tag')
+                ->andWhere('job.isPublished = :isPublished')
+                ->setParameter('isPublished', true)
+                ->orderBy('job.createdAt', 'DESC')
+                ->addOrderBy('job.id', 'DESC');
+
+            if ($filters['contractType'] !== '') {
+                $qb->andWhere('job.contractType = :contractType')
+                    ->setParameter('contractType', $filters['contractType']);
+            }
+
+            if ($filters['workMode'] !== '') {
+                $qb->andWhere('job.workMode = :workMode')
+                    ->setParameter('workMode', $filters['workMode']);
+            }
+
+            if ($filters['experienceLevel'] !== '') {
+                $qb->andWhere('job.experienceLevel = :experienceLevel')
+                    ->setParameter('experienceLevel', $filters['experienceLevel']);
+            }
+
+            if ($filters['location'] !== '') {
+                $qb->andWhere('LOWER(job.location) LIKE :location')
+                    ->setParameter('location', '%' . mb_strtolower($filters['location']) . '%');
+            }
+
+            $esIds = $this->searchIdsFromElastic([
+                'q' => $filters['q'],
+                'company' => '',
+                'location' => $filters['location'],
+            ]);
+            if ($esIds !== null) {
+                if ($esIds === []) {
+                    return [
+                        'items' => [],
+                        'pagination' => [
+                            'page' => $page,
+                            'limit' => $limit,
+                            'totalItems' => 0,
+                            'totalPages' => 0,
+                        ],
+                    ];
+                }
+
+                $qb->andWhere('job.id IN (:esIds)')
+                    ->setParameter('esIds', $esIds);
+            }
+
+            $query = $qb
+                ->setFirstResult(($page - 1) * $limit)
+                ->setMaxResults($limit)
+                ->getQuery();
+
+            $paginator = new Paginator($query, true);
+            $totalItems = $paginator->count();
+
+            $items = [];
+            /** @var Job $job */
+            foreach ($paginator as $job) {
+                $items[] = [
+                    'id' => $job->getId(),
+                    'slug' => $job->getSlug(),
+                    'title' => $job->getTitle(),
+                    'company' => [
+                        'name' => $job->getCompany()?->getName() ?? '',
+                        'logo' => $job->getCompany()?->getLogo() ?? '',
+                        'sector' => $job->getCompany()?->getSector() ?? '',
+                        'size' => $job->getCompany()?->getSize() ?? '',
+                    ],
+                    'location' => $job->getLocation(),
+                    'contractType' => $job->getContractTypeValue(),
+                    'workMode' => $job->getWorkModeValue(),
+                    'schedule' => $job->getScheduleValue(),
+                    'experienceLevel' => $job->getExperienceLevelValue(),
+                    'yearsExperienceMin' => $job->getYearsExperienceMin(),
+                    'yearsExperienceMax' => $job->getYearsExperienceMax(),
+                    'salary' => [
+                        'min' => $job->getSalary()?->getMin() ?? 0,
+                        'max' => $job->getSalary()?->getMax() ?? 0,
+                        'currency' => $job->getSalary()?->getCurrency() ?? 'EUR',
+                        'period' => $job->getSalary()?->getPeriod() ?? 'year',
+                    ],
+                    'postedAtLabel' => $this->buildPostedAtLabel($job->getCreatedAt()),
+                    'summary' => $job->getSummary(),
+                    'matchScore' => $job->getMatchScore(),
+                    'badges' => array_map(static fn ($badge): string => $badge->getLabel(), $job->getBadges()->toArray()),
+                    'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $job->getTags()->toArray()),
+                    'missionTitle' => $job->getMissionTitle(),
+                    'missionDescription' => $job->getMissionDescription(),
+                    'responsibilities' => $job->getResponsibilities(),
+                    'profile' => $job->getProfile(),
+                    'benefits' => $job->getBenefits(),
+                ];
+            }
+
+            return [
+                'items' => $items,
+                'pagination' => [
+                    'page' => $page,
+                    'limit' => $limit,
+                    'totalItems' => $totalItems,
+                    'totalPages' => $totalItems > 0 ? (int)ceil($totalItems / $limit) : 0,
+                ],
+            ];
+        });
+
+        $result['meta'] = [
+            'scope' => 'general',
+            'filters' => array_filter($filters, static fn (string $value): bool => $value !== ''),
+        ];
+
+        return $result;
+    }
+
     private function buildPostedAtLabel(?DateTimeImmutable $createdAt): string
     {
         if ($createdAt === null) {

--- a/src/Recruit/Transport/Controller/Api/V1/General/GetGeneralJobController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/GetGeneralJobController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\General;
+
+use App\Recruit\Application\Service\JobPublicDetailService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Job')]
+final readonly class GetGeneralJobController
+{
+    public function __construct(
+        private JobPublicDetailService $jobPublicDetailService,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/general/jobs/{jobSlug}', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'Détail public général d\'un job publié avec jobs similaires indexés.',
+        security: [],
+        parameters: [
+            new OA\Parameter(name: 'jobSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+    )]
+    public function __invoke(string $jobSlug): JsonResponse
+    {
+        return new JsonResponse($this->jobPublicDetailService->getGeneralDetail($jobSlug));
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobsController.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\General;
+
+use App\Recruit\Application\Service\JobPublicListService;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Job')]
+final readonly class ListGeneralJobsController
+{
+    public function __construct(
+        private JobPublicListService $jobPublicListService,
+    ) {
+    }
+
+    /**
+     * @throws JsonException
+     * @throws InvalidArgumentException
+     */
+    #[Route(path: '/v1/recruit/general/jobs', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'Liste publique générale des offres jobs publiées, paginée et filtrable.',
+        security: [],
+        parameters: [
+            new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 1, minimum: 1)),
+            new OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 20, minimum: 1, maximum: 100)),
+            new OA\Parameter(name: 'q', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'location', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
+            new OA\Parameter(name: 'workMode', in: 'query', required: false, schema: new OA\Schema(type: 'string', enum: ['Onsite', 'Remote', 'Hybrid'])),
+            new OA\Parameter(name: 'contractType', in: 'query', required: false, schema: new OA\Schema(type: 'string', enum: ['CDI', 'CDD', 'Freelance', 'Internship'])),
+            new OA\Parameter(name: 'experienceLevel', in: 'query', required: false, schema: new OA\Schema(type: 'string', enum: ['Junior', 'Mid', 'Senior', 'Lead'])),
+        ],
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse($this->jobPublicListService->getGeneralList($request));
+    }
+}


### PR DESCRIPTION
### Motivation
- Permettre l'accès public global aux offres publiées sans contrainte d'application spécifique.
- Fournir des endpoints cohérents avec les contrôleurs publics existants et enrichir la doc OpenAPI pour les clients externes.

### Description
- Ajout des contrôleurs `ListGeneralJobsController` et `GetGeneralJobController` exposant `GET /v1/recruit/general/jobs` et `GET /v1/recruit/general/jobs/{jobSlug}` avec attributs OpenAPI (`OA\nGet`, `OA\nParameter`) et paramètres de query `q`, `location`, `workMode`, `contractType`, `experienceLevel`, `page`, `limit`.
- Extension de `JobPublicListService` avec `getGeneralList(Request $request)` qui renvoie uniquement les jobs publiés (`job.isPublished = true`), supporte la pagination et les filtres demandés et utilise la même convention de cache que la liste publique par application.
- Extension de `JobPublicDetailService` avec `getGeneralDetail(string $jobSlug)` et durcissement de la résolution existante pour ne retourner que des jobs publiés; réutilisation de la logique des jobs similaires avec un fallback global via `getGeneralSimilarJobs`.

### Testing
- Vérification de la syntaxe PHP avec `php -l` sur les fichiers modifiés (`JobPublicListService.php`, `JobPublicDetailService.php`, `ListGeneralJobsController.php`, `GetGeneralJobController.php`) — toutes les vérifications ont réussi.
- Validation basique locale de compilation/syntaxe des fichiers concernés — succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc85f8d608326af9a003330bb4116)