### PR TITLE
feat(crm): add general subtask attach/detach endpoints and parent relation guard

### DIFF
--- a/src/Crm/Application/Service/TaskParentRelationGuard.php
+++ b/src/Crm/Application/Service/TaskParentRelationGuard.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Domain\Entity\Task;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final class TaskParentRelationGuard
+{
+    public function assertCanAssignParent(Task $task, Task $parentTask, string $projectErrorMessage): void
+    {
+        if ($parentTask->getId() === $task->getId()) {
+            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Task cannot be its own parent.');
+        }
+
+        if ($parentTask->getProject()?->getId() !== $task->getProject()?->getId()) {
+            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, $projectErrorMessage);
+        }
+
+        if ($this->isDescendantOf($parentTask, $task)) {
+            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Circular parent relation is not allowed.');
+        }
+    }
+
+    private function isDescendantOf(Task $candidate, Task $task): bool
+    {
+        $current = $candidate->getParentTask();
+        while ($current !== null) {
+            if ($current->getId() === $task->getId()) {
+                return true;
+            }
+
+            $current = $current->getParentTask();
+        }
+
+        return false;
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/General/CreateGeneralSubTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/CreateGeneralSubTaskController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\General;
 
+use App\Crm\Application\Service\TaskParentRelationGuard;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Enum\TaskPriority;
 use App\Crm\Domain\Enum\TaskStatus;
@@ -31,6 +32,7 @@ final readonly class CreateGeneralSubTaskController
     public function __construct(
         private EntityManagerInterface $entityManager,
         private SprintRepository $sprintRepository,
+        private TaskParentRelationGuard $taskParentRelationGuard,
     ) {
     }
 
@@ -50,12 +52,13 @@ final readonly class CreateGeneralSubTaskController
 
         $subTask = (new Task())
             ->setProject($task->getProject())
-            ->setParentTask($task)
             ->setTitle($title)
             ->setDescription($this->nullableString($payload['description'] ?? null))
             ->setStatus(TaskStatus::tryFrom((string) ($payload['status'] ?? 'todo')) ?? TaskStatus::TODO)
             ->setPriority(TaskPriority::tryFrom((string) ($payload['priority'] ?? 'medium')) ?? TaskPriority::MEDIUM)
             ->setDueAt($this->parseNullableDate($payload['dueAt'] ?? null));
+        $this->taskParentRelationGuard->assertCanAssignParent($subTask, $task, 'Provided parent task must belong to the same project.');
+        $subTask->setParentTask($task);
 
         if (isset($payload['estimatedHours']) && is_numeric($payload['estimatedHours'])) {
             $subTask->setEstimatedHours((float) $payload['estimatedHours']);
@@ -78,4 +81,3 @@ final readonly class CreateGeneralSubTaskController
         return new JsonResponse(['id' => $subTask->getId()], JsonResponse::HTTP_CREATED);
     }
 }
-

--- a/src/Crm/Transport/Controller/Api/V1/General/CreateGeneralTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/CreateGeneralTaskController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\General;
 
+use App\Crm\Application\Service\TaskParentRelationGuard;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Enum\TaskPriority;
 use App\Crm\Domain\Enum\TaskStatus;
@@ -35,6 +36,7 @@ final readonly class CreateGeneralTaskController
         private ProjectRepository $projectRepository,
         private SprintRepository $sprintRepository,
         private TaskRepository $taskRepository,
+        private TaskParentRelationGuard $taskParentRelationGuard,
     ) {
     }
 
@@ -88,10 +90,7 @@ final readonly class CreateGeneralTaskController
                     throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Parent task not found.');
                 }
 
-                if ($parentTask->getProject()?->getId() !== $project->getId()) {
-                    throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Provided "parentTaskId" does not belong to the provided "projectId".');
-                }
-
+                $this->taskParentRelationGuard->assertCanAssignParent($task, $parentTask, 'Provided "parentTaskId" does not belong to the provided "projectId".');
                 $task->setParentTask($parentTask);
             }
         }

--- a/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralDetachSubTaskFromTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralDetachSubTaskFromTaskController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Role\Domain\Enum\Role;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class DeleteGeneralDetachSubTaskFromTaskController
+{
+    public function __construct(private TaskRepository $taskRepository)
+    {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/general/tasks/{task}/subtasks/{subtask}', methods: [Request::METHOD_DELETE])]
+    #[OA\Delete(
+        summary: 'General - Detach Subtask From Task',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Sous-task détachée avec succès.'),
+            new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),
+            new OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Accès refusé.'),
+            new OA\Response(response: JsonResponse::HTTP_NOT_FOUND, description: 'Ressource introuvable.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'La sous-task n est pas liée à cette task.'),
+        ],
+    )]
+    public function __invoke(Task $task, Task $subtask): JsonResponse
+    {
+        if ($subtask->getParentTask()?->getId() !== $task->getId()) {
+            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Provided subtask is not attached to the provided task.');
+        }
+
+        $subtask->setParentTask(null);
+        $this->taskRepository->save($subtask);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/General/PatchGeneralSubTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PatchGeneralSubTaskController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\General;
 
+use App\Crm\Application\Service\TaskParentRelationGuard;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Enum\TaskPriority;
 use App\Crm\Domain\Enum\TaskStatus;
@@ -31,6 +32,7 @@ final readonly class PatchGeneralSubTaskController
     public function __construct(
         private EntityManagerInterface $entityManager,
         private TaskRepository $taskRepository,
+        private TaskParentRelationGuard $taskParentRelationGuard,
     ) {
     }
 
@@ -97,15 +99,7 @@ final readonly class PatchGeneralSubTaskController
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Parent task not found.');
         }
 
