### PR TITLE
feat(crm): require sprint id path param for tasks-by-sprint endpoint

### DIFF
--- a/docs/crm-get-endpoints.md
+++ b/docs/crm-get-endpoints.md
@@ -8,7 +8,7 @@
 - `GET /v1/crm/applications/{applicationSlug}/sprints` — filters: `q`, `status`; pagination: `page`, `limit`.
 - `GET /v1/crm/applications/{applicationSlug}/tasks` — filters: `q`, `title`, `status`, `priority`; pagination: `page`, `limit`.
 - `GET /v1/crm/applications/{applicationSlug}/task-requests` — filters: `q`, `status`; pagination: `page`, `limit`.
-- `GET /v1/crm/applications/{applicationSlug}/tasks/by-sprint` — business filters: board/sprint scope.
+- `GET /v1/crm/applications/{applicationSlug}/tasks/by-sprint/{sprint}` — business filters: board/sprint scope.
 - `GET /v1/crm/applications/{applicationSlug}/sprints/{sprint}/tasks` — business filters: sprint scope.
 - `GET /v1/crm/applications/{applicationSlug}/me/tasks` — business filters: current user tasks.
 

--- a/src/Crm/Application/Service/TaskBoardService.php
+++ b/src/Crm/Application/Service/TaskBoardService.php
@@ -25,7 +25,7 @@ final readonly class TaskBoardService
     /**
      * @return array{items:list<array<string,mixed>>}
      */
-    public function listBySprint(string $applicationSlug): array
+    public function listBySprint(string $applicationSlug, string $sprintId): array
     {
         $crm = $this->applicationScopeResolver->resolveOrFail($applicationSlug);
 
@@ -38,7 +38,9 @@ final readonly class TaskBoardService
             ->leftJoin('task.project', 'project')
             ->leftJoin('project.company', 'company')
             ->andWhere('company.crm = :crm')
+            ->andWhere('sprint.id = :sprintId')
             ->setParameter('crm', $crm->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->setParameter('sprintId', $sprintId, UuidBinaryOrderedTimeType::NAME)
             ->orderBy('sprint.createdAt', 'DESC')
             ->addOrderBy('task.createdAt', 'DESC')
             ->addOrderBy('taskRequest.createdAt', 'DESC')

--- a/src/Crm/Transport/Controller/Api/V1/Task/ListTasksBySprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/ListTasksBySprintController.php
@@ -23,16 +23,17 @@ final readonly class ListTasksBySprintController
     ) {
     }
 
-    #[Route('/v1/crm/applications/{applicationSlug}/tasks/by-sprint', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/applications/{applicationSlug}/tasks/by-sprint/{sprint}', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'sprint', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Get(
         summary: 'List Tasks By Sprint',
         responses: [
             new OA\Response(response: JsonResponse::HTTP_OK, description: 'Board payload grouped by sprint with sprint.name.'),
         ],
     )]
-    public function __invoke(string $applicationSlug): JsonResponse
+    public function __invoke(string $applicationSlug, string $sprint): JsonResponse
     {
-        return new JsonResponse($this->taskBoardService->listBySprint($applicationSlug));
+        return new JsonResponse($this->taskBoardService->listBySprint($applicationSlug, $sprint));
     }
 }


### PR DESCRIPTION
### Motivation

- Make the tasks-by-sprint endpoint explicitly scoped to a single sprint in the URL so clients must provide a sprint identifier. 

### Description

- Changed the controller route from `GET /v1/crm/applications/{applicationSlug}/tasks/by-sprint` to `GET /v1/crm/applications/{applicationSlug}/tasks/by-sprint/{sprint}` and updated the controller signature to accept the `sprint` path parameter (`src/Crm/Transport/Controller/Api/V1/Task/ListTasksBySprintController.php`).
- Added OpenAPI metadata for the new `sprint` UUID path parameter in the controller (`#[OA\u005CParameter(... format: 'uuid')]`).
- Updated `TaskBoardService::listBySprint()` signature to `listBySprint(string $applicationSlug, string $sprintId)` and added the query filter `->andWhere('sprint.id = :sprintId')` with the corresponding parameter (`src/Crm/Application/Service/TaskBoardService.php`).
- Updated the CRM GET endpoints inventory documentation to reflect the new route (`docs/crm-get-endpoints.md`).

### Testing

- Ran PHP lint on modified files with `php -l src/Crm/Transport/Controller/Api/V1/Task/ListTasksBySprintController.php` and it succeeded. 
- Ran PHP lint on the service with `php -l src/Crm/Application/Service/TaskBoardService.php` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e46f04a4f08326bf69b891328ed4d3)