### PR TITLE
Add parent_task index mapping and expand OpenAPI for CRM subtask endpoints

### DIFF
--- a/src/Crm/Domain/Entity/Task.php
+++ b/src/Crm/Domain/Entity/Task.php
@@ -23,7 +23,10 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Throwable;
 
 #[ORM\Entity]
-#[ORM\Table(name: 'crm_task')]
+#[ORM\Table(
+    name: 'crm_task',
+    indexes: [new ORM\Index(name: 'IDX_FA9A9B9D801B5A19', columns: ['parent_task_id'])]
+)]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Task implements EntityInterface
 {

--- a/src/Crm/Transport/Controller/Api/V1/General/CreateGeneralSubTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/CreateGeneralSubTaskController.php
@@ -37,7 +37,15 @@ final readonly class CreateGeneralSubTaskController
     }
 
     #[Route('/v1/crm/general/tasks/{task}/subtasks', methods: [Request::METHOD_POST])]
-    #[OA\Post(summary: 'General - Create Subtask', requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(example: ['title' => 'Créer un script de migration', 'priority' => 'high'])), responses: [new OA\Response(response: 201, description: 'Sous-task créée', content: new OA\JsonContent(example: ['id' => 'uuid']))])]
+    #[OA\Post(
+        summary: 'General - Create Subtask',
+        parameters: [new OA\Parameter(name: 'task', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))],
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(example: ['title' => 'Créer un script de migration', 'priority' => 'high'])),
+        responses: [
+            new OA\Response(response: 201, description: 'Sous-task créée', content: new OA\JsonContent(example: ['id' => 'uuid'])),
+            new OA\Response(response: 422, description: 'La task parente n est pas dans le même projet ou la relation est circulaire.'),
+        ]
+    )]
     public function __invoke(Task $task, Request $request): JsonResponse
     {
         $payload = $this->decodePayload($request);

--- a/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralDetachSubTaskFromTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralDetachSubTaskFromTaskController.php
@@ -33,6 +33,10 @@ final readonly class DeleteGeneralDetachSubTaskFromTaskController
     #[Route('/v1/crm/general/tasks/{task}/subtasks/{subtask}', methods: [Request::METHOD_DELETE])]
     #[OA\Delete(
         summary: 'General - Detach Subtask From Task',
+        parameters: [
+            new OA\Parameter(name: 'task', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid')),
+            new OA\Parameter(name: 'subtask', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid')),
+        ],
         responses: [
             new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Sous-task détachée avec succès.'),
             new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),

--- a/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralSubTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralSubTaskController.php
@@ -25,7 +25,11 @@ final readonly class DeleteGeneralSubTaskController
     }
 
     #[Route('/v1/crm/general/subtasks/{subtask}', methods: [Request::METHOD_DELETE])]
-    #[OA\Delete(summary: 'General - Delete Subtask', responses: [new OA\Response(response: 204, description: 'Sous-task supprimée')])]
+    #[OA\Delete(
+        summary: 'General - Delete Subtask',
+        parameters: [new OA\Parameter(name: 'subtask', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))],
+        responses: [new OA\Response(response: 204, description: 'Sous-task supprimée')]
+    )]
     public function __invoke(Task $subtask): JsonResponse
     {
         if ($subtask->getParentTask() === null) {
@@ -38,4 +42,3 @@ final readonly class DeleteGeneralSubTaskController
         return new JsonResponse(null, JsonResponse::HTTP_NO_CONTENT);
     }
 }
-

--- a/src/Crm/Transport/Controller/Api/V1/General/GetGeneralTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/GetGeneralTaskController.php
@@ -23,6 +23,17 @@ final readonly class GetGeneralTaskController
     }
 
     #[Route('/v1/crm/general/tasks/{task}', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'General - Get Task',
