### PR TITLE
Tolerate legacy 'uk' values in EnumLanguageType and EnumLocaleType conversions

### DIFF
--- a/src/General/Domain/Doctrine/DBAL/Types/EnumLanguageType.php
+++ b/src/General/Domain/Doctrine/DBAL/Types/EnumLanguageType.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\General\Domain\Doctrine\DBAL\Types;
 
 use App\General\Domain\Enum\Language;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Override;
 
 /**
  * @package App\General
@@ -13,4 +15,19 @@ class EnumLanguageType extends EnumType
 {
     protected static string $name = Types::ENUM_LANGUAGE;
     protected static string $enum = Language::class;
+
+    /**
+     * Be tolerant to legacy/dirty values in production data.
+     */
+    #[Override]
+    public function convertToPHPValue($value, AbstractPlatform $platform): Language
+    {
+        $normalized = strtolower(trim((string)$value));
+
+        if ($normalized === 'uk') {
+            $normalized = Language::UA->value;
+        }
+
+        return Language::tryFrom($normalized) ?? Language::getDefault();
+    }
 }

--- a/src/General/Domain/Doctrine/DBAL/Types/EnumLocaleType.php
+++ b/src/General/Domain/Doctrine/DBAL/Types/EnumLocaleType.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\General\Domain\Doctrine\DBAL\Types;
 
 use App\General\Domain\Enum\Locale;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Override;
 
 /**
  * @package App\General
@@ -13,4 +15,19 @@ class EnumLocaleType extends EnumType
 {
     protected static string $name = Types::ENUM_LOCALE;
     protected static string $enum = Locale::class;
+
+    /**
+     * Be tolerant to legacy/dirty values in production data.
+     */
+    #[Override]
+    public function convertToPHPValue($value, AbstractPlatform $platform): Locale
+    {
+        $normalized = strtolower(trim((string)$value));
+
+        if ($normalized === 'uk') {
+            $normalized = Locale::UA->value;
+        }
+
+        return Locale::tryFrom($normalized) ?? Locale::getDefault();
+    }
 }


### PR DESCRIPTION
### Motivation
- Normalize and tolerate legacy/dirty database values (e.g. `'uk'`) when converting DB strings to enum objects to avoid runtime errors.
- Provide a safe fallback to the enum default for unknown or malformed values to make production data handling more robust.

### Description
- Added `convertToPHPValue` to `EnumLanguageType` and `EnumLocaleType` with the `#[Override]` attribute and an `AbstractPlatform` parameter. 
- Each method normalizes input via `strtolower` and `trim`, maps the legacy `'uk'` token to the canonical `UA` value, and converts using `tryFrom(...)` with a fallback to `Enum::getDefault()`.
- Imported `Doctrine\DBAL\Platforms\AbstractPlatform` and `Override` to support the new method signatures and annotations.

### Testing
- Ran the project test suite using `vendor/bin/phpunit` and the tests completed successfully. 
- No new unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e469de04108326942eaae37f6dc897)