### PR TITLE
feat(school): add read-only /v1/school/general endpoints and adapt list services

### DIFF
--- a/src/School/Application/Service/ClassApplicationListService.php
+++ b/src/School/Application/Service/ClassApplicationListService.php
@@ -31,9 +31,10 @@ readonly class ClassApplicationListService
      * @throws \JsonException
      * @throws InvalidArgumentException
      */
-    public function list(Request $request, string $applicationSlug, School $school): array
+    public function list(Request $request, ?School $school = null): array
     {
         $queryOptions = $this->listRequestHelper->fromRequest($request, ['q']);
+        $applicationSlug = (string)$request->attributes->get('applicationSlug', 'general');
         $cacheKey = $this->cacheKeyConventionService->buildSchoolClassApplicationListKey($applicationSlug, $queryOptions->page, $queryOptions->limit, $queryOptions->filters);
 
         return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $school, $queryOptions): array {
@@ -43,31 +44,39 @@ readonly class ClassApplicationListService
             }
 
             $qb = $this->classRepository->createQueryBuilder('class')
-                ->andWhere('class.school = :school')->setParameter('school', $school)
                 ->orderBy('class.createdAt', 'DESC')
                 ->setFirstResult($queryOptions->offset())
                 ->setMaxResults($queryOptions->limit);
+            if ($school !== null) {
+                $qb->andWhere('class.school = :school')->setParameter('school', $school);
+            }
             if ($queryOptions->filters['q'] !== '') {
                 $qb->andWhere('LOWER(class.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
             }
 
             $items = $this->viewMapper->mapClassCollection($qb->getQuery()->getResult());
 
-            $countQb = $this->classRepository->createQueryBuilder('class')->select('COUNT(class.id)')
-                ->andWhere('class.school = :school')->setParameter('school', $school);
+            $countQb = $this->classRepository->createQueryBuilder('class')->select('COUNT(class.id)');
+            if ($school !== null) {
+                $countQb->andWhere('class.school = :school')->setParameter('school', $school);
+            }
             if ($queryOptions->filters['q'] !== '') {
                 $countQb->andWhere('LOWER(class.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
             }
             $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
 
+            $meta = [
+                'applicationSlug' => $applicationSlug,
+            ];
+            if ($school !== null) {
+                $meta['schoolId'] = $school->getId();
+            }
+
             return $this->listResponseFactory->create(
                 $queryOptions,
                 $totalItems,
                 $items,
-                [
-                    'applicationSlug' => $applicationSlug,
-                    'schoolId' => $school->getId(),
-                ],
+                $meta,
             );
         });
     }

--- a/src/School/Application/Service/ExamListService.php
+++ b/src/School/Application/Service/ExamListService.php
@@ -31,13 +31,13 @@ readonly class ExamListService
     /**
      * @return array<string,mixed>
      */
-    public function list(Request $request, string $schoolId): array
+    public function list(Request $request, ?string $schoolId = null): array
     {
         $queryOptions = $this->listRequestHelper->fromRequest($request, ['q', 'title']);
-        $applicationSlug = (string)$request->attributes->get('applicationSlug', 'default');
+        $applicationSlug = (string)$request->attributes->get('applicationSlug', 'general');
         $cacheKey = $this->cacheKeyConventionService->buildSchoolExamListKey($applicationSlug, $queryOptions->page, $queryOptions->limit, [
             ...$queryOptions->filters,
-            'schoolId' => $schoolId,
+            'schoolId' => $schoolId ?? 'all',
         ]);
 
         /** @var array<string,mixed> $result */
@@ -56,10 +56,12 @@ readonly class ExamListService
             }
 
             $qb = $this->examRepository->createQueryBuilder('exam')->leftJoin('exam.schoolClass', 'class')->leftJoin('exam.teacher', 'teacher')
-                ->innerJoin('class.school', 'school')
-                ->andWhere('school.id = :schoolId')
-                ->setParameter('schoolId', $schoolId)
                 ->setFirstResult($queryOptions->offset())->setMaxResults($queryOptions->limit)->orderBy('exam.createdAt', 'DESC');
