### PR TITLE
Create dedicated services for general recruit endpoints

### DIFF
--- a/src/Recruit/Application/Service/GeneralApplicantService.php
+++ b/src/Recruit/Application/Service/GeneralApplicantService.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Domain\Entity\Applicant;
+use App\Recruit\Infrastructure\Repository\ApplicantRepository;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+use function is_string;
+use function trim;
+
+readonly class GeneralApplicantService
+{
+    public function __construct(
+        private ApplicantRepository $applicantRepository,
+        private ResumeRepository $resumeRepository,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array{id: string}
+     *
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    public function create(array $payload, User $loggedInUser): array
+    {
+        $resumeId = $payload['resumeId'] ?? null;
+        $coverLetter = $payload['coverLetter'] ?? '';
+
+        if (!is_string($resumeId) || !Uuid::isValid($resumeId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "resumeId" must be a valid UUID.');
+        }
+
+        if (!is_string($coverLetter)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "coverLetter" must be a string.');
+        }
+
+        $resume = $this->resumeRepository->find($resumeId);
+        if ($resume === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "resumeId".');
+        }
+
+        if ($resume->getOwner()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'The given resume does not belong to the authenticated user.');
+        }
+
+        $applicant = new Applicant()
+            ->setUser($loggedInUser)
+            ->setResume($resume)
+            ->setCoverLetter(trim($coverLetter));
+
+        $this->applicantRepository->save($applicant);
+
+        return [
+            'id' => $applicant->getId(),
+        ];
+    }
+}

--- a/src/Recruit/Application/Service/GeneralApplicationService.php
+++ b/src/Recruit/Application/Service/GeneralApplicationService.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Domain\Entity\Application;
+use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Recruit\Infrastructure\Repository\ApplicantRepository;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Infrastructure\Repository\JobRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+use function is_string;
+
+readonly class GeneralApplicationService
+{
+    public function __construct(
+        private ApplicationRepository $applicationRepository,
+        private ApplicantRepository $applicantRepository,
+        private JobRepository $jobRepository,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array{id: string, status: string}
+     *
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    public function create(array $payload, User $loggedInUser): array
+    {
+        $applicantId = $payload['applicantId'] ?? null;
+        $jobId = $payload['jobId'] ?? null;
+        if (!is_string($applicantId) || !Uuid::isValid($applicantId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "applicantId" must be a valid UUID.');
+        }
+
+        if (!is_string($jobId) || !Uuid::isValid($jobId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "jobId" must be a valid UUID.');
+        }
+
+        $applicant = $this->applicantRepository->find($applicantId);
+        if ($applicant === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicantId".');
+        }
+
+        if ($applicant->getUser()->getId() !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'The given applicant does not belong to the authenticated user.');
+        }
+
+        $job = $this->jobRepository->find($jobId);
+        if ($job === null) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "jobId".');
+        }
+
+        $existingApplication = $this->applicationRepository->findActiveByApplicantAndJob($applicant, $job);
+        if ($existingApplication instanceof Application) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'An active application already exists for this applicant and job.');
+        }
+
+        $application = new Application()
+            ->setApplicant($applicant)
+            ->setJob($job)
+            ->setStatus(ApplicationStatus::WAITING);
+
+        $this->applicationRepository->save($application);
+
+        return [
+            'id' => $application->getId(),
+            'status' => $application->getStatusValue(),
+        ];
+    }
+}

