### PR TITLE
Add general cart API controllers without applicationSlug

### DIFF
--- a/src/Shop/Transport/Controller/Api/V1/General/AddGeneralCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/AddGeneralCartItemController.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\Shop\Application\Service\CartService;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Shop\Transport\Controller\Api\V1\Input\Cart\AddCartItemInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Cart\CartInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class AddGeneralCartItemController
+{
+    public function __construct(
+        private Security $security,
+        private ShopRepository $shopRepository,
+        private ProductRepository $productRepository,
+        private CartService $cartService,
+        private CartInputValidator $cartInputValidator,
+    ) {
+    }
+
+    /**
+     * @throws ORMException
+     * @throws JsonException
+     * @throws OptimisticLockException
+     */
+    #[Route('/v1/shop/general/carts/{shopId}/items', methods: [Request::METHOD_POST])]
+    public function __invoke(string $shopId, Request $request): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');
+        }
+
+        $shop = $this->shopRepository->find($shopId);
+        if (!$shop instanceof Shop) {
+            return new JsonResponse([
+                'message' => 'Shop not found.',
+            ], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        try {
+            $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
+
+        $input = AddCartItemInput::fromArray($payload);
+        $validationResponse = $this->cartInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $productId = $input->productId;
+        $quantity = $input->quantity;
+
+        $product = $this->productRepository->find($productId);
+        if (!$product instanceof Product || $product->getShop()?->getId() !== $shop->getId()) {
+            return new JsonResponse([
+                'message' => 'Product not found for this shop.',
+            ], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $cart = $this->cartService->getOrCreateActiveCart($user, $shop);
+        $cart = $this->cartService->addProduct($cart, $product, $quantity);
+
+        return new JsonResponse($this->cartService->serializeCart($cart), JsonResponse::HTTP_CREATED);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/General/DeleteGeneralCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/DeleteGeneralCartItemController.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\Shop\Application\Service\CartService;
+use App\Shop\Domain\Entity\CartItem;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\CartItemRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class DeleteGeneralCartItemController
+{
+    public function __construct(
+        private ShopRepository $shopRepository,
+        private CartItemRepository $cartItemRepository,
+        private CartService $cartService,
+    ) {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/shop/general/carts/{shopId}/items/{itemId}', methods: [Request::METHOD_DELETE])]
+    public function __invoke(string $shopId, string $itemId, User $loggedInUser): JsonResponse
+    {
+        $shop = $this->shopRepository->find($shopId);
+        if (!$shop instanceof Shop) {
+            return new JsonResponse([
+                'message' => 'Shop not found.',
+            ], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $cart = $this->cartService->getOrCreateActiveCart($loggedInUser, $shop);
+
+        $item = $this->cartItemRepository->find($itemId);
+        if (!$item instanceof CartItem || $item->getCart()?->getId() !== $cart->getId()) {
+            return new JsonResponse([
+                'message' => 'Cart item not found.',
+            ], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $cart = $this->cartService->removeItem($cart, $item);
+
+        return new JsonResponse($this->cartService->serializeCart($cart));
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/General/GetGeneralCartController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/GetGeneralCartController.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\Shop\Application\Service\CartService;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class GetGeneralCartController
+{
+    public function __construct(
+        private ShopRepository $shopRepository,
+        private CartService $cartService,
+    ) {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/shop/general/carts/{shopId}', methods: [Request::METHOD_GET])]
+    public function __invoke(string $shopId, User $loggedInUser): JsonResponse
+    {
+        $shop = $this->shopRepository->find($shopId);
+        if (!$shop instanceof Shop) {
+            return new JsonResponse([
+                'message' => 'Shop not found.',
+            ], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $cart = $this->cartService->getOrCreateActiveCart($loggedInUser, $shop);
+        $cart = $this->cartService->recalculate($cart);
+
+        return new JsonResponse($this->cartService->serializeCart($cart));
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/General/PatchGeneralCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/PatchGeneralCartItemController.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\Shop\Application\Service\CartService;
+use App\Shop\Domain\Entity\CartItem;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\CartItemRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Shop\Transport\Controller\Api\V1\Input\Cart\CartInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Cart\PatchCartItemInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class PatchGeneralCartItemController
+{
+    public function __construct(
+        private Security $security,
+        private ShopRepository $shopRepository,
+        private CartItemRepository $cartItemRepository,
+        private CartService $cartService,
+        private CartInputValidator $cartInputValidator,
+    ) {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     * @throws JsonException
+     */
+    #[Route('/v1/shop/general/carts/{shopId}/items/{itemId}', methods: [Request::METHOD_PATCH])]
+    public function __invoke(string $shopId, string $itemId, Request $request): JsonResponse
+    {
+        $user = $this->security->getUser();
+        if (!$user instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Authenticated user required.');
+        }
+
+        $shop = $this->shopRepository->find($shopId);
+        if (!$shop instanceof Shop) {
+            return new JsonResponse([
+                'message' => 'Shop not found.',
+            ], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $cart = $this->cartService->getOrCreateActiveCart($user, $shop);
+
+        $item = $this->cartItemRepository->find($itemId);
+        if (!$item instanceof CartItem || $item->getCart()?->getId() !== $cart->getId()) {
+            return new JsonResponse([
+                'message' => 'Cart item not found.',
+            ], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        try {
+            $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
+
+        $input = PatchCartItemInput::fromArray($payload);
+        $validationResponse = $this->cartInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $quantity = $input->quantity;
+
+        $cart = $this->cartService->updateItemQuantity($cart, $item, $quantity);
+
+        return new JsonResponse($this->cartService->serializeCart($cart));
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide global-scope cart endpoints that behave like existing `Api/V1/Cart/*` controllers but do not require an `applicationSlug`, so consumers can manage carts in a shop-wide context.
- Reuse existing input/validation and `CartService` logic to keep behavior and error messages consistent with current cart endpoints.

### Description
- Added `GetGeneralCartController` with route `GET /v1/shop/general/carts/{shopId}` that resolves the shop via `ShopRepository`, calls `CartService::getOrCreateActiveCart`, recalculates with `CartService::recalculate`, and returns `CartService::serializeCart`.
- Added `AddGeneralCartItemController` with route `POST /v1/shop/general/carts/{shopId}/items` that reuses `AddCartItemInput`, `CartInputValidator` and `ValidationResponseFactory`, verifies the `productId` belongs to the shop, and calls `CartService::addProduct` returning the serialized cart with HTTP 201.
- Added `PatchGeneralCartItemController` with route `PATCH /v1/shop/general/carts/{shopId}/items/{itemId}` that reuses `PatchCartItemInput` and validation, checks the item belongs to the active cart, and calls `CartService::updateItemQuantity` returning the serialized cart.
- Added `DeleteGeneralCartItemController` with route `DELETE /v1/shop/general/carts/{shopId}/items/{itemId}` that verifies cart item ownership and calls `CartService::removeItem`, returning the serialized cart; all controllers include the `IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)` attribute and preserve existing error messages like `Shop not found.`, `Product not found for this shop.`, and `Cart item not found.`.

### Testing
- Ran PHP syntax checks with `php -l` on all four new files and confirmed there were no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfebc130c8832697dbba449d5a7433)