### PR TITLE
Add resumeInformation and rich metadata to recruit resumes

### DIFF
--- a/migrations/Version20260419120000.php
+++ b/migrations/Version20260419120000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260419120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Extend recruit resume schema with contact information and rich section metadata.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE recruit_resume ADD information_full_name VARCHAR(255) DEFAULT NULL, ADD information_email VARCHAR(255) DEFAULT NULL, ADD information_phone VARCHAR(50) DEFAULT NULL, ADD information_homepage VARCHAR(255) DEFAULT NULL, ADD information_repo_profile VARCHAR(255) DEFAULT NULL, ADD information_address VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE recruit_resume_certification ADD attachments JSON DEFAULT NULL');
+        $this->addSql('ALTER TABLE recruit_resume_education ADD school VARCHAR(255) DEFAULT NULL, ADD start_date DATE DEFAULT NULL COMMENT "(DC2Type:date_immutable)", ADD end_date DATE DEFAULT NULL COMMENT "(DC2Type:date_immutable)", ADD location VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE recruit_resume_experience ADD company VARCHAR(255) DEFAULT NULL, ADD start_date DATE DEFAULT NULL COMMENT "(DC2Type:date_immutable)", ADD end_date DATE DEFAULT NULL COMMENT "(DC2Type:date_immutable)"');
+        $this->addSql('ALTER TABLE recruit_resume_language ADD level VARCHAR(100) DEFAULT NULL');
+        $this->addSql('ALTER TABLE recruit_resume_project ADD attachments JSON DEFAULT NULL, ADD home_page VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE recruit_resume_project DROP attachments, DROP home_page');
+        $this->addSql('ALTER TABLE recruit_resume_language DROP level');
+        $this->addSql('ALTER TABLE recruit_resume_experience DROP company, DROP start_date, DROP end_date');
+        $this->addSql('ALTER TABLE recruit_resume_education DROP school, DROP start_date, DROP end_date, DROP location');
+        $this->addSql('ALTER TABLE recruit_resume_certification DROP attachments');
+        $this->addSql('ALTER TABLE recruit_resume DROP information_full_name, DROP information_email, DROP information_phone, DROP information_homepage, DROP information_repo_profile, DROP information_address');
+    }
+}

--- a/src/Recruit/Application/Service/ResumeNormalizerService.php
+++ b/src/Recruit/Application/Service/ResumeNormalizerService.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace App\Recruit\Application\Service;
 
+use App\Recruit\Domain\Entity\Certification;
+use App\Recruit\Domain\Entity\Education;
+use App\Recruit\Domain\Entity\Experience;
+use App\Recruit\Domain\Entity\Language;
+use App\Recruit\Domain\Entity\Project;
 use App\Recruit\Domain\Entity\Resume;
 
 class ResumeNormalizerService
@@ -26,6 +31,14 @@ class ResumeNormalizerService
         return [
             'id' => $resume->getId(),
             'documentUrl' => $resume->getDocumentUrl(),
+            'resumeInformation' => [
+                'fullName' => $resume->getInformationFullName(),
+                'email' => $resume->getInformationEmail(),
+                'phone' => $resume->getInformationPhone(),
+                'homepage' => $resume->getInformationHomepage(),
+                'repo_profile' => $resume->getInformationRepoProfile(),
+                'adresse' => $resume->getInformationAddress(),
+            ],
             'experiences' => $this->normalizeSections($resume->getExperiences()->toArray()),
             'educations' => $this->normalizeSections($resume->getEducations()->toArray()),
             'skills' => $this->normalizeSections($resume->getSkills()->toArray()),
@@ -40,17 +53,44 @@ class ResumeNormalizerService
     /**
      * @param array<int, object> $sections
      *
-     * @return array<int, array<string, string>>
+     * @return array<int, array<string, mixed>>
      */
     private function normalizeSections(array $sections): array
     {
-        return array_map(
-            static fn (object $section): array => [
+        return array_map(function (object $section): array {
+            $payload = [
                 'id' => $section->getId(),
                 'title' => $section->getTitle(),
                 'description' => $section->getDescription(),
-            ],
-            $sections,
-        );
+            ];
+
+            if ($section instanceof Language) {
+                $payload['level'] = $section->getLevel();
+            }
+
+            if ($section instanceof Certification) {
+                $payload['attachments'] = $section->getAttachments() ?? [];
+            }
+
+            if ($section instanceof Project) {
+                $payload['attachments'] = $section->getAttachments() ?? [];
+                $payload['home_page'] = $section->getHomePage();
+            }
+
+            if ($section instanceof Education) {
+                $payload['school'] = $section->getSchool();
+                $payload['startDate'] = $section->getStartDate()?->format('Y-m-d');
+                $payload['endDate'] = $section->getEndDate()?->format('Y-m-d');
+                $payload['location'] = $section->getLocation();
+            }
+
+            if ($section instanceof Experience) {
+                $payload['company'] = $section->getCompany();
+                $payload['startDate'] = $section->getStartDate()?->format('Y-m-d');
+                $payload['endDate'] = $section->getEndDate()?->format('Y-m-d');
+            }
+
+            return $payload;
+        }, $sections);
     }
 }

