### PR TITLE
feat(crm): expose CRM general variants of project GitHub endpoints

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubIssueCommentController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubIssueCommentController.php
@@ -32,6 +32,7 @@ final readonly class AddProjectGithubIssueCommentController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}/comments', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/general/projects/{project}/github/issues/{number}/comments', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
@@ -53,7 +54,7 @@ final readonly class AddProjectGithubIssueCommentController
             new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error while commenting issue.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
+    public function __invoke(Project $project, int $number, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);
         if ($payload instanceof JsonResponse) {

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubRepositoryController.php
@@ -34,6 +34,7 @@ final readonly class AddProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/general/projects/{project}/github/repositories', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12')]
     #[OA\Post(
@@ -121,7 +122,7 @@ final readonly class AddProjectGithubRepositoryController
             ),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    public function __invoke(Project $project, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);
         if ($payload instanceof JsonResponse) {

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubBranchController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubBranchController.php
@@ -32,6 +32,7 @@ final readonly class CreateProjectGithubBranchController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/branches/create', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/general/projects/{project}/github/branches/create', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
@@ -100,7 +101,7 @@ final readonly class CreateProjectGithubBranchController
             ),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    public function __invoke(Project $project, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);
         if ($payload instanceof JsonResponse) {

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubIssueController.php
@@ -32,6 +32,7 @@ final readonly class CreateProjectGithubIssueController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/general/projects/{project}/github/issues', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
@@ -102,7 +103,7 @@ final readonly class CreateProjectGithubIssueController
             ),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    public function __invoke(Project $project, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);
         if ($payload instanceof JsonResponse) {

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubProjectBoardController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubProjectBoardController.php
@@ -32,6 +32,7 @@ final readonly class CreateProjectGithubProjectBoardController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/general/projects/{project}/github/projects', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
@@ -98,7 +99,7 @@ final readonly class CreateProjectGithubProjectBoardController
             ),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    public function __invoke(Project $project, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);
         if ($payload instanceof JsonResponse) {

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubRepositoryController.php
@@ -32,6 +32,7 @@ final readonly class CreateProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/create', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/general/projects/{project}/github/repositories/create', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
@@ -99,7 +100,7 @@ final readonly class CreateProjectGithubRepositoryController
             ),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    public function __invoke(Project $project, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);
         if ($payload instanceof JsonResponse) {

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/DeleteProjectGithubBranchController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/DeleteProjectGithubBranchController.php
@@ -32,6 +32,7 @@ final readonly class DeleteProjectGithubBranchController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/branches/delete', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/crm/general/projects/{project}/github/branches/delete', methods: [Request::METHOD_DELETE])]
     #[OA\Delete(
         summary: 'Delete Project GitHub Branch',
         requestBody: new OA\RequestBody(
@@ -49,7 +50,7 @@ final readonly class DeleteProjectGithubBranchController
             new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    public function __invoke(Project $project, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);
         if ($payload instanceof JsonResponse) {

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/DeleteProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/DeleteProjectGithubRepositoryController.php
@@ -37,6 +37,7 @@ final readonly class DeleteProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/{repositoryId}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/crm/general/projects/{project}/github/repositories/{repositoryId}', methods: [Request::METHOD_DELETE])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12')]
     #[OA\Parameter(name: 'repositoryId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: '03463358-2e8f-4f63-a893-69d5313b05d2')]
