### PR TITLE
Add general sprint-task attach/detach controllers and integration tests

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralDetachTaskFromSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralDetachTaskFromSprintController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\Role\Domain\Enum\Role;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class DeleteGeneralDetachTaskFromSprintController
+{
+    public function __construct(
+        private TaskRepository $taskRepository,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/general/sprints/{sprint}/tasks/{task}', methods: [Request::METHOD_DELETE])]
+    #[OA\Parameter(name: 'sprint', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'task', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Delete(
+        summary: 'General - Detach Task From Sprint',
+        description: 'Détache une tâche d un sprint dans le périmètre CRM général.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Tâche détachée avec succès.'),
+            new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),
+            new OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Accès refusé.'),
+            new OA\Response(response: JsonResponse::HTTP_NOT_FOUND, description: 'Ressource introuvable.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'Erreur de validation métier.'),
+        ],
+    )]
+    public function __invoke(Sprint $sprint, Task $task): JsonResponse
+    {
+        if ($task->getProject()?->getId() !== $sprint->getProject()?->getId()) {
+            return $this->errorResponseFactory->outOfScopeReference('Task and sprint must belong to the same project.');
+        }
+
+        $task->setSprint(null);
+        $this->taskRepository->save($task);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/General/PutGeneralAttachTaskToSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PutGeneralAttachTaskToSprintController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
+use App\Role\Domain\Enum\Role;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class PutGeneralAttachTaskToSprintController
+{
+    public function __construct(
+        private TaskRepository $taskRepository,
+        private CrmApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/general/sprints/{sprint}/tasks/{task}', methods: [Request::METHOD_PUT])]
+    #[OA\Parameter(name: 'sprint', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Parameter(name: 'task', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
+    #[OA\Put(
+        summary: 'General - Attach Task To Sprint',
+        description: 'Attache une tâche à un sprint dans le périmètre CRM général.',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Tâche attachée avec succès.'),
+            new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),
+            new OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Accès refusé.'),
+            new OA\Response(response: JsonResponse::HTTP_NOT_FOUND, description: 'Ressource introuvable.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'Erreur de validation métier.'),
+        ],
+    )]
+    public function __invoke(Sprint $sprint, Task $task): JsonResponse
+    {
+        if ($task->getProject()?->getId() !== $sprint->getProject()?->getId()) {
+            return $this->errorResponseFactory->outOfScopeReference('Task and sprint must belong to the same project.');
+        }
+
+        $task->setSprint($sprint);
+        $this->taskRepository->save($task);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/tests/Application/Crm/Transport/Controller/Api/V1/GeneralSprintTaskControllerTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/GeneralSprintTaskControllerTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Crm\Transport\Controller\Api\V1;
+
+use App\Crm\Infrastructure\Repository\CrmRepository;
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class GeneralSprintTaskControllerTest extends WebTestCase
+{
+    private const string PRIMARY_APPLICATION_SLUG = 'crm-sales-hub';
+    private const string UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
+
+    public function testGeneralSprintTaskEndpointsSuccess(): void
+    {
+        $companyId = $this->createGeneralCompany();
+        $projectId = $this->createGeneralProject($companyId);
+        $taskId = $this->createGeneralTask($projectId);
+        $sprintId = $this->createGeneralSprint($projectId);
+
+        $managerClient = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+
+        $managerClient->request('PUT', sprintf('%s/v1/crm/general/sprints/%s/tasks/%s', self::API_URL_PREFIX, $sprintId, $taskId));
+        self::assertSame(Response::HTTP_NO_CONTENT, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('GET', sprintf('%s/v1/crm/general/tasks/%s', self::API_URL_PREFIX, $taskId));
+        self::assertSame(Response::HTTP_OK, $managerClient->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($managerClient->getResponse()->getContent());
+        self::assertSame($sprintId, $payload['sprint']['id'] ?? null);
+
+        $managerClient->request('DELETE', sprintf('%s/v1/crm/general/sprints/%s/tasks/%s', self::API_URL_PREFIX, $sprintId, $taskId));
+        self::assertSame(Response::HTTP_NO_CONTENT, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('GET', sprintf('%s/v1/crm/general/tasks/%s', self::API_URL_PREFIX, $taskId));
+        self::assertSame(Response::HTTP_OK, $managerClient->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($managerClient->getResponse()->getContent());
+        self::assertNull($payload['sprint']);
+    }
+
+    public function testGeneralSprintTaskEndpointsNotFound(): void
+    {
+        $companyId = $this->createGeneralCompany();
+        $projectId = $this->createGeneralProject($companyId);
+        $taskId = $this->createGeneralTask($projectId);
+        $sprintId = $this->createGeneralSprint($projectId);
+
+        $managerClient = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+
+        foreach ([
+            sprintf('%s/v1/crm/general/sprints/%s/tasks/%s', self::API_URL_PREFIX, self::UNKNOWN_UUID, $taskId),
+            sprintf('%s/v1/crm/general/sprints/%s/tasks/%s', self::API_URL_PREFIX, $sprintId, self::UNKNOWN_UUID),
+        ] as $path) {
+            $managerClient->request('PUT', $path);
+            self::assertSame(Response::HTTP_NOT_FOUND, $managerClient->getResponse()->getStatusCode());
+
+            $managerClient->request('DELETE', $path);
+            self::assertSame(Response::HTTP_NOT_FOUND, $managerClient->getResponse()->getStatusCode());
+        }
+    }
+
+    public function testGeneralSprintTaskEndpointsMismatchProject(): void
+    {
+        $companyId = $this->createGeneralCompany();
+        $projectAId = $this->createGeneralProject($companyId);
+        $projectBId = $this->createGeneralProject($companyId);
+        $taskId = $this->createGeneralTask($projectAId);
+        $sprintId = $this->createGeneralSprint($projectBId);
+
+        $managerClient = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+
+        foreach (['PUT', 'DELETE'] as $method) {
+            $managerClient->request($method, sprintf('%s/v1/crm/general/sprints/%s/tasks/%s', self::API_URL_PREFIX, $sprintId, $taskId));
+            self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $managerClient->getResponse()->getStatusCode());
+            $payload = $this->decodeJsonResponse($managerClient->getResponse()->getContent());
+            self::assertSame('Task and sprint must belong to the same project.', $payload['message'] ?? null);
+        }
+    }
+
+    private function createGeneralCompany(): string
+    {
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/companies', self::API_URL_PREFIX),
+            content: JSON::encode([
+                'crmId' => $this->getPrimaryCrmId(),
+                'name' => 'General Sprint Task Company ' . uniqid('', true),
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function createGeneralProject(string $companyId): string
+    {
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/projects', self::API_URL_PREFIX),
+            content: JSON::encode([
+                'companyId' => $companyId,
+                'name' => 'General Sprint Task Project ' . uniqid('', true),
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function createGeneralTask(string $projectId): string
+    {
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/tasks', self::API_URL_PREFIX),
+            content: JSON::encode([
+                'projectId' => $projectId,
+                'title' => 'General Sprint Task Task ' . uniqid('', true),
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function createGeneralSprint(string $projectId): string
+    {
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/sprints', self::API_URL_PREFIX),
+            content: JSON::encode([
+                'projectId' => $projectId,
+                'name' => 'General Sprint Task Sprint ' . uniqid('', true),
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function getPrimaryCrmId(): string
+    {
+        static::bootKernel();
+        $crmRepository = static::getContainer()->get(CrmRepository::class);
+        $crm = $crmRepository->findOneByApplicationSlug(self::PRIMARY_APPLICATION_SLUG);
+        self::assertNotNull($crm);
+
+        return $crm->getId();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJsonResponse(string|false $content): array
+    {
+        self::assertNotFalse($content);
+        $decoded = JSON::decode($content, true);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide `general`-scoped endpoints to attach and detach a `Task` to/from a `Sprint` matching existing application-scoped behavior. 
- Ensure the same project-scope validation is applied so tasks and sprints cannot be linked across different projects.

### Description
- Add `PutGeneralAttachTaskToSprintController` implementing `PUT /v1/crm/general/sprints/{sprint}/tasks/{task}` that validates project equality, calls `setSprint($sprint)`, persists via `TaskRepository::save` and returns `204 No Content`.
- Add `DeleteGeneralDetachTaskFromSprintController` implementing `DELETE /v1/crm/general/sprints/{sprint}/tasks/{task}` that validates project equality, calls `setSprint(null)`, persists via `TaskRepository::save` and returns `204 No Content`.
- Add integration test `GeneralSprintTaskControllerTest` covering success (attach + detach and task state verification), not found cases (unknown sprint/task), and mismatch project validation returning `422` with the expected message.

### Testing
- Ran syntax checks with `php -l` on the two controllers and the new test file and they reported no syntax errors.
- Attempted to run the PHPUnit test file via `./vendor/bin/phpunit` but `vendor/bin/phpunit` is not available in this environment so full test execution could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c468bd3c8326bcbb0717fdd50820)