--- a/src/Recruit/Application/Service/ResumePayloadService.php
+++ b/src/Recruit/Application/Service/ResumePayloadService.php
@@ -13,6 +13,8 @@ use App\Recruit\Domain\Entity\Project;
 use App\Recruit\Domain\Entity\Reference;
 use App\Recruit\Domain\Entity\Resume;
 use App\Recruit\Domain\Entity\Skill;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use JsonException;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -111,6 +113,53 @@ class ResumePayloadService
     /**
      * @param array<string, mixed> $payload
      */
+    public function applyResumeInformationForCreate(Resume $resume, array $payload, User $user): void
+    {
+        $input = $this->extractResumeInformationInput($payload);
+        $profile = $user->getProfile();
+
+        $defaultFullName = trim($user->getFirstName() . ' ' . $user->getLastName());
+        $resume->setInformationFullName($this->nullableTrimmedString($input['fullName'] ?? null) ?? ($defaultFullName !== '' ? $defaultFullName : null));
+        $resume->setInformationEmail($this->nullableTrimmedString($input['email'] ?? null) ?? $user->getEmail());
+        $resume->setInformationPhone($this->nullableTrimmedString($input['phone'] ?? null) ?? $profile?->getPhone());
+        $resume->setInformationHomepage($this->nullableTrimmedString($input['homepage'] ?? null));
+        $resume->setInformationRepoProfile($this->nullableTrimmedString($input['repo_profile'] ?? null));
+        $resume->setInformationAddress($this->nullableTrimmedString($input['adresse'] ?? null) ?? $profile?->getLocation());
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    public function applyResumeInformationForPatch(Resume $resume, array $payload): void
+    {
+        $input = $this->extractResumeInformationInput($payload);
+        if ($input === null) {
+            return;
+        }
+
+        if (array_key_exists('fullName', $input)) {
+            $resume->setInformationFullName($this->nullableTrimmedString($input['fullName']));
+        }
+        if (array_key_exists('email', $input)) {
+            $resume->setInformationEmail($this->nullableTrimmedString($input['email']));
+        }
+        if (array_key_exists('phone', $input)) {
+            $resume->setInformationPhone($this->nullableTrimmedString($input['phone']));
+        }
+        if (array_key_exists('homepage', $input)) {
+            $resume->setInformationHomepage($this->nullableTrimmedString($input['homepage']));
+        }
+        if (array_key_exists('repo_profile', $input)) {
+            $resume->setInformationRepoProfile($this->nullableTrimmedString($input['repo_profile']));
+        }
+        if (array_key_exists('adresse', $input)) {
+            $resume->setInformationAddress($this->nullableTrimmedString($input['adresse']));
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
     public function replaceResumeSections(Resume $resume, array $payload): void
     {
         foreach (self::RESUME_SECTION_FIELDS as $field) {
@@ -159,6 +208,33 @@ class ResumePayloadService
             $section = $this->newSection($field);
             $section->setTitle(trim($title));
             $section->setDescription(trim($description));
+
+            if ($field === 'languages' && $section instanceof Language) {
+                $section->setLevel($this->nullableTrimmedString($item['level'] ?? null));
+            }
+
+            if ($field === 'certifications' && $section instanceof Certification) {
+                $section->setAttachments($this->normalizeStringArray($item['attachments'] ?? null, 'attachments'));
+            }
+
+            if ($field === 'projects' && $section instanceof Project) {
+                $section->setAttachments($this->normalizeStringArray($item['attachments'] ?? null, 'attachments'));
+                $section->setHomePage($this->nullableTrimmedString($item['home_page'] ?? null));
+            }
+
+            if ($field === 'educations' && $section instanceof Education) {
+                $section->setSchool($this->nullableTrimmedString($item['school'] ?? null));
+                $section->setStartDate($this->nullableDate($item['startDate'] ?? null, 'startDate'));
+                $section->setEndDate($this->nullableDate($item['endDate'] ?? null, 'endDate'));
+                $section->setLocation($this->nullableTrimmedString($item['location'] ?? null));
+            }
+
+            if ($field === 'experiences' && $section instanceof Experience) {
+                $section->setCompany($this->nullableTrimmedString($item['company'] ?? null));
+                $section->setStartDate($this->nullableDate($item['startDate'] ?? null, 'startDate'));
+                $section->setEndDate($this->nullableDate($item['endDate'] ?? null, 'endDate'));
+            }
+
             $this->addSection($resume, $field, $section);
         }
     }
@@ -207,5 +283,90 @@ class ResumePayloadService
             'references' => $resume->addReference($section),
             'hobbies' => $resume->addHobby($section),
         };
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function nullableTrimmedString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Expected a string or null value.');
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+
+    /**
+     * @param mixed $value
+     * @return list<string>|null
+     */
+    private function normalizeStringArray(mixed $value, string $field): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_array($value)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" must be an array of strings or null.');
+        }
+
+        $normalized = [];
+        foreach ($value as $item) {
+            if (!is_string($item)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" must contain only strings.');
+            }
+
+            $trimmed = trim($item);
+            if ($trimmed !== '') {
+                $normalized[] = $trimmed;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function nullableDate(mixed $value, string $field): ?DateTimeImmutable
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!is_string($value) || trim($value) === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" must be a date string or null.');
+        }
+
+        try {
+            return new DateTimeImmutable(trim($value));
+        } catch (\Throwable) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" must be a valid date string.');
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return array<string, mixed>|null
+     */
+    private function extractResumeInformationInput(array $payload): ?array
+    {
+        $input = $payload['resumeInformation'] ?? $payload['resume_infomation'] ?? null;
+        if ($input === null) {
+            return null;
+        }
+
+        if (!is_array($input)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "resumeInformation" must be an object.');
+        }
+
+        return $input;
     }
 }

--- a/src/Recruit/Domain/Entity/Certification.php
+++ b/src/Recruit/Domain/Entity/Certification.php
@@ -39,6 +39,9 @@ class Certification implements EntityInterface
     ])]
     private string $description = '';
 
