### PR TITLE
Return 400 for malformed multipart resume section JSON and normalize blank section strings

### DIFF
--- a/src/Recruit/Application/Service/ResumePayloadService.php
+++ b/src/Recruit/Application/Service/ResumePayloadService.php
@@ -23,6 +23,7 @@ use function array_key_exists;
 use function is_array;
 use function is_string;
 use function json_decode;
+use function sprintf;
 use function trim;
 
 class ResumePayloadService
@@ -57,10 +58,33 @@ class ResumePayloadService
             $payload = $request->request->all();
 
             foreach (self::RESUME_SECTION_FIELDS as $field) {
-                if (is_string($payload[$field] ?? null)) {
-                    $decoded = json_decode($payload[$field], true, 512, JSON_THROW_ON_ERROR);
-                    $payload[$field] = is_array($decoded) ? $decoded : [];
+                if (!is_string($payload[$field] ?? null)) {
+                    continue;
                 }
+
+                if (trim($payload[$field]) === '') {
+                    $payload[$field] = [];
+                    continue;
+                }
+
+                try {
+                    $decoded = json_decode($payload[$field], true, 512, JSON_THROW_ON_ERROR);
+                } catch (JsonException $exception) {
+                    throw new HttpException(
+                        JsonResponse::HTTP_BAD_REQUEST,
+                        sprintf('Field "%s" must be a valid JSON array string.', $field),
+                        $exception,
+                    );
+                }
+
+                if (!is_array($decoded)) {
+                    throw new HttpException(
+                        JsonResponse::HTTP_BAD_REQUEST,
+                        sprintf('Field "%s" must decode to an array.', $field),
+                    );
+                }
+
+                $payload[$field] = $decoded;
             }
 
             return $payload;

--- a/tests/Unit/Recruit/Application/Service/ResumePayloadServiceTest.php
+++ b/tests/Unit/Recruit/Application/Service/ResumePayloadServiceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Recruit\Application\Service;
+
+use App\Recruit\Application\Service\ResumePayloadService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class ResumePayloadServiceTest extends TestCase
+{
+    public function testExtractPayloadRejectsInvalidJsonSectionInMultipartPayload(): void
+    {
+        $service = new ResumePayloadService($this->createMock(EntityManagerInterface::class));
+
+        $request = new Request([], [
+            'skills' => 'string',
+        ]);
+
+        try {
+            $service->extractPayload($request);
+            self::fail('Expected HttpException was not thrown.');
+        } catch (HttpException $exception) {
+            self::assertSame(Response::HTTP_BAD_REQUEST, $exception->getStatusCode());
+            self::assertSame('Field "skills" must be a valid JSON array string.', $exception->getMessage());
+        }
+    }
+
+    public function testExtractPayloadTreatsEmptySectionStringAsEmptyArray(): void
+    {
+        $service = new ResumePayloadService($this->createMock(EntityManagerInterface::class));
+
+        $request = new Request([], [
+            'skills' => '   ',
+        ]);
+
+        $payload = $service->extractPayload($request);
+
+        self::assertArrayHasKey('skills', $payload);
+        self::assertSame([], $payload['skills']);
+    }
+}


### PR DESCRIPTION
### Motivation
- Multipart form fields for resume sections could contain malformed JSON or blank strings and were causing internal `JsonException`s that surfaced as `500` responses instead of client errors.
- The change aims to validate and normalize these section fields earlier so clients receive clear `400 Bad Request` errors for invalid input.

### Description
- Update `ResumePayloadService::extractPayload()` in `src/Recruit/Application/Service/ResumePayloadService.php` to ignore non-string section values, convert blank strings to empty arrays, and decode JSON with error handling.
- Map `JsonException` from `json_decode(..., JSON_THROW_ON_ERROR)` to an explicit `HttpException` with `JsonResponse::HTTP_BAD_REQUEST` and a field-specific message using `sprintf` when JSON is malformed.
- Enforce that decoded values are arrays and throw a `400` `HttpException` when they are not, instead of silently converting to an empty array.
- Add unit tests in `tests/Unit/Recruit/Application/Service/ResumePayloadServiceTest.php` covering malformed JSON (`skills: "string"`) producing `400` and blank section string normalization to `[]`.

### Testing
- Syntax checks with `php -l src/Recruit/Application/Service/ResumePayloadService.php` succeeded with no syntax errors.
- Syntax checks with `php -l tests/Unit/Recruit/Application/Service/ResumePayloadServiceTest.php` succeeded with no syntax errors.
- Attempted to run the new unit test via `vendor/bin/phpunit tests/Unit/Recruit/Application/Service/ResumePayloadServiceTest.php` but it could not be executed in this environment because `vendor/bin/phpunit` is not present (test run unavailable here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e042e3878483268d37d2f7427ec792)