### PR TITLE
Allow reassigning project in PatchGeneralTaskController

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/General/PatchGeneralTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PatchGeneralTaskController.php
@@ -8,6 +8,7 @@ use App\Crm\Application\Service\TaskParentRelationGuard;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Enum\TaskPriority;
 use App\Crm\Domain\Enum\TaskStatus;
+use App\Crm\Infrastructure\Repository\ProjectRepository;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\Role\Domain\Enum\Role;
 use Doctrine\ORM\EntityManagerInterface;
@@ -32,6 +33,7 @@ final readonly class PatchGeneralTaskController
     public function __construct(
         private EntityManagerInterface $entityManager,
         private TaskRepository $taskRepository,
+        private ProjectRepository $projectRepository,
         private TaskParentRelationGuard $taskParentRelationGuard,
     ) {}
 
@@ -68,6 +70,10 @@ final readonly class PatchGeneralTaskController
             $task->setEstimatedHours((float) $payload['estimatedHours']);
         }
 
+        if (array_key_exists('projectId', $payload)) {
+            $this->assignProject($task, $payload['projectId']);
+        }
+
         if (array_key_exists('parentTaskId', $payload)) {
             $this->assignParentTask($task, $payload['parentTaskId']);
         }
@@ -96,5 +102,24 @@ final readonly class PatchGeneralTaskController
 
         $this->taskParentRelationGuard->assertCanAssignParent($task, $parentTask, 'Provided "parentTaskId" must belong to the same project.');
         $task->setParentTask($parentTask);
+    }
+
+    private function assignProject(Task $task, mixed $projectId): void
+    {
+        if (!is_string($projectId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "projectId" must be a UUID string.');
+        }
+
+        $project = $this->projectRepository->find($projectId);
+        if ($project === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Project not found.');
+        }
+
+        $task->setProject($project);
+
+        $sprint = $task->getSprint();
+        if ($sprint !== null && $sprint->getProject()?->getId() !== $project->getId()) {
+            $task->setSprint(null);
+        }
     }
 }

