### PR TITLE
Refactor controllers Recruit (general) to reuse shared Resume services

### DIFF
--- a/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralResumeController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralResumeController.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\General;
 
-use App\Recruit\Application\Service\GeneralResumeService;
+use App\Recruit\Application\Service\ResumeDocumentUploaderService;
+use App\Recruit\Application\Service\ResumePayloadService;
+use App\Recruit\Domain\Entity\Resume;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
@@ -20,7 +24,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class CreateGeneralResumeController
 {
     public function __construct(
-        private GeneralResumeService $generalResumeService,
+        private ResumeRepository $resumeRepository,
+        private ResumeDocumentUploaderService $resumeDocumentUploaderService,
+        private ResumePayloadService $resumePayloadService,
     ) {
     }
 
@@ -31,11 +37,46 @@ final readonly class CreateGeneralResumeController
         content: [
             new OA\MediaType(
                 mediaType: 'application/json',
-                schema: new OA\Schema(ref: '#/components/schemas/RecruitGeneralResumePayloadInput'),
+                schema: new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'experiences', type: 'array', items: new OA\Items(type: 'object', required: ['title'], properties: [new OA\Property(property: 'title', type: 'string'), new OA\Property(property: 'description', type: 'string')])),
+                        new OA\Property(property: 'educations', type: 'array', items: new OA\Items(type: 'object', required: ['title'], properties: [new OA\Property(property: 'title', type: 'string'), new OA\Property(property: 'description', type: 'string')])),
+                        new OA\Property(property: 'skills', type: 'array', items: new OA\Items(type: 'object', required: ['title'], properties: [new OA\Property(property: 'title', type: 'string'), new OA\Property(property: 'description', type: 'string')])),
+                        new OA\Property(property: 'languages', type: 'array', items: new OA\Items(type: 'object', required: ['title'], properties: [new OA\Property(property: 'title', type: 'string'), new OA\Property(property: 'description', type: 'string')])),
+                        new OA\Property(property: 'certifications', type: 'array', items: new OA\Items(type: 'object', required: ['title'], properties: [new OA\Property(property: 'title', type: 'string'), new OA\Property(property: 'description', type: 'string')])),
+                        new OA\Property(property: 'projects', type: 'array', items: new OA\Items(type: 'object', required: ['title'], properties: [new OA\Property(property: 'title', type: 'string'), new OA\Property(property: 'description', type: 'string')])),
+                        new OA\Property(property: 'references', type: 'array', items: new OA\Items(type: 'object', required: ['title'], properties: [new OA\Property(property: 'title', type: 'string'), new OA\Property(property: 'description', type: 'string')])),
+                        new OA\Property(property: 'hobbies', type: 'array', items: new OA\Items(type: 'object', required: ['title'], properties: [new OA\Property(property: 'title', type: 'string'), new OA\Property(property: 'description', type: 'string')])),
+                    ],
+                    type: 'object',
+                    example: [
+                        'experiences' => [[
+                            'title' => 'Backend Developer',
+                            'description' => 'Symfony API',
+                        ]],
+                        'skills' => [[
+                            'title' => 'PHP',
+                            'description' => '8.x',
+                        ]],
+                    ],
+                ),
             ),
             new OA\MediaType(
                 mediaType: 'multipart/form-data',
-                schema: new OA\Schema(ref: '#/components/schemas/RecruitGeneralResumePayloadMultipartInput'),
+                schema: new OA\Schema(
+                    properties: [
+                        new OA\Property(property: 'document', description: 'Fichier CV PDF.', type: 'string', format: 'binary'),
+                        new OA\Property(property: 'experiences', description: 'JSON stringifié: [{"title":"...","description":"..."}]', type: 'string'),
+                        new OA\Property(property: 'educations', description: 'JSON stringifié', type: 'string'),
+                        new OA\Property(property: 'skills', description: 'JSON stringifié', type: 'string'),
+                        new OA\Property(property: 'languages', description: 'JSON stringifié', type: 'string'),
+                        new OA\Property(property: 'certifications', description: 'JSON stringifié', type: 'string'),
+                        new OA\Property(property: 'projects', description: 'JSON stringifié', type: 'string'),
+                        new OA\Property(property: 'references', description: 'JSON stringifié', type: 'string'),
+                        new OA\Property(property: 'hobbies', description: 'JSON stringifié', type: 'string'),
+                    ],
+                    type: 'object',
+                ),
             ),
         ],
     )]
@@ -58,53 +99,24 @@ final readonly class CreateGeneralResumeController
     #[OA\Response(response: 401, description: 'Authentication required')]
     public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {
-        return new JsonResponse($this->generalResumeService->create($request, $loggedInUser), JsonResponse::HTTP_CREATED);
+        $payload = $this->resumePayloadService->extractPayload($request);
+
+        $resume = new Resume()->setOwner($loggedInUser);
+
+        /** @var UploadedFile|null $document */
+        $document = $request->files->get('document');
+        if ($document instanceof UploadedFile) {
+            $documentUrl = $this->resumeDocumentUploaderService->upload($request, $document, '/uploads/resumes');
+            $resume->setDocumentUrl($documentUrl);
+        }
+
+        $this->resumePayloadService->hydrateResumeSections($resume, $payload);
+
+        $this->resumeRepository->save($resume);
+
+        return new JsonResponse([
+            'id' => $resume->getId(),
+            'documentUrl' => $resume->getDocumentUrl(),
+        ], JsonResponse::HTTP_CREATED);
     }
