### PR TITLE
Ajouter des fixtures « general-core » pour CRM, School et Recruit

### DIFF
--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -51,6 +51,7 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
             'crm-sales-hub',
             'crm-pipeline-pro',
             'crm-support-desk',
+            'crm-general-core',
         ],
     ];
 
@@ -116,6 +117,7 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
     {
         $faker = Factory::create('fr_FR');
         $faker->seed(self::FAKER_SEED);
+        $generalOwner = $this->getReference('User-john-root', User::class);
 
         $profile = self::VOLUME_PROFILES[$this->resolveVolume()] ?? self::VOLUME_PROFILES[self::DEFAULT_VOLUME];
         $crmUsers = $this->getCrmUsers($manager);
@@ -123,9 +125,17 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
         foreach ($this->getApplicationsByPlatform(PlatformKey::CRM) as $application) {
             $applicationHasBlogPlugin = $this->applicationHasBlogPlugin($manager, $application);
             $crm = $this->findOrCreateCrm($manager, $application);
+            $applicationKey = $application->getSlug();
+            $this->addReference('Crm-' . $applicationKey, $crm);
+            if ($applicationKey === 'crm-general-core') {
+                $this->addReference('Crm-General-Core', $crm);
+            }
 
             // Companies
             $companies = $this->generateCompanies($manager, $faker, $crm, $application, $profile['companies']);
+            if ($companies !== []) {
+                $this->addReference('Crm-Company-' . $applicationKey . '-1', $companies[0]);
+            }
 
             foreach ($companies as $companyIndex => $company) {
                 // Contacts
@@ -145,6 +155,9 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                     $profile['projectAttachments'],
                     $profile['wikiPagesPerProject'],
                 );
+                if ($projects !== []) {
+                    $this->addReference('Crm-Project-' . $applicationKey . '-' . ($companyIndex + 1) . '-1', $projects[0]);
+                }
 
                 foreach ($projects as $project) {
                     // Sprints
@@ -162,6 +175,9 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                             $profile['taskAttachments'],
                             $applicationHasBlogPlugin,
                         );
+                        if ($tasks !== []) {
+                            $this->addReference('Crm-Task-' . $applicationKey . '-' . ($companyIndex + 1) . '-' . $project->getCode() . '-1', $tasks[0]);
+                        }
 
                         // Task requests
                         $this->generateTaskRequests($manager, $faker, $application, $tasks, $profile['taskRequestsPerTask']);
@@ -171,6 +187,10 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                 // Billings
                 $this->generateBillings($manager, $faker, $company, $profile['billingsPerCompany']);
             }
+        }
+
+        if ($generalOwner instanceof User) {
+            $this->addReference('Crm-General-Owner', $generalOwner);
         }
 
         $manager->flush();

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
@@ -532,6 +532,66 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                 ],
             ],
         ],
