### PR TITLE
feat(school): add general scope POST/PUT/DELETE endpoints

### DIFF
--- a/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
@@ -33,7 +33,10 @@ final readonly class PatchSchoolApplicationResourceController
         private MessageBusInterface $messageBus,
     ) {
     }
-    #[Route('/v1/school/applications/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_PATCH], requirements: [
+    #[Route('/v1/school/applications/{applicationSlug}/{resource}/{id}', methods: [Request::METHOD_PATCH, Request::METHOD_PUT], requirements: [
+        'resource' => 'classes|students|teachers|exams|grades',
+    ])]
+    #[Route('/v1/school/general/{resource}/{id}', methods: [Request::METHOD_PATCH, Request::METHOD_PUT], defaults: ['applicationSlug' => 'general'], requirements: [
         'resource' => 'classes|students|teachers|exams|grades',
     ])]
     #[OA\Patch(

--- a/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php
@@ -30,6 +30,7 @@ final readonly class CreateClassByApplicationController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/classes', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/general/classes', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[Route('/v1/school/classes', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[OA\Post(
         summary: 'Créer une classe dans une application',

--- a/src/School/Transport/Controller/Api/V1/Class/DeleteClassController.php
+++ b/src/School/Transport/Controller/Api/V1/Class/DeleteClassController.php
@@ -27,6 +27,7 @@ final readonly class DeleteClassController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/classes/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/general/classes/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[Route('/v1/school/classes/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[OA\Delete(
         summary: 'Supprimer une classe',

--- a/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
@@ -55,6 +55,7 @@ final readonly class CreateExamController
         ],
     )]
     #[Route('/v1/school/applications/{applicationSlug}/exams', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/general/exams', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[Route('/v1/school/exams', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse

--- a/src/School/Transport/Controller/Api/V1/Exam/DeleteExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/DeleteExamController.php
@@ -27,6 +27,7 @@ final readonly class DeleteExamController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/exams/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/general/exams/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[Route('/v1/school/exams/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse

--- a/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php
@@ -30,6 +30,7 @@ final readonly class CreateGradeController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/grades', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/general/grades', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[Route('/v1/school/grades', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]

--- a/src/School/Transport/Controller/Api/V1/Grade/DeleteGradeController.php
+++ b/src/School/Transport/Controller/Api/V1/Grade/DeleteGradeController.php
@@ -27,6 +27,7 @@ final readonly class DeleteGradeController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/grades/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/general/grades/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[Route('/v1/school/grades/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse

--- a/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
@@ -30,6 +30,7 @@ final readonly class CreateStudentController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/students', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/general/students', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[Route('/v1/school/students', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[OA\Post(
         summary: 'Créer un étudiant',

--- a/src/School/Transport/Controller/Api/V1/Student/DeleteStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/DeleteStudentController.php
@@ -27,6 +27,7 @@ final readonly class DeleteStudentController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/students/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/general/students/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[Route('/v1/school/students/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse

--- a/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
@@ -30,6 +30,7 @@ final readonly class CreateTeacherController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/teachers', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/general/teachers', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[Route('/v1/school/teachers', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError'))]

--- a/src/School/Transport/Controller/Api/V1/Teacher/DeleteTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/DeleteTeacherController.php
@@ -27,6 +27,7 @@ final readonly class DeleteTeacherController
     }
 
     #[Route('/v1/school/applications/{applicationSlug}/teachers/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/general/teachers/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[Route('/v1/school/teachers/{id}', methods: [Request::METHOD_DELETE], defaults: ['applicationSlug' => 'general'])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     public function __invoke(string $applicationSlug, string $id, ?User $loggedInUser): JsonResponse

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php
@@ -91,4 +91,24 @@ final class SchoolCrudValidationPaginationTest extends WebTestCase
         $client->request('DELETE', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/classes/' . $createdClassId);
         self::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
     }
+
+    #[TestDox('School general scope exposes POST, PUT and DELETE endpoints for CRUD workflows.')]
+    public function testSchoolGeneralPostPutDeleteRoutes(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/general/classes', [], [], [], JSON::encode([
+            'name' => 'Classe General CRUD',
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+        $classId = JSON::decode((string)$client->getResponse()->getContent(), true)['id'];
+
+        $client->request('PUT', self::API_URL_PREFIX . '/v1/school/general/classes/' . $classId, [], [], [], JSON::encode([
+            'name' => 'Classe General CRUD Updated',
+        ]));
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $client->request('DELETE', self::API_URL_PREFIX . '/v1/school/general/classes/' . $classId);
+        self::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
+    }
 }


### PR DESCRIPTION
### Motivation
- Exposer des endpoints CRUD accessibles en scope `general` pour permettre des créations, mises à jour (PUT) et suppressions centralisées des ressources school (classes, students, teachers, exams, grades).
- Permettre au contrôleur de mutation d'accepter `PUT` en plus de `PATCH` pour supporter des mises à jour complètes via la route générale.

### Description
- Ajout de routes alias `POST /v1/school/general/*` dans les contrôleurs de création pour `classes`, `students`, `teachers`, `exams` et `grades` (création via le scope `general`).
- Ajout de routes alias `DELETE /v1/school/general/*/{id}` dans les contrôleurs de suppression pour les mêmes ressources (suppression via le scope `general`).
- Extension de `PatchSchoolApplicationResourceController` pour accepter `PUT` en plus de `PATCH` et ajout de la route mutation `/v1/school/general/{resource}/{id}` qui mappe sur le scope `general`.
- Ajout d'un test d'intégration `testSchoolGeneralPostPutDeleteRoutes` dans `tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php` qui vérifie le flux `POST -> PUT -> DELETE` sur `/v1/school/general/classes`.

### Testing
- Exécuté des vérifications de syntaxe PHP avec `php -l` sur tous les contrôleurs modifiés et le fichier de test, et toutes les vérifications sont passées.
- Tentative d'exécuter le test ciblé avec `./vendor/bin/phpunit tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php` a échoué car les dépendances de projet ne sont pas installées (binaire PHPUnit manquant dans cet environnement).
- Aucun échec de compilation/syntaxe détecté après les modifications (controllers + tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62423fca48326a26909b6da20c63b)