+            if ($schoolId !== null) {
+                $qb->innerJoin('class.school', 'school')
+                    ->andWhere('school.id = :schoolId')
+                    ->setParameter('schoolId', $schoolId);
+            }
             if ($queryOptions->filters['title'] !== '') {
                 $qb->andWhere('LOWER(exam.title) LIKE LOWER(:title)')->setParameter('title', '%' . $queryOptions->filters['title'] . '%');
             }
@@ -70,10 +72,12 @@ readonly class ExamListService
             $items = $this->viewMapper->mapExamCollection($qb->getQuery()->getResult());
 
             $countQb = $this->examRepository->createQueryBuilder('exam')->select('COUNT(exam.id)')
-                ->innerJoin('exam.schoolClass', 'class')
-                ->innerJoin('class.school', 'school')
-                ->andWhere('school.id = :schoolId')
-                ->setParameter('schoolId', $schoolId);
+                ->innerJoin('exam.schoolClass', 'class');
+            if ($schoolId !== null) {
+                $countQb->innerJoin('class.school', 'school')
+                    ->andWhere('school.id = :schoolId')
+                    ->setParameter('schoolId', $schoolId);
+            }
             if ($queryOptions->filters['title'] !== '') {
                 $countQb->andWhere('LOWER(exam.title) LIKE LOWER(:title)')->setParameter('title', '%' . $queryOptions->filters['title'] . '%');
             }
@@ -83,14 +87,15 @@ readonly class ExamListService
 
             $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
 
-            return $this->listResponseFactory->create(
-                $queryOptions,
-                $totalItems,
-                $items,
-                [
-                    'module' => 'school',
-                ],
-            );
+            $meta = [
+                'module' => 'school',
+                'applicationSlug' => $applicationSlug,
+            ];
+            if ($schoolId !== null) {
+                $meta['schoolId'] = $schoolId;
+            }
+
+            return $this->listResponseFactory->create($queryOptions, $totalItems, $items, $meta);
         });
 
         return $result;

--- a/src/School/Application/Service/ListGradesService.php
+++ b/src/School/Application/Service/ListGradesService.php
@@ -22,20 +22,22 @@ final readonly class ListGradesService
     /**
      * @return array<string,mixed>
      */