--- a/src/Recruit/Application/Service/GeneralApplicationStatusService.php
+++ b/src/Recruit/Application/Service/GeneralApplicationStatusService.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+use function is_string;
+
+readonly class GeneralApplicationStatusService
+{
+    public function __construct(
+        private ApplicationRepository $applicationRepository,
+        private ApplicationStatusTransitionService $applicationStatusTransitionService,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array{id: string, status: string}
+     *
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    public function updateStatus(string $applicationId, array $payload, User $loggedInUser): array
+    {
+        $application = $this->applicationRepository->find($applicationId);
+
+        if ($application === null) {
+            throw new NotFoundHttpException('Application not found.');
+        }
+
+        $ownerId = $application->getJob()->getOwner()?->getId();
+        if ($ownerId === null || $ownerId !== $loggedInUser->getId()) {
+            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You are not allowed to update the status for this application.');
+        }
+
+        $comment = is_string($payload['comment'] ?? null) ? $payload['comment'] : null;
+        $this->applicationStatusTransitionService->applyStatusTransition($application, $payload['status'] ?? null, $loggedInUser, $comment);
+
+        $this->applicationRepository->save($application);
+
+        return [
+            'id' => $application->getId(),
+            'status' => $application->getStatusValue(),
+        ];
+    }
+}

--- a/src/Recruit/Application/Service/GeneralJobApplicationListService.php
+++ b/src/Recruit/Application/Service/GeneralJobApplicationListService.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\User\Domain\Entity\User;
+
+readonly class GeneralJobApplicationListService
+{
+    public function __construct(
+        private JobApplicationListService $jobApplicationListService,
+    ) {
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getList(User $loggedInUser, ?string $jobId, ?string $jobSlug): array
+    {
+        return $this->jobApplicationListService->getList($loggedInUser, $jobId, $jobSlug);
+    }
+}

--- a/src/Recruit/Application/Service/GeneralMyJobListService.php
+++ b/src/Recruit/Application/Service/GeneralMyJobListService.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\User\Domain\Entity\User;
+
+readonly class GeneralMyJobListService
+{
+    public function __construct(
+        private MyJobListService $myJobListService,
+    ) {
+    }
+
+    /**
+     * @return array<string, list<array<string, mixed>>>
+     */
+    public function getList(User $loggedInUser): array
+    {
+        return $this->myJobListService->getList($loggedInUser);
+    }
+}

--- a/src/Recruit/Application/Service/GeneralResumeService.php
+++ b/src/Recruit/Application/Service/GeneralResumeService.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Recruit\Domain\Entity\Resume;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\User\Domain\Entity\User;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+
+readonly class GeneralResumeService
+{
+    public function __construct(
+        private ResumeRepository $resumeRepository,
+        private ResumeDocumentUploaderService $resumeDocumentUploaderService,
+        private ResumePayloadService $resumePayloadService,
+        private ResumeNormalizerService $resumeNormalizerService,
+    ) {
+    }
+
+    /**
+     * @return array{id: string, documentUrl: ?string}
+     */
+    public function create(Request $request, User $loggedInUser): array
+    {
+        $payload = $this->resumePayloadService->extractPayload($request);
+
+        $resume = new Resume()->setOwner($loggedInUser);
+
+        /** @var UploadedFile|null $document */
+        $document = $request->files->get('document');
+        if ($document instanceof UploadedFile) {
+            $documentUrl = $this->resumeDocumentUploaderService->upload($request, $document, '/uploads/resumes');
+            $resume->setDocumentUrl($documentUrl);
+        }
+
+        $this->resumePayloadService->hydrateResumeSections($resume, $payload);
+
+        $this->resumeRepository->save($resume);
+
+        return [
+            'id' => $resume->getId(),
+            'documentUrl' => $resume->getDocumentUrl(),
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getMyResumes(User $loggedInUser): array
+    {
+        $resumes = $this->resumeRepository->findBy([
+            'owner' => $loggedInUser,
+        ], [
+            'createdAt' => 'DESC',
+        ]);
+
+        return $this->resumeNormalizerService->normalizeCollection($resumes);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicantController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicantController.php
@@ -4,24 +4,17 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\General;
 
-use App\Recruit\Domain\Entity\Applicant;
-use App\Recruit\Infrastructure\Repository\ApplicantRepository;
-use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\Recruit\Application\Service\GeneralApplicantService;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use OpenApi\Attributes as OA;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-
-use function is_string;
-use function trim;
 
 #[AsController]
 #[OA\Tag(name: 'Recruit Applicant')]
@@ -29,8 +22,7 @@ use function trim;
 final readonly class CreateGeneralApplicantController
 {
     public function __construct(
-        private ApplicantRepository $applicantRepository,
-        private ResumeRepository $resumeRepository,
+        private GeneralApplicantService $generalApplicantService,
     ) {
     }
 
@@ -61,35 +53,6 @@ final readonly class CreateGeneralApplicantController
         /** @var array<string, mixed> $payload */
         $payload = $request->toArray();
 
-        $resumeId = $payload['resumeId'] ?? null;
-        $coverLetter = $payload['coverLetter'] ?? '';
-
-        if (!is_string($resumeId) || !Uuid::isValid($resumeId)) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "resumeId" must be a valid UUID.');
-        }
-
-        if (!is_string($coverLetter)) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "coverLetter" must be a string.');
-        }
-
-        $resume = $this->resumeRepository->find($resumeId);
-        if ($resume === null) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "resumeId".');
-        }
-
-        if ($resume->getOwner()->getId() !== $loggedInUser->getId()) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'The given resume does not belong to the authenticated user.');
-        }
-
-        $applicant = new Applicant()
-            ->setUser($loggedInUser)
-            ->setResume($resume)
-            ->setCoverLetter(trim($coverLetter));
-
-        $this->applicantRepository->save($applicant);
-
-        return new JsonResponse([
-            'id' => $applicant->getId(),
-        ], JsonResponse::HTTP_CREATED);
+        return new JsonResponse($this->generalApplicantService->create($payload, $loggedInUser), JsonResponse::HTTP_CREATED);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicationController.php
@@ -4,20 +4,14 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\General;
 
-use App\Recruit\Domain\Entity\Application;
-use App\Recruit\Domain\Enum\ApplicationStatus;
-use App\Recruit\Infrastructure\Repository\ApplicantRepository;
-use App\Recruit\Infrastructure\Repository\ApplicationRepository;
-use App\Recruit\Infrastructure\Repository\JobRepository;
+use App\Recruit\Application\Service\GeneralApplicationService;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use OpenApi\Attributes as OA;
-use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -28,9 +22,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateGeneralApplicationController
 {
     public function __construct(
-        private ApplicationRepository $applicationRepository,
-        private ApplicantRepository $applicantRepository,
-        private JobRepository $jobRepository,
+        private GeneralApplicationService $generalApplicationService,
     ) {
     }
 
@@ -61,45 +53,6 @@ final readonly class CreateGeneralApplicationController
         /** @var array<string, mixed> $payload */
         $payload = $request->toArray();
 
-        $applicantId = $payload['applicantId'] ?? null;
-        $jobId = $payload['jobId'] ?? null;
-        if (!is_string($applicantId) || !Uuid::isValid($applicantId)) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "applicantId" must be a valid UUID.');
-        }
-
-        if (!is_string($jobId) || !Uuid::isValid($jobId)) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "jobId" must be a valid UUID.');
-        }
-
-        $applicant = $this->applicantRepository->find($applicantId);
-        if ($applicant === null) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicantId".');
-        }
-
-        if ($applicant->getUser()->getId() !== $loggedInUser->getId()) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'The given applicant does not belong to the authenticated user.');
-        }
-
-        $job = $this->jobRepository->find($jobId);
-        if ($job === null) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "jobId".');
-        }
-
-        $existingApplication = $this->applicationRepository->findActiveByApplicantAndJob($applicant, $job);
-        if ($existingApplication instanceof Application) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'An active application already exists for this applicant and job.');
-        }
-
-        $application = new Application()
-            ->setApplicant($applicant)
-            ->setJob($job)
-            ->setStatus(ApplicationStatus::WAITING);
-
-        $this->applicationRepository->save($application);
-
-        return new JsonResponse([
-            'id' => $application->getId(),
-            'status' => $application->getStatusValue(),
-        ], JsonResponse::HTTP_CREATED);
+        return new JsonResponse($this->generalApplicationService->create($payload, $loggedInUser), JsonResponse::HTTP_CREATED);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralResumeController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralResumeController.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\General;
 
