### PR TITLE
docs(recruit): complete OpenAPI coverage on V1 General controllers

### DIFF
--- a/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicantController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicantController.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
-#[OA\Tag(name: 'Recruit Applicant')]
+#[OA\Tag(name: 'Recruit General Applicant')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class CreateGeneralApplicantController
 {
@@ -46,6 +46,9 @@ final readonly class CreateGeneralApplicantController
         responses: [
             new OA\Response(response: 201, description: 'Candidat créé.'),
             new OA\Response(response: 400, description: 'Payload invalide.'),
+            new OA\Response(response: 401, description: 'Authentification requise.'),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Ressource liée introuvable.'),
         ],
     )]
     public function __invoke(Request $request, User $loggedInUser): JsonResponse

--- a/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralApplicationController.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
-#[OA\Tag(name: 'Recruit Application')]
+#[OA\Tag(name: 'Recruit General Application')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class CreateGeneralApplicationController
 {
@@ -46,6 +46,9 @@ final readonly class CreateGeneralApplicationController
         responses: [
             new OA\Response(response: 201, description: 'Candidature créée.'),
             new OA\Response(response: 400, description: 'Payload invalide.'),
+            new OA\Response(response: 401, description: 'Authentification requise.'),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Ressource liée introuvable.'),
         ],
     )]
     public function __invoke(Request $request, User $loggedInUser): JsonResponse

--- a/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralResumeController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralResumeController.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
-#[OA\Tag(name: 'Recruit Resume')]
+#[OA\Tag(name: 'Recruit General Resume')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class CreateGeneralResumeController
 {
@@ -97,6 +97,8 @@ final readonly class CreateGeneralResumeController
     )]
     #[OA\Response(response: 400, description: 'Invalid payload or file format')]
     #[OA\Response(response: 401, description: 'Authentication required')]
+    #[OA\Response(response: 403, description: 'Access denied')]
+    #[OA\Response(response: 404, description: 'Related resource not found')]
     public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {
         $payload = $this->resumePayloadService->extractPayload($request);

--- a/src/Recruit/Transport/Controller/Api/V1/General/GetGeneralJobController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/GetGeneralJobController.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[AsController]
-#[OA\Tag(name: 'Recruit Job')]
+#[OA\Tag(name: 'Recruit General Job')]
 final readonly class GetGeneralJobController
 {
     public function __construct(
@@ -26,6 +26,13 @@ final readonly class GetGeneralJobController
         security: [],
         parameters: [
             new OA\Parameter(name: 'jobSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string')),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Détail du job récupéré.'),
+            new OA\Response(response: 400, description: 'Paramètre invalide.'),
+            new OA\Response(response: 401, description: 'Authentification requise.'),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Job introuvable.'),
         ],
     )]
     public function __invoke(string $jobSlug): JsonResponse

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobApplicationsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobApplicationsController.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
-#[OA\Tag(name: 'Recruit Application')]
+#[OA\Tag(name: 'Recruit General Application')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[IsGranted(RecruitPermissions::INTERVIEW_VIEW)]
 final readonly class ListGeneralJobApplicationsController
@@ -75,7 +75,10 @@ final readonly class ListGeneralJobApplicationsController
                     ),
                 ),
             ),
+            new OA\Response(response: 400, description: 'Paramètres de recherche invalides.'),
+            new OA\Response(response: 401, description: 'Authentification requise.'),
             new OA\Response(response: 403, description: 'Vous n\'êtes pas propriétaire du job.'),
+            new OA\Response(response: 404, description: 'Job introuvable.'),
         ],
     )]
     public function __invoke(Request $request, User $loggedInUser): JsonResponse

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobsController.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Routing\Attribute\Route;
 
 #[AsController]
-#[OA\Tag(name: 'Recruit Job')]
+#[OA\Tag(name: 'Recruit General Job')]
 final readonly class ListGeneralJobsController
 {
     public function __construct(
@@ -38,6 +38,13 @@ final readonly class ListGeneralJobsController
             new OA\Parameter(name: 'workMode', in: 'query', required: false, schema: new OA\Schema(type: 'string', enum: ['Onsite', 'Remote', 'Hybrid'])),
             new OA\Parameter(name: 'contractType', in: 'query', required: false, schema: new OA\Schema(type: 'string', enum: ['CDI', 'CDD', 'Freelance', 'Internship'])),
             new OA\Parameter(name: 'experienceLevel', in: 'query', required: false, schema: new OA\Schema(type: 'string', enum: ['Junior', 'Mid', 'Senior', 'Lead'])),
+        ],
+        responses: [
+            new OA\Response(response: 200, description: 'Liste des jobs récupérée.'),
+            new OA\Response(response: 400, description: 'Paramètres de filtre invalides.'),
+            new OA\Response(response: 401, description: 'Authentification requise.'),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Ressource introuvable.'),
         ],
     )]
     public function __invoke(Request $request): JsonResponse

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyJobsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyJobsController.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
-#[OA\Tag(name: 'Recruit Job')]
+#[OA\Tag(name: 'Recruit General Job')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class ListGeneralMyJobsController
 {
@@ -90,7 +90,10 @@ final readonly class ListGeneralMyJobsController
                     ],
                 ),
             ),
