### PR TITLE
Update shop fixtures (categories/products) and assign john user photos

### DIFF
--- a/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
+++ b/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
@@ -19,6 +19,8 @@ use Override;
 
 final class LoadShopData extends Fixture implements OrderedFixtureInterface
 {
+    private const string ASSET_HOST = 'https://localhost';
+
     /**
      * @var array<non-empty-string, array<int, non-empty-string>>
      */
@@ -34,12 +36,146 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
     public function load(ObjectManager $manager): void
     {
         $globalShop = $this->findOrCreateGlobalShop($manager);
-        $coinsCategory = $this->findOrCreateCategory($manager, $globalShop, 'Coins', 'coins', 'Pièces virtuelles à créditer sur le solde utilisateur.');
-        $coinsPackCategory = $this->findOrCreateCategory($manager, $globalShop, 'Packs coins', 'packs-coins', 'Packs de coins prêts à être achetés et crédités automatiquement.');
 
-        $this->findOrCreateCoinProduct($manager, $globalShop, $coinsCategory, 'Pack 200 coins', 'COINS-200', 300, 200);
-        $this->findOrCreateCoinProduct($manager, $globalShop, $coinsPackCategory, 'Pack 500 coins', 'COINS-500', 500, 500);
-        $this->findOrCreateCoinProduct($manager, $globalShop, $coinsPackCategory, 'Pack 1000 coins', 'COINS-1000', 800, 1000);
+        $coinsCategory = $this->findOrCreateCategory(
+            $manager,
+            $globalShop,
+            'Coins',
+            'coins',
+            sprintf('Packs de coins virtuels. Image: %s', $this->buildAssetUrl('/img/shop/categories/coins.png')),
+        );
+
+        $housesCategory = $this->findOrCreateCategory(
+            $manager,
+            $globalShop,
+            'Houses',
+            'houses',
+            sprintf('Maisons et décor premium. Image: %s', $this->buildAssetUrl('/img/shop/categories/houses.png')),
+        );
+
+        $furnitureCategory = $this->findOrCreateCategory(
+            $manager,
+            $globalShop,
+            'Meubles',
+            'meubles',
+            sprintf('Mobilier et décoration intérieure. Image: %s', $this->buildAssetUrl('/img/shop/categories/meubles.png')),
+        );
+
+        $this->findOrCreateProduct(
+            manager: $manager,
+            shop: $globalShop,
+            category: $coinsCategory,
+            name: '200 coins',
+            sku: 'COINS-200',
+            price: 200,
+            stock: 999999,
+            description: sprintf('Crédite 200 coins. Image: %s', $this->buildAssetUrl('/img/shop/products/200.png')),
+            coinsAmount: 200,
+            isFeatured: true,
+        );
+
+        $this->findOrCreateProduct(
+            manager: $manager,
+            shop: $globalShop,
+            category: $coinsCategory,
+            name: '400 coins',
+            sku: 'COINS-400',
+            price: 360,
+            stock: 999999,
+            description: sprintf('Crédite 400 coins. Image: %s', $this->buildAssetUrl('/img/shop/products/400.png')),
+            coinsAmount: 400,
+            isFeatured: true,
+        );
+
+        $this->findOrCreateProduct(
+            manager: $manager,
+            shop: $globalShop,
+            category: $coinsCategory,
+            name: '600 coins',
+            sku: 'COINS-600',
+            price: 500,
+            stock: 999999,
+            description: sprintf('Crédite 600 coins. Image: %s', $this->buildAssetUrl('/img/shop/products/600.png')),
+            coinsAmount: 600,
+            isFeatured: true,
+        );
+
+        $this->findOrCreateProduct(
+            manager: $manager,
+            shop: $globalShop,
+            category: $housesCategory,
+            name: 'House Pack 1',
+            sku: 'HOUSE-001',
+            price: 15900,
+            stock: 120,
+            description: sprintf('Pack maison 1. Image: %s', $this->buildAssetUrl('/img/shop/products/product-1-min.jpeg')),
+        );
+
+        $this->findOrCreateProduct(
+            manager: $manager,
+            shop: $globalShop,
+            category: $housesCategory,
+            name: 'House Pack 2',
+            sku: 'HOUSE-002',
+            price: 22900,
+            stock: 80,
+            description: sprintf('Pack maison 2. Image: %s', $this->buildAssetUrl('/img/shop/products/product-2-min.jpeg')),
+        );
+
+        $this->findOrCreateProduct(
+            manager: $manager,
+            shop: $globalShop,
+            category: $housesCategory,
+            name: 'House Pack 3',
+            sku: 'HOUSE-003',
+            price: 31900,
+            stock: 60,
+            description: sprintf('Pack maison 3. Image: %s', $this->buildAssetUrl('/img/shop/products/product-3-min.jpeg')),
+        );
+
+        $this->findOrCreateProduct(
+            manager: $manager,
+            shop: $globalShop,
+            category: $furnitureCategory,
+            name: 'Meuble Set 1',
+            sku: 'FURN-001',
+            price: 3900,
+            stock: 250,
+            description: sprintf('Set meuble 1. Image: %s', $this->buildAssetUrl('/img/shop/products/product-details-1.jpg')),
+        );
+
+        $this->findOrCreateProduct(
+            manager: $manager,
+            shop: $globalShop,
+            category: $furnitureCategory,
+            name: 'Meuble Set 2',
+            sku: 'FURN-002',
+            price: 4900,
+            stock: 220,
+            description: sprintf('Set meuble 2. Image: %s', $this->buildAssetUrl('/img/shop/products/product-details-2.jpg')),
+        );
+
+        $this->findOrCreateProduct(
+            manager: $manager,
+            shop: $globalShop,
+            category: $furnitureCategory,
+            name: 'Meuble Set 3',
+            sku: 'FURN-003',
+            price: 5900,
+            stock: 180,
+            description: sprintf('Set meuble 3. Image: %s', $this->buildAssetUrl('/img/shop/products/product-details-3.jpg')),
+        );
+
+        $this->findOrCreateProduct(
+            manager: $manager,
+            shop: $globalShop,
+            category: $furnitureCategory,
+            name: 'Meuble Set 4',
+            sku: 'FURN-004',
+            price: 7900,
+            stock: 140,
+            description: sprintf('Set meuble 4. Image: %s', $this->buildAssetUrl('/img/shop/products/product-details-4.jpg')),
+        );
 
         foreach ($this->getApplicationsByPlatform(PlatformKey::SHOP) as $application) {
             $existingCatalog = $manager->getRepository(Shop::class)->findOneBy([
@@ -143,8 +279,18 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
         return $category;
     }
 
-    private function findOrCreateCoinProduct(ObjectManager $manager, Shop $shop, Category $category, string $name, string $sku, int $price, int $coinsAmount): Product
-    {
+    private function findOrCreateProduct(
+        ObjectManager $manager,
+        Shop $shop,
+        Category $category,
+        string $name,
+        string $sku,
+        int $price,
+        int $stock,
+        string $description,
+        int $coinsAmount = 0,
+        bool $isFeatured = false,
+    ): Product {
         $product = $manager->getRepository(Product::class)->findOneBy(['sku' => $sku]);
 
         if ($product instanceof Product) {
@@ -152,13 +298,13 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
                 ->setShop($shop)
                 ->setCategory($category)
                 ->setName($name)
-                ->setDescription(sprintf('Crédite %d coins sur le compte utilisateur après paiement validé.', $coinsAmount))
+                ->setDescription($description)
                 ->setPrice($price)
                 ->setCurrencyCode('EUR')
-                ->setStock(999999)
+                ->setStock($stock)
                 ->setCoinsAmount($coinsAmount)
                 ->setStatus(ProductStatus::ACTIVE)
-                ->setIsFeatured(true);
+                ->setIsFeatured($isFeatured);
         }
 
         $product = (new Product())
@@ -166,16 +312,21 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
             ->setCategory($category)
             ->setName($name)
             ->setSku($sku)
-            ->setDescription(sprintf('Crédite %d coins sur le compte utilisateur après paiement validé.', $coinsAmount))
+            ->setDescription($description)
             ->setPrice($price)
             ->setCurrencyCode('EUR')
-            ->setStock(999999)
+            ->setStock($stock)
             ->setCoinsAmount($coinsAmount)
             ->setStatus(ProductStatus::ACTIVE)
-            ->setIsFeatured(true);
+            ->setIsFeatured($isFeatured);
         $manager->persist($product);
 
         return $product;
+    }
+
+    private function buildAssetUrl(string $path): string
+    {
+        return self::ASSET_HOST . $path;
     }
 
     /**

--- a/src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php
+++ b/src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php
@@ -29,6 +29,18 @@ final class LoadUserData extends Fixture implements OrderedFixtureInterface
     /**
      * @var array<non-empty-string, non-empty-string>
      */
+    private const array USER_PHOTOS = [
+        'john' => 'https://localhost/img/team-1.jpg',
+        'john-logged' => 'https://localhost/img/team-2.jpg',
+        'john-api' => 'https://localhost/img/team-3.jpg',
+        'john-user' => 'https://localhost/img/team-4.jpg',
+        'john-admin' => 'https://localhost/img/team-5.jpg',
+        'john-root' => 'https://localhost/img/team-9.jpeg',
+    ];
+
+    /**
+     * @var array<non-empty-string, non-empty-string>
+     */
     public static array $uuids = [
         'john' => '20000000-0000-1000-8000-000000000001',
         'john-logged' => '20000000-0000-1000-8000-000000000002',
@@ -114,6 +126,11 @@ final class LoadUserData extends Fixture implements OrderedFixtureInterface
             ->setLanguage(Language::EN)
             ->setLocale(Locale::EN)
             ->setPlainPassword('password' . $suffix);
+
+        $username = $entity->getUsername();
+        if (isset(self::USER_PHOTOS[$username])) {
+            $entity->setPhoto(self::USER_PHOTOS[$username]);
+        }
 
         if ($role !== null) {
             /** @var UserGroup $userGroup */


### PR DESCRIPTION
## Summary
- Updated global shop fixtures to use 3 requested categories: `coins`, `houses`, `meubles`.
- Added requested products:
  - Coins: `200`, `400`, `600` with prices `2.00€`, `3.60€`, `5.00€` and image URLs under `/img/shop/products`.
  - Houses: 3 products using `product-1-min.jpeg`, `product-2-min.jpeg`, `product-3-min.jpeg`.
  - Meubles: 4 products using existing `product-details-1.jpg` to `product-details-4.jpg` paths.
- Ensured category and product image references are stored as absolute HTTPS URLs (`https://localhost/...`) in fixture descriptions.
- Updated john-related users to use 6 available team photos:
  - `john`, `john-logged`, `john-api`, `john-user`, `john-admin`, `john-root`
  - mapped to `team-1.jpg`..`team-5.jpg` and `team-9.jpeg`.

## Validation
- Verified PHP syntax for modified fixture files.
- Verified all referenced image files exist under `public/img/...`.

## Notes
- The requested meuble filenames (`product-1-detail.jpg` etc.) do not exist in the repository; existing files are `product-details-1.jpg` etc., and these were used after path verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfda2652c48326a15d10e72e4497d6)