### PR TITLE
Add explicit existence/scope checks for general sprint-task attach/detach

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralDetachTaskFromSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralDetachTaskFromSprintController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Controller\Api\V1\General;
 
 use App\Crm\Domain\Entity\Sprint;
-use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\SprintRepository;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class DeleteGeneralDetachTaskFromSprintController
 {
     public function __construct(
+        private SprintRepository $sprintRepository,
         private TaskRepository $taskRepository,
         private CrmApiErrorResponseFactory $errorResponseFactory,
     ) {
@@ -47,14 +48,24 @@ final readonly class DeleteGeneralDetachTaskFromSprintController
             new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'Erreur de validation métier.'),
         ],
     )]
-    public function __invoke(Sprint $sprint, Task $task): JsonResponse
+    public function __invoke(string $sprint, string $task): JsonResponse
     {
-        if ($task->getProject()?->getId() !== $sprint->getProject()?->getId()) {
+        $sprintEntity = $this->sprintRepository->find($sprint);
+        if (!$sprintEntity instanceof Sprint) {
+            return $this->errorResponseFactory->notFoundReference('sprint');
+        }
+
+        $taskEntity = $this->taskRepository->find($task);
+        if ($taskEntity === null) {
+            return $this->errorResponseFactory->notFoundReference('task');
+        }
+
+        if ($taskEntity->getProject()?->getId() !== $sprintEntity->getProject()?->getId()) {
             return $this->errorResponseFactory->outOfScopeReference('Task and sprint must belong to the same project.');
         }
 
-        $task->setSprint(null);
-        $this->taskRepository->save($task);
+        $taskEntity->setSprint(null);
+        $this->taskRepository->save($taskEntity);
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }

--- a/src/Crm/Transport/Controller/Api/V1/General/PutGeneralAttachTaskToSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PutGeneralAttachTaskToSprintController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Controller\Api\V1\General;
 
 use App\Crm\Domain\Entity\Sprint;
-use App\Crm\Domain\Entity\Task;
+use App\Crm\Infrastructure\Repository\SprintRepository;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Role\Domain\Enum\Role;
@@ -24,6 +24,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class PutGeneralAttachTaskToSprintController
 {
     public function __construct(
+        private SprintRepository $sprintRepository,
         private TaskRepository $taskRepository,
         private CrmApiErrorResponseFactory $errorResponseFactory,
     ) {
@@ -47,14 +48,24 @@ final readonly class PutGeneralAttachTaskToSprintController
             new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'Erreur de validation métier.'),
         ],
     )]
