### PR TITLE
Single CRM platform, add `school-general-core` scope and slug-less school routes

### DIFF
--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
@@ -103,7 +103,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
             'status' => PlatformStatus::ACTIVE,
             'private' => false,
             'ownerReference' => 'User-john-root',
-            'platformReference' => 'Platform-CR-CRM 2',
+            'platformReference' => 'Platform-CR-CRM 1',
             'appConfigurations' => [
                 [
                     'uuid' => '61000000-0000-1000-8000-000000000003',

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadPlatformData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadPlatformData.php
@@ -31,14 +31,6 @@ final class LoadPlatformData extends Fixture implements OrderedFixtureInterface
             'description' => 'Complete CRM module to centralize customer relationships, track opportunities, and structure commercial activity.',
         ],
         [
-            'uuid' => '40000000-0000-1000-8000-000000000002',
-            'code' => 'CR',
-            'platformKey' => 'crm',
-            'name' => 'CRM 2',
-            'enabled' => true,
-            'description' => 'Complete CRM module to centralize customer relationships, track opportunities, and structure commercial activity.',
-        ],
-        [
             'uuid' => '40000000-0000-1000-8000-000000000003',
             'code' => 'SH',
             'platformKey' => 'shop',

--- a/src/School/Application/Service/SchoolApplicationScopeResolver.php
+++ b/src/School/Application/Service/SchoolApplicationScopeResolver.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 final readonly class SchoolApplicationScopeResolver
 {
+    private const string GENERAL_APPLICATION_SLUG = 'school-general-core';
+
     public function __construct(
         private SchoolRepository $schoolRepository,
         private EntityManagerInterface $entityManager
@@ -23,6 +25,10 @@ final readonly class SchoolApplicationScopeResolver
 
     public function resolveOrCreateSchoolByApplicationSlug(string $applicationSlug, ?User $user): School
     {
+        if ($applicationSlug === 'general' || $applicationSlug === '') {
+            $applicationSlug = self::GENERAL_APPLICATION_SLUG;
+        }
+
         $school = $this->schoolRepository->findOneByApplicationSlug($applicationSlug);
         if ($school instanceof School) {
             $this->assertApplicationAccess($school->getApplication(), PlatformKey::SCHOOL, $user);

--- a/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
+++ b/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
@@ -61,6 +61,7 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
             $this->addReference('School-' . $appKey, $school);
             if ($appKey === 'school-general-core') {
                 $this->addReference('School-General-Core', $school);
+                $this->addReference('School-general', $school);
             }
 
             $classes = [];
@@ -78,6 +79,9 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
 
                 $classes[$label] = $class;
                 $this->addReference('SchoolClass-' . $appKey . '-' . $label, $class);
+                if ($appKey === 'school-general-core') {
+                    $this->addReference('SchoolClass-general-' . $label, $class);
+                }
             }
             $this->addReference('SchoolClass-' . $appKey . '-1', $classes['small']);
 

--- a/src/School/Transport/Controller/Api/V1/Class/AssignClassTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/AssignClassTeacherController.php
@@ -25,7 +25,8 @@ final readonly class AssignClassTeacherController
         private SchoolApplicationScopeResolver $scopeResolver,
     ) {
     }
-    #[Route('/v1/school/applications/{applicationSlug}/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_POST])]
+    #[Route('/v1/school/applications/{applicationSlug}/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id, string $teacherId, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
@@ -29,7 +29,8 @@ final readonly class CreateClassByApplicationController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_POST])]
+    #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/classes', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[OA\Post(
         summary: 'Créer une classe dans une application',
         requestBody: new OA\RequestBody(

--- a/src/School/Transport/Controller/Api/V1/Class/DeleteClassController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/DeleteClassController.php
@@ -26,7 +26,8 @@ final readonly class DeleteClassController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/classes/{id}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/school/applications/{applicationSlug}/classes/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/classes/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[OA\Delete(
         summary: 'Supprimer une classe',
         parameters: [

--- a/src/School/Transport/Controller/Api/V1/Class/ListClassesByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/ListClassesByApplicationController.php
@@ -32,7 +32,8 @@ final readonly class ListClassesByApplicationController
      * @throws InvalidArgumentException
      * @throws JsonException
      */
-    #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_GET])]
+    #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/classes', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
     #[OA\Get(
         summary: 'Lister les classes d\'une application',
         parameters: [

--- a/src/School/Transport/Controller/Api/V1/Class/UnassignClassTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/UnassignClassTeacherController.php
@@ -25,7 +25,8 @@ final readonly class UnassignClassTeacherController
         private SchoolApplicationScopeResolver $scopeResolver,
     ) {
     }
-    #[Route('/v1/school/applications/{applicationSlug}/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/school/applications/{applicationSlug}/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/classes/{id}/teachers/{teacherId}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id, string $teacherId, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
@@ -54,7 +54,8 @@ final readonly class CreateExamController
             new OA\Response(response: 422, description: 'Validation failed', content: new OA\JsonContent(ref: '#/components/schemas/SchoolValidationError')),
         ],
     )]
-    #[Route('/v1/school/applications/{applicationSlug}/exams', methods: [Request::METHOD_POST])]
+    #[Route('/v1/school/applications/{applicationSlug}/exams', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/exams', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Exam/DeleteExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/DeleteExamController.php
@@ -26,7 +26,8 @@ final readonly class DeleteExamController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/exams/{id}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/school/applications/{applicationSlug}/exams/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/exams/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Exam/ListExamsController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/ListExamsController.php
@@ -26,7 +26,8 @@ final readonly class ListExamsController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/exams', methods: [Request::METHOD_GET])]
+    #[Route('/v1/school/applications/{applicationSlug}/exams', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/exams', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/General/ListGeneralClassesController.php
+++ b/src/School/Transport/Controller/Api/V1/General/ListGeneralClassesController.php
@@ -29,7 +29,7 @@ final readonly class ListGeneralClassesController
      * @throws InvalidArgumentException
      * @throws JsonException
      */
-    #[Route('/v1/school/general/classes', methods: [Request::METHOD_GET])]
+    #[Route('/v1/school/general/classes', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
     #[OA\Get(summary: 'Lister globalement les classes school (scope General en lecture seule)')]
     public function __invoke(Request $request): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/General/ListGeneralExamsController.php
+++ b/src/School/Transport/Controller/Api/V1/General/ListGeneralExamsController.php
@@ -23,7 +23,7 @@ final readonly class ListGeneralExamsController
     ) {
     }
 
-    #[Route('/v1/school/general/exams', methods: [Request::METHOD_GET])]
+    #[Route('/v1/school/general/exams', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
     #[OA\Get(summary: 'Lister globalement les examens school (scope General en lecture seule)')]
     public function __invoke(Request $request): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/General/ListGeneralGradesController.php
+++ b/src/School/Transport/Controller/Api/V1/General/ListGeneralGradesController.php
@@ -23,7 +23,7 @@ final readonly class ListGeneralGradesController
     ) {
     }
 
