### PR TITLE
feat(shop): add pro-grade general catalog CRUD + seo/similarity/promo filtering

### DIFF
--- a/migrations/Version20260415110000.php
+++ b/migrations/Version20260415110000.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260415110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Extend shop product with SEO/promotion/similarity metadata.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("ALTER TABLE shop_product ADD texture VARCHAR(120) DEFAULT NULL, ADD promotion_percentage SMALLINT NOT NULL DEFAULT 0, ADD seo_title VARCHAR(255) DEFAULT NULL, ADD seo_description LONGTEXT DEFAULT NULL, ADD seo_keywords JSON NOT NULL COMMENT '(DC2Type:json)'");
+        $this->addSql("UPDATE shop_product SET seo_keywords = '[]'");
+
+        $this->addSql("CREATE TABLE shop_product_similarity (product_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', similar_product_id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', INDEX IDX_EB0E08A24584665A (product_id), INDEX IDX_EB0E08A2EB959B11 (similar_product_id), PRIMARY KEY(product_id, similar_product_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+        $this->addSql('ALTER TABLE shop_product_similarity ADD CONSTRAINT FK_EB0E08A24584665A FOREIGN KEY (product_id) REFERENCES shop_product (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE shop_product_similarity ADD CONSTRAINT FK_EB0E08A2EB959B11 FOREIGN KEY (similar_product_id) REFERENCES shop_product (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE shop_product_similarity DROP FOREIGN KEY FK_EB0E08A24584665A');
+        $this->addSql('ALTER TABLE shop_product_similarity DROP FOREIGN KEY FK_EB0E08A2EB959B11');
+        $this->addSql('DROP TABLE shop_product_similarity');
+        $this->addSql('ALTER TABLE shop_product DROP texture, DROP promotion_percentage, DROP seo_title, DROP seo_description, DROP seo_keywords');
+    }
+}

--- a/src/Shop/Application/Service/ProductHydratorService.php
+++ b/src/Shop/Application/Service/ProductHydratorService.php
@@ -10,6 +10,7 @@ use App\Shop\Domain\Entity\Shop;
 use App\Shop\Domain\Entity\Tag;
 use App\Shop\Domain\Enum\ProductStatus;
 use App\Shop\Infrastructure\Repository\CategoryRepository;
+use App\Shop\Infrastructure\Repository\ProductRepository;
 use App\Shop\Infrastructure\Repository\TagRepository;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
@@ -19,6 +20,7 @@ final readonly class ProductHydratorService
     public function __construct(
         private CategoryRepository $categoryRepository,
         private TagRepository $tagRepository,
+        private ProductRepository $productRepository,
     ) {
     }
 
@@ -42,6 +44,9 @@ final readonly class ProductHydratorService
         if (!$partial || array_key_exists('description', $payload)) {
             $product->setDescription(($payload['description'] ?? null) !== null ? (string)$payload['description'] : null);
         }
+        if (!$partial || array_key_exists('texture', $payload)) {
+            $product->setTexture(($payload['texture'] ?? null) !== null ? (string)$payload['texture'] : null);
+        }
         if (!$partial || array_key_exists('photo', $payload)) {
             $product->setPhoto((string)($payload['photo'] ?? ''));
         }
@@ -53,6 +58,19 @@ final readonly class ProductHydratorService
         }
         if (!$partial || array_key_exists('coinsAmount', $payload)) {
             $product->setCoinsAmount((int)($payload['coinsAmount'] ?? 0));
+        }
+        if (!$partial || array_key_exists('promotionPercentage', $payload)) {
+            $product->setPromotionPercentage((int)($payload['promotionPercentage'] ?? 0));
+        }
+        if (!$partial || array_key_exists('seoTitle', $payload)) {
+            $product->setSeoTitle(($payload['seoTitle'] ?? null) !== null ? (string)$payload['seoTitle'] : null);
+        }
+        if (!$partial || array_key_exists('seoDescription', $payload)) {
+            $product->setSeoDescription(($payload['seoDescription'] ?? null) !== null ? (string)$payload['seoDescription'] : null);
+        }
+        if (!$partial || array_key_exists('seoKeywords', $payload)) {
+            $keywords = array_values(array_filter((array)($payload['seoKeywords'] ?? []), static fn (mixed $keyword): bool => is_string($keyword) && trim($keyword) !== ''));
+            $product->setSeoKeywords($keywords);
         }
         if (!$partial || array_key_exists('isFeatured', $payload)) {
             $product->setIsFeatured((bool)($payload['isFeatured'] ?? false));
@@ -92,6 +110,29 @@ final readonly class ProductHydratorService
                 }
 
                 $product->addTag($tag);
+            }
+        }
+
+        if (!$partial || array_key_exists('similarProductIds', $payload)) {
+            foreach ($product->getSimilarProducts()->toArray() as $similarProduct) {
+                $product->removeSimilarProduct($similarProduct);
+            }
+
+            foreach ((array)($payload['similarProductIds'] ?? []) as $similarProductId) {
+                if (!is_string($similarProductId) || $similarProductId === $product->getId()) {
+                    continue;
+                }
+
+                $similarProduct = $this->productRepository->find($similarProductId);
+                if (!$similarProduct instanceof Product) {
+                    continue;
+                }
+
+                if ($product->getShop() instanceof Shop && $similarProduct->getShop()?->getId() !== $product->getShop()?->getId()) {
+                    continue;
+                }
+
+                $product->addSimilarProduct($similarProduct);
             }
         }
 

--- a/src/Shop/Application/Service/ProductListService.php
+++ b/src/Shop/Application/Service/ProductListService.php
@@ -40,6 +40,9 @@ readonly class ProductListService
             'name' => trim((string)$request->query->get('name', '')),
             'category' => trim((string)$request->query->get('category', '')),
             'status' => trim((string)$request->query->get('status', '')),
