### PR TITLE
feat(recruit): enrich OpenAPI docs for general my jobs endpoint

### DIFF
--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyJobsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyJobsController.php
@@ -25,7 +25,74 @@ final readonly class ListGeneralMyJobsController
     }
 
     #[Route(path: '/v1/recruit/general/private/me/jobs', methods: [Request::METHOD_GET])]
-    #[OA\Get(summary: 'Retourne les jobs créés et les jobs postulés par le user connecté.')]
+    #[OA\Get(
+        summary: 'Retourne les jobs créés et les jobs postulés par le user connecté.',
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: 'Liste des jobs créés et des candidatures du user connecté.',
+                content: new OA\JsonContent(
+                    type: 'object',
+                    properties: [
+                        new OA\Property(
+                            property: 'createdJobs',
+                            type: 'array',
+                            items: new OA\Items(
+                                type: 'object',
+                                properties: [
+                                    new OA\Property(property: 'id', type: 'string', format: 'uuid', example: '018f4f85-70f0-7f89-8d59-7cfc7b6d93b0'),
+                                    new OA\Property(property: 'slug', type: 'string', example: 'developpeur-php-senior-paris'),
+                                    new OA\Property(property: 'title', type: 'string', example: 'Développeur PHP Senior'),
+                                    new OA\Property(property: 'company', type: 'string', example: 'BroWorld Tech'),
+                                    new OA\Property(property: 'location', type: 'string', example: 'Paris'),
+                                    new OA\Property(property: 'contractType', type: 'string', example: 'CDI'),
+                                    new OA\Property(property: 'workMode', type: 'string', example: 'HYBRID'),
+                                    new OA\Property(property: 'schedule', type: 'string', example: 'FULL_TIME'),
+                                    new OA\Property(property: 'createdAt', type: 'string', format: 'date-time', example: '2026-04-16T10:30:00+00:00', nullable: true),
+                                    new OA\Property(property: 'owner', type: 'boolean', example: true),
+                                    new OA\Property(property: 'apply', type: 'boolean', example: false),
+                                ],
+                            ),
+                        ),
+                        new OA\Property(
+                            property: 'appliedJobs',
+                            type: 'array',
+                            items: new OA\Items(
+                                type: 'object',
+                                properties: [
+                                    new OA\Property(property: 'applicationId', type: 'string', format: 'uuid', example: '018f4f85-73ba-7b9a-8e9b-4a1406828cf1'),
+                                    new OA\Property(
+                                        property: 'status',
+                                        type: 'string',
+                                        enum: ['WAITING', 'SCREENING', 'INTERVIEW_PLANNED', 'INTERVIEW_DONE', 'OFFER_SENT', 'HIRED', 'REJECTED'],
+                                        example: 'INTERVIEW_PLANNED',
+                                    ),
+                                    new OA\Property(property: 'appliedAt', type: 'string', format: 'date-time', example: '2026-04-15T09:15:00+00:00', nullable: true),
+                                    new OA\Property(
+                                        property: 'job',
+                                        type: 'object',
+                                        properties: [
+                                            new OA\Property(property: 'id', type: 'string', format: 'uuid', example: '018f4f85-70f0-7f89-8d59-7cfc7b6d93b0'),
+                                            new OA\Property(property: 'slug', type: 'string', example: 'backend-engineer-lyon'),
+                                            new OA\Property(property: 'title', type: 'string', example: 'Backend Engineer'),
+                                            new OA\Property(property: 'company', type: 'string', example: 'BroWorld Tech'),
+                                            new OA\Property(property: 'location', type: 'string', example: 'Lyon'),
+                                            new OA\Property(property: 'contractType', type: 'string', example: 'CDI'),
+                                            new OA\Property(property: 'workMode', type: 'string', example: 'REMOTE'),
+                                            new OA\Property(property: 'schedule', type: 'string', example: 'FULL_TIME'),
+                                            new OA\Property(property: 'owner', type: 'boolean', example: false),
+                                            new OA\Property(property: 'apply', type: 'boolean', example: true),
+                                        ],
+                                    ),
+                                ],
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+            new OA\Response(response: 401, description: 'Utilisateur non authentifié.'),
+        ],
+    )]
     public function __invoke(User $loggedInUser): JsonResponse
     {
         return new JsonResponse($this->generalMyJobListService->getList($loggedInUser));


### PR DESCRIPTION
### Motivation
- Fournir une documentation OpenAPI complète pour la route `GET /v1/recruit/general/private/me/jobs` afin que les clients comprennent précisément la structure des tableaux `createdJobs` et `appliedJobs` et les valeurs possibles de `status`.
- Rendre explicite la réponse 401 pour les appels non authentifiés.

### Description
- Ajout d'une annotation `OA"Get` détaillée dans `src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyJobsController.php` décrivant le schéma JSON de la réponse (propriétés `createdJobs` et `appliedJobs` avec types, formats et exemples). 
- Documenté l'objet imbriqué `job` dans `appliedJobs` et listé l'enum `status` avec exemples (`WAITING`, `SCREENING`, `INTERVIEW_PLANNED`, `INTERVIEW_DONE`, `OFFER_SENT`, `HIRED`, `REJECTED`).
- Ajout d'une réponse `401` dans les annotations; le contrôleur continue d'utiliser `GeneralMyJobListService` (qui délègue à `MyJobListService`).

### Testing
- Vérification de syntaxe PHP avec `php -l src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyJobsController.php` et aucun erreur détectée. 
- Le fichier modifié a été commit après validation (commit message: "feat(recruit): document general my jobs response schema").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0320171cc8326a7fa92340f7663c9)