-    #[Route('/v1/school/general/grades', methods: [Request::METHOD_GET])]
+    #[Route('/v1/school/general/grades', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
     #[OA\Get(summary: 'Lister globalement les notes school (scope General en lecture seule)')]
     public function __invoke(Request $request): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/General/ListGeneralStudentsController.php
+++ b/src/School/Transport/Controller/Api/V1/General/ListGeneralStudentsController.php
@@ -23,7 +23,7 @@ final readonly class ListGeneralStudentsController
     ) {
     }
 
-    #[Route('/v1/school/general/students', methods: [Request::METHOD_GET])]
+    #[Route('/v1/school/general/students', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
     #[OA\Get(summary: 'Lister globalement les étudiants school (scope General en lecture seule)')]
     public function __invoke(Request $request): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/General/ListGeneralTeachersController.php
+++ b/src/School/Transport/Controller/Api/V1/General/ListGeneralTeachersController.php
@@ -23,7 +23,7 @@ final readonly class ListGeneralTeachersController
     ) {
     }
 
-    #[Route('/v1/school/general/teachers', methods: [Request::METHOD_GET])]
+    #[Route('/v1/school/general/teachers', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
     #[OA\Get(summary: 'Lister globalement les enseignants school (scope General en lecture seule)')]
     public function __invoke(Request $request): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
@@ -29,7 +29,8 @@ final readonly class CreateGradeController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/grades', methods: [Request::METHOD_POST])]
+    #[Route('/v1/school/applications/{applicationSlug}/grades', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/grades', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]
     #[OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]