+    #[ORM\Column(name: 'attachments', type: Types::JSON, nullable: true)]
+    private ?array $attachments = null;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
@@ -76,6 +79,16 @@ class Certification implements EntityInterface
     public function setDescription(string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+    public function getAttachments(): ?array
+    {
+        return $this->attachments;
+    }
+    public function setAttachments(?array $attachments): self
+    {
+        $this->attachments = $attachments;
 
         return $this;
     }

--- a/src/Recruit/Domain/Entity/Education.php
+++ b/src/Recruit/Domain/Entity/Education.php
@@ -39,6 +39,18 @@ class Education implements EntityInterface
     ])]
     private string $description = '';
 
+    #[ORM\Column(name: 'school', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $school = null;
+
+    #[ORM\Column(name: 'start_date', type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $startDate = null;
+
+    #[ORM\Column(name: 'end_date', type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $endDate = null;
+
+    #[ORM\Column(name: 'location', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $location = null;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
@@ -76,6 +88,46 @@ class Education implements EntityInterface
     public function setDescription(string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+    public function getSchool(): ?string
+    {
+        return $this->school;
+    }
+    public function setSchool(?string $school): self
+    {
+        $this->school = $school;
+
+        return $this;
+    }
+    public function getStartDate(): ?\DateTimeImmutable
+    {
+        return $this->startDate;
+    }
+    public function setStartDate(?\DateTimeImmutable $startDate): self
+    {
+        $this->startDate = $startDate;
+
+        return $this;
+    }
+    public function getEndDate(): ?\DateTimeImmutable
+    {
+        return $this->endDate;
+    }
+    public function setEndDate(?\DateTimeImmutable $endDate): self
+    {
+        $this->endDate = $endDate;
+
+        return $this;
+    }
+    public function getLocation(): ?string
+    {
+        return $this->location;
+    }
+    public function setLocation(?string $location): self
+    {
+        $this->location = $location;
 
         return $this;
     }

--- a/src/Recruit/Domain/Entity/Experience.php
+++ b/src/Recruit/Domain/Entity/Experience.php
@@ -39,6 +39,15 @@ class Experience implements EntityInterface
     ])]
     private string $description = '';
 