-use App\Recruit\Application\Service\ResumeDocumentUploaderService;
-use App\Recruit\Application\Service\ResumePayloadService;
-use App\Recruit\Domain\Entity\Resume;
-use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\Recruit\Application\Service\GeneralResumeService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -24,9 +20,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateGeneralResumeController
 {
     public function __construct(
-        private ResumeRepository $resumeRepository,
-        private ResumeDocumentUploaderService $resumeDocumentUploaderService,
-        private ResumePayloadService $resumePayloadService,
+        private GeneralResumeService $generalResumeService,
     ) {
     }
 
@@ -64,25 +58,7 @@ final readonly class CreateGeneralResumeController
     #[OA\Response(response: 401, description: 'Authentication required')]
     public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {
-        $payload = $this->resumePayloadService->extractPayload($request);
-
-        $resume = new Resume()->setOwner($loggedInUser);
-
-        /** @var UploadedFile|null $document */
-        $document = $request->files->get('document');
-        if ($document instanceof UploadedFile) {
-            $documentUrl = $this->resumeDocumentUploaderService->upload($request, $document, '/uploads/resumes');
-            $resume->setDocumentUrl($documentUrl);
-        }
-
-        $this->resumePayloadService->hydrateResumeSections($resume, $payload);
-
-        $this->resumeRepository->save($resume);
-
-        return new JsonResponse([
-            'id' => $resume->getId(),
-            'documentUrl' => $resume->getDocumentUrl(),
-        ], JsonResponse::HTTP_CREATED);
+        return new JsonResponse($this->generalResumeService->create($request, $loggedInUser), JsonResponse::HTTP_CREATED);
     }
 }
 

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobApplicationsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobApplicationsController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Recruit\Transport\Controller\Api\V1\General;
 
 use App\Recruit\Application\Security\RecruitPermissions;
