### PR TITLE
Add public general applications catalog endpoint and enrich fixtures

### DIFF
--- a/src/Platform/Application/Service/PublicGeneralApplicationCatalogService.php
+++ b/src/Platform/Application/Service/PublicGeneralApplicationCatalogService.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Service;
+
+use App\Configuration\Domain\Entity\Configuration;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\ApplicationPlugin;
+use App\Platform\Domain\Repository\Interfaces\ApplicationRepositoryInterface;
+
+readonly class PublicGeneralApplicationCatalogService
+{
+    public function __construct(
+        private ApplicationRepositoryInterface $applicationRepository,
+    ) {
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getCatalog(): array
+    {
+        $items = [];
+
+        foreach ($this->applicationRepository->findPublicGeneralApplications() as $application) {
+            $items[] = $this->normalizeApplication($application);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeApplication(Application $application): array
+    {
+        return [
+            'id' => $application->getId(),
+            'title' => $application->getTitle(),
+            'slug' => $application->getSlug(),
+            'description' => $application->getDescription(),
+            'photo' => $application->getPhoto(),
+            'status' => $application->getStatus()->value,
+            'platform' => [
+                'id' => $application->getPlatform()?->getId(),
+                'name' => $application->getPlatform()?->getName(),
+                'key' => $application->getPlatform()?->getPlatformKeyValue(),
+                'description' => $application->getPlatform()?->getDescription(),
+            ],
+            'configurations' => array_map(
+                static fn (Configuration $configuration): array => [
+                    'id' => $configuration->getId(),
+                    'key' => $configuration->getConfigurationKey(),
+                    'value' => $configuration->getConfigurationValue(),
+                ],
+                $application->getConfigurations()->toArray(),
+            ),
+            'plugins' => array_map(
+                static fn (ApplicationPlugin $applicationPlugin): array => [
+                    'id' => $applicationPlugin->getId(),
+                    'name' => $applicationPlugin->getPlugin()?->getName(),
+                    'key' => $applicationPlugin->getPlugin()?->getPluginKeyValue(),
+                    'description' => $applicationPlugin->getPlugin()?->getDescription(),
+                    'configurations' => array_map(
+                        static fn (Configuration $configuration): array => [
+                            'id' => $configuration->getId(),
+                            'key' => $configuration->getConfigurationKey(),
+                            'value' => $configuration->getConfigurationValue(),
+                        ],
+                        $applicationPlugin->getConfigurations()->toArray(),
+                    ),
+                ],
+                $application->getApplicationPlugins()->toArray(),
+            ),
+        ];
+    }
+}

--- a/src/Platform/Domain/Repository/Interfaces/ApplicationRepositoryInterface.php
+++ b/src/Platform/Domain/Repository/Interfaces/ApplicationRepositoryInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Platform\Domain\Repository\Interfaces;
 
+use App\Platform\Domain\Entity\Application;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\Query;
 
@@ -20,4 +21,9 @@ interface ApplicationRepositoryInterface
      * @param array<int, string>|null $esIds
      */
     public function countList(array $filters, ?User $loggedInUser, ?array $esIds): int;
+
+    /**
+     * @return array<int, Application>
+     */
+    public function findPublicGeneralApplications(): array;
 }

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
@@ -550,10 +550,28 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                     'key' => 'application.shop.general',
                     'value' => [
                         'enabled' => true,
+                        'context' => 'bro-shop-general',
+                        'checkoutMode' => 'hybrid',
                     ],
                 ],
             ],