-        if ($parentTask->getId() === $subtask->getId()) {
-            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Task cannot be its own parent.');
-        }
-
-        if ($parentTask->getProject()?->getId() !== $subtask->getProject()?->getId()) {
-            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Provided "parentTaskId" must belong to the same project.');
-        }
-
+        $this->taskParentRelationGuard->assertCanAssignParent($subtask, $parentTask, 'Provided "parentTaskId" must belong to the same project.');
         $subtask->setParentTask($parentTask);
     }
 }
-

--- a/src/Crm/Transport/Controller/Api/V1/General/PatchGeneralTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PatchGeneralTaskController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Transport\Controller\Api\V1\General;
 
+use App\Crm\Application\Service\TaskParentRelationGuard;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Enum\TaskPriority;
 use App\Crm\Domain\Enum\TaskStatus;
@@ -28,7 +29,11 @@ final readonly class PatchGeneralTaskController
 {
     use GeneralCrudApiTrait;
 
-    public function __construct(private EntityManagerInterface $entityManager, private TaskRepository $taskRepository) {}
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private TaskRepository $taskRepository,
+        private TaskParentRelationGuard $taskParentRelationGuard,
+    ) {}
 
     #[Route('/v1/crm/general/tasks/{task}', methods: [Request::METHOD_PATCH])]
     #[OA\Patch(summary: 'General - Update Task', requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(example: ['status' => 'in_progress', 'estimatedHours' => 4.5, 'parentTaskId' => 'uuid'])), responses: [new OA\Response(response: 200, description: 'Task mise à jour', content: new OA\JsonContent(example: ['id' => 'uuid']))])]
@@ -89,32 +94,7 @@ final readonly class PatchGeneralTaskController
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Parent task not found.');
         }
 
-        if ($parentTask->getId() === $task->getId()) {
-            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Task cannot be its own parent.');
-        }
-
-        if ($parentTask->getProject()?->getId() !== $task->getProject()?->getId()) {
-            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Provided "parentTaskId" must belong to the same project.');
-        }
-
-        if ($this->isDescendantOf($parentTask, $task)) {
-            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Circular parent relation is not allowed.');
-        }
-
+        $this->taskParentRelationGuard->assertCanAssignParent($task, $parentTask, 'Provided "parentTaskId" must belong to the same project.');
         $task->setParentTask($parentTask);
-    }
-
-    private function isDescendantOf(Task $candidate, Task $task): bool
-    {
-        $current = $candidate->getParentTask();
-        while ($current !== null) {
-            if ($current->getId() === $task->getId()) {
-                return true;
-            }
-
-            $current = $current->getParentTask();
-        }
-
-        return false;
     }
 }

--- a/src/Crm/Transport/Controller/Api/V1/General/PutGeneralAttachSubTaskToTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PutGeneralAttachSubTaskToTaskController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Application\Service\TaskParentRelationGuard;
+use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\TaskRepository;
+use App\Role\Domain\Enum\Role;
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class PutGeneralAttachSubTaskToTaskController
+{
+    public function __construct(
+        private TaskRepository $taskRepository,
+        private TaskParentRelationGuard $taskParentRelationGuard,
+    ) {
+    }
+
+    /**
+     * @throws OptimisticLockException
+     * @throws ORMException
+     */
+    #[Route('/v1/crm/general/tasks/{task}/subtasks/{subtask}', methods: [Request::METHOD_PUT])]
+    #[OA\Put(
+        summary: 'General - Attach Subtask To Task',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Sous-task rattachée avec succès.'),
+            new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),
+            new OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Accès refusé.'),
+            new OA\Response(response: JsonResponse::HTTP_NOT_FOUND, description: 'Ressource introuvable.'),
+            new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'Relation invalide.'),
+        ],
+    )]
+    public function __invoke(Task $task, Task $subtask): JsonResponse
+    {
+        $this->taskParentRelationGuard->assertCanAssignParent($subtask, $task, 'Provided task and subtask must belong to the same project.');
+
+        $subtask->setParentTask($task);
+        $this->taskRepository->save($subtask);
+
+        return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
+    }
+}

--- a/tests/Application/Crm/Transport/Controller/Api/V1/GeneralSubTaskControllerTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/GeneralSubTaskControllerTest.php
@@ -114,6 +114,43 @@ final class GeneralSubTaskControllerTest extends WebTestCase
         self::assertSame(Response::HTTP_NOT_FOUND, $managerClient->getResponse()->getStatusCode());
     }
 