-use App\Recruit\Application\Service\JobApplicationListService;
+use App\Recruit\Application\Service\GeneralJobApplicationListService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListGeneralJobApplicationsController
 {
     public function __construct(
-        private JobApplicationListService $jobApplicationListService,
+        private GeneralJobApplicationListService $generalJobApplicationListService,
     ) {
     }
 
@@ -40,7 +40,7 @@ final readonly class ListGeneralJobApplicationsController
     )]
     public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {
-        return new JsonResponse($this->jobApplicationListService->getList(
+        return new JsonResponse($this->generalJobApplicationListService->getList(
             $loggedInUser,
             $request->query->getString('jobId', ''),
             $request->query->getString('jobSlug', ''),

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyJobsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyJobsController.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\General;
 
-use App\Recruit\Application\Service\MyJobListService;
+use App\Recruit\Application\Service\GeneralMyJobListService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListGeneralMyJobsController
 {
     public function __construct(
-        private MyJobListService $myJobListService,
+        private GeneralMyJobListService $generalMyJobListService,
     ) {
     }
 
@@ -28,6 +28,6 @@ final readonly class ListGeneralMyJobsController
     #[OA\Get(summary: 'Retourne les jobs créés et les jobs postulés par le user connecté.')]
     public function __invoke(User $loggedInUser): JsonResponse
     {
-        return new JsonResponse($this->myJobListService->getList($loggedInUser));
+        return new JsonResponse($this->generalMyJobListService->getList($loggedInUser));
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyResumesController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyResumesController.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\General;
 
-use App\Recruit\Application\Service\ResumeNormalizerService;
-use App\Recruit\Infrastructure\Repository\ResumeRepository;
+use App\Recruit\Application\Service\GeneralResumeService;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -21,8 +20,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListGeneralMyResumesController
 {
     public function __construct(
-        private ResumeRepository $resumeRepository,
-        private ResumeNormalizerService $resumeNormalizerService,
+        private GeneralResumeService $generalResumeService,
     ) {
     }
 
@@ -30,12 +28,6 @@ final readonly class ListGeneralMyResumesController
     #[OA\Get(summary: 'Retourne les CV du user connecté.')]
     public function __invoke(User $loggedInUser): JsonResponse
     {
-        $resumes = $this->resumeRepository->findBy([
-            'owner' => $loggedInUser,
-        ], [
-            'createdAt' => 'DESC',
-        ]);
-
-        return new JsonResponse($this->resumeNormalizerService->normalizeCollection($resumes));
+        return new JsonResponse($this->generalResumeService->getMyResumes($loggedInUser));
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/General/UpdateGeneralApplicationStatusController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/UpdateGeneralApplicationStatusController.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace App\Recruit\Transport\Controller\Api\V1\General;
 
 use App\Recruit\Application\Security\RecruitPermissions;
-use App\Recruit\Application\Service\ApplicationStatusTransitionService;
-use App\Recruit\Infrastructure\Repository\ApplicationRepository;
+use App\Recruit\Application\Service\GeneralApplicationStatusService;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
@@ -14,13 +13,9 @@ use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
-use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
-
-use function is_string;
 
 #[AsController]
 #[OA\Tag(name: 'Recruit Application')]
@@ -29,8 +24,7 @@ use function is_string;
 final readonly class UpdateGeneralApplicationStatusController
 {
     public function __construct(
-        private ApplicationRepository $applicationRepository,
-        private ApplicationStatusTransitionService $applicationStatusTransitionService,
+        private GeneralApplicationStatusService $generalApplicationStatusService,
     ) {
     }
 
@@ -61,27 +55,9 @@ final readonly class UpdateGeneralApplicationStatusController
     )]
     public function __invoke(string $applicationId, Request $request, User $loggedInUser): JsonResponse
     {
-        $application = $this->applicationRepository->find($applicationId);
-
-        if ($application === null) {
-            throw new NotFoundHttpException('Application not found.');
-        }
-
-        $ownerId = $application->getJob()->getOwner()?->getId();
-        if ($ownerId === null || $ownerId !== $loggedInUser->getId()) {
-            throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You are not allowed to update the status for this application.');
-        }
-
         /** @var array<string, mixed> $payload */
         $payload = $request->toArray();
-        $comment = is_string($payload['comment'] ?? null) ? $payload['comment'] : null;
-        $this->applicationStatusTransitionService->applyStatusTransition($application, $payload['status'] ?? null, $loggedInUser, $comment);
 
-        $this->applicationRepository->save($application);
-
-        return new JsonResponse([
-            'id' => $application->getId(),
-            'status' => $application->getStatusValue(),
-        ]);
+        return new JsonResponse($this->generalApplicationStatusService->updateStatus($applicationId, $payload, $loggedInUser));
     }
 }


### PR DESCRIPTION
### Motivation
- Séparer la logique métier des endpoints « general » en services dédiés pour faciliter la réutilisation et les tests.
- Supprimer la dépendance des endpoints general à `RecruitResolverService::resolveByApplicationSlug()` afin d’isoler les flux génériques de la notion d’`applicationSlug`.
- Conserver les règles de sécurité/ownership pour les endpoints privés et garder la compatibilité des payloads/réponses front.

### Description
- Ajout des services sous `src/Recruit/Application/Service/`: `GeneralApplicantService`, `GeneralApplicationService`, `GeneralMyJobListService`, `GeneralJobApplicationListService`, `GeneralApplicationStatusService`, et `GeneralResumeService` qui encapsulent la logique existante des endpoints general.
- Refactor des controllers généralistes sous `src/Recruit/Transport/Controller/Api/V1/General/` pour déléguer la logique aux nouveaux services tout en conservant les mêmes formes de payloads et réponses.
- Retrait de la dépendance aux résolveurs d’application dans les flux general : les services general n’appellent plus `RecruitResolverService::resolveByApplicationSlug()` et la vérification d’appartenance est appliquée via les services/entités concernés.
- Conservation explicite des validations et règles métier : validations UUID, contrôle d’ownership (resume/applicant/job), anti-duplication d’une candidature active et transitions de statut via `ApplicationStatusTransitionService`.

### Testing
- Exécution de vérifications syntaxiques PHP sur les nouveaux fichiers et controllers avec la commande `for f in <files>; do php -l "$f" || exit 1; done` (vérification `php -l` sur tous les fichiers modifiés/ajoutés) et toutes les vérifications ont réussi.
- Les changements ont été commités (`Add dedicated services for general recruit flows`) et la PR préparée via l’outil interne de création de PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e030a8bb7083268af43747b4262f7c)