### PR TITLE
fix(crm): stop exposing applicationSlug on CRM general GitHub endpoints

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubIssueCommentController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubIssueCommentController.php
@@ -33,7 +33,6 @@ final readonly class AddProjectGithubIssueCommentController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}/comments', methods: [Request::METHOD_POST])]
     #[Route('/v1/crm/general/projects/{project}/github/issues/{number}/comments', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
     #[OA\Post(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubRepositoryController.php
@@ -35,7 +35,6 @@ final readonly class AddProjectGithubRepositoryController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories', methods: [Request::METHOD_POST])]
     #[Route('/v1/crm/general/projects/{project}/github/repositories', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12')]
     #[OA\Post(
         description: 'Ajoute un repository GitHub existant au projet CRM courant à partir du fullName `owner/name`.',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubBranchController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubBranchController.php
@@ -33,7 +33,6 @@ final readonly class CreateProjectGithubBranchController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/branches/create', methods: [Request::METHOD_POST])]
     #[Route('/v1/crm/general/projects/{project}/github/branches/create', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
         summary: 'Create Project GitHub Branch',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubIssueController.php
@@ -33,7 +33,6 @@ final readonly class CreateProjectGithubIssueController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues', methods: [Request::METHOD_POST])]
     #[Route('/v1/crm/general/projects/{project}/github/issues', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
         summary: 'Create Project GitHub Issue',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubProjectBoardController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubProjectBoardController.php
@@ -33,7 +33,6 @@ final readonly class CreateProjectGithubProjectBoardController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects', methods: [Request::METHOD_POST])]
     #[Route('/v1/crm/general/projects/{project}/github/projects', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
         summary: 'Create Project GitHub Project Board',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubRepositoryController.php
@@ -33,7 +33,6 @@ final readonly class CreateProjectGithubRepositoryController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/create', methods: [Request::METHOD_POST])]
     #[Route('/v1/crm/general/projects/{project}/github/repositories/create', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
         summary: 'Create Project GitHub Repository',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/DeleteProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/DeleteProjectGithubRepositoryController.php
@@ -38,7 +38,6 @@ final readonly class DeleteProjectGithubRepositoryController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/{repositoryId}', methods: [Request::METHOD_DELETE])]
     #[Route('/v1/crm/general/projects/{project}/github/repositories/{repositoryId}', methods: [Request::METHOD_DELETE])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12')]
     #[OA\Parameter(name: 'repositoryId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: '03463358-2e8f-4f63-a893-69d5313b05d2')]
     #[OA\Parameter(name: 'deleteRemote', in: 'query', required: false, schema: new OA\Schema(type: 'boolean', default: false), example: true)]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubDashboardController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubDashboardController.php
@@ -26,7 +26,6 @@ final readonly class GetProjectGithubDashboardController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/dashboard', methods: [Request::METHOD_GET])]
     #[Route('/v1/crm/general/projects/{project}/github/dashboard', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Get(
         description: 'Exécute l action metier Get Project Github Dashboard dans le perimetre de l application CRM.',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubIssueController.php
@@ -30,7 +30,6 @@ final readonly class GetProjectGithubIssueController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}', methods: [Request::METHOD_GET])]
     #[Route('/v1/crm/general/projects/{project}/github/issues/{number}', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
     #[OA\Parameter(name: 'repo', in: 'query', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubPullRequestDetailController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubPullRequestDetailController.php
@@ -26,7 +26,6 @@ final readonly class GetProjectGithubPullRequestDetailController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests/{number}', methods: [Request::METHOD_GET])]
     #[Route('/v1/crm/general/projects/{project}/github/pull-requests/{number}', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Get(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubRepositoryController.php
@@ -30,7 +30,6 @@ final readonly class GetProjectGithubRepositoryController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/{repository}', methods: [Request::METHOD_GET])]
     #[Route('/v1/crm/general/projects/{project}/github/repositories/{repository}', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'repository', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
     #[OA\Get(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListGithubAccountRepositoriesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListGithubAccountRepositoriesController.php
@@ -26,7 +26,6 @@ final readonly class ListGithubAccountRepositoriesController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/account/repositories', methods: [Request::METHOD_GET])]
     #[Route('/v1/crm/general/projects/{project}/github/account/repositories', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]
     #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100), example: 20)]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubBranchesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubBranchesController.php
@@ -26,7 +26,6 @@ final readonly class ListProjectGithubBranchesController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/branches', methods: [Request::METHOD_GET])]
     #[Route('/v1/crm/general/projects/{project}/github/branches', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(ref: '#/components/parameters/applicationSlug')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(ref: '#/components/parameters/page')]
     #[OA\Parameter(ref: '#/components/parameters/limit')]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubIssuesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubIssuesController.php