+    #[ORM\Column(name: 'company', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $company = null;
+
+    #[ORM\Column(name: 'start_date', type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $startDate = null;
+
+    #[ORM\Column(name: 'end_date', type: Types::DATE_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $endDate = null;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
@@ -76,6 +85,36 @@ class Experience implements EntityInterface
     public function setDescription(string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+    public function getCompany(): ?string
+    {
+        return $this->company;
+    }
+    public function setCompany(?string $company): self
+    {
+        $this->company = $company;
+
+        return $this;
+    }
+    public function getStartDate(): ?\DateTimeImmutable
+    {
+        return $this->startDate;
+    }
+    public function setStartDate(?\DateTimeImmutable $startDate): self
+    {
+        $this->startDate = $startDate;
+
+        return $this;
+    }
+    public function getEndDate(): ?\DateTimeImmutable
+    {
+        return $this->endDate;
+    }
+    public function setEndDate(?\DateTimeImmutable $endDate): self
+    {
+        $this->endDate = $endDate;
 
         return $this;
     }

--- a/src/Recruit/Domain/Entity/Language.php
+++ b/src/Recruit/Domain/Entity/Language.php
@@ -39,6 +39,9 @@ class Language implements EntityInterface
     ])]
     private string $description = '';
 
+    #[ORM\Column(name: 'level', type: Types::STRING, length: 100, nullable: true)]
+    private ?string $level = null;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
@@ -76,6 +79,16 @@ class Language implements EntityInterface
     public function setDescription(string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+    public function getLevel(): ?string
+    {
+        return $this->level;
+    }
+    public function setLevel(?string $level): self
+    {
+        $this->level = $level;
 
         return $this;
     }

--- a/src/Recruit/Domain/Entity/Project.php
+++ b/src/Recruit/Domain/Entity/Project.php
@@ -39,6 +39,12 @@ class Project implements EntityInterface
     ])]
     private string $description = '';
 
