### PR TITLE
fix(fixtures): include sprint in CRM task reference key

### DIFF
--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -163,7 +163,7 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                     // Sprints
                     $sprints = $this->generateSprints($manager, $faker, $project, $profile['sprintsPerProject']);
 
-                    foreach ($sprints as $sprint) {
+                    foreach ($sprints as $sprintIndex => $sprint) {
                         // Tasks
                         $tasks = $this->generateTasks(
                             $manager,
@@ -176,7 +176,10 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                             $applicationHasBlogPlugin,
                         );
                         if ($tasks !== []) {
-                            $this->addReference('Crm-Task-' . $applicationKey . '-' . ($companyIndex + 1) . '-' . $project->getCode() . '-1', $tasks[0]);
+                            $this->addReference(
+                                'Crm-Task-' . $applicationKey . '-' . ($companyIndex + 1) . '-' . $project->getCode() . '-S' . ($sprintIndex + 1) . '-T1',
+                                $tasks[0],
+                            );
                         }
 
                         // Task requests


### PR DESCRIPTION
### Motivation
- Avoid collisions between task fixture references and provide sprint-level granularity by including the sprint (and task) in the reference key.

### Description
- Change the sprint loop to `foreach ($sprints as $sprintIndex => $sprint)` and update the `addReference` call to use `'Crm-Task-<app>-<company>-<project>-S{n}-T1'`, so the stored task reference is unique per sprint.

### Testing
- Ran `php -l src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfce73ecf88326af1697cc8eaff288)