### PR TITLE
Add CRM general GitHub sync endpoints and update general app fixture photos

### DIFF
--- a/src/Crm/Infrastructure/Repository/CrmGithubSyncJobRepository.php
+++ b/src/Crm/Infrastructure/Repository/CrmGithubSyncJobRepository.php
@@ -28,4 +28,42 @@ final class CrmGithubSyncJobRepository extends BaseRepository
         protected ManagerRegistry $managerRegistry,
     ) {
     }
+
+    public function findLatestByApplicationSlug(string $applicationSlug): ?CrmGithubSyncJob
+    {
+        /** @var CrmGithubSyncJob|null $job */
+        $job = $this->createQueryBuilder('job')
+            ->andWhere('job.applicationSlug = :applicationSlug')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->orderBy('job.createdAt', 'DESC')
+            ->addOrderBy('job.id', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $job;
+    }
+
+    /**
+     * @return array<int, CrmGithubSyncJob>
+     */
+    public function findRecentByApplicationSlug(string $applicationSlug, int $limit = 20, ?string $status = null): array
+    {
+        $qb = $this->createQueryBuilder('job')
+            ->andWhere('job.applicationSlug = :applicationSlug')
+            ->setParameter('applicationSlug', $applicationSlug)
+            ->orderBy('job.createdAt', 'DESC')
+            ->addOrderBy('job.id', 'DESC')
+            ->setMaxResults($limit);
+
+        if ($status !== null && $status !== '') {
+            $qb->andWhere('job.status = :status')
+                ->setParameter('status', $status);
+        }
+
+        /** @var array<int, CrmGithubSyncJob> $items */
+        $items = $qb->getQuery()->getResult();
+
+        return $items;
+    }
 }