+            'minPrice' => max(0, (float)$request->query->get('minPrice', 0)),
+            'maxPrice' => max(0, (float)$request->query->get('maxPrice', 0)),
+            'minPromotion' => max(0, min(100, (int)$request->query->get('promotion', $request->query->get('minPromotion', 0)))),
         ];
 
         $cacheKey = $this->cacheKeyConventionService->buildShopProductListKey($page, $limit, $filters);
@@ -83,6 +86,15 @@ readonly class ProductListService
             if ($filters['status'] !== '') {
                 $qb->andWhere('product.status = :status')->setParameter('status', $filters['status']);
             }
+            if ($filters['minPrice'] > 0) {
+                $qb->andWhere('product.price >= :minPrice')->setParameter('minPrice', (int)round($filters['minPrice'] * 100));
+            }
+            if ($filters['maxPrice'] > 0) {
+                $qb->andWhere('product.price <= :maxPrice')->setParameter('maxPrice', (int)round($filters['maxPrice'] * 100));
+            }
+            if ($filters['minPromotion'] > 0) {
+                $qb->andWhere('product.promotionPercentage >= :minPromotion')->setParameter('minPromotion', $filters['minPromotion']);
+            }
 
             if ($esIds !== null) {
                 $qb->andWhere('product.id IN (:ids)')->setParameter('ids', $esIds);
@@ -101,6 +113,15 @@ readonly class ProductListService
             }
             if ($filters['status'] !== '') {
                 $countQb->andWhere('product.status = :status')->setParameter('status', $filters['status']);
+            }
+            if ($filters['minPrice'] > 0) {
+                $countQb->andWhere('product.price >= :minPrice')->setParameter('minPrice', (int)round($filters['minPrice'] * 100));
+            }
+            if ($filters['maxPrice'] > 0) {
+                $countQb->andWhere('product.price <= :maxPrice')->setParameter('maxPrice', (int)round($filters['maxPrice'] * 100));
+            }
+            if ($filters['minPromotion'] > 0) {
+                $countQb->andWhere('product.promotionPercentage >= :minPromotion')->setParameter('minPromotion', $filters['minPromotion']);
             }
             if ($esIds !== null) {
                 $countQb->andWhere('product.id IN (:ids)')->setParameter('ids', $esIds);
@@ -122,7 +143,7 @@ readonly class ProductListService
             ];
         });
 
-        $result['meta']['filters'] = array_filter($filters, static fn (string $value): bool => $value !== '');
+        $result['meta']['filters'] = array_filter($filters, static fn (mixed $value): bool => $value !== '' && $value !== 0 && $value !== 0.0);
 
         return $result;
     }
@@ -141,6 +162,9 @@ readonly class ProductListService
             'name' => trim((string)$request->query->get('name', '')),
             'category' => trim((string)$request->query->get('category', '')),
             'status' => trim((string)$request->query->get('status', '')),
+            'minPrice' => max(0, (float)$request->query->get('minPrice', 0)),
+            'maxPrice' => max(0, (float)$request->query->get('maxPrice', 0)),
+            'minPromotion' => max(0, min(100, (int)$request->query->get('promotion', $request->query->get('minPromotion', 0)))),
         ];
 
         $cacheKey = $this->cacheKeyConventionService->buildShopProductListKey($page, $limit, array_merge($filters, ['scope' => 'global']));
@@ -186,6 +210,15 @@ readonly class ProductListService
             if ($filters['status'] !== '') {
                 $qb->andWhere('product.status = :status')->setParameter('status', $filters['status']);
             }
+            if ($filters['minPrice'] > 0) {
+                $qb->andWhere('product.price >= :minPrice')->setParameter('minPrice', (int)round($filters['minPrice'] * 100));
+            }
+            if ($filters['maxPrice'] > 0) {
+                $qb->andWhere('product.price <= :maxPrice')->setParameter('maxPrice', (int)round($filters['maxPrice'] * 100));
+            }
+            if ($filters['minPromotion'] > 0) {
+                $qb->andWhere('product.promotionPercentage >= :minPromotion')->setParameter('minPromotion', $filters['minPromotion']);
+            }
 
             if ($esIds !== null) {
                 $qb->andWhere('product.id IN (:ids)')->setParameter('ids', $esIds);
@@ -208,6 +241,15 @@ readonly class ProductListService
             if ($filters['status'] !== '') {
                 $countQb->andWhere('product.status = :status')->setParameter('status', $filters['status']);
             }
+            if ($filters['minPrice'] > 0) {
+                $countQb->andWhere('product.price >= :minPrice')->setParameter('minPrice', (int)round($filters['minPrice'] * 100));
+            }
+            if ($filters['maxPrice'] > 0) {
+                $countQb->andWhere('product.price <= :maxPrice')->setParameter('maxPrice', (int)round($filters['maxPrice'] * 100));
+            }
+            if ($filters['minPromotion'] > 0) {
+                $countQb->andWhere('product.promotionPercentage >= :minPromotion')->setParameter('minPromotion', $filters['minPromotion']);
+            }
             if ($esIds !== null) {
                 $countQb->andWhere('product.id IN (:ids)')->setParameter('ids', $esIds);
             }
@@ -229,7 +271,7 @@ readonly class ProductListService
             ];
         });
 
-        $result['meta']['filters'] = array_filter($filters, static fn (string $value): bool => $value !== '');
+        $result['meta']['filters'] = array_filter($filters, static fn (mixed $value): bool => $value !== '' && $value !== 0 && $value !== 0.0);
 
         return $result;
     }
@@ -244,21 +286,37 @@ readonly class ProductListService
             'name' => $product->getName(),
             'sku' => $product->getSku(),
             'description' => $product->getDescription(),
+            'texture' => $product->getTexture(),
             'photo' => $product->getPhoto(),
             'price' => MoneyFormatter::toApiAmount($product->getPrice()),
