### PR TITLE
Complete OpenAPI docs for general job applications list endpoint

### DIFF
--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobApplicationsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobApplicationsController.php
@@ -34,7 +34,47 @@ final readonly class ListGeneralJobApplicationsController
             new OA\Parameter(name: 'jobSlug', description: 'Slug du job', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
         ],
         responses: [
-            new OA\Response(response: 200, description: 'Liste des candidatures du job.'),
+            new OA\Response(
+                response: 200,
+                description: 'Liste des candidatures du job.',
+                content: new OA\JsonContent(
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                            new OA\Property(property: 'status', type: 'string'),
+                            new OA\Property(property: 'createdAt', type: 'string', format: 'date-time', nullable: true),
+                            new OA\Property(
+                                property: 'applicant',
+                                properties: [
+                                    new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                                    new OA\Property(property: 'coverLetter', type: 'string', nullable: true),
+                                    new OA\Property(
+                                        property: 'user',
+                                        properties: [
+                                            new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                                            new OA\Property(property: 'username', type: 'string', nullable: true),
+                                            new OA\Property(property: 'firstName', type: 'string', nullable: true),
+                                            new OA\Property(property: 'lastName', type: 'string', nullable: true),
+                                            new OA\Property(property: 'email', type: 'string', format: 'email', nullable: true),
+                                        ],
+                                        type: 'object',
+                                    ),
+                                    new OA\Property(
+                                        property: 'resume',
+                                        properties: [
+                                            new OA\Property(property: 'id', type: 'string', format: 'uuid', nullable: true),
+                                        ],
+                                        type: 'object',
+                                    ),
+                                ],
+                                type: 'object',
+                            ),
+                        ],
+                        type: 'object',
+                    ),
+                ),
+            ),
             new OA\Response(response: 403, description: 'Vous n\'êtes pas propriétaire du job.'),
         ],
     )]


### PR DESCRIPTION
### Motivation
- Fournir une documentation OpenAPI complète pour la route `GET /v1/recruit/general/private/job-applications` afin de décrire précisément la structure de la réponse (applicant, user, resume, status, createdAt) et s'aligner sur le comportement existant.

### Description
- Complété le schéma de réponse `200` dans `ListGeneralJobApplicationsController` pour décrire un tableau d'objets contenant `id`, `status`, `createdAt` et le bloc `applicant` avec ses sous-champs `user` et `resume`; la route et les paramètres query `jobId`/`jobSlug` restent inchangés et l'appel à `GeneralJobApplicationListService` est conservé, préservant le contrôle d'accès propriétaire du job.

### Testing
- Exécuté `php -l src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobApplicationsController.php` qui a retourné "No syntax errors detected".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e032b0e0e08326b1aa6cd766f5162d)