-    public function list(Request $request, School $school): array
+    public function list(Request $request, ?School $school = null): array
     {
         $queryOptions = $this->listRequestHelper->fromRequest($request, ['q']);
 
         $qb = $this->gradeRepository->createQueryBuilder('grade')
             ->innerJoin('grade.exam', 'exam')
             ->innerJoin('grade.student', 'student')
-            ->innerJoin('exam.schoolClass', 'class')
-            ->innerJoin('class.school', 'school')
-            ->andWhere('school.id = :schoolId')
-            ->setParameter('schoolId', $school->getId())
             ->orderBy('grade.createdAt', 'DESC')
             ->setFirstResult($queryOptions->offset())
             ->setMaxResults($queryOptions->limit);
+        if ($school !== null) {
+            $qb->innerJoin('exam.schoolClass', 'class')
+                ->innerJoin('class.school', 'school')
+                ->andWhere('school.id = :schoolId')
+                ->setParameter('schoolId', $school->getId());
+        }
         if ($queryOptions->filters['q'] !== '') {
             $qb->andWhere('LOWER(exam.title) LIKE LOWER(:q) OR LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
@@ -44,17 +46,19 @@ final readonly class ListGradesService
 
         $countQb = $this->gradeRepository->createQueryBuilder('grade')->select('COUNT(grade.id)')
             ->innerJoin('grade.exam', 'exam')
-            ->innerJoin('grade.student', 'student')
-            ->innerJoin('exam.schoolClass', 'class')
-            ->innerJoin('class.school', 'school')
-            ->andWhere('school.id = :schoolId')
-            ->setParameter('schoolId', $school->getId());
+            ->innerJoin('grade.student', 'student');
+        if ($school !== null) {
+            $countQb->innerJoin('exam.schoolClass', 'class')
+                ->innerJoin('class.school', 'school')
+                ->andWhere('school.id = :schoolId')
+                ->setParameter('schoolId', $school->getId());
+        }
         if ($queryOptions->filters['q'] !== '') {
             $countQb->andWhere('LOWER(exam.title) LIKE LOWER(:q) OR LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
         $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
 
-        return $this->listResponseFactory->create($queryOptions, $totalItems, $items, [
+        return $this->listResponseFactory->create($queryOptions, $totalItems, $items, $school === null ? [] : [
             'schoolId' => $school->getId(),
         ]);
     }

--- a/src/School/Application/Service/ListStudentsService.php
+++ b/src/School/Application/Service/ListStudentsService.php
@@ -22,35 +22,39 @@ final readonly class ListStudentsService
     /**
      * @return array<string,mixed>
      */
-    public function list(Request $request, School $school): array
+    public function list(Request $request, ?School $school = null): array
     {
         $queryOptions = $this->listRequestHelper->fromRequest($request, ['q']);
 
         $qb = $this->studentRepository->createQueryBuilder('student')
-            ->innerJoin('student.schoolClass', 'class')
-            ->innerJoin('class.school', 'school')
-            ->andWhere('school.id = :schoolId')
-            ->setParameter('schoolId', $school->getId())
             ->orderBy('student.createdAt', 'DESC')
             ->setFirstResult($queryOptions->offset())
             ->setMaxResults($queryOptions->limit);
+        if ($school !== null) {
+            $qb->innerJoin('student.schoolClass', 'class')
+                ->innerJoin('class.school', 'school')
+                ->andWhere('school.id = :schoolId')
+                ->setParameter('schoolId', $school->getId());
+        }
         if ($queryOptions->filters['q'] !== '') {
             $qb->andWhere('LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
 
         $items = $this->viewMapper->mapStudentCollection($qb->getQuery()->getResult());
 
-        $countQb = $this->studentRepository->createQueryBuilder('student')->select('COUNT(student.id)')
-            ->innerJoin('student.schoolClass', 'class')
-            ->innerJoin('class.school', 'school')
-            ->andWhere('school.id = :schoolId')
-            ->setParameter('schoolId', $school->getId());
+        $countQb = $this->studentRepository->createQueryBuilder('student')->select('COUNT(student.id)');
+        if ($school !== null) {
+            $countQb->innerJoin('student.schoolClass', 'class')
+                ->innerJoin('class.school', 'school')
+                ->andWhere('school.id = :schoolId')
+                ->setParameter('schoolId', $school->getId());
+        }
         if ($queryOptions->filters['q'] !== '') {
             $countQb->andWhere('LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
         $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
 
-        return $this->listResponseFactory->create($queryOptions, $totalItems, $items, [
+        return $this->listResponseFactory->create($queryOptions, $totalItems, $items, $school === null ? [] : [
             'schoolId' => $school->getId(),
         ]);
     }

--- a/src/School/Application/Service/ListTeachersService.php
+++ b/src/School/Application/Service/ListTeachersService.php
@@ -22,36 +22,40 @@ final readonly class ListTeachersService
     /**
      * @return array<string,mixed>
      */
-    public function list(Request $request, School $school): array
+    public function list(Request $request, ?School $school = null): array
     {
         $queryOptions = $this->listRequestHelper->fromRequest($request, ['q']);
 
         $qb = $this->teacherRepository->createQueryBuilder('teacher')
-            ->innerJoin('teacher.classes', 'class')
-            ->innerJoin('class.school', 'school')
-            ->andWhere('school.id = :schoolId')
-            ->setParameter('schoolId', $school->getId())
             ->orderBy('teacher.createdAt', 'DESC')
             ->distinct()
             ->setFirstResult($queryOptions->offset())
             ->setMaxResults($queryOptions->limit);
+        if ($school !== null) {
+            $qb->innerJoin('teacher.classes', 'class')
+                ->innerJoin('class.school', 'school')
+                ->andWhere('school.id = :schoolId')
+                ->setParameter('schoolId', $school->getId());
+        }
         if ($queryOptions->filters['q'] !== '') {
             $qb->andWhere('LOWER(teacher.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
 
         $items = $this->viewMapper->mapTeacherCollection($qb->getQuery()->getResult());
 
-        $countQb = $this->teacherRepository->createQueryBuilder('teacher')->select('COUNT(DISTINCT teacher.id)')
-            ->innerJoin('teacher.classes', 'class')
-            ->innerJoin('class.school', 'school')
-            ->andWhere('school.id = :schoolId')
-            ->setParameter('schoolId', $school->getId());
+        $countQb = $this->teacherRepository->createQueryBuilder('teacher')->select('COUNT(DISTINCT teacher.id)');
+        if ($school !== null) {
+            $countQb->innerJoin('teacher.classes', 'class')
+                ->innerJoin('class.school', 'school')
+                ->andWhere('school.id = :schoolId')
+                ->setParameter('schoolId', $school->getId());
+        }
         if ($queryOptions->filters['q'] !== '') {
             $countQb->andWhere('LOWER(teacher.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
         $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
 
-        return $this->listResponseFactory->create($queryOptions, $totalItems, $items, [
+        return $this->listResponseFactory->create($queryOptions, $totalItems, $items, $school === null ? [] : [
             'schoolId' => $school->getId(),
         ]);
     }

--- a/src/School/Transport/Controller/Api/V1/Class/ListClassesByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/ListClassesByApplicationController.php
@@ -69,6 +69,6 @@ final readonly class ListClassesByApplicationController
         $request->attributes->set('applicationSlug', $applicationSlug);
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
 
-        return new JsonResponse($this->classApplicationListService->list($request, $applicationSlug, $school));
+        return new JsonResponse($this->classApplicationListService->list($request, $school));
     }
 }

--- a/src/School/Transport/Controller/Api/V1/General/GetGeneralSchoolResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/General/GetGeneralSchoolResourceController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1\General;
+
+use App\School\Application\Service\SchoolResourceViewService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class GetGeneralSchoolResourceController
+{
+    public function __construct(
+        private SchoolResourceViewService $resourceViewService,
+    ) {
+    }
+
+    #[Route('/v1/school/general/{resource}/{id}', methods: [Request::METHOD_GET], requirements: [
+        'resource' => 'classes|students|teachers|exams|grades',
+    ])]
+    #[OA\Get(summary: 'Détail global d\'une ressource school (scope General en lecture seule)')]
+    public function __invoke(string $resource, string $id): JsonResponse
+    {
+        $entity = $this->resourceViewService->findOr404($resource, $id);
+
+        return new JsonResponse($this->resourceViewService->map($entity));
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/General/ListGeneralClassesController.php
+++ b/src/School/Transport/Controller/Api/V1/General/ListGeneralClassesController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1\General;
+
+use App\School\Application\Service\ClassApplicationListService;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ListGeneralClassesController
+{
+    public function __construct(
+        private ClassApplicationListService $classApplicationListService,
+    ) {
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     * @throws JsonException
+     */
+    #[Route('/v1/school/general/classes', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Lister globalement les classes school (scope General en lecture seule)')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $request->attributes->set('applicationSlug', 'general');
+
+        return new JsonResponse($this->classApplicationListService->list($request));
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/General/ListGeneralExamsController.php
+++ b/src/School/Transport/Controller/Api/V1/General/ListGeneralExamsController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1\General;
+
+use App\School\Application\Service\ExamListService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ListGeneralExamsController
+{
+    public function __construct(
+        private ExamListService $examListService,
+    ) {
+    }
+
+    #[Route('/v1/school/general/exams', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Lister globalement les examens school (scope General en lecture seule)')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $request->attributes->set('applicationSlug', 'general');
+
+        return new JsonResponse($this->examListService->list($request));
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/General/ListGeneralGradesController.php
+++ b/src/School/Transport/Controller/Api/V1/General/ListGeneralGradesController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1\General;
+
+use App\School\Application\Service\ListGradesService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ListGeneralGradesController
+{
+    public function __construct(
+        private ListGradesService $listGradesService,
+    ) {
+    }
+
+    #[Route('/v1/school/general/grades', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Lister globalement les notes school (scope General en lecture seule)')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse($this->listGradesService->list($request));
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/General/ListGeneralStudentsController.php
+++ b/src/School/Transport/Controller/Api/V1/General/ListGeneralStudentsController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1\General;
+
+use App\School\Application\Service\ListStudentsService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ListGeneralStudentsController
+{
+    public function __construct(
+        private ListStudentsService $listStudentsService,
+    ) {
+    }
+
+    #[Route('/v1/school/general/students', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Lister globalement les étudiants school (scope General en lecture seule)')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse($this->listStudentsService->list($request));
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/General/ListGeneralTeachersController.php
+++ b/src/School/Transport/Controller/Api/V1/General/ListGeneralTeachersController.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1\General;
+
+use App\School\Application\Service\ListTeachersService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ListGeneralTeachersController
+{
+    public function __construct(
+        private ListTeachersService $listTeachersService,
+    ) {
+    }
+
+    #[Route('/v1/school/general/teachers', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Lister globalement les enseignants school (scope General en lecture seule)')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse($this->listTeachersService->list($request));
+    }
+}


### PR DESCRIPTION
### Motivation
- Fournir des endpoints globaux en lecture seule pour consulter les ressources `school` sans scope application spécifique. 
- Réutiliser la logique de récupération des listes existantes hors du contexte `applicationSlug` pour exposer un scope `general` partagé.
- Empêcher l’exposition d’opérations de mutation dans le scope `General` (seulement des `GET`).

### Description
- Ajout du namespace de contrôleurs `src/School/Transport/Controller/Api/V1/General/` avec les endpoints `GET /v1/school/general/classes`, `GET /v1/school/general/teachers`, `GET /v1/school/general/students`, `GET /v1/school/general/exams`, `GET /v1/school/general/grades` et `GET /v1/school/general/{resource}/{id}` (resources autorisées : `classes|students|teachers|exams|grades`).
- `ClassApplicationListService` refactorisé pour accepter un `School` optionnel, lire `applicationSlug` depuis les attributs de la requête (défaut `general`) et appliquer le filtre `school` seulement s’il est fourni.
- `ExamListService` modifié pour accepter un `?string $schoolId`, adapter la clé de cache et la méta `applicationSlug` par défaut à `general` et n’appliquer le filtrage par `school` que si `schoolId` est fourni.
- `ListTeachersService`, `ListStudentsService`, `ListGradesService` changés pour accepter un `?School` et conditionner les `JOIN`/filtres par `school` afin de pouvoir lister globalement ou par école.
- `ListClassesByApplicationController` adapté à la nouvelle signature de `ClassApplicationListService` tout en conservant le comportement scoped par application.
- Aucun endpoint de mutation (create/update/delete/assign/unassign) ajouté sous `/v1/school/general` — scope General explicitement read-only.

### Testing
- Exécution de vérification syntaxique `php -l` sur les fichiers modifiés et nouveaux (`ClassApplicationListService`, `ExamListService`, `ListGradesService`, `ListStudentsService`, `ListTeachersService`, `ListClassesByApplicationController` et tous les nouveaux contrôleurs `General`) a réussi. 
- Tentative d’inspection du routeur avec `php bin/console debug:router | rg '/v1/school/general'` a échoué dans cet environnement en raison de dépendances manquantes (message : `Try running "composer install"`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfc960574883268649e57f2f2b96dd)