### PR TITLE
Align general assignee controllers with application-scope conventions

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralProjectAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralProjectAssigneeController.php
@@ -22,8 +22,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class DeleteGeneralProjectAssigneeController
 {
-    public function __construct(private ProjectRepository $projectRepository)
-    {
+    public function __construct(
+        private ProjectRepository $projectRepository
+    ) {
     }
 
     /**
@@ -34,8 +35,8 @@ final readonly class DeleteGeneralProjectAssigneeController
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Delete(
-        summary: 'General - Remove Project Assignee',
-        description: 'Retire un assignee d un project dans le périmètre CRM général.',
+        summary: 'Remove Project Assignee (General)',
+        description: 'Exécute l action metier Remove Project Assignee dans le perimetre CRM general.',
         responses: [
             new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee retiré avec succès.'),
             new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),

--- a/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralSprintAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralSprintAssigneeController.php
@@ -22,8 +22,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class DeleteGeneralSprintAssigneeController
 {
-    public function __construct(private SprintRepository $sprintRepository)
-    {
+    public function __construct(
+        private SprintRepository $sprintRepository
+    ) {
     }
 
     /**
@@ -34,8 +35,8 @@ final readonly class DeleteGeneralSprintAssigneeController
     #[OA\Parameter(name: 'sprint', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Delete(
-        summary: 'General - Remove Sprint Assignee',
-        description: 'Retire un assignee d un sprint dans le périmètre CRM général.',
+        summary: 'Remove Sprint Assignee (General)',
+        description: 'Exécute l action metier Remove Sprint Assignee dans le perimetre CRM general.',
         responses: [
             new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee retiré avec succès.'),
             new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),

--- a/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralTaskAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralTaskAssigneeController.php
@@ -22,8 +22,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class DeleteGeneralTaskAssigneeController
 {
-    public function __construct(private TaskRepository $taskRepository)
-    {
+    public function __construct(
+        private TaskRepository $taskRepository
+    ) {
     }
 
     /**
@@ -34,8 +35,8 @@ final readonly class DeleteGeneralTaskAssigneeController
     #[OA\Parameter(name: 'task', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Delete(
-        summary: 'General - Remove Task Assignee',
-        description: 'Retire un assignee d une task dans le périmètre CRM général.',
+        summary: 'Remove Task Assignee (General)',
+        description: 'Exécute l action metier Remove Task Assignee dans le perimetre CRM general.',
         responses: [
             new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee retiré avec succès.'),
             new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),

--- a/src/Crm/Transport/Controller/Api/V1/General/PutGeneralProjectAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PutGeneralProjectAssigneeController.php
@@ -22,8 +22,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class PutGeneralProjectAssigneeController
 {
-    public function __construct(private ProjectRepository $projectRepository)
-    {
+    public function __construct(
+        private ProjectRepository $projectRepository
+    ) {
     }
 
     /**
@@ -34,8 +35,8 @@ final readonly class PutGeneralProjectAssigneeController
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Put(
-        summary: 'General - Add Project Assignee',
-        description: 'Ajoute un assignee à un project dans le périmètre CRM général.',
+        summary: 'Add Project Assignee (General)',
+        description: 'Exécute l action metier Add Project Assignee dans le perimetre CRM general.',
         responses: [
             new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee ajouté avec succès.'),
             new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),

--- a/src/Crm/Transport/Controller/Api/V1/General/PutGeneralSprintAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PutGeneralSprintAssigneeController.php
@@ -22,8 +22,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class PutGeneralSprintAssigneeController
 {
-    public function __construct(private SprintRepository $sprintRepository)
-    {
+    public function __construct(
+        private SprintRepository $sprintRepository
+    ) {
     }
 
     /**
@@ -34,8 +35,8 @@ final readonly class PutGeneralSprintAssigneeController
     #[OA\Parameter(name: 'sprint', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Put(
-        summary: 'General - Add Sprint Assignee',
-        description: 'Ajoute un assignee à un sprint dans le périmètre CRM général.',
+        summary: 'Add Sprint Assignee (General)',
+        description: 'Exécute l action metier Add Sprint Assignee dans le perimetre CRM general.',
         responses: [
             new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee ajouté avec succès.'),
             new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),

--- a/src/Crm/Transport/Controller/Api/V1/General/PutGeneralTaskAssigneeController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PutGeneralTaskAssigneeController.php
@@ -22,8 +22,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(Role::CRM_MANAGER->value)]
 final readonly class PutGeneralTaskAssigneeController
 {
-    public function __construct(private TaskRepository $taskRepository)
-    {
+    public function __construct(
+        private TaskRepository $taskRepository
+    ) {
     }
 
     /**
@@ -34,8 +35,8 @@ final readonly class PutGeneralTaskAssigneeController
     #[OA\Parameter(name: 'task', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'user', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Put(
-        summary: 'General - Add Task Assignee',
-        description: 'Ajoute un assignee à une task dans le périmètre CRM général.',
+        summary: 'Add Task Assignee (General)',
+        description: 'Exécute l action metier Add Task Assignee dans le perimetre CRM general.',
         responses: [
             new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Assignee ajouté avec succès.'),
             new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),


### PR DESCRIPTION
### Motivation
- Harmoniser les contrôleurs CRM « general » avec les conventions utilisées pour les contrôleurs au périmètre application (format du constructeur et wording OpenAPI). 
- Garder la logique métier et les contrats HTTP existants inchangés tout en améliorant la cohérence des docs API.

### Description
- Mise à jour des 6 contrôleurs dans `src/Crm/Transport/Controller/Api/V1/General/`: `Put/Delete` pour `Project`, `Task` et `Sprint` assignees. 
- Normalisation du format du constructeur (passage en multi-ligne) dans chaque contrôleur. 
- Alignement des attributs OpenAPI `summary` et `description` pour utiliser le même libellé que les contrôleurs application-scope, sans modifier la logique `addAssignee` / `removeAssignee` ni l'appel `repository->save(...)`. 

### Testing
- Vérification de la syntaxe PHP avec `php -l` sur chacun des six fichiers mentionnés; toutes les vérifications ont réussi (aucune erreur de syntaxe).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1cb5490fc832685eea81753000c24)