--- a/src/School/Transport/Controller/Api/V1/Grade/DeleteGradeController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/DeleteGradeController.php
@@ -26,7 +26,8 @@ final readonly class DeleteGradeController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/grades/{id}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/school/applications/{applicationSlug}/grades/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/grades/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Grade/ListGradesController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/ListGradesController.php
@@ -26,7 +26,8 @@ final readonly class ListGradesController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/grades', methods: [Request::METHOD_GET])]
+    #[Route('/v1/school/applications/{applicationSlug}/grades', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/grades', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
@@ -29,7 +29,8 @@ final readonly class CreateStudentController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/students', methods: [Request::METHOD_POST])]
+    #[Route('/v1/school/applications/{applicationSlug}/students', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/students', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[OA\Post(
         summary: 'Créer un étudiant',
         requestBody: new OA\RequestBody(

--- a/src/School/Transport/Controller/Api/V1/Student/DeleteStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/DeleteStudentController.php
@@ -26,7 +26,8 @@ final readonly class DeleteStudentController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/students/{id}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/school/applications/{applicationSlug}/students/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/students/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Student/ListStudentsController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/ListStudentsController.php
@@ -26,7 +26,8 @@ final readonly class ListStudentsController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/students', methods: [Request::METHOD_GET])]
+    #[Route('/v1/school/applications/{applicationSlug}/students', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/students', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
@@ -29,7 +29,8 @@ final readonly class CreateTeacherController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/teachers', methods: [Request::METHOD_POST])]
+    #[Route('/v1/school/applications/{applicationSlug}/teachers', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/teachers', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]
     #[OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]

--- a/src/School/Transport/Controller/Api/V1/Teacher/DeleteTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/DeleteTeacherController.php
@@ -26,7 +26,8 @@ final readonly class DeleteTeacherController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/teachers/{id}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/school/applications/{applicationSlug}/teachers/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/teachers/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse
     {

--- a/src/School/Transport/Controller/Api/V1/Teacher/ListTeachersController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/ListTeachersController.php
@@ -26,7 +26,8 @@ final readonly class ListTeachersController
     ) {
     }
 
-    #[Route('/v1/school/applications/{applicationSlug}/teachers', methods: [Request::METHOD_GET])]
+    #[Route('/v1/school/applications/{applicationSlug}/teachers', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/teachers', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, Request $request, ?User $loggedInUser): JsonResponse
     {

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php
@@ -313,4 +313,25 @@ final class SchoolApplicationScopedRoutesTest extends WebTestCase
         $client->request('DELETE', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes/' . $classId);
         self::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
     }
+
+    #[TestDox('School routes without application slug fallback to school general scope.')]
+    public function testRoutesWithoutApplicationSlugFallbackToSchoolGeneralScope(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/school/classes?page=1&limit=100');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $withoutSlug = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/school/applications/school-general-core/classes?page=1&limit=100');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $withGeneralSlug = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        self::assertSame(
+            array_column($withGeneralSlug['items'], 'id'),
+            array_column($withoutSlug['items'], 'id'),
+        );
+        self::assertSame('general', $withoutSlug['meta']['applicationSlug']);
+        self::assertSame('school-general-core', $withGeneralSlug['meta']['applicationSlug']);
+    }
 }


### PR DESCRIPTION
### Motivation
- Consolidate duplicate CRM platforms into a single CRM platform so CRM applications are attached to one canonical platform and fixtures are less noisy.
- Provide a reusable "general" school scope so endpoints can return general school data when no `applicationSlug` is provided.
- Make school endpoints usable both with `applicationSlug` and without it (fallback to general) to simplify consumers that do not pass an app slug.

### Description
- Removed the duplicate CRM platform entry from `src/Platform/Infrastructure/DataFixtures/ORM/LoadPlatformData.php` and re-attached `crm-support-desk` to `Platform-CR-CRM 1` in `src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php`.
- Added explicit general school references in `src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php` (`School-general` and `SchoolClass-general-*`) to expose the general scope from fixtures.
- Mapped `general` (and empty slug) to the canonical `school-general-core` in `SchoolApplicationScopeResolver::resolveOrCreateSchoolByApplicationSlug` by introducing `GENERAL_APPLICATION_SLUG` in `src/School/Application/Service/SchoolApplicationScopeResolver.php`.
- Added route aliases without `applicationSlug` for school resources (classes, students, teachers, exams, grades) by adding `defaults: ['applicationSlug' => 'general']` and duplicate `#[Route('/v1/school/...')]` entries in the controllers under `src/School/Transport/Controller/Api/V1/*` so requests to endpoints like `/v1/school/classes` fallback to the general scope.
- Added an integration assertion in `tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php` that checks `/v1/school/classes` returns the same class IDs as `/v1/school/applications/school-general-core/classes`.

### Testing
- Ran PHP syntax checks with `php -l` over all modified PHP files and confirmed there are no syntax errors (success).
- Attempted to run the specific test file with `./vendor/bin/phpunit tests/Application/School/Transport/Controller/Api/V1/SchoolApplicationScopedRoutesTest.php`, but it could not run in this environment because `vendor/bin/phpunit` is not available (failure due to missing dependencies).
- All modified files were committed after changes and `php -l` verification passed for each changed file (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6182dc0f08326a33ea68eea631071)