+    #[ORM\Column(name: 'attachments', type: Types::JSON, nullable: true)]
+    private ?array $attachments = null;
+
+    #[ORM\Column(name: 'home_page', type: Types::STRING, length: 255, nullable: true)]
+    private ?string $homePage = null;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
@@ -76,6 +82,26 @@ class Project implements EntityInterface
     public function setDescription(string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+    public function getAttachments(): ?array
+    {
+        return $this->attachments;
+    }
+    public function setAttachments(?array $attachments): self
+    {
+        $this->attachments = $attachments;
+
+        return $this;
+    }
+    public function getHomePage(): ?string
+    {
+        return $this->homePage;
+    }
+    public function setHomePage(?string $homePage): self
+    {
+        $this->homePage = $homePage;
 
         return $this;
     }

--- a/src/Recruit/Domain/Entity/Resume.php
+++ b/src/Recruit/Domain/Entity/Resume.php
@@ -37,6 +37,24 @@ class Resume implements EntityInterface
     #[ORM\Column(name: 'document_url', type: 'string', length: 255, nullable: true)]
     private ?string $documentUrl = null;
 
+    #[ORM\Column(name: 'information_full_name', type: 'string', length: 255, nullable: true)]
+    private ?string $informationFullName = null;
+
+    #[ORM\Column(name: 'information_email', type: 'string', length: 255, nullable: true)]
+    private ?string $informationEmail = null;
+
+    #[ORM\Column(name: 'information_phone', type: 'string', length: 50, nullable: true)]
+    private ?string $informationPhone = null;
+
+    #[ORM\Column(name: 'information_homepage', type: 'string', length: 255, nullable: true)]
+    private ?string $informationHomepage = null;
+
+    #[ORM\Column(name: 'information_repo_profile', type: 'string', length: 255, nullable: true)]
+    private ?string $informationRepoProfile = null;
+
+    #[ORM\Column(name: 'information_address', type: 'string', length: 255, nullable: true)]
+    private ?string $informationAddress = null;
+
     /** @var Collection<int, Experience>|ArrayCollection<int, Experience> */
     #[ORM\OneToMany(targetEntity: Experience::class, mappedBy: 'resume', cascade: ['persist', 'remove'], orphanRemoval: true)]
     private Collection|ArrayCollection $experiences;
@@ -108,6 +126,66 @@ class Resume implements EntityInterface
     public function setDocumentUrl(?string $documentUrl): self
     {
         $this->documentUrl = $documentUrl;
+
+        return $this;
+    }
+    public function getInformationFullName(): ?string
+    {
+        return $this->informationFullName;
+    }
+    public function setInformationFullName(?string $informationFullName): self
+    {
+        $this->informationFullName = $informationFullName;
+
+        return $this;
+    }
+    public function getInformationEmail(): ?string
+    {
+        return $this->informationEmail;
+    }
+    public function setInformationEmail(?string $informationEmail): self
+    {
+        $this->informationEmail = $informationEmail;
+
+        return $this;
+    }
+    public function getInformationPhone(): ?string
+    {
+        return $this->informationPhone;
+    }
+    public function setInformationPhone(?string $informationPhone): self
+    {
+        $this->informationPhone = $informationPhone;
+
+        return $this;
+    }
+    public function getInformationHomepage(): ?string
+    {
+        return $this->informationHomepage;
+    }
+    public function setInformationHomepage(?string $informationHomepage): self
+    {
+        $this->informationHomepage = $informationHomepage;
+
+        return $this;
+    }
+    public function getInformationRepoProfile(): ?string
+    {
+        return $this->informationRepoProfile;
+    }
+    public function setInformationRepoProfile(?string $informationRepoProfile): self
+    {
+        $this->informationRepoProfile = $informationRepoProfile;
+
+        return $this;
+    }
+    public function getInformationAddress(): ?string
+    {
+        return $this->informationAddress;
+    }
+    public function setInformationAddress(?string $informationAddress): self
+    {
+        $this->informationAddress = $informationAddress;
 
         return $this;
     }

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitApplicationData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitApplicationData.php
@@ -220,18 +220,23 @@ final class LoadRecruitApplicationData extends Fixture implements OrderedFixture
     {
         $resume = (new Resume())->setOwner($owner);
         $resume
-            ->addExperience((new Experience())->setTitle('Senior Developer')->setDescription('8+ ans en développement web et API.'))
-            ->addExperience((new Experience())->setTitle('Lead Projet')->setDescription('Pilotage technique, mentoring et revue de code.'))
-            ->addEducation((new Education())->setTitle('Master Informatique')->setDescription('Spécialisation architecture logicielle.'))
-            ->addEducation((new Education())->setTitle('Certification Agile')->setDescription('Pratiques Scrum et delivery continue.'))
+            ->setInformationFullName($owner->getFirstName() . ' ' . $owner->getLastName())
+            ->setInformationEmail($owner->getEmail())
+            ->setInformationPhone($owner->getProfile()?->getPhone())
+            ->setInformationAddress($owner->getProfile()?->getLocation());
+        $resume
+            ->addExperience((new Experience())->setTitle('Senior Developer')->setDescription('8+ ans en développement web et API.')->setCompany('Bro World')->setStartDate(new \DateTimeImmutable('2018-01-01'))->setEndDate(new \DateTimeImmutable('2021-12-31')))
+            ->addExperience((new Experience())->setTitle('Lead Projet')->setDescription('Pilotage technique, mentoring et revue de code.')->setCompany('Bro World Labs')->setStartDate(new \DateTimeImmutable('2022-01-01')))
+            ->addEducation((new Education())->setTitle('Master Informatique')->setDescription('Spécialisation architecture logicielle.')->setSchool('Université de Paris')->setStartDate(new \DateTimeImmutable('2014-09-01'))->setEndDate(new \DateTimeImmutable('2016-06-30'))->setLocation('Paris'))
+            ->addEducation((new Education())->setTitle('Certification Agile')->setDescription('Pratiques Scrum et delivery continue.')->setSchool('Scrum Institute')->setStartDate(new \DateTimeImmutable('2017-01-01'))->setEndDate(new \DateTimeImmutable('2017-02-01'))->setLocation('Lyon'))
             ->addSkill((new Skill())->setTitle('PHP / Symfony')->setDescription('Conception DDD, CQRS et APIs robustes.'))
             ->addSkill((new Skill())->setTitle('TypeScript / React')->setDescription('UI complexes, tests front et accessibilité.'))
-            ->addLanguage((new Language())->setTitle('Français')->setDescription('Natif'))
-            ->addLanguage((new Language())->setTitle('Anglais')->setDescription('Professionnel'))
-            ->addCertification((new Certification())->setTitle('AWS Cloud Practitioner')->setDescription('Fondamentaux cloud et sécurité.'))
-            ->addCertification((new Certification())->setTitle('Doctrine ORM Expert')->setDescription('Optimisation des mappings et requêtes.'))
-            ->addProject((new Project())->setTitle('Plateforme RH')->setDescription('Mise en place d\'un ATS multi-tenant.'))
-            ->addProject((new Project())->setTitle('Suite API interne')->setDescription('Refonte et documentation OpenAPI.'))
+            ->addLanguage((new Language())->setTitle('Français')->setDescription('Natif')->setLevel('native'))
+            ->addLanguage((new Language())->setTitle('Anglais')->setDescription('Professionnel')->setLevel('b2'))
+            ->addCertification((new Certification())->setTitle('AWS Cloud Practitioner')->setDescription('Fondamentaux cloud et sécurité.')->setAttachments(['https://cdn.example.com/certs/aws-cloud.pdf']))
+            ->addCertification((new Certification())->setTitle('Doctrine ORM Expert')->setDescription('Optimisation des mappings et requêtes.')->setAttachments(['https://cdn.example.com/certs/doctrine-orm.pdf']))
+            ->addProject((new Project())->setTitle('Plateforme RH')->setDescription('Mise en place d\'un ATS multi-tenant.')->setHomePage('https://rh.example.com')->setAttachments(['https://cdn.example.com/projects/rh-spec.pdf']))
+            ->addProject((new Project())->setTitle('Suite API interne')->setDescription('Refonte et documentation OpenAPI.')->setHomePage('https://api.example.com')->setAttachments(['https://cdn.example.com/projects/api-docs.pdf']))
             ->addReference((new ResumeReference())->setTitle('CTO précédent')->setDescription('Référence managériale et technique.'))
             ->addReference((new ResumeReference())->setTitle('Product Owner')->setDescription('Référence orientée collaboration produit.'))
             ->addHobby((new Hobby())->setTitle('Open source')->setDescription('Contributions régulières sur des libs PHP.'))

--- a/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralResumeController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/General/CreateGeneralResumeController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Recruit\Transport\Controller\Api\V1\General;
 
 use App\Recruit\Application\Service\ResumeDocumentUploaderService;
+use App\Recruit\Application\Service\ResumeNormalizerService;
 use App\Recruit\Application\Service\ResumePayloadService;
 use App\Recruit\Domain\Entity\Resume;
 use App\Recruit\Infrastructure\Repository\ResumeRepository;
@@ -31,6 +32,7 @@ final readonly class CreateGeneralResumeController
         private ResumeRepository $resumeRepository,
         private ResumeDocumentUploaderService $resumeDocumentUploaderService,
         private ResumePayloadService $resumePayloadService,
+        private ResumeNormalizerService $resumeNormalizerService,
     ) {
     }
 
@@ -114,6 +116,7 @@ final readonly class CreateGeneralResumeController
         $payload = $this->resumePayloadService->extractPayload($request);
 
         $resume = new Resume()->setOwner($loggedInUser);
+        $this->resumePayloadService->applyResumeInformationForCreate($resume, $payload, $loggedInUser);
 
         /** @var UploadedFile|null $document */
         $document = $request->files->get('document');
@@ -126,9 +129,6 @@ final readonly class CreateGeneralResumeController
 
         $this->resumeRepository->save($resume);
 
-        return new JsonResponse([
-            'id' => $resume->getId(),
-            'documentUrl' => $resume->getDocumentUrl(),
-        ], JsonResponse::HTTP_CREATED);
+        return new JsonResponse($this->resumeNormalizerService->normalize($resume), JsonResponse::HTTP_CREATED);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumePatchController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/MyResumePatchController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Recruit\Transport\Controller\Api\V1\Resume;
 
 use App\Recruit\Application\Service\ResumePayloadService;
+use App\Recruit\Application\Service\ResumeNormalizerService;
 use App\Recruit\Domain\Entity\Resume;
 use App\Recruit\Infrastructure\Repository\ResumeRepository;
 use App\User\Domain\Entity\User;
@@ -26,6 +27,7 @@ readonly class MyResumePatchController
     public function __construct(
         private ResumeRepository $resumeRepository,
         private ResumePayloadService $resumePayloadService,
+        private ResumeNormalizerService $resumeNormalizerService,
     ) {
     }
 
@@ -51,12 +53,10 @@ readonly class MyResumePatchController
         /** @var array<string, mixed> $payload */
         $payload = $request->toArray();
         $this->resumePayloadService->replaceResumeSections($resume, $payload);
+        $this->resumePayloadService->applyResumeInformationForPatch($resume, $payload);
 
         $this->resumeRepository->save($resume);
 
-        return new JsonResponse([
-            'id' => $resume->getId(),
-            'documentUrl' => $resume->getDocumentUrl(),
-        ]);
+        return new JsonResponse($this->resumeNormalizerService->normalize($resume));
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Resume/ResumeCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/ResumeCreateController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Recruit\Transport\Controller\Api\V1\Resume;
 
 use App\Recruit\Application\Service\ResumeDocumentUploaderService;
+use App\Recruit\Application\Service\ResumeNormalizerService;
 use App\Recruit\Application\Service\ResumePayloadService;
 use App\Recruit\Domain\Entity\Resume;
 use App\Recruit\Infrastructure\Repository\ResumeRepository;
@@ -27,6 +28,7 @@ readonly class ResumeCreateController
         private ResumeRepository $resumeRepository,
         private ResumeDocumentUploaderService $resumeDocumentUploaderService,
         private ResumePayloadService $resumePayloadService,
+        private ResumeNormalizerService $resumeNormalizerService,
     ) {
     }
 