@@ -30,7 +30,6 @@ final readonly class ListProjectGithubIssuesController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues', methods: [Request::METHOD_GET])]
     #[Route('/v1/crm/general/projects/{project}/github/issues', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(ref: '#/components/parameters/applicationSlug')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'repo', in: 'query', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
     #[OA\Parameter(ref: '#/components/parameters/status')]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectItemsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectItemsController.php
@@ -30,7 +30,6 @@ final readonly class ListProjectGithubProjectItemsController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects/{projectId}/items', methods: [Request::METHOD_GET])]
     #[Route('/v1/crm/general/projects/{project}/github/projects/{projectId}/items', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'projectId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'PVT_kwDOBfke3c4A9v0F')]
     #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectsController.php
@@ -30,7 +30,6 @@ final readonly class ListProjectGithubProjectsController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects', methods: [Request::METHOD_GET])]
     #[Route('/v1/crm/general/projects/{project}/github/projects', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'repo', in: 'query', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
     #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestsController.php
@@ -26,7 +26,6 @@ final readonly class ListProjectGithubPullRequestsController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests', methods: [Request::METHOD_GET])]
     #[Route('/v1/crm/general/projects/{project}/github/pull-requests', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]
     #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100), example: 20)]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubRepositoriesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubRepositoriesController.php
@@ -26,7 +26,6 @@ final readonly class ListProjectGithubRepositoriesController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories', methods: [Request::METHOD_GET])]
     #[Route('/v1/crm/general/projects/{project}/github/repositories', methods: [Request::METHOD_GET])]
-    #[OA\Parameter(ref: '#/components/parameters/applicationSlug')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(ref: '#/components/parameters/page')]
     #[OA\Parameter(ref: '#/components/parameters/limit')]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/MoveProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/MoveProjectGithubIssueController.php
@@ -33,7 +33,6 @@ final readonly class MoveProjectGithubIssueController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/projects/{projectId}/items/{itemId}/move', methods: [Request::METHOD_POST])]
     #[Route('/v1/crm/general/projects/{project}/github/projects/{projectId}/items/{itemId}/move', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'projectId', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'itemId', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ProjectGithubPullRequestActionController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ProjectGithubPullRequestActionController.php
@@ -30,7 +30,6 @@ final readonly class ProjectGithubPullRequestActionController
      */
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests/{number}/action', methods: [Request::METHOD_POST])]
     #[Route('/v1/crm/general/projects/{project}/github/pull-requests/{number}/action', methods: [Request::METHOD_POST])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubIssueStateController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubIssueStateController.php
@@ -33,7 +33,6 @@ final readonly class UpdateProjectGithubIssueStateController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}', methods: [Request::METHOD_PATCH])]
     #[Route('/v1/crm/general/projects/{project}/github/issues/{number}', methods: [Request::METHOD_PATCH])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
     #[OA\Patch(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubRepositoryController.php
@@ -36,7 +36,6 @@ final readonly class UpdateProjectGithubRepositoryController
 
     #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/{repositoryId}', methods: [Request::METHOD_PUT])]
     #[Route('/v1/crm/general/projects/{project}/github/repositories/{repositoryId}', methods: [Request::METHOD_PUT])]
-    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'crm-sales-hub')]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12')]
     #[OA\Parameter(name: 'repositoryId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: '03463358-2e8f-4f63-a893-69d5313b05d2')]
     #[OA\Put(


### PR DESCRIPTION
### Motivation
- The `crm/general` GitHub endpoints were documented with a required `applicationSlug` path parameter even though the `general` routes are meant to be application-independent. 
- The goal is to avoid forcing `applicationSlug` in OpenAPI docs/clients for endpoints that expose both `/v1/crm/applications/{applicationSlug}/...` and `/v1/crm/general/...` variants.

### Description
- Removed the OpenAPI `#[OA\Parameter(... 'applicationSlug' ...)]` annotations from GitHub-related CRM controllers under `src/Crm/Transport/Controller/Api/V1/Project/Github/*Controller.php` so `crm/general` routes are no longer documented as requiring `applicationSlug`.
- Changed 22 controller files in `src/Crm/Transport/Controller/Api/V1/Project/Github/` (only annotation removals; no route or runtime logic changes).
- No database, service, or business-logic changes were made; runtime routing behavior remains identical.

### Testing
- Ran PHP syntax checks on all modified files with `php -l` and verified `PHP lint passed on changed files`.
- All automated checks run in this change passed (no failing lint errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e435cec19483268e3737673ba0af4c)