### PR TITLE
Respect APP_PUBLIC_BASE_URL for uploaded media URLs

### DIFF
--- a/.env
+++ b/.env
@@ -79,6 +79,7 @@ APP_SHARE_DIR=var/share
 # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
 # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
 DEFAULT_URI=http://localhost
+APP_PUBLIC_BASE_URL=https://bro-world.org
 ###< symfony/routing ###
 
 ###> doctrine/doctrine-bundle ###

--- a/.env.prod
+++ b/.env.prod
@@ -13,6 +13,7 @@ APP_ENV=prod
 APP_SECRET=42f011ec3a7bde0bec87364b1d967194
 APP_DEBUG=0
 DEFAULT_URI=
+APP_PUBLIC_BASE_URL=https://bro-world.org
 
 ###> doctrine/doctrine-bundle ###
 DATABASE_URL=mysql://root:${MYSQL_ROOT_PASSWORD}@mysql:3306/symfony

--- a/.env.staging
+++ b/.env.staging
@@ -13,6 +13,7 @@ APP_ENV=staging
 APP_SECRET=42f011ec3a7bde0bec87364b1d967194
 APP_DEBUG=0
 DEFAULT_URI=
+APP_PUBLIC_BASE_URL=https://bro-world.org
 
 ###> doctrine/doctrine-bundle ###
 DATABASE_URL=mysql://root:${MYSQL_ROOT_PASSWORD}@mysql:3306/symfony

--- a/src/Media/Application/Service/MediaUploaderService.php
+++ b/src/Media/Application/Service/MediaUploaderService.php
@@ -15,6 +15,8 @@ use function bin2hex;
 use function in_array;
 use function is_int;
 use function random_bytes;
+use function rtrim;
+use function str_starts_with;
 use function strtolower;
 use function trim;
 
@@ -23,6 +25,7 @@ readonly class MediaUploaderService
     public function __construct(
         private Filesystem $filesystem,
         private string $projectDir,
+        private string $publicBaseUrl = '',
     ) {
     }
 
@@ -53,7 +56,7 @@ readonly class MediaUploaderService
             $file->move($targetDirectory, $fileName);
 
             $uploadedFiles[] = [
-                'url' => $request->getSchemeAndHttpHost() . $normalizedDirectory . '/' . $fileName,
+                'url' => $this->resolvePublicBaseUrl($request) . $normalizedDirectory . '/' . $fileName,
                 'originalName' => $originalName,
                 'mimeType' => $mimeType,
                 'size' => $size,
@@ -94,5 +97,18 @@ readonly class MediaUploaderService
         $size = $file->getSize();
 
         return is_int($size) ? $size : 0;
+    }
+
+    private function resolvePublicBaseUrl(Request $request): string
+    {
+        $normalizedPublicBaseUrl = rtrim(trim($this->publicBaseUrl), '/');
+        if (
+            $normalizedPublicBaseUrl !== ''
+            && (str_starts_with($normalizedPublicBaseUrl, 'https://') || str_starts_with($normalizedPublicBaseUrl, 'http://'))
+        ) {
+            return $normalizedPublicBaseUrl;
+        }
+
+        return $request->getSchemeAndHttpHost();
     }
 }


### PR DESCRIPTION
### Motivation
- Uploaded media URLs were being built from the incoming request host (so uploads triggered via e.g. Nuxt on `localhost:3000` produced `https://localhost:3000/uploads/...`) instead of the intended public domain.
- The change ensures API responses return stable, public-facing URLs (e.g. `https://bro-world.org/uploads/...`) independent of the caller host when desired.

### Description
- `MediaUploaderService` now accepts a configurable `$publicBaseUrl` and uses a new `resolvePublicBaseUrl(Request $request)` method to prefer a valid `APP_PUBLIC_BASE_URL` and fall back to `$request->getSchemeAndHttpHost()` when not set.
- The URL construction for uploaded files was changed from `$request->getSchemeAndHttpHost() . $normalizedDirectory . '/' . $fileName` to use the resolver so returned `url` uses the configured public base URL.
- Added `APP_PUBLIC_BASE_URL=https://bro-world.org` to `.env`, `.env.prod` and `.env.staging` so environments produce the expected bro-world.org URLs by default.
- Minor imports added (`rtrim`, `str_starts_with`) and default parameter for the new constructor argument were introduced.

### Testing
- Ran PHP syntax check with `php -l src/Media/Application/Service/MediaUploaderService.php` which returned no syntax errors.
- Attempted to run `./vendor/bin/phpunit tests/Application/User/Transport/Controller/Api/V1/Profile/UploadPhotoControllerTest.php` but `vendor/bin/phpunit` is not available in the current environment so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2bfb3df608326ac990b5b7afad71e)