+        parameters: [new OA\Parameter(name: 'task', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))],
+        responses: [new OA\Response(response: 200, description: 'Task détaillée', content: new OA\JsonContent(example: [
+            'id' => 'uuid',
+            'title' => 'Implémenter la migration',
+            'projectId' => 'uuid',
+            'parentTaskId' => null,
+            'subTasks' => [['id' => 'uuid', 'title' => 'Créer migration', 'parentTaskId' => 'uuid']],
+        ]))]
+    )]
     public function __invoke(Task $task): JsonResponse
     {
         return new JsonResponse($this->normalizer->normalizeTask($task));

--- a/src/Crm/Transport/Controller/Api/V1/General/PatchGeneralSubTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PatchGeneralSubTaskController.php
@@ -37,7 +37,15 @@ final readonly class PatchGeneralSubTaskController
     }
 
     #[Route('/v1/crm/general/subtasks/{subtask}', methods: [Request::METHOD_PATCH])]
-    #[OA\Patch(summary: 'General - Update Subtask', requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(example: ['status' => 'in_progress', 'parentTaskId' => 'uuid'])), responses: [new OA\Response(response: 200, description: 'Sous-task mise à jour', content: new OA\JsonContent(example: ['id' => 'uuid']))])]
+    #[OA\Patch(
+        summary: 'General - Update Subtask',
+        parameters: [new OA\Parameter(name: 'subtask', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))],
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(example: ['status' => 'in_progress', 'parentTaskId' => 'uuid'])),
+        responses: [
+            new OA\Response(response: 200, description: 'Sous-task mise à jour', content: new OA\JsonContent(example: ['id' => 'uuid'])),
+            new OA\Response(response: 422, description: 'La task parente n est pas dans le même projet ou la relation est circulaire.'),
+        ]
+    )]
     public function __invoke(Task $subtask, Request $request): JsonResponse
     {
         if ($subtask->getParentTask() === null) {

--- a/src/Crm/Transport/Controller/Api/V1/General/PutGeneralAttachSubTaskToTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/PutGeneralAttachSubTaskToTaskController.php
@@ -35,6 +35,10 @@ final readonly class PutGeneralAttachSubTaskToTaskController
     #[Route('/v1/crm/general/tasks/{task}/subtasks/{subtask}', methods: [Request::METHOD_PUT])]
     #[OA\Put(
         summary: 'General - Attach Subtask To Task',
+        parameters: [
+            new OA\Parameter(name: 'task', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid')),
+            new OA\Parameter(name: 'subtask', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid')),
+        ],
         responses: [
             new OA\Response(response: JsonResponse::HTTP_NO_CONTENT, description: 'Sous-task rattachée avec succès.'),
             new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),


### PR DESCRIPTION
### Motivation
- Ensure the Doctrine entity mapping for `Task` explicitly includes the existing `parent_task_id` index so ORM metadata matches the DB migration.
- Improve OpenAPI documentation and examples for the General subtask endpoints to make API usage clearer and include path parameter schemas.
- Surface the `parentTaskId` and `subTasks` structure in the task GET example for better API discoverability.

### Description
- Added an explicit table-level index for `parent_task_id` on the `Task` entity by updating `#[ORM/Table(...)]` in `src/Crm/Domain/Entity/Task.php`.
- Enhanced OpenAPI annotations for subtask endpoints by adding path `parameters` and additional `responses` where appropriate in the following controllers: `src/Crm/Transport/Controller/Api/V1/General/CreateGeneralSubTaskController.php`, `src/Crm/Transport/Controller/Api/V1/General/PatchGeneralSubTaskController.php`, `src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralSubTaskController.php`, `src/Crm/Transport/Controller/Api/V1/General/PutGeneralAttachSubTaskToTaskController.php`, and `src/Crm/Transport/Controller/Api/V1/General/DeleteGeneralDetachSubTaskFromTaskController.php`.
- Added an OpenAPI `GET` example for `GET /v1/crm/general/tasks/{task}` showing `parentTaskId` and `subTasks` in `src/Crm/Transport/Controller/Api/V1/General/GetGeneralTaskController.php`.
- No behavioral changes to validation or permission logic were introduced; existing safeguards (same project, anti-loop, manager permission) and the previously-created migration `migrations/Version20260417100000.php` remain in effect.

### Testing
- Ran PHP syntax checks on all modified files with `php -l` which completed successfully for each changed file.
- No additional automated tests were run as part of this PR; all changes are annotation/mapping and OpenAPI documentation updates only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1cd599fd483268a1934e1a0e9352d)