### PR TITLE
Add general CRM assignee endpoints for projects, tasks and sprints

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralProjectAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralProjectAssigneeController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Role\Domain\Enum\Role;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class DeleteGeneralProjectAssigneeController
+{
+    public function __construct(private ProjectRepository $projectRepository)
+    {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/general/projects/{project}/assignees/{user}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Delete(
+        summary: 'General - Remove Project Assignee',
+        description: 'Retire un assignee d un project dans le périmètre CRM général.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee retiré avec succès.'),
+            new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),
+            new OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Accès refusé.'),
+            new OA\Response(response: JsonResponse::HTTP_NOT_FOUND, description: 'Ressource introuvable.'),
+        ],
+    )]
+    public function __invoke(Project $project, User $user): JsonResponse
+    {
+        $project->removeAssignee($user);
+        $this->projectRepository->save($project);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralSprintAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralSprintAssigneeController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Role\Domain\Enum\Role;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class DeleteGeneralSprintAssigneeController
+{
+    public function __construct(private SprintRepository $sprintRepository)
+    {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/general/sprints/{sprint}/assignees/{user}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'sprint', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Delete(
+        summary: 'General - Remove Sprint Assignee',
+        description: 'Retire un assignee d un sprint dans le périmètre CRM général.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee retiré avec succès.'),
+            new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),
+            new OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Accès refusé.'),
+            new OA\Response(response: JsonResponse::HTTP_NOT_FOUND, description: 'Ressource introuvable.'),
+        ],
+    )]
+    public function __invoke(Sprint $sprint, User $user): JsonResponse
+    {
+        $sprint->removeAssignee($user);
+        $this->sprintRepository->save($sprint);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralTaskAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralTaskAssigneeController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Role\Domain\Enum\Role;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class DeleteGeneralTaskAssigneeController
+{
+    public function __construct(private TaskRepository $taskRepository)
+    {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/general/tasks/{task}/assignees/{user}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'task', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Delete(
+        summary: 'General - Remove Task Assignee',
+        description: 'Retire un assignee d une task dans le périmètre CRM général.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee retiré avec succès.'),
+            new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),
+            new OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Accès refusé.'),
+            new OA\Response(response: JsonResponse::HTTP_NOT_FOUND, description: 'Ressource introuvable.'),
+        ],
+    )]
+    public function __invoke(Task $task, User $user): JsonResponse
+    {
+        $task->removeAssignee($user);
+        $this->taskRepository->save($task);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/General/PutGeneralProjectAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PutGeneralProjectAssigneeController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
+use App\Role\Domain\Enum\Role;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class PutGeneralProjectAssigneeController
+{
+    public function __construct(private ProjectRepository $projectRepository)
+    {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/general/projects/{project}/assignees/{user}', methods: [Request::METHOD_PUT])]
+    #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Put(
+        summary: 'General - Add Project Assignee',
+        description: 'Ajoute un assignee à un project dans le périmètre CRM général.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee ajouté avec succès.'),
+            new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),
+            new OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Accès refusé.'),
+            new OA\Response(response: JsonResponse::HTTP_NOT_FOUND, description: 'Ressource introuvable.'),
+        ],
+    )]
+    public function __invoke(Project $project, User $user): JsonResponse
+    {
+        $project->addAssignee($user);
+        $this->projectRepository->save($project);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/General/PutGeneralSprintAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PutGeneralSprintAssigneeController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Infrastructure\Repository\SprintRepository;
+use App\Role\Domain\Enum\Role;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class PutGeneralSprintAssigneeController
+{
+    public function __construct(private SprintRepository $sprintRepository)
+    {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/general/sprints/{sprint}/assignees/{user}', methods: [Request::METHOD_PUT])]
+    #[OA\Parameter(name: 'sprint', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Put(
+        summary: 'General - Add Sprint Assignee',
+        description: 'Ajoute un assignee à un sprint dans le périmètre CRM général.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee ajouté avec succès.'),
+            new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),
+            new OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Accès refusé.'),
+            new OA\Response(response: JsonResponse::HTTP_NOT_FOUND, description: 'Ressource introuvable.'),
+        ],
+    )]
+    public function __invoke(Sprint $sprint, User $user): JsonResponse
+    {
+        $sprint->addAssignee($user);
+        $this->sprintRepository->save($sprint);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/General/PutGeneralTaskAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PutGeneralTaskAssigneeController.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Role\Domain\Enum\Role;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class PutGeneralTaskAssigneeController
+{
+    public function __construct(private TaskRepository $taskRepository)
+    {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/general/tasks/{task}/assignees/{user}', methods: [Request::METHOD_PUT])]
+    #[OA\Parameter(name: 'task', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Put(
+        summary: 'General - Add Task Assignee',
+        description: 'Ajoute un assignee à une task dans le périmètre CRM général.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee ajouté avec succès.'),
+            new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),
+            new OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Accès refusé.'),
+            new OA\Response(response: JsonResponse::HTTP_NOT_FOUND, description: 'Ressource introuvable.'),
+        ],
+    )]
+    public function __invoke(Task $task, User $user): JsonResponse
+    {
+        $task->addAssignee($user);
+        $this->taskRepository->save($task);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/tests/Application/Crm/Transport/Controller/Api/V1/GeneralAssigneeControllerTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/GeneralAssigneeControllerTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Crm\Transport\Controller\Api\V1;
+
+use App\Crm\Infrastructure\Repository\CrmRepository;
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use App\User\Infrastructure\Repository\UserRepository;
+use Symfony\Component\HttpFoundation\Response;
+
+final class GeneralAssigneeControllerTest extends WebTestCase
+{
+    private const string PRIMARY_APPLICATION_SLUG = 'crm-sales-hub';
+    private const string UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
+
+    public function testGeneralAssigneeEndpointsSuccess(): void
+    {
+        $companyId = $this->createGeneralCompany();
+        $projectId = $this->createGeneralProject($companyId);
+        $taskId = $this->createGeneralTask($projectId);
+        $sprintId = $this->createGeneralSprint($projectId);
+        $assigneeId = $this->getAssigneeUserId();
+
+        $managerClient = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+
+        $managerClient->request('PUT', sprintf('%s/v1/crm/general/projects/%s/assignees/%s', self::API_URL_PREFIX, $projectId, $assigneeId));
+        self::assertSame(Response::HTTP_NO_CONTENT, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('DELETE', sprintf('%s/v1/crm/general/projects/%s/assignees/%s', self::API_URL_PREFIX, $projectId, $assigneeId));
+        self::assertSame(Response::HTTP_NO_CONTENT, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('PUT', sprintf('%s/v1/crm/general/tasks/%s/assignees/%s', self::API_URL_PREFIX, $taskId, $assigneeId));
+        self::assertSame(Response::HTTP_NO_CONTENT, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('DELETE', sprintf('%s/v1/crm/general/tasks/%s/assignees/%s', self::API_URL_PREFIX, $taskId, $assigneeId));
+        self::assertSame(Response::HTTP_NO_CONTENT, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('PUT', sprintf('%s/v1/crm/general/sprints/%s/assignees/%s', self::API_URL_PREFIX, $sprintId, $assigneeId));
+        self::assertSame(Response::HTTP_NO_CONTENT, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('DELETE', sprintf('%s/v1/crm/general/sprints/%s/assignees/%s', self::API_URL_PREFIX, $sprintId, $assigneeId));
+        self::assertSame(Response::HTTP_NO_CONTENT, $managerClient->getResponse()->getStatusCode());
+    }
+
+    public function testGeneralAssigneeEndpointsForbiddenForViewer(): void
+    {
+        $companyId = $this->createGeneralCompany();
+        $projectId = $this->createGeneralProject($companyId);
+        $taskId = $this->createGeneralTask($projectId);
+        $sprintId = $this->createGeneralSprint($projectId);
+        $assigneeId = $this->getAssigneeUserId();
+
+        $viewerClient = $this->getTestClient('john-crm_viewer', 'password-crm_viewer');
+
+        foreach ([
+            sprintf('%s/v1/crm/general/projects/%s/assignees/%s', self::API_URL_PREFIX, $projectId, $assigneeId),
+            sprintf('%s/v1/crm/general/tasks/%s/assignees/%s', self::API_URL_PREFIX, $taskId, $assigneeId),
+            sprintf('%s/v1/crm/general/sprints/%s/assignees/%s', self::API_URL_PREFIX, $sprintId, $assigneeId),
+        ] as $path) {
+            $viewerClient->request('PUT', $path);
+            self::assertSame(Response::HTTP_FORBIDDEN, $viewerClient->getResponse()->getStatusCode());
+
+            $viewerClient->request('DELETE', $path);
+            self::assertSame(Response::HTTP_FORBIDDEN, $viewerClient->getResponse()->getStatusCode());
+        }
+    }
+
+    public function testGeneralAssigneeEndpointsNotFound(): void
+    {
+        $companyId = $this->createGeneralCompany();
+        $projectId = $this->createGeneralProject($companyId);
+        $taskId = $this->createGeneralTask($projectId);
+        $sprintId = $this->createGeneralSprint($projectId);
+
+        $managerClient = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+
+        foreach ([
+            sprintf('%s/v1/crm/general/projects/%s/assignees/%s', self::API_URL_PREFIX, $projectId, self::UNKNOWN_UUID),
+            sprintf('%s/v1/crm/general/tasks/%s/assignees/%s', self::API_URL_PREFIX, $taskId, self::UNKNOWN_UUID),
+            sprintf('%s/v1/crm/general/sprints/%s/assignees/%s', self::API_URL_PREFIX, $sprintId, self::UNKNOWN_UUID),
+        ] as $path) {
+            $managerClient->request('PUT', $path);
+            self::assertSame(Response::HTTP_NOT_FOUND, $managerClient->getResponse()->getStatusCode());
+
+            $managerClient->request('DELETE', $path);
+            self::assertSame(Response::HTTP_NOT_FOUND, $managerClient->getResponse()->getStatusCode());
+        }
+    }
+
+    private function createGeneralCompany(): string
+    {
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/companies', self::API_URL_PREFIX),
+            content: JSON::encode([
+                'crmId' => $this->getPrimaryCrmId(),
+                'name' => 'General Assignee Company ' . uniqid('', true),
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function createGeneralProject(string $companyId): string
+    {
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/projects', self::API_URL_PREFIX),
+            content: JSON::encode([
+                'companyId' => $companyId,
+                'name' => 'General Assignee Project ' . uniqid('', true),
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function createGeneralTask(string $projectId): string
+    {
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/tasks', self::API_URL_PREFIX),
+            content: JSON::encode([
+                'projectId' => $projectId,
+                'title' => 'General Assignee Task ' . uniqid('', true),
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function createGeneralSprint(string $projectId): string
+    {
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/sprints', self::API_URL_PREFIX),
+            content: JSON::encode([
+                'projectId' => $projectId,
+                'name' => 'General Assignee Sprint ' . uniqid('', true),
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function getAssigneeUserId(): string
+    {
+        static::bootKernel();
+        $userRepository = static::getContainer()->get(UserRepository::class);
+        $assignee = $userRepository->findOneBy([
+            'username' => 'alice',
+        ]);
+        self::assertNotNull($assignee);
+
+        return $assignee->getId();
+    }
+
+    private function getPrimaryCrmId(): string
+    {
+        static::bootKernel();
+        $crmRepository = static::getContainer()->get(CrmRepository::class);
+        $crm = $crmRepository->findOneByApplicationSlug(self::PRIMARY_APPLICATION_SLUG);
+        self::assertNotNull($crm);
+
+        return $crm->getId();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJsonResponse(string|false $content): array
+    {
+        self::assertNotFalse($content);
+        $decoded = JSON::decode($content, true);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
### Motivation
- Expose general-scope API endpoints to add/remove assignees on CRM `projects`, `tasks` and `sprints` with consistent permissions and HTTP semantics to match existing application-scope controllers.

### Description
- Added six controllers under `src/Crm/Transport/Controller/Api/V1/General/`: `PutGeneralProjectAssigneeController`, `DeleteGeneralProjectAssigneeController`, `PutGeneralTaskAssigneeController`, `DeleteGeneralTaskAssigneeController`, `PutGeneralSprintAssigneeController`, and `DeleteGeneralSprintAssigneeController`.
- Implemented routes via attributes for `PUT/DELETE /v1/crm/general/projects/{project}/assignees/{user}`, `PUT/DELETE /v1/crm/general/tasks/{task}/assignees/{user}` and `PUT/DELETE /v1/crm/general/sprints/{sprint}/assignees/{user}` and added OpenAPI annotations for path params, operations and responses.
- Reused existing domain logic (`addAssignee` / `removeAssignee`) and repository persistence (`->save(...)`) inside controllers, harmonized permissions to `Role::CRM_MANAGER`, and standardized responses to `204 No Content` on success.
- Added integration test `tests/Application/Crm/Transport/Controller/Api/V1/GeneralAssigneeControllerTest.php` covering success (204), forbidden (403) and not found (404) scenarios for the new endpoints.

### Testing
- Ran `php -l` on all new controller files and the new test file with no syntax errors detected.
- Attempting to run runtime tests failed in this environment because project dependencies are missing; `php bin/console` reports "Dependencies are missing. Try running `composer install`" and PHPUnit binary was not available, so automated integration tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c2a37b208326bd361fc028845df1)