-            'plugins' => [],
+            'plugins' => [
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000023',
+                    'reference' => 'Plugin-CRM-Assistant',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000023',
+                            'key' => 'plugin.chat.general',
+                            'value' => [
+                                'realTime' => true,
+                                'transport' => 'mercure',
+                                'channels' => ['shop-support', 'order-escalation'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ],
         [
             'uuid' => '60000000-0000-1000-8000-000000000014',
@@ -571,10 +589,58 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                     'key' => 'application.crm.general',
                     'value' => [
                         'enabled' => true,
+                        'context' => 'bro-crm-general',
+                        'defaultPipeline' => 'enterprise',
                     ],
                 ],
             ],
-            'plugins' => [],
+            'plugins' => [
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000024',
+                    'reference' => 'Plugin-Analytics-Booster',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000024',
+                            'key' => 'plugin.calendar.general',
+                            'value' => [
+                                'realTime' => false,
+                                'syncProvider' => 'internal',
+                                'workingDays' => ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000025',
+                    'reference' => 'Plugin-Knowledge-Base-Connector',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000025',
+                            'key' => 'plugin.blog.general',
+                            'value' => [
+                                'realTime' => true,
+                                'transport' => 'mercure',
+                                'moderation' => 'post',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000026',
+                    'reference' => 'Plugin-CRM-Assistant',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000026',
+                            'key' => 'plugin.chat.general',
+                            'value' => [
+                                'realTime' => true,
+                                'transport' => 'mercure',
+                                'channels' => ['crm-general', 'lead-qualification'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ],
         [
             'uuid' => '60000000-0000-1000-8000-000000000015',
@@ -592,10 +658,58 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                     'key' => 'application.school.general',
                     'value' => [
                         'enabled' => true,
+                        'context' => 'bro-learning-general',
+                        'learningMode' => 'blended',
                     ],
                 ],
             ],
-            'plugins' => [],
+            'plugins' => [
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000027',
+                    'reference' => 'Plugin-Knowledge-Base-Connector',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000027',
+                            'key' => 'plugin.blog.learning',
+                            'value' => [
+                                'realTime' => false,
+                                'transport' => 'none',
+                                'editorialWorkflow' => 'teacher-review',
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000028',
+                    'reference' => 'Plugin-Analytics-Booster',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000028',
+                            'key' => 'plugin.calendar.learning',
+                            'value' => [
+                                'realTime' => true,
+                                'transport' => 'mercure',
+                                'reminderMinutesBefore' => 15,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000029',
+                    'reference' => 'Plugin-CRM-Assistant',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000029',
+                            'key' => 'plugin.chat.learning',
+                            'value' => [
+                                'realTime' => true,
+                                'transport' => 'mercure',
+                                'channels' => ['learning-classroom', 'mentor-office-hours'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ],
         [
             'uuid' => '60000000-0000-1000-8000-000000000016',
@@ -613,10 +727,28 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                     'key' => 'application.recruit.general',
                     'value' => [
                         'enabled' => true,
+                        'context' => 'bro-job-general',
+                        'defaultLanguage' => 'fr',
                     ],
                 ],
             ],
-            'plugins' => [],
+            'plugins' => [
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000030',
+                    'reference' => 'Plugin-CRM-Assistant',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000030',
+                            'key' => 'plugin.chat.job',
+                            'value' => [
+                                'realTime' => true,
+                                'transport' => 'mercure',
+                                'channels' => ['candidate-ops', 'hiring-managers'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
         ],
     ];
 

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php
@@ -26,19 +26,19 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
             'uuid' => '50000000-0000-1000-8000-000000000001',
             'key' => 'CRM-Assistant',
             'pluginKey' => 'chat',
-            'name' => 'CRM Assistant',
+            'name' => 'Chat',
             'enabled' => true,
             'private' => false,
-            'description' => 'AI assistant to summarize conversations, suggest follow-ups, and improve CRM workflows.',
+            'description' => 'Messagerie collaborative pour support, entraide et conversations temps reel.',
         ],
         [
             'uuid' => '50000000-0000-1000-8000-000000000002',
             'key' => 'Analytics-Booster',
             'pluginKey' => 'calendar',
-            'name' => 'Analytics Booster',
+            'name' => 'Calendar',
             'enabled' => true,
             'private' => false,
-            'description' => 'Advanced analytics plugin with dashboards, KPIs, and custom reporting blocks.',
+            'description' => 'Calendrier partage pour planifier taches, evenements et synchronisation equipe.',
         ],
         [
             'uuid' => '50000000-0000-1000-8000-000000000003',
@@ -62,10 +62,10 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
             'uuid' => '50000000-0000-1000-8000-000000000005',
             'key' => 'Knowledge-Base-Connector',
             'pluginKey' => 'blog',
-            'name' => 'Knowledge Base Connector',
+            'name' => 'Blog',
             'enabled' => true,
             'private' => false,
-            'description' => 'Connector to sync articles and FAQs from external knowledge base systems.',
+            'description' => 'Publication de contenus, annonces et connaissances produit pour la communaute.',
         ],
         [
             'uuid' => '50000000-0000-1000-8000-000000000006',
@@ -81,12 +81,15 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
      * @var array<non-empty-string, non-empty-string>
      */
     public static array $uuids = [
-        'CRM Assistant' => '50000000-0000-1000-8000-000000000001',
-        'Analytics Booster' => '50000000-0000-1000-8000-000000000002',
+        'Chat' => '50000000-0000-1000-8000-000000000001',
+        'Calendar' => '50000000-0000-1000-8000-000000000002',
         'Private Beta Plugin' => '50000000-0000-1000-8000-000000000003',
         'Disabled Public Plugin' => '50000000-0000-1000-8000-000000000004',
-        'Knowledge Base Connector' => '50000000-0000-1000-8000-000000000005',
+        'Blog' => '50000000-0000-1000-8000-000000000005',
         'Quiz Master' => '50000000-0000-1000-8000-000000000006',
+        'CRM Assistant' => '50000000-0000-1000-8000-000000000001',
+        'Analytics Booster' => '50000000-0000-1000-8000-000000000002',
+        'Knowledge Base Connector' => '50000000-0000-1000-8000-000000000005',
     ];
 
     /**

--- a/src/Platform/Infrastructure/Repository/ApplicationRepository.php
+++ b/src/Platform/Infrastructure/Repository/ApplicationRepository.php
@@ -19,6 +19,16 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class ApplicationRepository extends BaseRepository implements ApplicationRepositoryInterface
 {
+    /**
+     * @var array<int, string>
+     */
+    private const array GENERAL_APPLICATION_SLUGS = [
+        'crm-general-core',
+        'shop-general-core',
+        'recruit-general-core',
+        'school-general-core',
+    ];
+
     protected static string $entityName = Entity::class;
 
     protected static array $searchColumns = [
@@ -68,6 +78,34 @@ class ApplicationRepository extends BaseRepository implements ApplicationReposit
             ->resetDQLPart('orderBy')
             ->getQuery()
             ->getSingleScalarResult();
+    }
+
+    public function findPublicGeneralApplications(): array
+    {
+        /** @var array<int, Entity> $applications */
+        $applications = $this->createQueryBuilder('application')
+            ->leftJoin('application.platform', 'platform')
+            ->leftJoin('application.applicationPlugins', 'applicationPlugin')
+            ->leftJoin('applicationPlugin.plugin', 'plugin')
+            ->leftJoin('application.configurations', 'applicationConfiguration')
+            ->leftJoin('applicationPlugin.configurations', 'pluginConfiguration')
+            ->addSelect(
+                'platform',
+                'applicationPlugin',
+                'plugin',
+                'applicationConfiguration',
+                'pluginConfiguration',
+            )
+            ->andWhere('application.private = :publicApplication')
+            ->andWhere('application.slug IN (:slugs)')
+            ->setParameter('publicApplication', false)
+            ->setParameter('slugs', self::GENERAL_APPLICATION_SLUGS)
+            ->orderBy('application.title', 'ASC')
+            ->addOrderBy('application.id', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        return $applications;
     }
 
     private function createListIdsQueryBuilder(array $filters, ?User $loggedInUser, ?array $esIds): QueryBuilder

--- a/src/Platform/Transport/Controller/Api/V1/Application/PublicGeneralApplicationCatalogController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Application/PublicGeneralApplicationCatalogController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Transport\Controller\Api\V1\Application;
+
+use App\Platform\Application\Service\PublicGeneralApplicationCatalogService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Application')]
+readonly class PublicGeneralApplicationCatalogController
+{
+    public function __construct(
+        private PublicGeneralApplicationCatalogService $catalogService,
+    ) {
+    }
+
+    #[Route(path: '/v1/application/public/general', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'Liste des applications general publiques avec platform, plugins et configurations',
+        security: [],
+        responses: [
+            new OA\Response(response: 200, description: 'Catalogue des applications general publiques'),
+        ],
+    )]
+    public function __invoke(): JsonResponse
+    {
+        return new JsonResponse([
+            'items' => $this->catalogService->getCatalog(),
+        ]);
+    }
+}

--- a/tests/Application/Platform/Transport/Controller/Api/V1/PublicGeneralApplicationCatalogControllerTest.php
+++ b/tests/Application/Platform/Transport/Controller/Api/V1/PublicGeneralApplicationCatalogControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Platform\Transport\Controller\Api\V1;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class PublicGeneralApplicationCatalogControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/application/public/general';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/application/public/general` returns public general applications with platform, plugins and configurations.')]
+    public function testThatPublicGeneralCatalogReturnsStructuredPayload(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', $this->baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertArrayHasKey('items', $responseData);
+        self::assertIsArray($responseData['items']);
+        self::assertNotEmpty($responseData['items']);
+
+        $first = $responseData['items'][0];
+        self::assertArrayHasKey('title', $first);
+        self::assertArrayHasKey('slug', $first);
+        self::assertArrayHasKey('platform', $first);
+        self::assertArrayHasKey('plugins', $first);
+        self::assertArrayHasKey('configurations', $first);
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a single public endpoint that returns the public “general” applications catalog including platform metadata, attached plugins and all related configurations.  
- Standardize plugin display names in fixtures and attach plugins + realistic configuration (including real-time/Mercure flags) to the general applications used by the platform.  

### Description

- Add controller `PublicGeneralApplicationCatalogController` with route `GET /v1/application/public/general` to expose the catalog payload.  
- Implement `PublicGeneralApplicationCatalogService` to normalize applications with platform info, application configurations, plugins and plugin configurations.  
- Extend `ApplicationRepositoryInterface` and `ApplicationRepository` with `findPublicGeneralApplications()` and a `GENERAL_APPLICATION_SLUGS` constant to load the general applications with required joins for eager-loading.  
- Update fixtures: `LoadPluginData` renames plugin display names to `Chat`, `Calendar`, `Blog` (and preserves alias UUIDs for backward compatibility) and `LoadApplicationData` enriches `crm-general-core`, `shop-general-core`, `school-general-core`, and `recruit-general-core` with plugins and context-specific configurations (including `realTime`/`transport: mercure` where applicable).  
- Add functional test `PublicGeneralApplicationCatalogControllerTest` to validate the response structure includes `items`, `platform`, `plugins` and `configurations`.

### Testing

- Ran PHP syntax checks with `php -l` for `PublicGeneralApplicationCatalogService`, the new controller, `ApplicationRepository` and the modified fixtures and all returned no syntax errors.  
- Attempted to run the new functional test via `phpunit` but test runner is not available in this environment so `vendor/bin/phpunit` could not be executed (binary/dependencies not installed).  
- The changes were added with a focused unit/functional test file to be executed in CI or a local environment with dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e569e383a08326938397a77922f536)