### PR TITLE
docs(shop): expliciter parcours manuel checkout dans OpenAPI

### DIFF
--- a/src/Shop/Transport/Controller/Api/V1/General/AddGeneralCartItemController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/AddGeneralCartItemController.php
@@ -46,10 +46,10 @@ final readonly class AddGeneralCartItemController
      * @throws OptimisticLockException
      */
     #[Route('/v1/shop/general/carts/{shopId}/items', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'shopId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'shopId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: 'f95da407-b9f0-4d5f-a14e-15c4b22af6e3'))]
     #[OA\Post(
         summary: 'Add a product to the authenticated user cart in global shop scope.',
-        description: 'Independent from any application slug: creates or updates an active cart line for the authenticated user and the targeted shop.',
+        description: 'Manual /api/doc chain step 1/6: POST /v1/shop/general/carts/{shopId}/items. Use shopId=f95da407-b9f0-4d5f-a14e-15c4b22af6e3, then reuse the same shopId in step 2 (GET cart) and step 3 (checkout).',
         security: [['Bearer' => []]],
         requestBody: new OA\RequestBody(
             required: true,
@@ -61,8 +61,8 @@ final readonly class AddGeneralCartItemController
                 ],
                 examples: [
                     new OA\Examples(
-                        example: 'add_to_cart',
-                        summary: 'Add two units of a product',
+                        example: 'manual_step_1_add_item_input',
+                        summary: 'Step 1 input - add product with chainable shopId',
                         value: [
                             'productId' => '8b673f1d-8f2f-4a81-b5e8-6f2f14b26626',
                             'quantity' => 2,

--- a/src/Shop/Transport/Controller/Api/V1/General/CheckoutGeneralController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/CheckoutGeneralController.php
@@ -37,10 +37,10 @@ final readonly class CheckoutGeneralController
     }
 
     #[Route('/v1/shop/general/checkout/{shopId}', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'shopId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'shopId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: 'f95da407-b9f0-4d5f-a14e-15c4b22af6e3'))]
     #[OA\Post(
         summary: 'Create an order from the authenticated user cart in the global shop scope.',
-        description: 'Independent from any application slug: this endpoint converts the active cart of the authenticated user into an order for the provided shop.',
+        description: 'Manual /api/doc chain step 3/6: POST /v1/shop/general/checkout/{shopId}. Reuse shopId=f95da407-b9f0-4d5f-a14e-15c4b22af6e3 from steps 1-2 and store returned orderId=ord_8cb7be4f-2d27-430d-bc16-5b9fc4f2ef1e for steps 4-5.',
         security: [['Bearer' => []]],
         requestBody: new OA\RequestBody(
             required: true,
@@ -55,8 +55,8 @@ final readonly class CheckoutGeneralController
                 ],
                 examples: [
                     new OA\Examples(
-                        example: 'checkout',
-                        summary: 'Checkout request',
+                        example: 'manual_step_3_checkout_input',
+                        summary: 'Step 3 input - checkout using shopId from steps 1-2',
                         value: [
                             'billingAddress' => '42 Rue des Fleurs, 75001 Paris, FR',
                             'shippingAddress' => '15 Avenue Victor Hugo, 75016 Paris, FR',
@@ -75,8 +75,8 @@ final readonly class CheckoutGeneralController
         content: new OA\JsonContent(
             examples: [
                 new OA\Examples(
-                    example: 'order_created',
-                    summary: 'Checkout created',
+                    example: 'manual_step_3_checkout_output',
+                    summary: 'Step 3 output - capture orderId for steps 4-5',
                     value: [
                         'id' => 'ord_8cb7be4f-2d27-430d-bc16-5b9fc4f2ef1e',
                         'status' => 'pending_payment',

--- a/src/Shop/Transport/Controller/Api/V1/General/ConfirmGeneralPaymentController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/ConfirmGeneralPaymentController.php
@@ -35,10 +35,10 @@ final readonly class ConfirmGeneralPaymentController
      * @throws ORMException
      */
     #[Route('/v1/shop/general/orders/{orderId}/payment-confirm', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'orderId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'orderId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: 'ord_8cb7be4f-2d27-430d-bc16-5b9fc4f2ef1e'))]
     #[OA\Post(
         summary: 'Confirm a previously created payment intent for a global order.',
-        description: 'Independent from any application slug: validates provider callback data and updates transaction status for a global shop order.',
+        description: 'Manual /api/doc chain step 5/6: POST /v1/shop/general/orders/{orderId}/payment-confirm. Reuse orderId from step 3 and providerReference=pi_3QyQkL2x8d9 from step 4.',
         security: [['Bearer' => []]],
         requestBody: new OA\RequestBody(
             required: true,
@@ -50,8 +50,8 @@ final readonly class ConfirmGeneralPaymentController
                 ],
                 examples: [
                     new OA\Examples(
-                        example: 'confirm_payment',
-                        summary: 'Confirm Stripe payment',
+                        example: 'manual_step_5_payment_confirm_input',
+                        summary: 'Step 5 input - confirm using providerReference returned at step 4',
                         value: [
                             'providerReference' => 'pi_3QyQkL2x8d9',
                             'providerPayload' => [

--- a/src/Shop/Transport/Controller/Api/V1/General/CreateGeneralPaymentIntentController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/CreateGeneralPaymentIntentController.php
@@ -38,10 +38,10 @@ final readonly class CreateGeneralPaymentIntentController
      * @throws ORMException
      */
     #[Route('/v1/shop/general/orders/{orderId}/payment-intent', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'orderId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'orderId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: 'ord_8cb7be4f-2d27-430d-bc16-5b9fc4f2ef1e'))]
     #[OA\Post(
         summary: 'Create a payment intent for an existing global-scope order.',
-        description: 'Independent from application context: creates a transaction intent for a global shop order using the selected payment provider and method.',
+        description: 'Manual /api/doc chain step 4/6: POST /v1/shop/general/orders/{orderId}/payment-intent. Reuse orderId=ord_8cb7be4f-2d27-430d-bc16-5b9fc4f2ef1e from step 3 and keep providerReference for steps 5-6.',
         security: [['Bearer' => []]],
         requestBody: new OA\RequestBody(
             required: false,
@@ -53,8 +53,8 @@ final readonly class CreateGeneralPaymentIntentController
                 type: 'object',
                 examples: [
                     new OA\Examples(
-                        example: 'create_payment_intent',
-                        summary: 'Create payment intent with Stripe card flow',
+                        example: 'manual_step_4_payment_intent_input',
+                        summary: 'Step 4 input - create Stripe payment intent for orderId from step 3',
                         value: [
                             'provider' => 'stripe',
                             'paymentMethod' => 'stripe',
@@ -66,7 +66,7 @@ final readonly class CreateGeneralPaymentIntentController
     )]
     #[OA\Response(
         response: JsonResponse::HTTP_CREATED,
-        description: 'Payment intent created.',
+        description: 'Payment intent created (capture providerReference for step 5 and optional step 6).',
         content: new OA\JsonContent(example: [
             'id' => 'txn_8f96897f-bf44-4ed5-b2e8-cd8b64ac9ef8',
             'orderId' => 'ord_8cb7be4f-2d27-430d-bc16-5b9fc4f2ef1e',

--- a/src/Shop/Transport/Controller/Api/V1/General/GeneralPaymentWebhookController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/GeneralPaymentWebhookController.php
@@ -35,11 +35,11 @@ final readonly class GeneralPaymentWebhookController
         in: 'query',
         required: false,
         description: 'Optional provider hint used to route webhook events.',
-        schema: new OA\Schema(type: 'string', enum: ['paypal', 'stripe', 'mock']),
+        schema: new OA\Schema(type: 'string', enum: ['paypal', 'stripe', 'mock'], example: 'stripe'),
     )]
     #[OA\Post(
         summary: 'Receive provider webhook notifications for global shop payments.',
-        description: 'Public endpoint independent from application context. Providers notify payment state changes through this callback.',
+        description: 'Manual /api/doc optional step 6/6: POST /v1/shop/general/payments/webhook?provider=stripe. Reuse providerReference=pi_3QyQkL2x8d9 from step 4 to simulate asynchronous provider callbacks.',
         security: [],
         requestBody: new OA\RequestBody(
             required: true,
@@ -48,8 +48,8 @@ final readonly class GeneralPaymentWebhookController
                 description: 'Provider webhook payload (shape depends on provider).',
                 examples: [
                     new OA\Examples(
-                        example: 'webhook_payload',
-                        summary: 'Stripe webhook payload example',
+                        example: 'manual_step_6_webhook_input',
+                        summary: 'Optional step 6 input - Stripe event linked to providerReference from step 4',
                         value: [
                             'id' => 'evt_1QyQtx2x8d9',
                             'type' => 'payment_intent.succeeded',

--- a/src/Shop/Transport/Controller/Api/V1/General/GetGeneralCartController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/GetGeneralCartController.php
@@ -34,13 +34,32 @@ final readonly class GetGeneralCartController
      * @throws ORMException
      */
     #[Route('/v1/shop/general/carts/{shopId}', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'shopId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'shopId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid', example: 'f95da407-b9f0-4d5f-a14e-15c4b22af6e3'))]
     #[OA\Get(
         summary: 'Get the authenticated user active cart for a global shop.',
-        description: 'Independent from application scope: returns and recalculates the active cart for the authenticated user and selected shop.',
+        description: 'Manual /api/doc chain step 2/6: GET /v1/shop/general/carts/{shopId}. Reuse shopId=f95da407-b9f0-4d5f-a14e-15c4b22af6e3 from step 1 and verify cart totals before checkout in step 3.',
         security: [['Bearer' => []]],
     )]
-    #[OA\Response(response: JsonResponse::HTTP_OK, description: 'Cart retrieved.')]
+    #[OA\Response(
+        response: JsonResponse::HTTP_OK,
+        description: 'Cart retrieved.',
+        content: new OA\JsonContent(example: [
+            'id' => 'cart_8c501b14-4c4e-4f74-9ff7-cce9dd0cf1f7',
+            'shopId' => 'f95da407-b9f0-4d5f-a14e-15c4b22af6e3',
+            'userId' => 'aa5f0b80-6a57-4fa5-ab8f-321723ebfd6a',
+            'subtotal' => 129.9,
+            'itemsCount' => 2,
+            'currencyCode' => 'EUR',
+            'updatedAt' => '2026-04-15T10:10:20+00:00',
+            'items' => [[
+                'id' => 'item_922da95e-212f-435f-b20b-ced40f74f8dc',
+                'productId' => '8b673f1d-8f2f-4a81-b5e8-6f2f14b26626',
+                'quantity' => 2,
+                'unitPriceSnapshot' => 64.95,
+                'lineTotal' => 129.9,
+            ]],
+        ]),
+    )]
     #[OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Missing or invalid Bearer token.')]
     #[OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Authenticated user required.')]
     #[OA\Response(


### PR DESCRIPTION
### Motivation
- Permettre un test manuel clair et reproductible depuis `/api/doc` en fournissant un enchaînement explicite de 6 étapes (ajout produit → vérif panier → checkout → creation payment-intent → confirmation → option webhook) avec identifiants chaînés.

### Description
- Mise à jour des descriptions OpenAPI pour les endpoints globaux de checkout/paiement afin d’expliquer chaque étape du parcours manuel (étapes 1→6). 
- Ajout/renommage d’exemples de requêtes (`manual_step_*`) et d’exemples de réponses pour chaîner les IDs `shopId`, `orderId` et `providerReference` afin d’éviter toute ambiguïté dans Swagger UI. 
- Ajout d’exemples pour les paramètres de chemin/requête (`shopId`, `orderId`, `provider`) et ajout d’un exemple 200 détaillé pour `GET /v1/shop/general/carts/{shopId}`. 
- Fichiers modifiés : `AddGeneralCartItemController.php`, `GetGeneralCartController.php`, `CheckoutGeneralController.php`, `CreateGeneralPaymentIntentController.php`, `ConfirmGeneralPaymentController.php`, `GeneralPaymentWebhookController.php` (documentation-only changes, pas de logique métier).

### Testing
- Exécution de la validation de syntaxe PHP sur les contrôleurs modifiés avec `for f in ...; do php -l "$f" || exit 1; done` et aucun problème de syntaxe détecté (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfef43df648326be2a2202d4d32070)