+            'discountedPrice' => MoneyFormatter::toApiAmount(self::computeDiscountedPrice($product)),
             'currencyCode' => $product->getCurrencyCode(),
             'stock' => $product->getStock(),
             'coinsAmount' => $product->getCoinsAmount(),
+            'promotionPercentage' => $product->getPromotionPercentage(),
             'isFeatured' => $product->isFeatured(),
             'status' => $product->getStatus()->value,
             'categoryId' => $product->getCategory()?->getId(),
             'categoryName' => $product->getCategory()?->getName(),
             'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $product->getTags()->toArray()),
+            'seo' => [
+                'title' => $product->getSeoTitle(),
+                'description' => $product->getSeoDescription(),
+                'keywords' => $product->getSeoKeywords(),
+            ],
+            'similarProductIds' => array_map(static fn (Product $similarProduct): string => $similarProduct->getId(), $product->getSimilarProducts()->toArray()),
             'updatedAt' => $product->getUpdatedAt()?->format(DATE_ATOM),
         ];
     }
 
-    /** @param array<string, string> $filters
+    private static function computeDiscountedPrice(Product $product): int
+    {
+        $discountRatio = max(0.0, min(1.0, $product->getPromotionPercentage() / 100));
+
+        return (int)round($product->getPrice() * (1 - $discountRatio));
+    }
+
+    /** @param array<string, mixed> $filters
      * @return array<int, string>|null
      */
     private function searchIdsFromElastic(array $filters): ?array

--- a/src/Shop/Application/Service/SimilarProductService.php
+++ b/src/Shop/Application/Service/SimilarProductService.php
@@ -19,6 +19,21 @@ readonly class SimilarProductService
      */
     public function getSimilarProducts(Product $product, int $limit = 8): array
     {
-        return $this->productRepository->findSimilarCandidates($product, $limit);
+        $manual = $product->getSimilarProducts()->toArray();
+        $candidates = $this->productRepository->findSimilarCandidates($product, $limit);
+
+        $merged = [];
+        foreach (array_merge($manual, $candidates) as $item) {
+            if (!$item instanceof Product) {
+                continue;
+            }
+
+            $merged[$item->getId()] = $item;
+            if (count($merged) >= $limit) {
+                break;
+            }
+        }
+
+        return array_values($merged);
     }
 }

--- a/src/Shop/Domain/Entity/Product.php
+++ b/src/Shop/Domain/Entity/Product.php
@@ -45,6 +45,9 @@ class Product implements EntityInterface
     #[ORM\Column(name: 'description', type: Types::TEXT, nullable: true)]
     private ?string $description = null;
 
+    #[ORM\Column(name: 'texture', type: Types::STRING, length: 120, nullable: true)]
+    private ?string $texture = null;
+
     #[ORM\Column(name: 'photo', type: Types::STRING, length: 1024, options: [
         'default' => '',
     ])]
@@ -70,6 +73,23 @@ class Product implements EntityInterface
     ])]
     private int $coinsAmount = 0;
 
+    #[ORM\Column(name: 'promotion_percentage', type: Types::SMALLINT, options: [
+        'default' => 0,
+    ])]
+    private int $promotionPercentage = 0;
+
+    #[ORM\Column(name: 'seo_title', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $seoTitle = null;
+
+    #[ORM\Column(name: 'seo_description', type: Types::TEXT, nullable: true)]
+    private ?string $seoDescription = null;
+
+    /** @var array<int, string> */
+    #[ORM\Column(name: 'seo_keywords', type: Types::JSON, options: [
+        'default' => '[]',
+    ])]
+    private array $seoKeywords = [];
+
     #[ORM\Column(name: 'is_featured', type: Types::BOOLEAN, options: [
         'default' => false,
     ])]
@@ -83,10 +103,18 @@ class Product implements EntityInterface
     #[ORM\JoinTable(name: 'shop_product_tag')]
     private Collection|ArrayCollection $tags;
 
+    /** @var Collection<int, Product>|ArrayCollection<int, Product> */
+    #[ORM\ManyToMany(targetEntity: self::class)]
+    #[ORM\JoinTable(name: 'shop_product_similarity')]
+    #[ORM\JoinColumn(name: 'product_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    #[ORM\InverseJoinColumn(name: 'similar_product_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
+    private Collection|ArrayCollection $similarProducts;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
         $this->tags = new ArrayCollection();
+        $this->similarProducts = new ArrayCollection();
     }
 
     #[Override]
@@ -155,6 +183,18 @@ class Product implements EntityInterface
         return $this;
     }
 
+    public function getTexture(): ?string
+    {
+        return $this->texture;
+    }
+
+    public function setTexture(?string $texture): self
+    {
+        $this->texture = $texture !== null ? trim($texture) : null;
+
+        return $this;
+    }
+
     public function getPhoto(): string
     {
         return $this->photo;
@@ -215,6 +255,60 @@ class Product implements EntityInterface
         return $this;
     }
 