+        [
+            'uuid' => '60000000-0000-1000-8000-000000000014',
+            'key' => 'crm-general-core',
+            'title' => 'CRM General Core',
+            'description' => 'Scope general CRM pour les endpoints transverses.',
+            'status' => PlatformStatus::ACTIVE,
+            'private' => false,
+            'ownerReference' => 'User-john-root',
+            'platformReference' => 'Platform-CR-CRM 1',
+            'appConfigurations' => [
+                [
+                    'uuid' => '61000000-0000-1000-8000-000000000014',
+                    'key' => 'application.crm.general',
+                    'value' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ],
+            'plugins' => [],
+        ],
+        [
+            'uuid' => '60000000-0000-1000-8000-000000000015',
+            'key' => 'school-general-core',
+            'title' => 'School General Core',
+            'description' => 'Scope general School pour les endpoints transverses.',
+            'status' => PlatformStatus::ACTIVE,
+            'private' => false,
+            'ownerReference' => 'User-john-root',
+            'platformReference' => 'Platform-SC-School Principal',
+            'appConfigurations' => [
+                [
+                    'uuid' => '61000000-0000-1000-8000-000000000015',
+                    'key' => 'application.school.general',
+                    'value' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ],
+            'plugins' => [],
+        ],
+        [
+            'uuid' => '60000000-0000-1000-8000-000000000016',
+            'key' => 'recruit-general-core',
+            'title' => 'Recruit General Core',
+            'description' => 'Scope general Recruit pour les endpoints transverses.',
+            'status' => PlatformStatus::ACTIVE,
+            'private' => false,
+            'ownerReference' => 'User-john-root',
+            'platformReference' => 'Platform-RE-Recruit Principal',
+            'appConfigurations' => [
+                [
+                    'uuid' => '61000000-0000-1000-8000-000000000016',
+                    'key' => 'application.recruit.general',
+                    'value' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ],
+            'plugins' => [],
+        ],
     ];
 
     /**
@@ -551,6 +611,9 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
         'recruit-hiring-pipeline' => '60000000-0000-1000-8000-000000000011',
         'recruit-interview-desk' => '60000000-0000-1000-8000-000000000012',
         'general' => '60000000-0000-1000-8000-000000000013',
+        'crm-general-core' => '60000000-0000-1000-8000-000000000014',
+        'school-general-core' => '60000000-0000-1000-8000-000000000015',
+        'recruit-general-core' => '60000000-0000-1000-8000-000000000016',
     ];
 
     /**

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitData.php
@@ -16,6 +16,7 @@ use App\Recruit\Domain\Enum\ContractType;
 use App\Recruit\Domain\Enum\ExperienceLevel;
 use App\Recruit\Domain\Enum\Schedule;
 use App\Recruit\Domain\Enum\WorkMode;
+use App\User\Domain\Entity\User;
 use DateTimeImmutable;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
@@ -29,6 +30,7 @@ use function sprintf;
 final class LoadRecruitData extends Fixture implements OrderedFixtureInterface
 {
     private const int JOB_COUNT_PER_APPLICATION = 12;
+    private const string GENERAL_APPLICATION_KEY = 'recruit-general-core';
 
     /**
      * @var array<int, array{name: string, logo: string, sector: string, size: string}>
@@ -103,6 +105,7 @@ final class LoadRecruitData extends Fixture implements OrderedFixtureInterface
     #[Override]
     public function load(ObjectManager $manager): void
     {
+        $generalOwner = $this->getReference('User-john-root', User::class);
         /** @var Application $application */
         $application = $this->getReference('Application-recruit-lite-app', Application::class);
 
@@ -126,6 +129,9 @@ final class LoadRecruitData extends Fixture implements OrderedFixtureInterface
             $manager->persist($company);
             $companies[] = $company;
         }
+        if ($companies !== []) {
+            $this->addReference('Recruit-Company-1', $companies[0]);
+        }
 
         $tags = [];
         foreach (self::TAGS as $item) {
@@ -133,12 +139,18 @@ final class LoadRecruitData extends Fixture implements OrderedFixtureInterface
             $manager->persist($tag);
             $tags[] = $tag;
         }
+        if ($tags !== []) {
+            $this->addReference('Recruit-Tag-1', $tags[0]);
+        }
 
         $badges = [];
         foreach (self::BADGES as $item) {
             $badge = (new Badge())->setLabel($item);
             $manager->persist($badge);
             $badges[] = $badge;
+        }
+        if ($badges !== []) {
+            $this->addReference('Recruit-Badge-1', $badges[0]);
         }
 
         $recruitApplications = $manager->getRepository(Application::class)
@@ -164,6 +176,11 @@ final class LoadRecruitData extends Fixture implements OrderedFixtureInterface
                 $recruit = (new Recruit())->setApplication($application);
                 $manager->persist($recruit);
             }
+            $applicationKey = $application->getSlug();
+            $this->addReference('Recruit-' . $applicationKey, $recruit);
+            if ($applicationKey === self::GENERAL_APPLICATION_KEY) {
+                $this->addReference('Recruit-General-Core', $recruit);
+            }
 
             for ($i = 1; $i <= self::JOB_COUNT_PER_APPLICATION; $i++) {
                 $loopIndex = ($applicationIndex * self::JOB_COUNT_PER_APPLICATION) + $i;
@@ -179,7 +196,7 @@ final class LoadRecruitData extends Fixture implements OrderedFixtureInterface
 
                 $job = (new Job())
                     ->setRecruit($recruit)
-                    ->setOwner($application->getUser())
+                    ->setOwner($applicationKey === self::GENERAL_APPLICATION_KEY && $generalOwner instanceof User ? $generalOwner : $application->getUser())
                     ->setTitle($title)
                     ->setCompany($company)
                     ->setSalary($salary)
@@ -242,9 +259,19 @@ final class LoadRecruitData extends Fixture implements OrderedFixtureInterface
                 $manager->persist($salary);
                 $manager->persist($job);
                 $this->addReference(sprintf('Recruit-Job-%03d', $jobReferenceIndex), $job);
+                if ($i === 1) {
+                    $this->addReference('Recruit-Job-' . $applicationKey . '-1', $job);
+                    if ($applicationKey === self::GENERAL_APPLICATION_KEY) {
+                        $this->addReference('Recruit-Job-General-Core-1', $job);
+                    }
+                }
 
                 $jobReferenceIndex++;
             }