@@ -104,6 +106,7 @@ readonly class ResumeCreateController
         $payload = $this->resumePayloadService->extractPayload($request);
 
         $resume = new Resume()->setOwner($loggedInUser);
+        $this->resumePayloadService->applyResumeInformationForCreate($resume, $payload, $loggedInUser);
 
         /** @var UploadedFile|null $document */
         $document = $request->files->get('document');
@@ -116,10 +119,7 @@ readonly class ResumeCreateController
 
         $this->resumeRepository->save($resume);
 
-        return new JsonResponse([
-            'id' => $resume->getId(),
-            'documentUrl' => $resume->getDocumentUrl(),
-        ], JsonResponse::HTTP_CREATED);
+        return new JsonResponse($this->resumeNormalizerService->normalize($resume), JsonResponse::HTTP_CREATED);
     }
 }
 

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumeListControllerTest.php
@@ -51,6 +51,10 @@ class MyResumeListControllerTest extends WebTestCase
         $resume = $payload[0];
         self::assertArrayHasKey('id', $resume);
         self::assertArrayHasKey('documentUrl', $resume);
+        self::assertArrayHasKey('resumeInformation', $resume);
+        self::assertIsArray($resume['resumeInformation']);
+        self::assertArrayHasKey('fullName', $resume['resumeInformation']);
+        self::assertArrayHasKey('email', $resume['resumeInformation']);
 
         foreach (['experiences', 'educations', 'skills', 'languages', 'certifications', 'projects', 'references', 'hobbies'] as $field) {
             self::assertArrayHasKey($field, $resume);
@@ -61,5 +65,13 @@ class MyResumeListControllerTest extends WebTestCase
             self::assertArrayHasKey('title', $resume[$field][0]);
             self::assertArrayHasKey('description', $resume[$field][0]);
         }
