### PR TITLE
Add invokable controllers for general recruit API v1 endpoints

### DIFF
--- a/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicantController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicantController.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\General;
+
+use App\Recruit\Domain\Entity\Applicant;
+use App\Recruit\Infrastructure\Repository\ApplicantRepository;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_string;
+use function trim;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Applicant')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class CreateGeneralApplicantController
+{
+    public function __construct(
+        private ApplicantRepository $applicantRepository,
+        private ResumeRepository $resumeRepository,
+    ) {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route(path: '/v1/recruit/general/applicants', methods: [Request::METHOD_POST])]
+    #[OA\Post(
+        summary: 'Crée un candidat lié au CV du user connecté.',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['resumeId'],
+                properties: [
+                    new OA\Property(property: 'resumeId', type: 'string', format: 'uuid'),
+                    new OA\Property(property: 'coverLetter', type: 'string', example: 'Je suis motivé pour ce poste.'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 201, description: 'Candidat créé.'),
+            new OA\Response(response: 400, description: 'Payload invalide.'),
+        ],
+    )]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+
+        $resumeId = $payload['resumeId'] ?? null;
+        $coverLetter = $payload['coverLetter'] ?? '';
+
+        if (!is_string($resumeId) || !Uuid::isValid($resumeId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "resumeId" must be a valid UUID.');
+        }
+
+        if (!is_string($coverLetter)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "coverLetter" must be a string.');
+        }
+
+        $resume = $this->resumeRepository->find($resumeId);
+        if ($resume === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "resumeId".');
+        }
+
+        if ($resume->getOwner()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'The given resume does not belong to the authenticated user.');
+        }
+
+        $applicant = new Applicant()
+            ->setUser($loggedInUser)
+            ->setResume($resume)
+            ->setCoverLetter(trim($coverLetter));
+
+        $this->applicantRepository->save($applicant);
+
+        return new JsonResponse([
+            'id' => $applicant->getId(),
+        ], JsonResponse::HTTP_CREATED);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicationController.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\General;
+
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Recruit\Infrastructure\Repository\ApplicantRepository;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Infrastructure\Repository\JobRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Application')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class CreateGeneralApplicationController
+{
+    public function __construct(
+        private ApplicationRepository $applicationRepository,
+        private ApplicantRepository $applicantRepository,
+        private JobRepository $jobRepository,
+    ) {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route(path: '/v1/recruit/general/applications', methods: [Request::METHOD_POST])]
+    #[OA\Post(
+        summary: 'Crée une candidature pour un job.',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['applicantId', 'jobId'],
+                properties: [
+                    new OA\Property(property: 'applicantId', type: 'string', format: 'uuid'),
+                    new OA\Property(property: 'jobId', type: 'string', format: 'uuid'),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 201, description: 'Candidature créée.'),
+            new OA\Response(response: 400, description: 'Payload invalide.'),
+        ],
+    )]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+
+        $applicantId = $payload['applicantId'] ?? null;
+        $jobId = $payload['jobId'] ?? null;
+        if (!is_string($applicantId) || !Uuid::isValid($applicantId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "applicantId" must be a valid UUID.');
+        }
+
+        if (!is_string($jobId) || !Uuid::isValid($jobId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "jobId" must be a valid UUID.');
+        }
+
+        $applicant = $this->applicantRepository->find($applicantId);
+        if ($applicant === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicantId".');
+        }
+
+        if ($applicant->getUser()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'The given applicant does not belong to the authenticated user.');
+        }
+
+        $job = $this->jobRepository->find($jobId);
+        if ($job === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "jobId".');
+        }
+
+        $existingApplication = $this->applicationRepository->findActiveByApplicantAndJob($applicant, $job);
+        if ($existingApplication instanceof Application) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'An active application already exists for this applicant and job.');
+        }
+
+        $application = new Application()
+            ->setApplicant($applicant)
+            ->setJob($job)
+            ->setStatus(ApplicationStatus::WAITING);
+
+        $this->applicationRepository->save($application);
+
+        return new JsonResponse([
+            'id' => $application->getId(),
+            'status' => $application->getStatusValue(),
+        ], JsonResponse::HTTP_CREATED);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralResumeController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralResumeController.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\General;
+
+use App\Recruit\Application\Service\ResumeDocumentUploaderService;
+use App\Recruit\Application\Service\ResumePayloadService;
+use App\Recruit\Domain\Entity\Resume;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Resume')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class CreateGeneralResumeController
+{
+    public function __construct(
+        private ResumeRepository $resumeRepository,
+        private ResumeDocumentUploaderService $resumeDocumentUploaderService,
+        private ResumePayloadService $resumePayloadService,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/general/resumes', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Crée un CV et permet l’upload optionnel d’un PDF.')]
+    #[OA\RequestBody(
+        required: false,
+        content: [
+            new OA\MediaType(
+                mediaType: 'application/json',
+                schema: new OA\Schema(ref: '#/components/schemas/RecruitGeneralResumePayloadInput'),
+            ),
+            new OA\MediaType(
+                mediaType: 'multipart/form-data',
+                schema: new OA\Schema(ref: '#/components/schemas/RecruitGeneralResumePayloadMultipartInput'),
+            ),
+        ],
+    )]
+    #[OA\Response(
+        response: 201,
+        description: 'Resume created',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                new OA\Property(property: 'documentUrl', type: 'string', nullable: true),
+            ],
+            type: 'object',
+            example: [
+                'id' => '0195f9b4-7c29-7dd2-89f6-2f7d3ef2e9aa',
+                'documentUrl' => 'https://localhost/uploads/resumes/0af6fe1514bdbce22f637d970a6e6042.pdf',
+            ],
+        ),
+    )]
+    #[OA\Response(response: 400, description: 'Invalid payload or file format')]
+    #[OA\Response(response: 401, description: 'Authentication required')]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        $payload = $this->resumePayloadService->extractPayload($request);
+
+        $resume = new Resume()->setOwner($loggedInUser);
+
+        /** @var UploadedFile|null $document */
+        $document = $request->files->get('document');
+        if ($document instanceof UploadedFile) {
+            $documentUrl = $this->resumeDocumentUploaderService->upload($request, $document, '/uploads/resumes');
+            $resume->setDocumentUrl($documentUrl);
+        }
+
+        $this->resumePayloadService->hydrateResumeSections($resume, $payload);
+
+        $this->resumeRepository->save($resume);
+
+        return new JsonResponse([
+            'id' => $resume->getId(),
+            'documentUrl' => $resume->getDocumentUrl(),
+        ], JsonResponse::HTTP_CREATED);
+    }
+}
+
+#[OA\Schema(
+    schema: 'RecruitGeneralResumePayloadInput',
+    properties: [
+        new OA\Property(property: 'experiences', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
+        new OA\Property(property: 'educations', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
+        new OA\Property(property: 'skills', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
+        new OA\Property(property: 'languages', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
+        new OA\Property(property: 'certifications', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
+        new OA\Property(property: 'projects', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
+        new OA\Property(property: 'references', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
+        new OA\Property(property: 'hobbies', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
+    ],
+    type: 'object',
+    example: [
+        'experiences' => [[
+            'title' => 'Backend Developer',
+            'description' => 'Symfony API',
+        ]],
+        'skills' => [[
+            'title' => 'PHP',
+            'description' => '8.x',
+        ]],
+    ],
+)]
+final class RecruitGeneralResumePayloadInputSchema
+{
+}
+
+#[OA\Schema(
+    schema: 'RecruitGeneralResumePayloadMultipartInput',
+    properties: [
+        new OA\Property(property: 'document', description: 'Fichier CV PDF.', type: 'string', format: 'binary'),
+        new OA\Property(property: 'experiences', description: 'JSON stringifié: [{"title":"...","description":"..."}]', type: 'string'),
+        new OA\Property(property: 'educations', description: 'JSON stringifié', type: 'string'),
+        new OA\Property(property: 'skills', description: 'JSON stringifié', type: 'string'),
+        new OA\Property(property: 'languages', description: 'JSON stringifié', type: 'string'),
+        new OA\Property(property: 'certifications', description: 'JSON stringifié', type: 'string'),
+        new OA\Property(property: 'projects', description: 'JSON stringifié', type: 'string'),
+        new OA\Property(property: 'references', description: 'JSON stringifié', type: 'string'),
+        new OA\Property(property: 'hobbies', description: 'JSON stringifié', type: 'string'),
+    ],
+    type: 'object',
+)]
+final class RecruitGeneralResumePayloadMultipartInputSchema
+{
+}

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobApplicationsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobApplicationsController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\General;
+
+use App\Recruit\Application\Security\RecruitPermissions;
+use App\Recruit\Application\Service\JobApplicationListService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Application')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::INTERVIEW_VIEW)]
+final readonly class ListGeneralJobApplicationsController
+{
+    public function __construct(
+        private JobApplicationListService $jobApplicationListService,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/general/private/job-applications', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'Liste privée des candidatures d\'un job.',
+        parameters: [
+            new OA\Parameter(name: 'jobId', description: 'UUID du job', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'uuid')),
+            new OA\Parameter(name: 'jobSlug', description: 'Slug du job', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Liste des candidatures du job.'),
+            new OA\Response(response: 403, description: 'Vous n\'êtes pas propriétaire du job.'),
+        ],
+    )]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->jobApplicationListService->getList(
+            $loggedInUser,
+            $request->query->getString('jobId', ''),
+            $request->query->getString('jobSlug', ''),
+        ));
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyJobsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyJobsController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\General;
+
+use App\Recruit\Application\Service\MyJobListService;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Job')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ListGeneralMyJobsController
+{
+    public function __construct(
+        private MyJobListService $myJobListService,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/general/private/me/jobs', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Retourne les jobs créés et les jobs postulés par le user connecté.')]
+    public function __invoke(User $loggedInUser): JsonResponse
+    {
+        return new JsonResponse($this->myJobListService->getList($loggedInUser));
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyResumesController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyResumesController.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\General;
+
+use App\Recruit\Application\Service\ResumeNormalizerService;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Resume')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class ListGeneralMyResumesController
+{
+    public function __construct(
+        private ResumeRepository $resumeRepository,
+        private ResumeNormalizerService $resumeNormalizerService,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/general/private/me/resumes', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'Retourne les CV du user connecté.')]
+    public function __invoke(User $loggedInUser): JsonResponse
+    {
+        $resumes = $this->resumeRepository->findBy([
+            'owner' => $loggedInUser,
+        ], [
+            'createdAt' => 'DESC',
+        ]);
+
+        return new JsonResponse($this->resumeNormalizerService->normalizeCollection($resumes));
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/General/UpdateGeneralApplicationStatusController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/UpdateGeneralApplicationStatusController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\General;
+
+use App\Recruit\Application\Security\RecruitPermissions;
+use App\Recruit\Application\Service\ApplicationStatusTransitionService;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_string;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Application')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted(RecruitPermissions::APPLICATION_STATUS_TRANSITION)]
+final readonly class UpdateGeneralApplicationStatusController
+{
+    public function __construct(
+        private ApplicationRepository $applicationRepository,
+        private ApplicationStatusTransitionService $applicationStatusTransitionService,
+    ) {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route(path: '/v1/recruit/general/private/applications/{applicationId}/status', methods: [Request::METHOD_PATCH])]
+    #[OA\Parameter(name: 'applicationId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Patch(
+        summary: 'Modifie le statut d\'une candidature.',
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: new OA\JsonContent(
+                required: ['status'],
+                properties: [
+                    new OA\Property(property: 'status', type: 'string', enum: ['WAITING', 'SCREENING', 'INTERVIEW_PLANNED', 'INTERVIEW_DONE', 'OFFER_SENT', 'HIRED', 'REJECTED']),
+                    new OA\Property(property: 'comment', type: 'string', nullable: true),
+                ],
+            ),
+        ),
+        responses: [
+            new OA\Response(response: 200, description: 'Statut de candidature mis à jour.'),
+            new OA\Response(response: 400, description: 'Transition invalide ou payload incomplet.'),
+            new OA\Response(response: 403, description: 'Vous n\'êtes pas propriétaire du job.'),
+            new OA\Response(response: 404, description: 'Candidature introuvable.'),
+        ],
+    )]
+    public function __invoke(string $applicationId, Request $request, User $loggedInUser): JsonResponse
+    {
+        $application = $this->applicationRepository->find($applicationId);
+
+        if ($application === null) {
+            throw new NotFoundHttpException('Application not found.');
+        }
+
+        $ownerId = $application->getJob()->getOwner()?->getId();
+        if ($ownerId === null || $ownerId !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You are not allowed to update the status for this application.');
+        }
+
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+        $comment = is_string($payload['comment'] ?? null) ? $payload['comment'] : null;
+        $this->applicationStatusTransitionService->applyStatusTransition($application, $payload['status'] ?? null, $loggedInUser, $comment);
+
+        $this->applicationRepository->save($application);
+
+        return new JsonResponse([
+            'id' => $application->getId(),
+            'status' => $application->getStatusValue(),
+        ]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose a set of "general" recruit API endpoints under `/v1/recruit/general` to support applicant, application and resume flows outside the application-scoped controllers. 
- Implement controllers as invokable `final readonly` classes with Symfony attributes to keep routing, OpenAPI docs and security consistent with existing controllers.

### Description
- Added controllers to handle general recruit flows: `CreateGeneralApplicantController`, `CreateGeneralApplicationController`, `CreateGeneralResumeController`, `ListGeneralMyJobsController`, `ListGeneralJobApplicationsController`, `UpdateGeneralApplicationStatusController`, and `ListGeneralMyResumesController` located in `src/Recruit/Transport/Controller/Api/V1/General`.
- Each controller is `#[AsController]`, routable with `#[Route]`, documented with OpenAPI attributes (`#[OA	ag]`, `#[OA\Post|Get|Patch]` and parameter/response schemas) and guards access with `#[IsGranted]` where required.
- Request payload validation, UUID checks, ownership checks and repository interactions mirror the conventions used by the existing non-general controllers (`ApplicationCreateController`, `ApplicantCreateController`, `JobApplicationListController`, `ApplicationStatusUpdateController`, `ResumeCreateController`, `MyResumeListController`, `MyJobListController`).
- Added OpenAPI schemas for resume JSON/multipart payloads and integrated optional file upload handling in the resume create controller.

### Testing
- Ran PHP syntax checks with `php -l` on all newly added controller files and the checks succeeded for each file. 
- All automated validations executed in the change pipeline passed (no syntax errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e02f8efb808326b9cac7a7e2334d27)