+        }
+
+        if ($generalOwner instanceof User) {
+            $this->addReference('Recruit-General-Owner', $generalOwner);
         }
 
         $manager->flush();

--- a/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
+++ b/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
@@ -15,6 +15,7 @@ use App\School\Domain\Entity\Teacher;
 use App\School\Domain\Enum\ExamStatus;
 use App\School\Domain\Enum\ExamType;
 use App\School\Domain\Enum\Term;
+use App\User\Domain\Entity\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -30,12 +31,14 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
             'school-campus-core',
             'school-course-flow',
             'school-grade-track',
+            'school-general-core',
         ],
     ];
 
     #[Override]
     public function load(ObjectManager $manager): void
     {
+        $generalOwner = $this->getReference('User-john-root', User::class);
         $examTypes = ExamType::cases();
         $examStatuses = ExamStatus::cases();
         $terms = Term::cases();
@@ -56,6 +59,9 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
 
             $school->setName($application->getTitle() . ' Academy');
             $this->addReference('School-' . $appKey, $school);
+            if ($appKey === 'school-general-core') {
+                $this->addReference('School-General-Core', $school);
+            }
 
             $classes = [];
             $classesByLabel = [
@@ -73,6 +79,7 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
                 $classes[$label] = $class;
                 $this->addReference('SchoolClass-' . $appKey . '-' . $label, $class);
             }
+            $this->addReference('SchoolClass-' . $appKey . '-1', $classes['small']);
 
             $teacherMath = (new Teacher())->setName('Mme Martin - ' . $applicationIndex);
             $teacherFrench = (new Teacher())->setName('M. Dubois - ' . $applicationIndex);
@@ -93,6 +100,7 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
             $this->addReference('Teacher-' . $appKey . '-math', $teacherMath);
             $this->addReference('Teacher-' . $appKey . '-french', $teacherFrench);
             $this->addReference('Teacher-' . $appKey . '-head', $teacherHead);
+            $this->addReference('Teacher-' . $appKey . '-1', $teacherMath);
 
             $students = [];
             $studentCounter = 1;
@@ -161,6 +169,10 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
                     }
                 }
             }
+        }
+
+        if ($generalOwner instanceof User) {
+            $this->addReference('School-General-Owner', $generalOwner);
         }
 
         $manager->flush();


### PR DESCRIPTION
### Motivation
- Préparer des entités globales utilisables par les nouveaux endpoints « General » en fournissant des applications « general-core » et des références fixtures stables pour les tests d’intégration.
- Associer ces ressources globales de manière fonctionnelle à l’utilisateur propriétaire `User-john-root` afin d’assurer un owner déterministe pour les scénarios transverses.

### Description
- Ajout de trois applications globales dans `src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php` : `crm-general-core`, `school-general-core`, `recruit-general-core` avec UUIDs et configurations dédiées.
- Extension de `src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php` pour inclure `crm-general-core`, récupérer `User-john-root` et exposer des références stables (`Crm-*`, `Crm-General-Core`, `Crm-Company-*`, `Crm-Project-*`, `Crm-Task-*`) pour les tests General.
- Extension de `src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php` pour inclure `school-general-core`, récupérer `User-john-root` et ajouter des références stables (`School-General-Core`, `SchoolClass-*-1`, `Teacher-*-1`, etc.).
- Extension de `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitData.php` pour inclure des références stables (companies/tags/badges, `Recruit-General-Core`, `Recruit-Job-General-Core-1`) et forcer l’`owner` des jobs du scope `recruit-general-core` vers `User-john-root`.

### Testing
- Linting PHP syntax via `php -l` a été exécuté sur les fichiers modifiés et a réussi pour `src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php`, `src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php`, `src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php` et `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitData.php`.
- Aucune erreur de syntaxe détectée après modification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfcaf05cb08326b1fcd0505d710cd6)