+
+        self::assertArrayHasKey('level', $resume['languages'][0]);
+        self::assertArrayHasKey('attachments', $resume['certifications'][0]);
+        self::assertArrayHasKey('attachments', $resume['projects'][0]);
+        self::assertArrayHasKey('home_page', $resume['projects'][0]);
+        self::assertArrayHasKey('school', $resume['educations'][0]);
+        self::assertArrayHasKey('startDate', $resume['educations'][0]);
+        self::assertArrayHasKey('company', $resume['experiences'][0]);
     }
 }

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumePatchDeleteControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/MyResumePatchDeleteControllerTest.php
@@ -26,10 +26,16 @@ class MyResumePatchDeleteControllerTest extends WebTestCase
         $client = $this->getTestClient('john-root', 'password-root');
         $client->request('PATCH', self::API_URL_PREFIX . '/v1/recruit/applications/recruit-talent-core/private/me/resumes/' . $resumeId, content: JSON::encode([
             'documentUrl' => 'https://localhost/uploads/resumes/updated.pdf',
+            'resumeInformation' => [
+                'fullName' => 'John Root Updated',
+                'phone' => '+1 555 000',
+            ],
             'experiences' => [
                 [
                     'title' => 'Staff Engineer',
                     'description' => 'Architecture API',
+                    'company' => 'Bro World',
+                    'startDate' => '2021-01-01',
                 ],
             ],
         ]));
@@ -41,6 +47,9 @@ class MyResumePatchDeleteControllerTest extends WebTestCase
 
         $payload = JSON::decode($content, true);
         self::assertSame('https://localhost/uploads/resumes/updated.pdf', $payload['documentUrl']);