-}
-
-#[OA\Schema(
-    schema: 'RecruitGeneralResumePayloadInput',
-    properties: [
-        new OA\Property(property: 'experiences', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
-        new OA\Property(property: 'educations', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
-        new OA\Property(property: 'skills', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
-        new OA\Property(property: 'languages', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
-        new OA\Property(property: 'certifications', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
-        new OA\Property(property: 'projects', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
-        new OA\Property(property: 'references', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
-        new OA\Property(property: 'hobbies', type: 'array', items: new OA\Items(ref: '#/components/schemas/RecruitResumeSectionInput')),
-    ],
-    type: 'object',
-    example: [
-        'experiences' => [[
-            'title' => 'Backend Developer',
-            'description' => 'Symfony API',
-        ]],
-        'skills' => [[
-            'title' => 'PHP',
-            'description' => '8.x',
-        ]],
-    ],
-)]
-final class RecruitGeneralResumePayloadInputSchema
-{
-}
-
-#[OA\Schema(
-    schema: 'RecruitGeneralResumePayloadMultipartInput',
-    properties: [
-        new OA\Property(property: 'document', description: 'Fichier CV PDF.', type: 'string', format: 'binary'),
-        new OA\Property(property: 'experiences', description: 'JSON stringifié: [{"title":"...","description":"..."}]', type: 'string'),
-        new OA\Property(property: 'educations', description: 'JSON stringifié', type: 'string'),
-        new OA\Property(property: 'skills', description: 'JSON stringifié', type: 'string'),
-        new OA\Property(property: 'languages', description: 'JSON stringifié', type: 'string'),
-        new OA\Property(property: 'certifications', description: 'JSON stringifié', type: 'string'),
-        new OA\Property(property: 'projects', description: 'JSON stringifié', type: 'string'),
-        new OA\Property(property: 'references', description: 'JSON stringifié', type: 'string'),
-        new OA\Property(property: 'hobbies', description: 'JSON stringifié', type: 'string'),
-    ],
-    type: 'object',
-)]
-final class RecruitGeneralResumePayloadMultipartInputSchema
-{
 }

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyResumesController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyResumesController.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace App\Recruit\Transport\Controller\Api\V1\General;
 
-use App\Recruit\Application\Service\GeneralResumeService;
+use App\Recruit\Application\Service\ResumeNormalizerService;
+use App\Recruit\Infrastructure\Repository\ResumeRepository;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -20,7 +21,8 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class ListGeneralMyResumesController
 {
     public function __construct(
-        private GeneralResumeService $generalResumeService,
+        private ResumeRepository $resumeRepository,
+        private ResumeNormalizerService $resumeNormalizerService,
     ) {
     }
 
@@ -28,6 +30,12 @@ final readonly class ListGeneralMyResumesController
     #[OA\Get(summary: 'Retourne les CV du user connecté.')]
     public function __invoke(User $loggedInUser): JsonResponse
     {
-        return new JsonResponse($this->generalResumeService->getMyResumes($loggedInUser));
+        $resumes = $this->resumeRepository->findBy([
+            'owner' => $loggedInUser,
+        ], [
+            'createdAt' => 'DESC',
+        ]);
+
+        return new JsonResponse($this->resumeNormalizerService->normalizeCollection($resumes));
     }
 }


### PR DESCRIPTION
### Motivation
- Unifier le comportement des endpoints « general » avec l’implémentation existante pour les resumes en réutilisant les services partagés pour l’extraction, l’upload et la normalisation des CV. 
- Conserver le schéma OpenAPI du endpoint create pour supporter `application/json` et `multipart/form-data` (champ binaire `document` + sections JSON stringifiées). 

### Description
- `CreateGeneralResumeController` a été réécrit pour réutiliser `ResumePayloadService` (extraction/hydratation), `ResumeDocumentUploaderService` (upload PDF) et `ResumeRepository` (persistance) sur la route `POST /v1/recruit/general/resumes`. 
- L’annotation OpenAPI du create général a été alignée sur celle de `ResumeCreateController` afin de supporter à la fois `application/json` et `multipart/form-data` avec le champ `document` binaire et les sections sérialisées en JSON. 
- `ListGeneralMyResumesController` a été réécrit pour réutiliser `ResumeRepository` + `ResumeNormalizerService` et retourner la collection triée par `createdAt DESC` sur `GET /v1/recruit/general/private/me/resumes`. 
- Suppression de la logique du service intermédiaire pour ces endpoints au profit de la réutilisation directe des services existants. 

### Testing
- Lint PHP des fichiers modifiés avec `php -l` sur `src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralResumeController.php` a réussi. 
- Lint PHP des fichiers modifiés avec `php -l` sur `src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyResumesController.php` a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e03431f37c8326b0fe70a120ee1544)