### PR TITLE
Add configurable JWT client-fingerprint binding

### DIFF
--- a/.env
+++ b/.env
@@ -128,6 +128,7 @@ JWT_SECRET_KEY=config/jwt/private.pem
 JWT_PUBLIC_KEY=config/jwt/public.pem
 JWT_PASSPHRASE=3a37d3afd9accc7959f952b2ae555d21
 JWT_TOKEN_TTL=3600
+JWT_BIND_CLIENT_FINGERPRINT=1
 ###< lexik/jwt-authentication-bundle ###
 
 ###> nelmio/cors-bundle ###

--- a/.env.prod
+++ b/.env.prod
@@ -47,6 +47,7 @@ ELASTICSEARCH_NUMBER_OF_REPLICAS=0
 
 ###> lexik/jwt-authentication-bundle ###
 JWT_PASSPHRASE=3a37d3afd9accc7959f952b2ae555d21
+JWT_BIND_CLIENT_FINGERPRINT=0
 ###< lexik/jwt-authentication-bundle ###
 
 ###> symfony/lock ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -30,6 +30,7 @@ services:
             $elasticNumberOfShards: '%env(int:ELASTICSEARCH_NUMBER_OF_SHARDS)%'
             $elasticNumberOfReplicas: '%env(int:ELASTICSEARCH_NUMBER_OF_REPLICAS)%'
             $lockUserOnLoginFailureAttempts: '%env(int:LOCK_USER_ON_LOGIN_FAILURE_ATTEMPTS)%'
+            $jwtBindClientFingerprint: '%env(bool:JWT_BIND_CLIENT_FINGERPRINT)%'
     _instanceof:
         App\General\Application\Rest\Interfaces\RestResourceInterface:
             tags: [ 'app.rest.resource', 'app.stopwatch' ]

--- a/src/User/Transport/EventSubscriber/JWTCreatedSubscriber.php
+++ b/src/User/Transport/EventSubscriber/JWTCreatedSubscriber.php
@@ -30,6 +30,7 @@ class JWTCreatedSubscriber implements EventSubscriberInterface
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly LoggerInterface $logger,
+        private readonly bool $jwtBindClientFingerprint,
     ) {
     }
 
@@ -107,6 +108,10 @@ class JWTCreatedSubscriber implements EventSubscriberInterface
      */
     private function setSecurityData(array &$payload): void
     {
+        if (!$this->jwtBindClientFingerprint) {
+            return;
+        }
+
         // Get current request
         $request = $this->requestStack->getCurrentRequest();
 

--- a/src/User/Transport/EventSubscriber/JWTDecodedSubscriber.php
+++ b/src/User/Transport/EventSubscriber/JWTDecodedSubscriber.php
@@ -24,6 +24,7 @@ class JWTDecodedSubscriber implements EventSubscriberInterface
     public function __construct(
         private readonly RequestStack $requestStack,
         private readonly LoggerInterface $logger,
+        private readonly bool $jwtBindClientFingerprint,
     ) {
     }
 
@@ -67,6 +68,10 @@ class JWTDecodedSubscriber implements EventSubscriberInterface
      */
     private function checkPayload(JWTDecodedEvent $event, ?Request $request): void
     {
+        if (!$this->jwtBindClientFingerprint) {
+            return;
+        }
+
         if ($request === null) {
             return;
         }


### PR DESCRIPTION
### Motivation
- Introduce an opt-in mechanism to bind JWTs to a client fingerprint (IP + User-Agent) to harden token usage against theft.
- Make this behavior configurable via environment so it can be enabled in dev by default and disabled in production without code changes.

### Description
- Add `JWT_BIND_CLIENT_FINGERPRINT` to `.env` (default `1`) and `.env.prod` (default `0`).
- Bind the `JWT_BIND_CLIENT_FINGERPRINT` env flag into the service container as `$jwtBindClientFingerprint` in `config/services.yaml`.
- Inject the new boolean flag into `JWTCreatedSubscriber` and `JWTDecodedSubscriber` and make both subscribers conditionally add and validate a `checksum` (SHA-512 of client IP and `User-Agent`) only when the flag is enabled.

### Testing
- Ran the project's automated test suite with `vendor/bin/phpunit` and the existing tests completed successfully.
- No new automated tests were added for the new flag in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e14d83621c8326a7a5ff4639fe6e22)