### PR TITLE
Add sprint-scoped task board endpoints and enrich subtask normalization

### DIFF
--- a/src/Crm/Application/Service/CrmApiNormalizer.php
+++ b/src/Crm/Application/Service/CrmApiNormalizer.php
@@ -44,14 +44,27 @@ final readonly class CrmApiNormalizer
             'attachments' => $task->getAttachments(),
             'assignees' => $assignees,
             'subTasks' => array_map(
-                static fn (Task $subTask): array => [
-                    'id' => $subTask->getId(),
-                    'title' => $subTask->getTitle(),
-                    'status' => $subTask->getStatus()->value,
-                    'priority' => $subTask->getPriority()->value,
-                    'parentTaskId' => $subTask->getParentTask()?->getId(),
-                    'projectId' => $subTask->getProject()?->getId(),
-                ],
+                function (Task $subTask): array {
+                    $subTaskAssignees = $this->mapUserAssignees($subTask->getAssignees());
+
+                    return [
+                        'id' => $subTask->getId(),
+                        'title' => $subTask->getTitle(),
+                        'description' => $subTask->getDescription(),
+                        'status' => $subTask->getStatus()->value,
+                        'priority' => $subTask->getPriority()->value,
+                        'parentTaskId' => $subTask->getParentTask()?->getId(),
+                        'projectId' => $subTask->getProject()?->getId(),
+                        'projectName' => $subTask->getProject()?->getName(),
+                        'sprintId' => $subTask->getSprint()?->getId(),
+                        'sprintName' => $subTask->getSprint()?->getName(),
+                        'dueAt' => $this->normalizeDate($subTask->getDueAt()),
+                        'estimatedHours' => $subTask->getEstimatedHours(),
+                        'updatedAt' => $this->normalizeDate($subTask->getUpdatedAt()),
+                        'attachments' => $subTask->getAttachments(),
+                        'assignees' => $subTaskAssignees,
+                    ];
+                },
                 $task->getSubTasks()->toArray()
             ),
             'children' => array_map(

--- a/src/Crm/Application/Service/TaskBoardService.php
+++ b/src/Crm/Application/Service/TaskBoardService.php
@@ -6,6 +6,8 @@ namespace App\Crm\Application\Service;
 
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Entity\TaskRequest;
+use App\Crm\Domain\Entity\Sprint;
+use App\Crm\Infrastructure\Repository\SprintRepository;
 use App\Crm\Infrastructure\Repository\TaskRepository;
 use App\User\Domain\Entity\User;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
@@ -14,6 +16,7 @@ final readonly class TaskBoardService
 {
     public function __construct(
         private TaskRepository $taskRepository,
+        private SprintRepository $sprintRepository,
         private CrmApplicationScopeResolver $applicationScopeResolver,
         private CrmApiNormalizer $crmApiNormalizer,
     ) {
@@ -61,6 +64,89 @@ final readonly class TaskBoardService
 
         return [
             'items' => array_values($items),
+        ];
+    }
+
+    /**
+     * @return array{items:list<array<string,mixed>>}
+     */
+    public function listBySprintGlobal(): array
+    {
+        /** @var list<Task> $tasks */
+        $tasks = $this->taskRepository->createQueryBuilder('task')
+            ->leftJoin('task.sprint', 'sprint')->addSelect('sprint')
+            ->leftJoin('task.taskRequests', 'taskRequest')->addSelect('taskRequest')
+            ->leftJoin('task.assignees', 'taskAssignee')->addSelect('taskAssignee')
+            ->leftJoin('task.subTasks', 'subTask')->addSelect('subTask')
+            ->leftJoin('subTask.assignees', 'subTaskAssignee')->addSelect('subTaskAssignee')
+            ->leftJoin('taskRequest.assignees', 'taskRequestAssignee')->addSelect('taskRequestAssignee')
+            ->orderBy('sprint.createdAt', 'DESC')
+            ->addOrderBy('task.createdAt', 'DESC')
+            ->addOrderBy('taskRequest.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        return $this->groupTasksBySprint($tasks);
+    }
+
+    /**
+     * @return array{items:list<array<string,mixed>>,meta:array<string,mixed>}
+     */
+    public function listByLatestSprintGlobal(): array
+    {
+        /** @var Sprint|null $latestSprint */
+        $latestSprint = $this->sprintRepository->createQueryBuilder('sprint')
+            ->orderBy('sprint.createdAt', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        if (!$latestSprint instanceof Sprint) {
+            return [
+                'items' => [],
+                'meta' => [
+                    'sprint' => null,
+                ],
+            ];
+        }
+
+        /** @var list<Task> $tasks */
+        $tasks = $this->taskRepository->createQueryBuilder('task')
+            ->leftJoin('task.sprint', 'sprint')->addSelect('sprint')
+            ->leftJoin('task.taskRequests', 'taskRequest')->addSelect('taskRequest')
+            ->leftJoin('task.assignees', 'taskAssignee')->addSelect('taskAssignee')
+            ->leftJoin('task.subTasks', 'subTask')->addSelect('subTask')
+            ->leftJoin('subTask.assignees', 'subTaskAssignee')->addSelect('subTaskAssignee')
+            ->leftJoin('taskRequest.assignees', 'taskRequestAssignee')->addSelect('taskRequestAssignee')
+            ->andWhere('task.sprint = :sprint')
+            ->setParameter('sprint', $latestSprint->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->orderBy('task.createdAt', 'DESC')
+            ->addOrderBy('taskRequest.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+
+        return [
+            'items' => [
+                [
+                    'sprint' => [
+                        'id' => $latestSprint->getId(),
+                        'name' => $latestSprint->getName(),
+                        'status' => $latestSprint->getStatus()->value,
+                        'startDate' => $latestSprint->getStartDate()?->format(DATE_ATOM),
+                        'endDate' => $latestSprint->getEndDate()?->format(DATE_ATOM),
+                    ],
+                    'tasks' => array_map(fn (Task $task): array => $this->normalizeTask($task), $tasks),
+                ],
+            ],
+            'meta' => [
+                'sprint' => [
+                    'id' => $latestSprint->getId(),
+                    'name' => $latestSprint->getName(),
+                    'status' => $latestSprint->getStatus()->value,
+                    'startDate' => $latestSprint->getStartDate()?->format(DATE_ATOM),
+                    'endDate' => $latestSprint->getEndDate()?->format(DATE_ATOM),
+                ],
+            ],
         ];
     }
 
@@ -117,6 +203,36 @@ final readonly class TaskBoardService
     private function normalizeTask(Task $task): array
     {
         return $this->crmApiNormalizer->normalizeTask($task);
+    }
+
+    /**
+     * @param list<Task> $tasks
+     * @return array{items:list<array<string,mixed>>}
+     */
+    private function groupTasksBySprint(array $tasks): array
+    {
+        $items = [];
+        foreach ($tasks as $task) {
+            $sprintId = $task->getSprint()?->getId() ?? 'no-sprint';
+            if (!isset($items[$sprintId])) {
+                $items[$sprintId] = [
+                    'sprint' => [
+                        'id' => $task->getSprint()?->getId(),
+                        'name' => $task->getSprint()?->getName(),
+                        'status' => $task->getSprint()?->getStatus()->value,
+                        'startDate' => $task->getSprint()?->getStartDate()?->format(DATE_ATOM),
+                        'endDate' => $task->getSprint()?->getEndDate()?->format(DATE_ATOM),
+                    ],
+                    'tasks' => [],
+                ];
+            }
+
+            $items[$sprintId]['tasks'][] = $this->normalizeTask($task);
+        }
+
+        return [
+            'items' => array_values($items),
+        ];
     }
 
     /**

--- a/src/Crm/Transport/Controller/Api/V1/General/GetGeneralTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/GetGeneralTaskController.php
@@ -22,7 +22,7 @@ final readonly class GetGeneralTaskController
     {
     }
 
-    #[Route('/v1/crm/general/tasks/{task}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/tasks/{task}', methods: [Request::METHOD_GET], requirements: ['task' => '[0-9a-fA-F\\-]{36}'])]
     #[OA\Get(
         summary: 'General - Get Task',
         parameters: [new OA\Parameter(name: 'task', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))],

--- a/src/Crm/Transport/Controller/Api/V1/General/ListGeneralTasksByLatestSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/ListGeneralTasksByLatestSprintController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Application\Service\TaskBoardService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+final readonly class ListGeneralTasksByLatestSprintController
+{
+    public function __construct(
+        private TaskBoardService $taskBoardService,
+    ) {
+    }
+
+    #[Route('/v1/crm/general/tasks/by-latest-sprint', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'List General Tasks By Latest Sprint',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'Board payload for latest sprint with tasks and sub tasks.'),
+        ],
+    )]
+    public function __invoke(): JsonResponse
+    {
+        return new JsonResponse($this->taskBoardService->listByLatestSprintGlobal());
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/General/ListGeneralTasksBySprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/General/ListGeneralTasksBySprintController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\General;
+
+use App\Crm\Application\Service\TaskBoardService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+final readonly class ListGeneralTasksBySprintController
+{
+    public function __construct(
+        private TaskBoardService $taskBoardService,
+    ) {
+    }
+
+    #[Route('/v1/crm/general/tasks/by-sprint', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'List General Tasks By Sprint',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'Board payload grouped by sprint with tasks and sub tasks.'),
+        ],
+    )]
+    public function __invoke(): JsonResponse
+    {
+        return new JsonResponse($this->taskBoardService->listBySprintGlobal());
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide global and latest-sprint board views for tasks so consumers can fetch tasks grouped by sprint without application scoping logic. 
- Enrich the serialized subtask payload so clients receive more detailed subtask fields including description, sprint/project info, dates and assignees.

### Description
- Expanded `CrmApiNormalizer::normalizeTask` to include a richer mapping for `subTasks`, adding `description`, `projectName`, `sprintId`, `sprintName`, `dueAt`, `estimatedHours`, `updatedAt`, `attachments`, and `assignees` for each subtask. 
- Extended `TaskBoardService` by injecting `SprintRepository` and adding `listBySprintGlobal()`, `listByLatestSprintGlobal()`, and a helper `groupTasksBySprint()` to return tasks grouped by sprint (including sprint meta like `startDate`/`endDate`). 
- Updated queries in the new global list methods to eager-load `subTasks` and their assignees to avoid N+1 issues. 
- Tightened route requirements for `GetGeneralTaskController` task parameter to a UUID regex. 
- Added two new controllers: `ListGeneralTasksBySprintController` and `ListGeneralTasksByLatestSprintController` which expose the new service methods as GET endpoints.

### Testing
- Ran the automated test suite with `phpunit` and the tests covering task/sprint listing and normalization passed. 
- Ran static analysis (`phpstan`) and route resolution smoke checks for the new endpoints, and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e46232fdf88326ba79309f34912668)