+    public function getPromotionPercentage(): int
+    {
+        return $this->promotionPercentage;
+    }
+
+    public function setPromotionPercentage(int $promotionPercentage): self
+    {
+        $this->promotionPercentage = min(100, max(0, $promotionPercentage));
+
+        return $this;
+    }
+
+    public function getSeoTitle(): ?string
+    {
+        return $this->seoTitle;
+    }
+
+    public function setSeoTitle(?string $seoTitle): self
+    {
+        $this->seoTitle = $seoTitle !== null ? trim($seoTitle) : null;
+
+        return $this;
+    }
+
+    public function getSeoDescription(): ?string
+    {
+        return $this->seoDescription;
+    }
+
+    public function setSeoDescription(?string $seoDescription): self
+    {
+        $this->seoDescription = $seoDescription !== null ? trim($seoDescription) : null;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getSeoKeywords(): array
+    {
+        return $this->seoKeywords;
+    }
+
+    /**
+     * @param array<int, string> $seoKeywords
+     */
+    public function setSeoKeywords(array $seoKeywords): self
+    {
+        $this->seoKeywords = array_values(array_filter(array_map(static fn (mixed $keyword): string => trim((string)$keyword), $seoKeywords), static fn (string $keyword): bool => $keyword !== ''));
+
+        return $this;
+    }
+
     public function isFeatured(): bool
     {
         return $this->isFeatured;
@@ -259,6 +353,34 @@ class Product implements EntityInterface
     public function removeTag(Tag $tag): self
     {
         $this->tags->removeElement($tag);
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, Product>|ArrayCollection<int, Product>
+     */
+    public function getSimilarProducts(): Collection|ArrayCollection
+    {
+        return $this->similarProducts;
+    }
+
+    public function addSimilarProduct(Product $product): self
+    {
+        if ($product->getId() === $this->getId()) {
+            return $this;
+        }
+
+        if (!$this->similarProducts->contains($product)) {
+            $this->similarProducts->add($product);
+        }
+
+        return $this;
+    }
+
+    public function removeSimilarProduct(Product $product): self
+    {
+        $this->similarProducts->removeElement($product);
 
         return $this;
     }

--- a/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
+++ b/src/Shop/Infrastructure/DataFixtures/ORM/LoadShopData.php
@@ -72,10 +72,15 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
             sku: 'COINS-200',
             price: 200,
             stock: 999999,
-            description: 'Crédite 200 coins.',
+            description: 'Pack d’entrée idéal pour commencer rapidement: crédite 200 coins, actif immédiatement, et parfait pour débloquer les premières options premium.',
             photo: $this->buildAssetUrl('/img/shop/products/200.png'),
             coinsAmount: 200,
             isFeatured: true,
+            texture: 'digital-wallet',
+            promotionPercentage: 10,
+            seoTitle: 'Pack 200 coins - Starter',
+            seoDescription: 'Pack starter de 200 coins pour booster votre progression dès les premières minutes.',
+            seoKeywords: ['coins', 'starter', 'pack'],
         );
 
         $this->findOrCreateProduct(
@@ -86,10 +91,15 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
             sku: 'COINS-400',
             price: 360,
             stock: 999999,
-            description: 'Crédite 400 coins.',
+            description: 'Offre intermédiaire avec 400 coins, pensée pour les joueurs réguliers qui veulent une progression fluide et de meilleures marges d’optimisation.',
             photo: $this->buildAssetUrl('/img/shop/products/400.png'),
             coinsAmount: 400,
             isFeatured: true,
+            texture: 'digital-wallet',
+            promotionPercentage: 20,
+            seoTitle: 'Pack 400 coins - Smart Value',
+            seoDescription: 'Pack 400 coins avec excellent rapport quantité/prix pour progresser plus vite.',
+            seoKeywords: ['coins', 'value', 'promotion'],
         );
 
         $this->findOrCreateProduct(
@@ -100,10 +110,15 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
             sku: 'COINS-600',
             price: 500,
             stock: 999999,
-            description: 'Crédite 600 coins.',
+            description: 'Pack le plus avantageux de la gamme coins: 600 coins crédités avec un bonus tarifaire adapté aux sessions intensives et achats récurrents.',
             photo: $this->buildAssetUrl('/img/shop/products/600.png'),
             coinsAmount: 600,
             isFeatured: true,
+            texture: 'digital-wallet-premium',
+            promotionPercentage: 25,
+            seoTitle: 'Pack 600 coins - Best Seller',
+            seoDescription: 'Pack premium 600 coins pour les utilisateurs power et achats fréquents.',
+            seoKeywords: ['coins', 'premium', 'best seller'],
         );
 
         $this->findOrCreateProduct(
@@ -306,6 +321,11 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
         string $photo,
         int $coinsAmount = 0,
         bool $isFeatured = false,
+        ?string $texture = null,
+        int $promotionPercentage = 0,
+        ?string $seoTitle = null,
+        ?string $seoDescription = null,
+        array $seoKeywords = [],
     ): Product {
         $product = $manager->getRepository(Product::class)->findOneBy(['sku' => $sku]);
 
@@ -320,6 +340,11 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
                 ->setCurrencyCode('EUR')
                 ->setStock($stock)
                 ->setCoinsAmount($coinsAmount)
+                ->setTexture($texture)
+                ->setPromotionPercentage($promotionPercentage)
+                ->setSeoTitle($seoTitle)
+                ->setSeoDescription($seoDescription)
+                ->setSeoKeywords($seoKeywords)
                 ->setStatus(ProductStatus::ACTIVE)
                 ->setIsFeatured($isFeatured);
         }
@@ -335,6 +360,11 @@ final class LoadShopData extends Fixture implements OrderedFixtureInterface
             ->setCurrencyCode('EUR')
             ->setStock($stock)
             ->setCoinsAmount($coinsAmount)
+            ->setTexture($texture)
+            ->setPromotionPercentage($promotionPercentage)
+            ->setSeoTitle($seoTitle)
+            ->setSeoDescription($seoDescription)
+            ->setSeoKeywords($seoKeywords)
             ->setStatus(ProductStatus::ACTIVE)
             ->setIsFeatured($isFeatured);
         $manager->persist($product);

--- a/src/Shop/Transport/Controller/Api/V1/General/CreateGeneralCategoryController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/CreateGeneralCategoryController.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\General\Application\Message\EntityCreated;
+use App\Shop\Application\Service\SlugBuilderService;
+use App\Shop\Domain\Entity\Category;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Shop\Transport\Controller\Api\V1\Input\Category\CategoryInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Category\CreateCategoryInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class CreateGeneralCategoryController
+{
+    public function __construct(
+        private ShopRepository $shopRepository,
+        private SlugBuilderService $slugBuilderService,
+        private CategoryInputValidator $categoryInputValidator,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    #[Route('/v1/shop/general/categories', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Create category in global shop scope')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $shop = $this->shopRepository->findGlobalShop();
+        if (!$shop instanceof Shop) {
+            return new JsonResponse(['message' => 'Global shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        try {
+            $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
+
+        $input = CreateCategoryInput::fromArray($payload);
+        $validationResponse = $this->categoryInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $category = (new Category())
+            ->setShop($shop)
+            ->setName($input->name)
+            ->setSlug($this->slugBuilderService->buildSlug((string)($input->slug ?? $input->name)))
+            ->setDescription($input->description)
+            ->setPhoto((string)($input->photo ?? ''));
+
+        $this->entityManager->persist($category);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('shop_category', $category->getId()));
+
+        return new JsonResponse(['id' => $category->getId()], JsonResponse::HTTP_CREATED);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/General/CreateGeneralProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/CreateGeneralProductController.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\General\Application\Message\EntityCreated;
+use App\Shop\Application\Service\ProductHydratorService;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Domain\Entity\Shop;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Shop\Transport\Controller\Api\V1\Input\Product\CreateProductInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Product\ProductInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class CreateGeneralProductController
+{
+    public function __construct(
+        private ShopRepository $shopRepository,
+        private ProductHydratorService $productHydratorService,
+        private ProductInputValidator $productInputValidator,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    #[Route('/v1/shop/general/products', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Create product in global shop scope')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        $shop = $this->shopRepository->findGlobalShop();
+        if (!$shop instanceof Shop) {
+            return new JsonResponse(['message' => 'Global shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        try {
+            $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
+
+        $input = CreateProductInput::fromArray($payload);
+        $validationResponse = $this->productInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $product = $this->productHydratorService->hydrateProduct(new Product()->setShop($shop), $payload);
+
+        $this->entityManager->persist($product);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('shop_product', $product->getId()));
+
+        return new JsonResponse(['id' => $product->getId()], JsonResponse::HTTP_CREATED);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/General/DeleteGeneralCategoryController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/DeleteGeneralCategoryController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\General\Application\Message\EntityDeleted;
+use App\Shop\Domain\Entity\Category;
+use App\Shop\Infrastructure\Repository\CategoryRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class DeleteGeneralCategoryController
+{
+    public function __construct(
+        private ShopRepository $shopRepository,
+        private CategoryRepository $categoryRepository,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    #[Route('/v1/shop/general/categories/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Delete(summary: 'Delete category from global shop scope')]
+    public function __invoke(string $id): JsonResponse
+    {
+        $globalShop = $this->shopRepository->findGlobalShop();
+        if ($globalShop === null) {
+            return new JsonResponse(['message' => 'Global shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $category = $this->categoryRepository->findOneByIdAndShop($id, $globalShop);
+        if (!$category instanceof Category) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($category);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('shop_category', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/General/DeleteGeneralProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/DeleteGeneralProductController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\General\Application\Message\EntityDeleted;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class DeleteGeneralProductController
+{
+    public function __construct(
+        private ShopRepository $shopRepository,
+        private ProductRepository $productRepository,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    #[Route('/v1/shop/general/products/{id}', methods: [Request::METHOD_DELETE])]
+    #[OA\Delete(summary: 'Delete product from global shop scope')]
+    public function __invoke(string $id): JsonResponse
+    {
+        $shop = $this->shopRepository->findGlobalShop();
+        if ($shop === null) {
+            return new JsonResponse(['message' => 'Global shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $product = $this->productRepository->findOneByIdAndShop($id, $shop);
+        if (!$product instanceof Product) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $this->entityManager->remove($product);
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityDeleted('shop_product', $id));
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/General/GetGeneralCategoryController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/GetGeneralCategoryController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\Shop\Application\Service\ShopApiSerializer;
+use App\Shop\Domain\Entity\Category;
+use App\Shop\Infrastructure\Repository\CategoryRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+final readonly class GetGeneralCategoryController
+{
+    public function __construct(
+        private ShopRepository $shopRepository,
+        private CategoryRepository $categoryRepository,
+    ) {
+    }
+
+    #[Route('/v1/shop/general/categories/{category}', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Get one category in global shop scope')]
+    public function __invoke(Category $category): JsonResponse
+    {
+        $shop = $this->shopRepository->findGlobalShop();
+        if ($shop === null) {
+            return new JsonResponse(['message' => 'Global shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $scopedCategory = $this->categoryRepository->findOneByIdAndShop($category->getId(), $shop);
+        if (!$scopedCategory instanceof Category) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        return new JsonResponse([
+            'category' => ShopApiSerializer::serializeCategory($scopedCategory),
+        ]);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/General/GetGeneralProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/GetGeneralProductController.php
@@ -8,6 +8,7 @@ use App\Shop\Application\Service\ProductListService;
 use App\Shop\Application\Service\SimilarProductService;
 use App\Shop\Domain\Entity\Product;
 use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,6 +23,7 @@ final readonly class GetGeneralProductController
 {
     public function __construct(
         private ProductRepository $productRepository,
+        private ShopRepository $shopRepository,
         private SimilarProductService $similarProductService,
     ) {
     }
@@ -31,13 +33,23 @@ final readonly class GetGeneralProductController
     #[OA\Parameter(name: 'id', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     public function __invoke(Product $product): JsonResponse
     {
+        $shop = $this->shopRepository->findGlobalShop();
+        if ($shop === null) {
+            return new JsonResponse(['message' => 'Global shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $scopedProduct = $this->productRepository->findOneByIdAndShop($product->getId(), $shop);
+        if (!$scopedProduct instanceof Product) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
         $similarProducts = array_map(
             static fn (Product $similarProduct): array => ProductListService::serializeProduct($similarProduct),
-            $this->similarProductService->getSimilarProducts($product),
+            $this->similarProductService->getSimilarProducts($scopedProduct),
         );
 
         return new JsonResponse([
-            'product' => ProductListService::serializeProduct($product),
+            'product' => ProductListService::serializeProduct($scopedProduct),
             'similarProducts' => $similarProducts,
         ]);
     }

--- a/src/Shop/Transport/Controller/Api/V1/General/ListGeneralProductsController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/ListGeneralProductsController.php
@@ -36,6 +36,9 @@ final readonly class ListGeneralProductsController
     #[OA\Parameter(name: 'name', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'category', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'status', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'minPrice', in: 'query', required: false, schema: new OA\Schema(type: 'number', format: 'float', minimum: 0))]
+    #[OA\Parameter(name: 'maxPrice', in: 'query', required: false, schema: new OA\Schema(type: 'number', format: 'float', minimum: 0))]
+    #[OA\Parameter(name: 'promotion', in: 'query', required: false, description: 'Minimum promotion percentage to match (e.g. 20 means >=20%).', schema: new OA\Schema(type: 'integer', minimum: 0, maximum: 100))]
     public function __invoke(Request $request): JsonResponse
     {
         return new JsonResponse($this->productListService->getGlobalList($request));

--- a/src/Shop/Transport/Controller/Api/V1/General/PatchGeneralCategoryController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/PatchGeneralCategoryController.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\General\Application\Message\EntityCreated;
+use App\Shop\Application\Service\SlugBuilderService;
+use App\Shop\Domain\Entity\Category;
+use App\Shop\Infrastructure\Repository\CategoryRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Shop\Transport\Controller\Api\V1\Input\Category\CategoryInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Category\CreateCategoryInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class PatchGeneralCategoryController
+{
+    public function __construct(
+        private ShopRepository $shopRepository,
+        private CategoryRepository $categoryRepository,
+        private SlugBuilderService $slugBuilderService,
+        private CategoryInputValidator $categoryInputValidator,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    #[Route('/v1/shop/general/categories/{id}', methods: [Request::METHOD_PATCH])]
+    #[OA\Patch(summary: 'Patch category in global shop scope')]
+    public function __invoke(string $id, Request $request): JsonResponse
+    {
+        $globalShop = $this->shopRepository->findGlobalShop();
+        if ($globalShop === null) {
+            return new JsonResponse(['message' => 'Global shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $category = $this->categoryRepository->findOneByIdAndShop($id, $globalShop);
+        if (!$category instanceof Category) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        try {
+            $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
+
+        $input = CreateCategoryInput::fromArray($payload);
+        $validationResponse = $this->categoryInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $category
+            ->setName($input->name)
+            ->setSlug($this->slugBuilderService->buildSlug((string)($input->slug ?? $input->name)))
+            ->setDescription($input->description)
+            ->setPhoto((string)($input->photo ?? ''));
+
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('shop_category', $category->getId()));
+
+        return new JsonResponse(['category' => [
+            'id' => $category->getId(),
+            'name' => $category->getName(),
+            'slug' => $category->getSlug(),
+            'description' => $category->getDescription(),
+            'photo' => $category->getPhoto(),
+        ]]);
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/General/PatchGeneralProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/General/PatchGeneralProductController.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shop\Transport\Controller\Api\V1\General;
+
+use App\General\Application\Message\EntityCreated;
+use App\Shop\Application\Service\ProductHydratorService;
+use App\Shop\Application\Service\ProductListService;
+use App\Shop\Domain\Entity\Product;
+use App\Shop\Infrastructure\Repository\ProductRepository;
+use App\Shop\Infrastructure\Repository\ShopRepository;
+use App\Shop\Transport\Controller\Api\V1\Input\Product\PatchProductInput;
+use App\Shop\Transport\Controller\Api\V1\Input\Product\ProductInputValidator;
+use App\Shop\Transport\Controller\Api\V1\Input\Support\ValidationResponseFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Shop')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class PatchGeneralProductController
+{
+    public function __construct(
+        private ShopRepository $shopRepository,
+        private ProductRepository $productRepository,
+        private ProductHydratorService $productHydratorService,
+        private ProductInputValidator $productInputValidator,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @throws ExceptionInterface
+     */
+    #[Route('/v1/shop/general/products/{id}', methods: [Request::METHOD_PATCH])]
+    #[OA\Patch(summary: 'Patch product in global shop scope')]
+    public function __invoke(string $id, Request $request): JsonResponse
+    {
+        $shop = $this->shopRepository->findGlobalShop();
+        if ($shop === null) {
+            return new JsonResponse(['message' => 'Global shop not found.'], JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        $product = $this->productRepository->findOneByIdAndShop($id, $shop);
+        if (!$product instanceof Product) {
+            return new JsonResponse(status: JsonResponse::HTTP_NOT_FOUND);
+        }
+
+        try {
+            $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return ValidationResponseFactory::invalidJson();
+        }
+
+        $input = PatchProductInput::fromArray($payload);
+        $validationResponse = $this->productInputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $this->productHydratorService->hydrateProduct($product, $payload, true);
+
+        $this->entityManager->flush();
+        $this->messageBus->dispatch(new EntityCreated('shop_product', $product->getId()));
+
+        return new JsonResponse(ProductListService::serializeProduct($product));
+    }
+}

--- a/src/Shop/Transport/Controller/Api/V1/Input/Product/CreateProductInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Product/CreateProductInput.php
@@ -24,15 +24,30 @@ final class CreateProductInput
     #[Assert\GreaterThanOrEqual(value: 0, message: 'coinsAmount must be greater than or equal to 0.')]
     public int $coinsAmount = 0;
 
+    #[Assert\Range(min: 0, max: 100, notInRangeMessage: 'promotionPercentage must be between {{ min }} and {{ max }}.')]
+    public int $promotionPercentage = 0;
+
     public ?string $description = null;
+    public ?string $texture = null;
     public ?string $photo = null;
     public ?string $currencyCode = null;
     public ?string $categoryId = null;
+    public ?string $seoTitle = null;
+    public ?string $seoDescription = null;
+
+    /**
+     * @var array<int, string>
+     */
+    public array $seoKeywords = [];
 
     /**
      * @var array<int, string>
      */
     public array $tagIds = [];
+    /**
+     * @var array<int, string>
+     */
+    public array $similarProductIds = [];
 
     public bool $isFeatured = false;
     public ?string $status = null;
@@ -50,11 +65,17 @@ final class CreateProductInput
         $input->price = (float)($payload['price'] ?? 0);
         $input->stock = (int)($payload['stock'] ?? 0);
         $input->coinsAmount = (int)($payload['coinsAmount'] ?? 0);
+        $input->promotionPercentage = (int)($payload['promotionPercentage'] ?? 0);
         $input->description = ($payload['description'] ?? null) !== null ? (string)$payload['description'] : null;
+        $input->texture = ($payload['texture'] ?? null) !== null ? (string)$payload['texture'] : null;
         $input->photo = is_string($payload['photo'] ?? null) ? trim((string)$payload['photo']) : null;
         $input->currencyCode = is_string($payload['currencyCode'] ?? null) ? trim((string)$payload['currencyCode']) : null;
         $input->categoryId = is_string($payload['categoryId'] ?? null) ? trim((string)$payload['categoryId']) : null;
+        $input->seoTitle = is_string($payload['seoTitle'] ?? null) ? trim((string)$payload['seoTitle']) : null;
+        $input->seoDescription = is_string($payload['seoDescription'] ?? null) ? trim((string)$payload['seoDescription']) : null;
+        $input->seoKeywords = array_values(array_filter((array)($payload['seoKeywords'] ?? []), static fn (mixed $keyword): bool => is_string($keyword) && trim($keyword) !== ''));
         $input->tagIds = array_values(array_filter((array)($payload['tagIds'] ?? []), static fn (mixed $id): bool => is_string($id)));
+        $input->similarProductIds = array_values(array_filter((array)($payload['similarProductIds'] ?? []), static fn (mixed $id): bool => is_string($id)));
         $input->isFeatured = (bool)($payload['isFeatured'] ?? false);
         $input->status = is_string($payload['status'] ?? null) ? (string)$payload['status'] : null;
         $input->shopId = is_string($payload['shopId'] ?? null) ? trim((string)$payload['shopId']) : null;

--- a/src/Shop/Transport/Controller/Api/V1/Input/Product/PatchProductInput.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Product/PatchProductInput.php
@@ -11,15 +11,27 @@ final class PatchProductInput
     public ?float $price = null;
     public ?int $stock = null;
     public ?int $coinsAmount = null;
+    public ?int $promotionPercentage = null;
     public ?string $description = null;
+    public ?string $texture = null;
     public ?string $photo = null;
     public ?string $currencyCode = null;
     public ?string $categoryId = null;
+    public ?string $seoTitle = null;
+    public ?string $seoDescription = null;
+    /**
+     * @var array<int, string>|null
+     */
+    public ?array $seoKeywords = null;
 
     /**
      * @var array<int, string>|null
      */
     public ?array $tagIds = null;
+    /**
+     * @var array<int, string>|null
+     */
+    public ?array $similarProductIds = null;
 
     public ?bool $isFeatured = null;
     public ?string $status = null;
@@ -35,12 +47,22 @@ final class PatchProductInput
         $input->price = array_key_exists('price', $payload) ? (float)$payload['price'] : null;
         $input->stock = array_key_exists('stock', $payload) ? (int)$payload['stock'] : null;
         $input->coinsAmount = array_key_exists('coinsAmount', $payload) ? (int)$payload['coinsAmount'] : null;
+        $input->promotionPercentage = array_key_exists('promotionPercentage', $payload) ? (int)$payload['promotionPercentage'] : null;
         $input->description = array_key_exists('description', $payload) ? (($payload['description'] ?? null) !== null ? (string)$payload['description'] : null) : null;
+        $input->texture = array_key_exists('texture', $payload) ? (($payload['texture'] ?? null) !== null ? (string)$payload['texture'] : null) : null;
         $input->photo = array_key_exists('photo', $payload) ? (($payload['photo'] ?? null) !== null ? trim((string)$payload['photo']) : null) : null;
         $input->currencyCode = array_key_exists('currencyCode', $payload) ? (($payload['currencyCode'] ?? null) !== null ? (string)$payload['currencyCode'] : null) : null;
         $input->categoryId = array_key_exists('categoryId', $payload) ? (($payload['categoryId'] ?? null) !== null ? (string)$payload['categoryId'] : null) : null;
+        $input->seoTitle = array_key_exists('seoTitle', $payload) ? (($payload['seoTitle'] ?? null) !== null ? (string)$payload['seoTitle'] : null) : null;
+        $input->seoDescription = array_key_exists('seoDescription', $payload) ? (($payload['seoDescription'] ?? null) !== null ? (string)$payload['seoDescription'] : null) : null;
+        if (array_key_exists('seoKeywords', $payload)) {
+            $input->seoKeywords = array_values(array_filter((array)$payload['seoKeywords'], static fn (mixed $keyword): bool => is_string($keyword) && trim($keyword) !== ''));
+        }
         if (array_key_exists('tagIds', $payload)) {
             $input->tagIds = array_values(array_filter((array)$payload['tagIds'], static fn (mixed $id): bool => is_string($id)));
+        }
+        if (array_key_exists('similarProductIds', $payload)) {
+            $input->similarProductIds = array_values(array_filter((array)$payload['similarProductIds'], static fn (mixed $id): bool => is_string($id)));
         }
         $input->isFeatured = array_key_exists('isFeatured', $payload) ? (bool)$payload['isFeatured'] : null;
         $input->status = array_key_exists('status', $payload) ? (($payload['status'] ?? null) !== null ? (string)$payload['status'] : null) : null;

--- a/src/Shop/Transport/Controller/Api/V1/Input/Product/ProductInputValidator.php
+++ b/src/Shop/Transport/Controller/Api/V1/Input/Product/ProductInputValidator.php
@@ -70,6 +70,13 @@ final readonly class ProductInputValidator
                 'code' => 'COINS_AMOUNT_INVALID',
             ];
         }
+        if ($input->promotionPercentage !== null && ($input->promotionPercentage < 0 || $input->promotionPercentage > 100)) {
+            $errors[] = [
+                'field' => 'promotionPercentage',
+                'message' => 'promotionPercentage must be between 0 and 100.',
+                'code' => 'PROMOTION_PERCENTAGE_INVALID',
+            ];
+        }
         if ($input->photo !== null && $input->photo !== '' && preg_match('#^https?://#i', $input->photo) !== 1) {
             $errors[] = [
                 'field' => 'photo',

--- a/tests/Application/Shop/Transport/Controller/Api/V1/GeneralShopCrudDocumentationExampleTest.php
+++ b/tests/Application/Shop/Transport/Controller/Api/V1/GeneralShopCrudDocumentationExampleTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Shop\Transport\Controller\Api\V1;
+
+use App\Tests\TestCase\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class GeneralShopCrudDocumentationExampleTest extends WebTestCase
+{
+    public function testGeneralShopCrudAndPromotionFilterFlowForApiDoc(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/general/categories',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'name' => 'General Decor Pro',
+                'description' => 'Catégorie premium de démonstration pour le flux API doc.',
+                'photo' => 'https://bro-world.org/img/shop/categories/decor-pro.png',
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(201);
+        /** @var array{id: string} $categoryPayload */
+        $categoryPayload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $client->request(
+            Request::METHOD_POST,
+            self::API_URL_PREFIX . '/v1/shop/general/products',
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'name' => 'General Product Pro',
+                'sku' => 'GENERAL-PRO-001',
+                'description' => 'Description longue pour un produit global de qualité professionnelle, optimisé pour la vitrine et le référencement.',
+                'texture' => 'matte-wood',
+                'price' => 129.90,
+                'promotionPercentage' => 25,
+                'seoTitle' => 'General Product Pro | Shop',
+                'seoDescription' => 'Produit premium optimisé SEO.',
+                'seoKeywords' => ['general', 'premium', 'seo'],
+                'categoryId' => $categoryPayload['id'],
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(201);
+        /** @var array{id: string} $productPayload */
+        $productPayload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+
+        $client->request(
+            Request::METHOD_PATCH,
+            self::API_URL_PREFIX . '/v1/shop/general/products/' . $productPayload['id'],
+            [],
+            [],
+            $this->getJsonHeaders(),
+            json_encode([
+                'similarProductIds' => [],
+                'tagIds' => [],
+                'promotionPercentage' => 30,
+            ], JSON_THROW_ON_ERROR)
+        );
+
+        self::assertResponseStatusCodeSame(200);
+
+        $client->request(
+            Request::METHOD_GET,
+            self::API_URL_PREFIX . '/v1/shop/general/products?promotion=20&minPrice=50&maxPrice=500'
+        );
+
+        self::assertResponseIsSuccessful();
+        /** @var array{items: array<int, array{promotionPercentage?: int}>} $listPayload */
+        $listPayload = json_decode((string)$client->getResponse()->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertNotEmpty($listPayload['items']);
+        self::assertContains(30, array_map(static fn (array $item): int => (int)($item['promotionPercentage'] ?? 0), $listPayload['items']));
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a professional global (general) catalog CRUD so platform-wide shops can manage categories and products independently from application-specific shops. 
- Expose advanced merchandising metadata (texture, promotion, SEO, manual similar products) so product teams can control SEO, display and promoted pricing. 
- Allow clients to filter product listings by price range and by minimum promotion percentage (e.g. `promotion=20` => >=20%).

### Description
- Extended the `Product` entity with `texture`, `promotionPercentage`, `seoTitle`, `seoDescription`, and `seoKeywords`, and added a many-to-many `shop_product_similarity` relation; migration at `migrations/Version20260415110000.php` adds the columns and similarity table. 
- Added full global-scope CRUD controllers under `/v1/shop/general/...` for categories and products: `CreateGeneralCategoryController`, `GetGeneralCategoryController`, `PatchGeneralCategoryController`, `DeleteGeneralCategoryController`, `CreateGeneralProductController`, `GetGeneralProductController`, `PatchGeneralProductController`, and `DeleteGeneralProductController`. 
- Extended input DTOs and validator (`CreateProductInput`, `PatchProductInput`, `ProductInputValidator`) and updated `ProductHydratorService` to support SEO, texture, `promotionPercentage` and `similarProductIds`; `SimilarProductService` now merges manual similar products with algorithmic candidates. 
- Enhanced `ProductListService::serializeProduct` to include `texture`, `promotionPercentage`, `discountedPrice`, `seo` block and `similarProductIds`, and added `minPrice`, `maxPrice` and `promotion` filters to product listing and global listing endpoints with OpenAPI parameters on `ListGeneralProductsController`. 
- Updated fixtures (`LoadShopData.php`) with longer product descriptions and example SEO/texture/promotion values, and added an example integration test `GeneralShopCrudDocumentationExampleTest` to demonstrate doc flow and the promotion filter.

### Testing
- Ran PHP syntax checks with `php -l` over all modified PHP files and there were no syntax errors. 
- Attempted to run the added PHPUnit example but the test runner was not available in this environment so `vendor/bin/phpunit` / `php bin/phpunit` could not be executed (no vendor/phpunit binary present).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dffed8b5948326873ea1b90784da28)