### PR TITLE
Add migration toggles and plugin migration configs to general fixtures

### DIFF
--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
@@ -552,10 +552,31 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                         'enabled' => true,
                         'context' => 'bro-shop-general',
                         'checkoutMode' => 'hybrid',
+                        'migrations' => [
+                            'shopware' => true,
+                            'shopify' => false,
+                            'oroEcommerce' => true,
+                            'sylius' => false,
+                        ],
                     ],
                 ],
             ],
             'plugins' => [
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000031',
+                    'reference' => 'Plugin-Analytics-Booster',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000031',
+                            'key' => 'plugin.calendar.general',
+                            'value' => [
+                                'realTime' => true,
+                                'transport' => 'mercure',
+                                'googleCalendarMigration' => true,
+                            ],
+                        ],
+                    ],
+                ],
                 [
                     'uuid' => '62000000-0000-1000-8000-000000000023',
                     'reference' => 'Plugin-CRM-Assistant',
@@ -567,6 +588,22 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                                 'realTime' => true,
                                 'transport' => 'mercure',
                                 'channels' => ['shop-support', 'order-escalation'],
+                                'slackSynchronization' => false,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000032',
+                    'reference' => 'Plugin-Knowledge-Base-Connector',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000032',
+                            'key' => 'plugin.blog.general',
+                            'value' => [
+                                'realTime' => true,
+                                'transport' => 'mercure',
+                                'contentMigration' => true,
                             ],
                         ],
                     ],
@@ -591,6 +628,11 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                         'enabled' => true,
                         'context' => 'bro-crm-general',
                         'defaultPipeline' => 'enterprise',
+                        'migrations' => [
+                            'github' => true,
+                            'google' => false,
+                            'azure' => true,
+                        ],
                     ],
                 ],
             ],
@@ -606,6 +648,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                                 'realTime' => false,
                                 'syncProvider' => 'internal',
                                 'workingDays' => ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'],
+                                'googleCalendarMigration' => true,
                             ],
                         ],
                     ],
@@ -621,6 +664,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                                 'realTime' => true,
                                 'transport' => 'mercure',
                                 'moderation' => 'post',
+                                'contentMigration' => false,
                             ],
                         ],
                     ],
@@ -636,6 +680,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                                 'realTime' => true,
                                 'transport' => 'mercure',
                                 'channels' => ['crm-general', 'lead-qualification'],
+                                'slackSynchronization' => true,
                             ],
                         ],
                     ],
@@ -660,6 +705,11 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                         'enabled' => true,
                         'context' => 'bro-learning-general',
                         'learningMode' => 'blended',
+                        'migrations' => [
+                            'github' => false,
+                            'google' => true,
+                            'azure' => false,
+                        ],
                     ],
                 ],
             ],
@@ -675,6 +725,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                                 'realTime' => false,
                                 'transport' => 'none',
                                 'editorialWorkflow' => 'teacher-review',
+                                'contentMigration' => true,
                             ],
                         ],
                     ],
@@ -690,6 +741,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                                 'realTime' => true,
                                 'transport' => 'mercure',
                                 'reminderMinutesBefore' => 15,
+                                'googleCalendarMigration' => false,
                             ],
                         ],
                     ],
@@ -705,6 +757,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                                 'realTime' => true,
                                 'transport' => 'mercure',
                                 'channels' => ['learning-classroom', 'mentor-office-hours'],
+                                'slackSynchronization' => true,
                             ],
                         ],
                     ],
@@ -729,10 +782,45 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                         'enabled' => true,
                         'context' => 'bro-job-general',
                         'defaultLanguage' => 'fr',
+                        'migrations' => [
+                            'github' => true,
+                            'google' => true,
+                            'azure' => false,
+                        ],
                     ],
                 ],
             ],
             'plugins' => [
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000033',
+                    'reference' => 'Plugin-Analytics-Booster',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000033',
+                            'key' => 'plugin.calendar.job',
+                            'value' => [
+                                'realTime' => true,
+                                'transport' => 'mercure',
+                                'googleCalendarMigration' => true,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000034',
+                    'reference' => 'Plugin-Knowledge-Base-Connector',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000034',
+                            'key' => 'plugin.blog.job',
+                            'value' => [
+                                'realTime' => true,
+                                'transport' => 'mercure',
+                                'contentMigration' => true,
+                            ],
+                        ],
+                    ],
+                ],
                 [
                     'uuid' => '62000000-0000-1000-8000-000000000030',
                     'reference' => 'Plugin-CRM-Assistant',
@@ -744,6 +832,7 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                                 'realTime' => true,
                                 'transport' => 'mercure',
                                 'channels' => ['candidate-ops', 'hiring-managers'],
+                                'slackSynchronization' => false,
                             ],
                         ],
                     ],


### PR DESCRIPTION
### Motivation
- Centralize migration feature flags and plugin migration/sync options in the general application fixtures to allow toggling imports per platform and per plugin.
- Ensure `crm`, `shop`, `school` and `recruit` general scopes expose consistent migration configuration alongside existing fixture data.

### Description
- Updated `src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php` to add a `migrations` array to `application.*.value` for `shop-general-core`, `crm-general-core`, `school-general-core` and `recruit-general-core` with boolean flags for the requested providers (e.g. `shopware`, `shopify`, `oroEcommerce`, `sylius`, `github`, `google`, `azure`).
- Added/extended plugin configurations for `calendar`, `chat` and `blog` across the general apps introducing `googleCalendarMigration`, `slackSynchronization` and `contentMigration` boolean fields respectively.
- Added missing `calendar` and `blog` plugin fixtures for `shop-general-core` and `recruit-general-core` so those scopes include the requested plugin configurations.

### Testing
- Ran `php -l src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php` to verify there are no syntax errors, and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e61af365a88326b4b5b35ad55839bc)