### PR TITLE
Add configurable APP_PUBLIC_BASE_URL and use it for media upload URLs

### DIFF
--- a/.env
+++ b/.env
@@ -79,6 +79,7 @@ APP_SHARE_DIR=var/share
 # Configure how to generate URLs in non-HTTP contexts, such as CLI commands.
 # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
 DEFAULT_URI=http://localhost
+APP_PUBLIC_BASE_URL=https://bro-world.org
 ###< symfony/routing ###
 
 ###> doctrine/doctrine-bundle ###

--- a/.env.prod
+++ b/.env.prod
@@ -13,6 +13,7 @@ APP_ENV=prod
 APP_SECRET=42f011ec3a7bde0bec87364b1d967194
 APP_DEBUG=0
 DEFAULT_URI=
+APP_PUBLIC_BASE_URL=https://bro-world.org
 
 ###> doctrine/doctrine-bundle ###
 DATABASE_URL=mysql://root:${MYSQL_ROOT_PASSWORD}@mysql:3306/symfony

--- a/.env.staging
+++ b/.env.staging
@@ -13,6 +13,7 @@ APP_ENV=staging
 APP_SECRET=42f011ec3a7bde0bec87364b1d967194
 APP_DEBUG=0
 DEFAULT_URI=
+APP_PUBLIC_BASE_URL=https://bro-world.org
 
 ###> doctrine/doctrine-bundle ###
 DATABASE_URL=mysql://root:${MYSQL_ROOT_PASSWORD}@mysql:3306/symfony

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -156,6 +156,10 @@ services:
         arguments:
             $serializer: '@app.serializer.external_message'
 
+    App\Media\Application\Service\MediaUploaderService:
+        arguments:
+            $publicBaseUrl: '%env(default::APP_PUBLIC_BASE_URL)%'
+
 
     App\Shop\Application\Monitoring\ShopMonitoringService:
         arguments:

--- a/src/Media/Application/Service/MediaUploaderService.php
+++ b/src/Media/Application/Service/MediaUploaderService.php
@@ -15,6 +15,8 @@ use function bin2hex;
 use function in_array;
 use function is_int;
 use function random_bytes;
+use function rtrim;
+use function str_starts_with;
 use function strtolower;
 use function trim;
 
@@ -23,6 +25,7 @@ readonly class MediaUploaderService
     public function __construct(
         private Filesystem $filesystem,
         private string $projectDir,
+        private string $publicBaseUrl = '',
     ) {
     }
 
@@ -53,7 +56,7 @@ readonly class MediaUploaderService
             $file->move($targetDirectory, $fileName);
 
             $uploadedFiles[] = [
-                'url' => $request->getSchemeAndHttpHost() . $normalizedDirectory . '/' . $fileName,
+                'url' => $this->resolvePublicBaseUrl($request) . $normalizedDirectory . '/' . $fileName,
                 'originalName' => $originalName,
                 'mimeType' => $mimeType,
                 'size' => $size,
@@ -94,5 +97,18 @@ readonly class MediaUploaderService
         $size = $file->getSize();
 
         return is_int($size) ? $size : 0;
+    }
+
+    private function resolvePublicBaseUrl(Request $request): string
+    {
+        $normalizedPublicBaseUrl = rtrim(trim($this->publicBaseUrl), '/');
+        if (
+            $normalizedPublicBaseUrl !== ''
+            && (str_starts_with($normalizedPublicBaseUrl, 'https://') || str_starts_with($normalizedPublicBaseUrl, 'http://'))
+        ) {
+            return $normalizedPublicBaseUrl;
+        }
+
+        return $request->getSchemeAndHttpHost();
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a way to configure a fixed public base URL for uploaded media so generated URLs can be consistent across reverse proxies, CDNs or environments.
- Avoid relying solely on `Request::getSchemeAndHttpHost()` when the public-facing host differs from the application host.
- Allow deployments to set the public base via environment variables for dev, staging and prod.

### Description
- Added `APP_PUBLIC_BASE_URL` to `.env`, `.env.staging` and `.env.prod` with a sample value and wired it into service configuration using `%env(default::APP_PUBLIC_BASE_URL)%` for `MediaUploaderService` in `config/services.yaml`.
- Extended `MediaUploaderService` to accept an optional `$publicBaseUrl` constructor argument and replaced `Request::getSchemeAndHttpHost()` with `resolvePublicBaseUrl()` when building uploaded file URLs.
- Implemented `resolvePublicBaseUrl()` to normalize the configured base URL, validate it starts with `http://` or `https://`, and fall back to the request host when not set or invalid.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2bfb3df608326ac990b5b7afad71e)