### PR TITLE
Tolerate legacy/dirty language values in EnumLanguage DBAL type

### DIFF
--- a/src/General/Domain/Doctrine/DBAL/Types/EnumLanguageType.php
+++ b/src/General/Domain/Doctrine/DBAL/Types/EnumLanguageType.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\General\Domain\Doctrine\DBAL\Types;
 
 use App\General\Domain\Enum\Language;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Override;
 
 /**
  * @package App\General
@@ -13,4 +15,19 @@ class EnumLanguageType extends EnumType
 {
     protected static string $name = Types::ENUM_LANGUAGE;
     protected static string $enum = Language::class;
+
+    /**
+     * Be tolerant to legacy/dirty values in production data.
+     */
+    #[Override]
+    public function convertToPHPValue($value, AbstractPlatform $platform): Language
+    {
+        $normalized = strtolower(trim((string)$value));
+
+        if ($normalized === 'uk') {
+            $normalized = Language::UA->value;
+        }
+
+        return Language::tryFrom($normalized) ?? Language::getDefault();
+    }
 }


### PR DESCRIPTION
### Motivation
- Doctrine hydration of `Language` enums caused HTTP 500 errors when legacy or dirty values were stored in the database, breaking endpoints like `/v1/crm/general/tasks/by-sprint`.
- The change aims to make DB enum conversion tolerant so a single bad value does not fail whole query hydration.

### Description
- Added an override of `EnumLanguageType::convertToPHPValue()` to normalize raw DB values with `trim` + `strtolower` before conversion.
- Legacy shorthand `uk` is mapped to the canonical `ua` value, and unknown values now fall back to `Language::getDefault()` instead of throwing.
- Imported `Doctrine\DBAL\Platforms\AbstractPlatform` and applied `#[Override]` on the new conversion method to make the type tolerant to dirty production data.

### Testing
- Ran PHP lint on the modified files with `php -l src/General/Domain/Doctrine/DBAL/Types/EnumLanguageType.php` and `php -l src/General/Domain/Doctrine/DBAL/Types/EnumType.php`, both succeeded.
- Attempted `composer test --no-interaction` but the repository has no `test` script, so no test suite ran via Composer.
- `vendor/bin/phpunit --testsuite unit` was not available in the environment, so unit tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e469de04108326942eaae37f6dc897)