--- a/src/Crm/Transport/Controller/Api/V1/CrmGithub/GetCrmGithubLatestSyncJobController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CrmGithub/GetCrmGithubLatestSyncJobController.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\CrmGithub;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\CrmGithubSyncJob;
+use App\Crm\Infrastructure\Repository\CrmGithubSyncJobRepository;
+use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class GetCrmGithubLatestSyncJobController
+{
+    private const string GENERAL_APPLICATION_SLUG = 'crm-general-core';
+
+    public function __construct(
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CrmGithubSyncJobRepository $syncJobRepository,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/github/sync/jobs/latest', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/github/sync/jobs/latest', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Get(
+        summary: 'Get latest CRM GitHub sync job',
+        responses: [
+            new OA\Response(
+                response: JsonResponse::HTTP_OK,
+                description: 'Latest sync job or null when there is no history.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'item', ref: '#/components/schemas/CrmGithubSyncJob', nullable: true),
+                    ],
+                    type: 'object',
+                )
+            ),
+        ],
+    )]
+    public function __invoke(?string $applicationSlug = null): JsonResponse
+    {
+        $applicationSlug ??= self::GENERAL_APPLICATION_SLUG;
+        $this->scopeResolver->resolveOrFail($applicationSlug);
+
+        $job = $this->syncJobRepository->findLatestByApplicationSlug($applicationSlug);
+
+        return new JsonResponse([
+            'item' => $job instanceof CrmGithubSyncJob ? $this->serializeJob($job) : null,
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function serializeJob(CrmGithubSyncJob $job): array
+    {
+        return [
+            'id' => $job->getId(),
+            'applicationSlug' => $job->getApplicationSlug(),
+            'owner' => $job->getOwner(),
+            'startedAt' => $job->getStartedAt()?->format(DATE_ATOM),
+            'finishedAt' => $job->getFinishedAt()?->format(DATE_ATOM),
+            'status' => $job->getStatus(),
+            'projectsCreated' => $job->getProjectsCreated(),
+            'reposAttached' => $job->getReposAttached(),
+            'issuesImported' => $job->getIssuesImported(),
+            'errorsCount' => $job->getErrorsCount(),
+            'errors' => $job->getErrors(),
+        ];
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/CrmGithub/ListCrmGithubSyncJobsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CrmGithub/ListCrmGithubSyncJobsController.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\CrmGithub;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Domain\Entity\CrmGithubSyncJob;
+use App\Crm\Infrastructure\Repository\CrmGithubSyncJobRepository;
+use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function max;
+use function min;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+#[IsGranted(Role::CRM_MANAGER->value)]
+final readonly class ListCrmGithubSyncJobsController
+{
+    private const string GENERAL_APPLICATION_SLUG = 'crm-general-core';
+
+    public function __construct(
+        private CrmApplicationScopeResolver $scopeResolver,
+        private CrmGithubSyncJobRepository $syncJobRepository,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/github/sync/jobs', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/github/sync/jobs', methods: [Request::METHOD_GET])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'status', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20))]
+    #[OA\Get(
+        summary: 'List CRM GitHub sync jobs',
+        responses: [
+            new OA\Response(
+                response: JsonResponse::HTTP_OK,
+                description: 'List of sync jobs for CRM scope.',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(property: 'items', type: 'array', items: new OA\Items(ref: '#/components/schemas/CrmGithubSyncJob')),
+                    ],
+                    type: 'object',
+                )
+            ),
+        ],
+    )]
+    public function __invoke(Request $request, ?string $applicationSlug = null): JsonResponse
+    {
+        $applicationSlug ??= self::GENERAL_APPLICATION_SLUG;
+        $this->scopeResolver->resolveOrFail($applicationSlug);
+
+        $status = $request->query->getString('status', '');
+        $status = $status !== '' ? $status : null;
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+
+        $jobs = $this->syncJobRepository->findRecentByApplicationSlug($applicationSlug, $limit, $status);
+
+        return new JsonResponse([
+            'items' => array_map(self::serializeJob(...), $jobs),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private static function serializeJob(CrmGithubSyncJob $job): array
+    {
+        return [
+            'id' => $job->getId(),
+            'applicationSlug' => $job->getApplicationSlug(),
+            'owner' => $job->getOwner(),
+            'startedAt' => $job->getStartedAt()?->format(DATE_ATOM),
+            'finishedAt' => $job->getFinishedAt()?->format(DATE_ATOM),
+            'status' => $job->getStatus(),
+            'projectsCreated' => $job->getProjectsCreated(),
+            'reposAttached' => $job->getReposAttached(),
+            'issuesImported' => $job->getIssuesImported(),
+            'errorsCount' => $job->getErrorsCount(),
+            'errors' => $job->getErrors(),
+        ];
+    }
+}

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
@@ -147,6 +147,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'key' => 'shop-ops-center',
             'title' => 'Shop Ops Center',
             'description' => 'Pilotage des operations e-commerce quotidiennes.',
+            'photo' => 'https://bro-world.org/img/platform/general/shop.png',
             'status' => PlatformStatus::ACTIVE,
             'private' => false,
             'ownerReference' => 'User-john-root',
@@ -456,6 +457,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'key' => 'general',
             'title' => 'General',
             'description' => 'Espace general pour les modules transverses declenches par les utilisateurs.',
+            'photo' => 'https://bro-world.org/img/platform/general/learning.png',
             'status' => PlatformStatus::ACTIVE,
             'private' => false,
             'ownerReference' => 'User-john-root',
@@ -533,10 +535,32 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             ],
         ],
         [
+            'uuid' => '60000000-0000-1000-8000-000000000017',
+            'key' => 'shop-general-core',
+            'title' => 'Shop General Core',
+            'description' => 'Scope general Shop pour les endpoints transverses.',
+            'photo' => 'https://bro-world.org/img/platform/general/shop.png',
+            'status' => PlatformStatus::ACTIVE,
+            'private' => false,
+            'ownerReference' => 'User-john-root',
+            'platformReference' => 'Platform-SH-Shop Principal',
+            'appConfigurations' => [
+                [
+                    'uuid' => '61000000-0000-1000-8000-000000000017',
+                    'key' => 'application.shop.general',
+                    'value' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ],
+            'plugins' => [],
+        ],
+        [
             'uuid' => '60000000-0000-1000-8000-000000000014',
             'key' => 'crm-general-core',
             'title' => 'CRM General Core',
             'description' => 'Scope general CRM pour les endpoints transverses.',
+            'photo' => 'https://bro-world.org/img/platform/general/crm.png',
             'status' => PlatformStatus::ACTIVE,
             'private' => false,
             'ownerReference' => 'User-john-root',
@@ -557,6 +581,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'key' => 'school-general-core',
             'title' => 'School General Core',
             'description' => 'Scope general School pour les endpoints transverses.',
+            'photo' => 'https://bro-world.org/img/platform/general/learning.png',
             'status' => PlatformStatus::ACTIVE,
             'private' => false,
             'ownerReference' => 'User-john-root',
@@ -577,6 +602,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'key' => 'recruit-general-core',
             'title' => 'Recruit General Core',
             'description' => 'Scope general Recruit pour les endpoints transverses.',
+            'photo' => 'https://bro-world.org/img/platform/general/job.png',
             'status' => PlatformStatus::ACTIVE,
             'private' => false,
             'ownerReference' => 'User-john-root',
@@ -614,6 +640,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
         'crm-general-core' => '60000000-0000-1000-8000-000000000014',
         'school-general-core' => '60000000-0000-1000-8000-000000000015',
         'recruit-general-core' => '60000000-0000-1000-8000-000000000016',
+        'shop-general-core' => '60000000-0000-1000-8000-000000000017',
     ];
 
     /**
@@ -634,6 +661,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                 ->setPlatform($platform)
                 ->setTitle($item['title'])
                 ->setDescription($item['description'])
+                ->setPhoto($item['photo'] ?? '')
                 ->setStatus($item['status'])
                 ->setPrivate($item['private']);
 


### PR DESCRIPTION
### Motivation

- Fournir des images explicites pour les fixtures d'applications `general` afin d'afficher des photos pour CRM, Shop, Learning et Job.
- Ajouter un scope général pour Shop (`application.shop.general`) pour couvrir les endpoints transverses Shop.
- Exposer des endpoints lisibles pour les jobs de synchronisation GitHub dans le périmètre CRM `general` afin de pouvoir consommer l'historique et le dernier job depuis des intégrations (ex: GitHub consumers). 

### Description

- Mise à jour de `src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php` pour ajouter les clés `photo` aux entrées générales (CRM/Shop/Learning/Recruit) et insertion d'une entrée `shop-general-core` avec son UUID, et le loader applique maintenant `->setPhoto($item['photo'] ?? '')` lors de la création d'`Application`.
- Ajout de deux nouveaux contrôleurs API pour CRM GitHub : `ListCrmGithubSyncJobsController` exposant `GET /v1/crm/general/github/sync/jobs` (et variante application) et `GetCrmGithubLatestSyncJobController` exposant `GET /v1/crm/general/github/sync/jobs/latest` (et variante application), chacun retournant des représentations JSON des `CrmGithubSyncJob`.
- Extension du repository `src/Crm/Infrastructure/Repository/CrmGithubSyncJobRepository.php` avec `findRecentByApplicationSlug(...)` et `findLatestByApplicationSlug(...)` pour supporter la pagination/filtrage par `status` et la recherche du dernier job.

### Testing

- Exécution de vérifications de syntaxe PHP via `php -l` sur les fichiers modifiés : `src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php`, `src/Crm/Infrastructure/Repository/CrmGithubSyncJobRepository.php`, `src/Crm/Transport/Controller/Api/V1/CrmGithub/ListCrmGithubSyncJobsController.php` et `src/Crm/Transport/Controller/Api/V1/CrmGithub/GetCrmGithubLatestSyncJobController.php` et les contrôleurs existants liés, et toutes les vérifications ont réussi sans erreurs de syntaxe.
- Les nouveaux endpoints reposent sur les méthodes de repository ajoutées et la résolution de scope via `CrmApplicationScopeResolver` (aucun test d'intégration exécuté dans ce changement, seulement vérifications statiques de syntaxe).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e564e644bc8326853440ec341eb4c0)