+        self::assertSame('John Root Updated', $payload['resumeInformation']['fullName']);
+        self::assertSame('+1 555 000', $payload['resumeInformation']['phone']);
+        self::assertSame('Bro World', $payload['experiences'][0]['company']);
 
         self::bootKernel();
         /** @var EntityManagerInterface $entityManager */
@@ -48,6 +57,7 @@ class MyResumePatchDeleteControllerTest extends WebTestCase
         $resume = $entityManager->getRepository(Resume::class)->find($resumeId);
         self::assertInstanceOf(Resume::class, $resume);
         self::assertSame('https://localhost/uploads/resumes/updated.pdf', $resume->getDocumentUrl());
+        self::assertSame('John Root Updated', $resume->getInformationFullName());
         self::assertCount(1, $resume->getExperiences());
         self::assertSame('Staff Engineer', $resume->getExperiences()->first()->getTitle());
     }

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/ResumeCreateControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Resume/ResumeCreateControllerTest.php
@@ -84,8 +84,11 @@ class ResumeCreateControllerTest extends WebTestCase
         $payload = JSON::decode($content, true);
         self::assertArrayHasKey('id', $payload);
         self::assertArrayHasKey('documentUrl', $payload);
+        self::assertArrayHasKey('resumeInformation', $payload);
         self::assertIsString($payload['documentUrl']);
         self::assertStringContainsString('/uploads/resumes/', $payload['documentUrl']);
+        self::assertNotEmpty($payload['resumeInformation']['fullName']);
+        self::assertNotEmpty($payload['resumeInformation']['email']);
 
         $documentPath = parse_url($payload['documentUrl'], PHP_URL_PATH);
         self::assertIsString($documentPath);
@@ -99,6 +102,7 @@ class ResumeCreateControllerTest extends WebTestCase
         $resume = $entityManager->getRepository(Resume::class)->find($payload['id']);
         self::assertInstanceOf(Resume::class, $resume);
         self::assertSame($payload['documentUrl'], $resume->getDocumentUrl());
+        self::assertSame($payload['resumeInformation']['email'], $resume->getInformationEmail());
 
         if (file_exists($absoluteDocumentPath)) {
             unlink($absoluteDocumentPath);


### PR DESCRIPTION
### Motivation
- Enrichir les CV pour stocker et exposer des informations de contact (`fullName`, `email`, `phone`, `homepage`, `repo_profile`, `adresse`) et des métadonnées plus complètes sur les sections (langues, certifications, projets, éducation, expériences). 
- Permettre que lors de la création d'un CV, les valeurs par défaut proviennent du `User` (nom complet construit depuis `firstName` + `lastName`, `email`, `profile.phone`, `profile.location`) lorsqu'aucune information n'est fournie.

### Description
- Ajout de champs persistés sur `Resume` : `information_full_name`, `information_email`, `information_phone`, `information_homepage`, `information_repo_profile`, `information_address` avec getters/setters; exposition via `resumeInformation` dans le normalizer (API read/create/patch). 
- Étendu les entités de sections : `Language.level`, `Certification.attachments` (JSON list), `Project.attachments` + `Project.home_page`, `Education.school` + `startDate`/`endDate` + `location`, `Experience.company` + `startDate`/`endDate`, et hydratation/validation côté `ResumePayloadService`. 
- Les contrôleurs de création et de patch retournent désormais la payload normalisée complète via `ResumeNormalizerService`, et la création applique les valeurs par défaut depuis l'utilisateur via `ResumePayloadService`. 
- Mise à jour des fixtures pour pré-peupler les nouveaux champs et ajout d'une migration Doctrine (`migrations/Version20260419120000.php`) pour ajouter les colonnes correspondantes.

### Testing
- Syntax check PHP : exécuté `php -l` sur tous les fichiers modifiés et aucun erreur de syntaxe détectée (succès). 
- Tests PHPUnit ciblés : tentative d'exécution de suites de tests liées (`ResumePayloadServiceTest.php` et plusieurs tests d'API Resume) a échoué dans cet environnement car `vendor/bin/phpunit` est absent (échec d'exécution des tests). 
- Les changements ont été testés localement par inspection statique et mise à jour des fixtures et assertions des tests d'API pour correspondre au nouveau format de réponse (tests modifiés pour vérifier `resumeInformation` et nouveaux attributs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e43e09c7ac83268b010d79124d37cf)