-    public function __invoke(Sprint $sprint, Task $task): JsonResponse
+    public function __invoke(string $sprint, string $task): JsonResponse
     {
-        if ($task->getProject()?->getId() !== $sprint->getProject()?->getId()) {
+        $sprintEntity = $this->sprintRepository->find($sprint);
+        if (!$sprintEntity instanceof Sprint) {
+            return $this->errorResponseFactory->notFoundReference('sprint');
+        }
+
+        $taskEntity = $this->taskRepository->find($task);
+        if ($taskEntity === null) {
+            return $this->errorResponseFactory->notFoundReference('task');
+        }
+
+        if ($taskEntity->getProject()?->getId() !== $sprintEntity->getProject()?->getId()) {
             return $this->errorResponseFactory->outOfScopeReference('Task and sprint must belong to the same project.');
         }
 
-        $task->setSprint($sprint);
-        $this->taskRepository->save($task);
+        $taskEntity->setSprint($sprintEntity);
+        $this->taskRepository->save($taskEntity);
 
         return new JsonResponse(status: JsonResponse::HTTP_NO_CONTENT);
     }

--- a/tests/Application/Crm/Transport/Controller/Api/V1/GeneralSprintTaskControllerTest.php
+++ b/tests/Application/Crm/Transport/Controller/Api/V1/GeneralSprintTaskControllerTest.php
@@ -50,14 +50,24 @@ final class GeneralSprintTaskControllerTest extends WebTestCase
         $managerClient = $this->getTestClient('john-crm_manager', 'password-crm_manager');
 
         foreach ([
-            sprintf('%s/v1/crm/general/sprints/%s/tasks/%s', self::API_URL_PREFIX, self::UNKNOWN_UUID, $taskId),
-            sprintf('%s/v1/crm/general/sprints/%s/tasks/%s', self::API_URL_PREFIX, $sprintId, self::UNKNOWN_UUID),
-        ] as $path) {
-            $managerClient->request('PUT', $path);
+            [
+                'path' => sprintf('%s/v1/crm/general/sprints/%s/tasks/%s', self::API_URL_PREFIX, self::UNKNOWN_UUID, $taskId),
+                'message' => 'Unknown "sprint" in this CRM scope.',
+            ],
+            [
+                'path' => sprintf('%s/v1/crm/general/sprints/%s/tasks/%s', self::API_URL_PREFIX, $sprintId, self::UNKNOWN_UUID),
+                'message' => 'Unknown "task" in this CRM scope.',
+            ],
+        ] as $testCase) {
+            $managerClient->request('PUT', $testCase['path']);
             self::assertSame(Response::HTTP_NOT_FOUND, $managerClient->getResponse()->getStatusCode());
+            $payload = $this->decodeJsonResponse($managerClient->getResponse()->getContent());
+            self::assertSame($testCase['message'], $payload['message'] ?? null);
 
-            $managerClient->request('DELETE', $path);
+            $managerClient->request('DELETE', $testCase['path']);
             self::assertSame(Response::HTTP_NOT_FOUND, $managerClient->getResponse()->getStatusCode());
+            $payload = $this->decodeJsonResponse($managerClient->getResponse()->getContent());
+            self::assertSame($testCase['message'], $payload['message'] ?? null);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Ensure the general sprint-task attach/detach endpoints validate that both `sprint` and `task` exist and belong to the same `project` before applying business changes. 
- Return coherent CRM API error responses (`404` for missing resources, `422` for out-of-scope references) instead of relying on implicit parameter-to-entity resolution. 
- Apply explicit attach/detach semantics using `setSprint($sprint)` and `setSprint(null)` and persist via the `TaskRepository` with a `204 No Content` success response.

### Description
- Updated `PutGeneralAttachTaskToSprintController` to accept route IDs (`string $sprint`, `string $task`), inject `SprintRepository`, resolve entities via `find`, return `notFoundReference('sprint')` or `notFoundReference('task')` when missing, validate same-project scope with `outOfScopeReference`, call `setSprint($sprint)` and save via `TaskRepository`. 
- Updated `DeleteGeneralDetachTaskFromSprintController` with symmetric changes to resolve IDs, return `404` when missing, validate scope, call `setSprint(null)` and save via `TaskRepository`. 
- Strengthened `tests/Application/Crm/Transport/Controller/Api/V1/GeneralSprintTaskControllerTest.php` to assert the exact `404` payload messages for missing `sprint` and `task` on both `PUT` and `DELETE` flows. 
- Kept existing authorization and OpenAPI annotations and preserved the `204 No Content` success responses for attach/detach operations.

### Testing
- Ran PHP syntax checks which passed for the modified files with `php -l src/Crm/Transport/Controller/Api/V1/General/PutGeneralAttachTaskToSprintController.php`, `php -l src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralDetachTaskFromSprintController.php` and `php -l tests/Application/Crm/Transport/Controller/Api/V1/GeneralSprintTaskControllerTest.php`. 
- Updated integration test `GeneralSprintTaskControllerTest` to validate error payloads, but full `phpunit` execution was not possible in this environment because `./vendor/bin/phpunit` is unavailable. 
- No syntax errors detected and local changes were validated with the linter; CI should run the full test suite including the updated integration test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1cc36d5908326b8e478e9ab586f16)