+    public function testDedicatedGeneralSubTaskAttachDetachEndpointsAndBusinessValidations(): void
+    {
+        $companyId = $this->createGeneralCompany();
+        $projectId = $this->createGeneralProject($companyId);
+        $rootTaskId = $this->createGeneralTask($projectId, 'Root task');
+        $childTaskId = $this->createGeneralTask($projectId, 'Child task');
+        $grandChildTaskId = $this->createGeneralTask($projectId, 'Grand child task');
+
+        $secondCompanyId = $this->createGeneralCompany();
+        $secondProjectId = $this->createGeneralProject($secondCompanyId);
+        $otherProjectTaskId = $this->createGeneralTask($secondProjectId, 'Task from another project');
+
+        $managerClient = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $managerClient->request('PUT', sprintf('%s/v1/crm/general/tasks/%s/subtasks/%s', self::API_URL_PREFIX, $rootTaskId, $childTaskId));
+        self::assertSame(Response::HTTP_NO_CONTENT, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('PUT', sprintf('%s/v1/crm/general/tasks/%s/subtasks/%s', self::API_URL_PREFIX, $childTaskId, $grandChildTaskId));
+        self::assertSame(Response::HTTP_NO_CONTENT, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('PUT', sprintf('%s/v1/crm/general/tasks/%s/subtasks/%s', self::API_URL_PREFIX, $grandChildTaskId, $rootTaskId));
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('PUT', sprintf('%s/v1/crm/general/tasks/%s/subtasks/%s', self::API_URL_PREFIX, $rootTaskId, $otherProjectTaskId));
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('DELETE', sprintf('%s/v1/crm/general/tasks/%s/subtasks/%s', self::API_URL_PREFIX, $rootTaskId, $childTaskId));
+        self::assertSame(Response::HTTP_NO_CONTENT, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('GET', sprintf('%s/v1/crm/general/tasks/%s', self::API_URL_PREFIX, $childTaskId));
+        self::assertSame(Response::HTTP_OK, $managerClient->getResponse()->getStatusCode());
+        $childPayload = $this->decodeJsonResponse($managerClient->getResponse()->getContent());
+        self::assertNull($childPayload['parentTaskId'] ?? null);
+
+        $managerClient->request('DELETE', sprintf('%s/v1/crm/general/tasks/%s/subtasks/%s', self::API_URL_PREFIX, $rootTaskId, $childTaskId));
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $managerClient->getResponse()->getStatusCode());
+    }
+
     private function createGeneralCompany(): string
     {
         $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
@@ -188,4 +225,3 @@ final class GeneralSubTaskControllerTest extends WebTestCase
         return $decoded;
     }
 }
-


### PR DESCRIPTION
### Motivation
- Permettre le rattachement/détachement explicite d'une sous-tâche à une tâche via des endpoints dédiés. 
- Appliquer et centraliser les validations métier liées aux relations parent/enfant (même projet, pas d'auto-parent, pas de boucle). 
- Garantir un comportement homogène entre création, mise à jour et endpoints dédiés pour les sous-tâches.

### Description
- Ajout d'un service `TaskParentRelationGuard` qui implémente les validations : pas d'auto-parent, appartenance au même projet et détection de cycles ascendants via `isDescendantOf` (fichier `src/Crm/Application/Service/TaskParentRelationGuard.php`).
- Nouveaux endpoints OpenAPI pour rattachement explicite et détachement : `PUT /v1/crm/general/tasks/{task}/subtasks/{subtask}` et `DELETE /v1/crm/general/tasks/{task}/subtasks/{subtask}` (controllers `PutGeneralAttachSubTaskToTaskController` et `DeleteGeneralDetachSubTaskFromTaskController`).
- Réutilisation du guard dans les handlers existants de création/patch de task/subtask (`CreateGeneralTaskController`, `PatchGeneralTaskController`, `CreateGeneralSubTaskController`, `PatchGeneralSubTaskController`) pour uniformiser les règles métier.
- Tests d'intégration étendus (`tests/Application/Crm/Transport/Controller/Api/V1/GeneralSubTaskControllerTest.php`) couvrant les nouveaux endpoints et scénarios métier (rattachement, détachement, rejet cross-project, rejet de boucle). La migration Doctrine pour `parent_task_id` + index existe déjà (`migrations/Version20260417100000.php`).

### Testing
- `php -l` a été exécuté sur les fichiers modifiés/créés et n'a retourné aucune erreur de syntaxe. 
- Les nouveaux et modifiés tests d'intégration ont été ajoutés (`tests/Application/Crm/Transport/Controller/Api/V1/GeneralSubTaskControllerTest.php`) mais une exécution complète de PHPUnit n'a pas pu être effectuée ici car `vendor/bin/phpunit` est absent de l'environnement. 
- Les modifications ont été limitées aux contrôleurs et au service de validation pour minimiser l'impact fonctionnel; la migration DB mentionnée est déjà incluse dans le dépôt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c55352688326a5c98695d0850dbb)