--- a/tests/Application/Crm/Transport/Controller/Api/V1/GeneralPatchTaskProjectControllerTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/GeneralPatchTaskProjectControllerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Crm\Transport\Controller\Api\V1;
+
+use App\Crm\Infrastructure\Repository\CrmRepository;
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+final class GeneralPatchTaskProjectControllerTest extends WebTestCase
+{
+    private const string PRIMARY_APPLICATION_SLUG = 'crm-sales-hub';
+    private const string UNKNOWN_UUID = '00000000-0000-0000-0000-000000000000';
+
+    public function testPatchGeneralTaskCanReassignProjectAndClearMismatchedSprint(): void
+    {
+        $companyId = $this->createGeneralCompany();
+        $projectAId = $this->createGeneralProject($companyId);
+        $projectBId = $this->createGeneralProject($companyId);
+        $sprintAId = $this->createGeneralSprint($projectAId);
+        $taskId = $this->createGeneralTask($projectAId, $sprintAId);
+
+        $managerClient = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $managerClient->request(
+            'PATCH',
+            sprintf('%s/v1/crm/general/tasks/%s', self::API_URL_PREFIX, $taskId),
+            content: JSON::encode([
+                'projectId' => $projectBId,
+            ])
+        );
+        self::assertSame(Response::HTTP_OK, $managerClient->getResponse()->getStatusCode());
+
+        $managerClient->request('GET', sprintf('%s/v1/crm/general/tasks/%s', self::API_URL_PREFIX, $taskId));
+        self::assertSame(Response::HTTP_OK, $managerClient->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($managerClient->getResponse()->getContent());
+        self::assertSame($projectBId, $payload['projectId'] ?? null);
+        self::assertNull($payload['sprintId'] ?? null);
+    }
+
+    public function testPatchGeneralTaskReturns404WhenProjectDoesNotExist(): void
+    {
+        $companyId = $this->createGeneralCompany();
+        $projectId = $this->createGeneralProject($companyId);
+        $taskId = $this->createGeneralTask($projectId);
+
+        $managerClient = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $managerClient->request(
+            'PATCH',
+            sprintf('%s/v1/crm/general/tasks/%s', self::API_URL_PREFIX, $taskId),
+            content: JSON::encode([
+                'projectId' => self::UNKNOWN_UUID,
+            ])
+        );
+
+        self::assertSame(Response::HTTP_NOT_FOUND, $managerClient->getResponse()->getStatusCode());
+        $payload = $this->decodeJsonResponse($managerClient->getResponse()->getContent());
+        self::assertSame('Project not found.', $payload['message'] ?? null);
+    }
+
+    private function createGeneralCompany(): string
+    {
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/companies', self::API_URL_PREFIX),
+            content: JSON::encode([
+                'crmId' => $this->getPrimaryCrmId(),
+                'name' => 'General Patch Task Project Company ' . uniqid('', true),
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function createGeneralProject(string $companyId): string
+    {
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/projects', self::API_URL_PREFIX),
+            content: JSON::encode([
+                'companyId' => $companyId,
+                'name' => 'General Patch Task Project ' . uniqid('', true),
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function createGeneralTask(string $projectId, ?string $sprintId = null): string
+    {
+        $payload = [
+            'projectId' => $projectId,
+            'title' => 'General Patch Task Project Task ' . uniqid('', true),
+        ];
+
+        if ($sprintId !== null) {
+            $payload['sprintId'] = $sprintId;
+        }
+
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/tasks', self::API_URL_PREFIX),
+            content: JSON::encode($payload)
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $responsePayload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $responsePayload['id'];
+    }
+
+    private function createGeneralSprint(string $projectId): string
+    {
+        $client = $this->getTestClient('john-crm_manager', 'password-crm_manager');
+        $client->request(
+            'POST',
+            sprintf('%s/v1/crm/general/sprints', self::API_URL_PREFIX),
+            content: JSON::encode([
+                'projectId' => $projectId,
+                'name' => 'General Patch Task Project Sprint ' . uniqid('', true),
+            ])
+        );
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+
+        $payload = $this->decodeJsonResponse($client->getResponse()->getContent());
+
+        return (string) $payload['id'];
+    }
+
+    private function getPrimaryCrmId(): string
+    {
+        static::bootKernel();
+        $crmRepository = static::getContainer()->get(CrmRepository::class);
+        $crm = $crmRepository->findOneByApplicationSlug(self::PRIMARY_APPLICATION_SLUG);
+        self::assertNotNull($crm);
+
+        return $crm->getId();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJsonResponse(string|false $content): array
+    {
+        self::assertNotFalse($content);
+        $decoded = JSON::decode($content, true);
+        self::assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
### Motivation
- Enable updating a task's `projectId` through the general task PATCH endpoint and ensure the domain remains consistent when a task moves between projects.
- Return `404` when a provided `projectId` does not exist and keep payload validation strict for UUID strings.
- If the task's current `sprint` no longer belongs to the new project, clear the sprint to avoid inconsistent cross-project sprint assignment.

### Description
- Injected `ProjectRepository` into `PatchGeneralTaskController` and added handling for `projectId` in the PATCH payload by calling a new `assignProject` helper method.
- Implemented `assignProject` to validate `projectId` type, load the `Project` via `ProjectRepository`, throw `404` when not found, call `$task->setProject($project)`, and clear `$task->setSprint(null)` when the sprint's project does not match the new project.
- Left existing parent-task handling intact and preserved previous behavior for other updatable fields (`title`, `description`, `status`, `priority`, `dueAt`, `estimatedHours`, `parentTaskId`).
- Added integration tests in `tests/Application/Crm/Transport/Controller/Api/V1/GeneralPatchTaskProjectControllerTest.php` covering successful project reassignment with sprint cleanup and the `404` error when the project is missing.

### Testing
- Ran PHP lint on modified files with `php -l src/Crm/Transport/Controller/Api/V1/General/PatchGeneralTaskController.php` and `php -l tests/.../GeneralPatchTaskProjectControllerTest.php`, both returned no syntax errors.
- Attempted to run the new integration test with `phpunit`, but the `phpunit` binary was not present in the execution environment so the tests could not be executed here.
- The new tests were added and validated for syntax; they should run in CI or a fully provisioned dev environment where `phpunit` is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c6df8d4c8326972b3372bf0a8e71)