+            new OA\Response(response: 400, description: 'Requête invalide.'),
             new OA\Response(response: 401, description: 'Utilisateur non authentifié.'),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Ressource introuvable.'),
         ],
     )]
     public function __invoke(User $loggedInUser): JsonResponse

--- a/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyResumesController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/ListGeneralMyResumesController.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
-#[OA\Tag(name: 'Recruit Resume')]
+#[OA\Tag(name: 'Recruit General Resume')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class ListGeneralMyResumesController
 {
@@ -27,7 +27,16 @@ final readonly class ListGeneralMyResumesController
     }
 
     #[Route(path: '/v1/recruit/general/private/me/resumes', methods: [Request::METHOD_GET])]
-    #[OA\Get(summary: 'Retourne les CV du user connecté.')]
+    #[OA\Get(
+        summary: 'Retourne les CV du user connecté.',
+        responses: [
+            new OA\Response(response: 200, description: 'Liste des CV récupérée.'),
+            new OA\Response(response: 400, description: 'Requête invalide.'),
+            new OA\Response(response: 401, description: 'Authentification requise.'),
+            new OA\Response(response: 403, description: 'Accès refusé.'),
+            new OA\Response(response: 404, description: 'Ressource introuvable.'),
+        ],
+    )]
     public function __invoke(User $loggedInUser): JsonResponse
     {
         $resumes = $this->resumeRepository->findBy([

--- a/src/Recruit/Transport/Controller/Api/V1/General/UpdateGeneralApplicationStatusController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/UpdateGeneralApplicationStatusController.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 use function is_string;
 
 #[AsController]
-#[OA\Tag(name: 'Recruit Application')]
+#[OA\Tag(name: 'Recruit General Application')]
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 #[IsGranted(RecruitPermissions::APPLICATION_STATUS_TRANSITION)]
 final readonly class UpdateGeneralApplicationStatusController
@@ -61,6 +61,7 @@ final readonly class UpdateGeneralApplicationStatusController
         responses: [
             new OA\Response(response: 200, description: 'Statut de candidature mis à jour.'),
             new OA\Response(response: 400, description: 'Transition invalide ou payload incomplet.'),
+            new OA\Response(response: 401, description: 'Authentification requise.'),
             new OA\Response(response: 403, description: 'Vous n\'êtes pas propriétaire du job.'),
             new OA\Response(response: 404, description: 'Candidature introuvable.'),
         ],


### PR DESCRIPTION
### Motivation
- Ensure the `General` variants of Recruit endpoints expose the same, explicit OpenAPI contract as their non-general counterparts to avoid API divergence and improve generated docs.
- Provide consistent tags and error responses so consumers and tools can rely on a full `200/201/400/401/403/404` matrix where applicable.

### Description
- Renamed OpenAPI tags to a coherent `Recruit General ...` convention in `General` controllers (e.g. `CreateGeneralApplicantController`, `CreateGeneralApplicationController`, `GetGeneralJobController`).
- Added explicit `OA\Response` annotations for `401`, `403` and `404` (and where appropriate `400`/`200`/`201`) across `src/Recruit/Transport/Controller/Api/V1/General/*` to complete response coverage.
- Kept existing `OA\Parameter` and `OA\RequestBody` schemas aligned with the non-general endpoints to avoid contract drift (applicant/application/resume/status schemas were preserved).
- No routing configuration changes were necessary because `config/routes.yaml` already loads `../src/Recruit/Transport/Controller/Api/` with attribute routing (which covers `Api/V1/General`).

### Testing
- Ran `php -l` on all updated controllers in `src/Recruit/Transport/Controller/Api/V1/General` and all files reported `No syntax errors detected` (checks passed).
- Verified `config/routes.yaml` contains the `recruit-controllers` resource pointing at `../src/Recruit/Transport/Controller/Api/` so attribute-loaded controllers in `Api/V1/General` are picked up automatically.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e034f86eb883269b0a21f0bfacc64c)