@@ -50,7 +51,7 @@ final readonly class DeleteProjectGithubRepositoryController
             new OA\Response(response: 422, description: 'Validation échouée ou erreur API GitHub.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, string $repositoryId, Request $request): JsonResponse
+    public function __invoke(Project $project, string $repositoryId, Request $request): JsonResponse
     {
         $input = $this->crmRequestHandler->mapAndValidate($request->query->all(), DeleteProjectGithubRepositoryRequest::class);
         if ($input instanceof JsonResponse) {

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubDashboardController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubDashboardController.php
@@ -25,6 +25,7 @@ final readonly class GetProjectGithubDashboardController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/dashboard', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/dashboard', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Get(
@@ -39,7 +40,7 @@ final readonly class GetProjectGithubDashboardController
             new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'Erreur de validation métier.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project): JsonResponse
+    public function __invoke(Project $project): JsonResponse
     {
         return new JsonResponse($this->crmGithubService->getDashboard($project));
     }

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubIssueController.php
@@ -29,6 +29,7 @@ final readonly class GetProjectGithubIssueController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/issues/{number}', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
@@ -40,7 +41,7 @@ final readonly class GetProjectGithubIssueController
             new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
+    public function __invoke(Project $project, int $number, Request $request): JsonResponse
     {
         return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
             $this->crmGithubService->getIssue($project, (string)$request->query->get('repo', ''), $number),

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubPullRequestDetailController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubPullRequestDetailController.php
@@ -25,6 +25,7 @@ final readonly class GetProjectGithubPullRequestDetailController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests/{number}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/pull-requests/{number}', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
@@ -40,7 +41,7 @@ final readonly class GetProjectGithubPullRequestDetailController
             new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'Erreur de validation métier.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
+    public function __invoke(Project $project, int $number, Request $request): JsonResponse
     {
         return new JsonResponse($this->crmGithubService->getPullRequest($project, (string)$request->query->get('repo', ''), $number));
     }

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubRepositoryController.php
@@ -29,6 +29,7 @@ final readonly class GetProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/{repository}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/repositories/{repository}', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'repository', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
@@ -39,7 +40,7 @@ final readonly class GetProjectGithubRepositoryController
             new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, string $repository): JsonResponse
+    public function __invoke(Project $project, string $repository): JsonResponse
     {
         return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
             $this->crmGithubService->getRepository($project, $repository),

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListGithubAccountRepositoriesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListGithubAccountRepositoriesController.php
@@ -25,6 +25,7 @@ final readonly class ListGithubAccountRepositoriesController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/account/repositories', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/account/repositories', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]
@@ -81,7 +82,7 @@ final readonly class ListGithubAccountRepositoriesController
             ),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    public function __invoke(Project $project, Request $request): JsonResponse
     {
         return new JsonResponse($this->crmGithubService->listAccountRepositories(
             $project,

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubBranchesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubBranchesController.php
@@ -25,6 +25,7 @@ final readonly class ListProjectGithubBranchesController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/branches', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/branches', methods: [Request::METHOD_GET])]
     #[OA\Parameter(ref: '#/components/parameters/applicationSlug')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(ref: '#/components/parameters/page')]
@@ -51,7 +52,7 @@ final readonly class ListProjectGithubBranchesController
             new OA\Response(ref: '#/components/responses/ValidationFailed422', response: 422),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    public function __invoke(Project $project, Request $request): JsonResponse
     {
         $repo = (string)$request->query->get('repo', '');
 

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubIssuesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubIssuesController.php
@@ -29,6 +29,7 @@ final readonly class ListProjectGithubIssuesController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/issues', methods: [Request::METHOD_GET])]
     #[OA\Parameter(ref: '#/components/parameters/applicationSlug')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'repo', in: 'query', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
@@ -51,7 +52,7 @@ final readonly class ListProjectGithubIssuesController
             new OA\Response(ref: '#/components/responses/ValidationFailed422', response: 422),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    public function __invoke(Project $project, Request $request): JsonResponse
     {
         return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse($this->crmGithubService->listIssues(
             $project,

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectItemsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectItemsController.php
@@ -29,6 +29,7 @@ final readonly class ListProjectGithubProjectItemsController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects/{projectId}/items', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/projects/{projectId}/items', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'projectId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'PVT_kwDOBfke3c4A9v0F')]
@@ -80,7 +81,7 @@ final readonly class ListProjectGithubProjectItemsController
             ),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, string $projectId, Request $request): JsonResponse
+    public function __invoke(Project $project, string $projectId, Request $request): JsonResponse
     {
         return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse($this->crmGithubService->getProjectItems(
             $project,

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectsController.php
@@ -29,6 +29,7 @@ final readonly class ListProjectGithubProjectsController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/projects', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'repo', in: 'query', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
@@ -80,7 +81,7 @@ final readonly class ListProjectGithubProjectsController
             ),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    public function __invoke(Project $project, Request $request): JsonResponse
     {
         return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse($this->crmGithubService->listRepositoryProjects(
             $project,

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestsController.php
@@ -25,6 +25,7 @@ final readonly class ListProjectGithubPullRequestsController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/pull-requests', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]
@@ -81,7 +82,7 @@ final readonly class ListProjectGithubPullRequestsController
             ),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, Request $request): JsonResponse
+    public function __invoke(Project $project, Request $request): JsonResponse
     {
         return new JsonResponse($this->crmGithubService->listPullRequests(
             $project,

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubRepositoriesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubRepositoriesController.php
@@ -25,6 +25,7 @@ final readonly class ListProjectGithubRepositoriesController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/repositories', methods: [Request::METHOD_GET])]
     #[OA\Parameter(ref: '#/components/parameters/applicationSlug')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(ref: '#/components/parameters/page')]
@@ -51,7 +52,7 @@ final readonly class ListProjectGithubRepositoriesController
             new OA\Response(ref: '#/components/responses/ValidationFailed422', response: 422),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project): JsonResponse
+    public function __invoke(Project $project): JsonResponse
     {
         return new JsonResponse([
             'items' => $this->crmGithubService->listRepositories($project),

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/MoveProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/MoveProjectGithubIssueController.php
@@ -32,6 +32,7 @@ final readonly class MoveProjectGithubIssueController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects/{projectId}/items/{itemId}/move', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/general/projects/{project}/github/projects/{projectId}/items/{itemId}/move', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'projectId', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
@@ -51,7 +52,7 @@ final readonly class MoveProjectGithubIssueController
             new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, string $projectId, string $itemId, Request $request): JsonResponse
+    public function __invoke(Project $project, string $projectId, string $itemId, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);
         if ($payload instanceof JsonResponse) {

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ProjectGithubPullRequestActionController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ProjectGithubPullRequestActionController.php
@@ -29,6 +29,7 @@ final readonly class ProjectGithubPullRequestActionController
      * @throws JsonException
      */
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests/{number}/action', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/general/projects/{project}/github/pull-requests/{number}/action', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
@@ -44,7 +45,7 @@ final readonly class ProjectGithubPullRequestActionController
             new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'Erreur de validation métier.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
+    public function __invoke(Project $project, int $number, Request $request): JsonResponse
     {
         $payload = json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
         $repo = isset($payload['repo']) ? (string)$payload['repo'] : '';

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubIssueStateController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubIssueStateController.php
@@ -32,6 +32,7 @@ final readonly class UpdateProjectGithubIssueStateController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/crm/general/projects/{project}/github/issues/{number}', methods: [Request::METHOD_PATCH])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
@@ -52,7 +53,7 @@ final readonly class UpdateProjectGithubIssueStateController
             new OA\Response(response: JsonResponse::HTTP_UNPROCESSABLE_ENTITY, description: 'GitHub API error.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, int $number, Request $request): JsonResponse
+    public function __invoke(Project $project, int $number, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);
         if ($payload instanceof JsonResponse) {

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubRepositoryController.php
@@ -35,6 +35,7 @@ final readonly class UpdateProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/{repositoryId}', methods: [Request::METHOD_PUT])]
+    #[Route('/v1/crm/general/projects/{project}/github/repositories/{repositoryId}', methods: [Request::METHOD_PUT])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12')]
     #[OA\Parameter(name: 'repositoryId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: '03463358-2e8f-4f63-a893-69d5313b05d2')]
@@ -75,7 +76,7 @@ final readonly class UpdateProjectGithubRepositoryController
             new OA\Response(response: 422, description: 'Validation échouée.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Project $project, string $repositoryId, Request $request): JsonResponse
+    public function __invoke(Project $project, string $repositoryId, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);
         if ($payload instanceof JsonResponse) {


### PR DESCRIPTION
### Motivation
- Provide the same project-level GitHub endpoints for a generic CRM scope that is not bound to an application slug.
- Allow callers to use `/v1/crm/general/...` routes in addition to the existing application-scoped `/v1/crm/applications/{applicationSlug}/...` routes.
- Remove unused `applicationSlug` parameters from controller handlers when they were only present for route binding.

### Description
- Added `crm general` route aliases to the project-level GitHub controllers under `src/Crm/Transport/Controller/Api/V1/Project/Github` so each endpoint is reachable via both `/v1/crm/applications/{applicationSlug}/projects/{project}/github/...` and `/v1/crm/general/projects/{project}/github/...`.
- Removed the unused `string $applicationSlug` argument from controller `__invoke` signatures where it was only used to bind the application-scoped route.
- Applied the same change across all project-level GitHub controllers (23 files updated) including list/read/write actions like repositories, issues, branches, pull requests, projects, project items and related actions.
- Preserved existing OpenAPI annotations and GitHub error-handling wrappers so behavior and docs remain consistent.

### Testing
- Ran PHP syntax checks on changed files with `php -l` in a loop, which completed successfully.
- No additional automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e41eac635483268ebd4332ae5840d9)