### PR TITLE
feat(school): link students/teachers to users; add Course and LearningSessionNote with exam/grade relations

### DIFF
--- a/migrations/Version20260420110000.php
+++ b/migrations/Version20260420110000.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260420110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'School domain: student/teacher linked to user, add courses and learning session notes, and relate exams/grades to courses.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE school_course (id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", class_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", teacher_id BINARY(16) DEFAULT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", name VARCHAR(255) NOT NULL, created_at DATETIME NOT NULL COMMENT \"(DC2Type:utcdatetime)\", updated_at DATETIME NOT NULL COMMENT \"(DC2Type:utcdatetime)\", INDEX idx_school_course_class_id (class_id), INDEX idx_school_course_teacher_id (teacher_id), UNIQUE INDEX uniq_school_course_class_name (class_id, name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE TABLE school_learning_session_note (id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", student_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", exam_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", course_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\", score DOUBLE PRECISION NOT NULL, passed TINYINT(1) NOT NULL, created_at DATETIME NOT NULL COMMENT \"(DC2Type:utcdatetime)\", updated_at DATETIME NOT NULL COMMENT \"(DC2Type:utcdatetime)\", INDEX idx_school_lsn_student_id (student_id), INDEX idx_school_lsn_exam_id (exam_id), INDEX idx_school_lsn_course_id (course_id), UNIQUE INDEX uniq_school_lsn_exam_student (exam_id, student_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+
+        $this->addSql('ALTER TABLE school_student ADD user_id BINARY(16) DEFAULT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\"');
+        $this->addSql('ALTER TABLE school_teacher ADD user_id BINARY(16) DEFAULT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\"');
+        $this->addSql('ALTER TABLE school_exam ADD course_id BINARY(16) DEFAULT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\"');
+        $this->addSql('ALTER TABLE school_grade ADD course_id BINARY(16) DEFAULT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\"');
+
+        $this->addSql('UPDATE school_student SET user_id = (SELECT id FROM user LIMIT 1) WHERE user_id IS NULL');
+        $this->addSql('UPDATE school_teacher SET user_id = (SELECT id FROM user LIMIT 1) WHERE user_id IS NULL');
+
+        $this->addSql('ALTER TABLE school_student MODIFY user_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\"');
+        $this->addSql('ALTER TABLE school_teacher MODIFY user_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\"');
+
+        $this->addSql('ALTER TABLE school_student DROP name');
+        $this->addSql('ALTER TABLE school_teacher DROP name');
+
+        $this->addSql('ALTER TABLE school_course ADD CONSTRAINT FK_B6F245838A98A09F FOREIGN KEY (class_id) REFERENCES school_class (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE school_course ADD CONSTRAINT FK_B6F2458341807C73 FOREIGN KEY (teacher_id) REFERENCES school_teacher (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE school_learning_session_note ADD CONSTRAINT FK_AA9E2E08CB944F1A FOREIGN KEY (student_id) REFERENCES school_student (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE school_learning_session_note ADD CONSTRAINT FK_AA9E2E08A5D7E69F FOREIGN KEY (exam_id) REFERENCES school_exam (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE school_learning_session_note ADD CONSTRAINT FK_AA9E2E08591CC992 FOREIGN KEY (course_id) REFERENCES school_course (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE school_student ADD CONSTRAINT FK_DF77A88BA76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE school_teacher ADD CONSTRAINT FK_3A1BFCDA76ED395 FOREIGN KEY (user_id) REFERENCES user (id) ON DELETE CASCADE');
+
+        $this->addSql('CREATE INDEX idx_school_student_user_id ON school_student (user_id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_school_student_user_class ON school_student (user_id, class_id)');
+        $this->addSql('CREATE INDEX idx_school_teacher_user_id ON school_teacher (user_id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_school_teacher_user ON school_teacher (user_id)');
+
+        $this->addSql('INSERT INTO school_course (id, class_id, teacher_id, name, created_at, updated_at)
+            SELECT UUID_TO_BIN(UUID(), 1), sc.id, (
+                SELECT sct.teacher_id FROM school_class_teacher sct WHERE sct.school_class_id = sc.id LIMIT 1
+            ), CONCAT(sc.name, " - Core"), NOW(), NOW() FROM school_class sc');
+
+        $this->addSql('UPDATE school_exam se
+            JOIN school_course c ON c.class_id = se.class_id
+            SET se.course_id = c.id
+            WHERE se.course_id IS NULL');
+        $this->addSql('UPDATE school_grade sg
+            JOIN school_exam se ON se.id = sg.exam_id
+            SET sg.course_id = se.course_id
+            WHERE sg.course_id IS NULL');
+
+        $this->addSql('ALTER TABLE school_exam MODIFY course_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\"');
+        $this->addSql('ALTER TABLE school_grade MODIFY course_id BINARY(16) NOT NULL COMMENT \"(DC2Type:uuid_binary_ordered_time)\"');
+
+        $this->addSql('ALTER TABLE school_exam ADD CONSTRAINT FK_39C8D6F3591CC992 FOREIGN KEY (course_id) REFERENCES school_course (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE school_grade ADD CONSTRAINT FK_DCA4BFD4591CC992 FOREIGN KEY (course_id) REFERENCES school_course (id) ON DELETE CASCADE');
+        $this->addSql('CREATE INDEX idx_school_exam_course_id ON school_exam (course_id)');
+        $this->addSql('CREATE INDEX idx_school_grade_course_id ON school_grade (course_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE school_grade DROP FOREIGN KEY FK_DCA4BFD4591CC992');
+        $this->addSql('ALTER TABLE school_exam DROP FOREIGN KEY FK_39C8D6F3591CC992');
+        $this->addSql('DROP INDEX idx_school_grade_course_id ON school_grade');
+        $this->addSql('DROP INDEX idx_school_exam_course_id ON school_exam');
+        $this->addSql('ALTER TABLE school_grade DROP course_id');
+        $this->addSql('ALTER TABLE school_exam DROP course_id');
+
+        $this->addSql('DROP INDEX uniq_school_teacher_user ON school_teacher');
+        $this->addSql('DROP INDEX idx_school_teacher_user_id ON school_teacher');
+        $this->addSql('DROP INDEX uniq_school_student_user_class ON school_student');
+        $this->addSql('DROP INDEX idx_school_student_user_id ON school_student');
+
+        $this->addSql('ALTER TABLE school_teacher DROP FOREIGN KEY FK_3A1BFCDA76ED395');
+        $this->addSql('ALTER TABLE school_student DROP FOREIGN KEY FK_DF77A88BA76ED395');
+
+        $this->addSql('ALTER TABLE school_teacher ADD name VARCHAR(255) NOT NULL');
+        $this->addSql('ALTER TABLE school_student ADD name VARCHAR(255) NOT NULL');
+        $this->addSql("UPDATE school_teacher SET name = 'Teacher'");
+        $this->addSql("UPDATE school_student SET name = 'Student'");
+
+        $this->addSql('ALTER TABLE school_teacher DROP user_id');
+        $this->addSql('ALTER TABLE school_student DROP user_id');
+
+        $this->addSql('ALTER TABLE school_learning_session_note DROP FOREIGN KEY FK_AA9E2E08591CC992');
+        $this->addSql('ALTER TABLE school_learning_session_note DROP FOREIGN KEY FK_AA9E2E08A5D7E69F');
+        $this->addSql('ALTER TABLE school_learning_session_note DROP FOREIGN KEY FK_AA9E2E08CB944F1A');
+        $this->addSql('ALTER TABLE school_course DROP FOREIGN KEY FK_B6F2458341807C73');
+        $this->addSql('ALTER TABLE school_course DROP FOREIGN KEY FK_B6F245838A98A09F');
+        $this->addSql('DROP TABLE school_learning_session_note');
+        $this->addSql('DROP TABLE school_course');
+    }
+}

--- a/src/School/Application/Serializer/SchoolViewMapper.php
+++ b/src/School/Application/Serializer/SchoolViewMapper.php
@@ -57,7 +57,8 @@ final readonly class SchoolViewMapper
     {
         return [
             'id' => $student->getId(),
-            'name' => $student->getName(),
+            'name' => $student->getDisplayName(),
+            'userId' => $student->getUser()?->getId(),
             'classId' => $student->getSchoolClass()?->getId(),
         ];
     }
@@ -82,7 +83,8 @@ final readonly class SchoolViewMapper
     {
         return [
             'id' => $teacher->getId(),
-            'name' => $teacher->getName(),
+            'name' => $teacher->getDisplayName(),
+            'userId' => $teacher->getUser()?->getId(),
         ];
     }
 
@@ -110,7 +112,9 @@ final readonly class SchoolViewMapper
             'classId' => $exam->getSchoolClass()?->getId(),
             'className' => $exam->getSchoolClass()?->getName(),
             'teacherId' => $exam->getTeacher()?->getId(),
-            'teacherName' => $exam->getTeacher()?->getName(),
+            'teacherName' => $exam->getTeacher()?->getDisplayName(),
+            'courseId' => $exam->getCourse()?->getId(),
+            'courseName' => $exam->getCourse()?->getName(),
             'type' => $exam->getType()->value,
             'status' => $exam->getStatus()->value,
             'term' => $exam->getTerm()->value,
@@ -141,6 +145,8 @@ final readonly class SchoolViewMapper
             'score' => $grade->getScore(),
             'studentId' => $grade->getStudent()?->getId(),
             'examId' => $grade->getExam()?->getId(),
+            'courseId' => $grade->getCourse()?->getId(),
+            'courseName' => $grade->getCourse()?->getName(),
         ];
     }
 }

--- a/src/School/Application/Service/CreateExamService.php
+++ b/src/School/Application/Service/CreateExamService.php
@@ -27,13 +27,19 @@ final readonly class CreateExamService
         School $school,
         string $title,
         ?string $classId,
+        ?string $courseId,
         ?string $teacherId,
         ExamType $type,
         ExamStatus $status,
         Term $term,
     ): Exam {
         $class = $this->referenceResolver->resolveClassInSchool($school, $classId);
+        $course = $this->referenceResolver->resolveCourseInSchool($school, $courseId);
         $teacher = $this->referenceResolver->resolveTeacherInSchool($school, $teacherId);
+
+        if ($course->getSchoolClass()?->getId() !== $class->getId()) {
+            throw SchoolRelationException::unprocessable('courseId must belong to classId');
+        }
 
         if (!$teacher->getClasses()->contains($class)) {
             throw SchoolRelationException::unprocessable('teacherId is not assigned to classId');
@@ -45,6 +51,7 @@ final readonly class CreateExamService
             ->setStatus($status)
             ->setTerm($term)
             ->setSchoolClass($class)
+            ->setCourse($course)
             ->setTeacher($teacher);
 
         $this->entityManager->persist($exam);

--- a/src/School/Application/Service/CreateGradeService.php
+++ b/src/School/Application/Service/CreateGradeService.php
@@ -32,6 +32,7 @@ final readonly class CreateGradeService
         $grade = (new Grade())->setScore($score);
         $grade->setStudent($student);
         $grade->setExam($exam);
+        $grade->setCourse($exam->getCourse());
 
         $this->entityManager->persist($grade);
         $this->entityManager->flush();

--- a/src/School/Application/Service/CreateStudentService.php
+++ b/src/School/Application/Service/CreateStudentService.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityCreated;
+use App\School\Application\Exception\SchoolRelationException;
 use App\School\Domain\Entity\School;
 use App\School\Domain\Entity\Student;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -16,14 +19,20 @@ final readonly class CreateStudentService
         private SchoolReferenceResolver $referenceResolver,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
+        private UserRepository $userRepository,
     ) {
     }
 
-    public function create(School $school, string $name, ?string $classId): Student
+    public function create(School $school, string $userId, ?string $classId): Student
     {
         $class = $this->referenceResolver->resolveClassInSchool($school, $classId);
 
-        $student = (new Student())->setName($name);
+        $user = $this->userRepository->find($userId);
+        if (!$user instanceof User) {
+            throw SchoolRelationException::notFound('userId');
+        }
+
+        $student = (new Student())->setUser($user);
         $student->setSchoolClass($class);
 
         $this->entityManager->persist($student);

--- a/src/School/Application/Service/CreateTeacherService.php
+++ b/src/School/Application/Service/CreateTeacherService.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\School\Application\Service;
 
 use App\General\Application\Message\EntityCreated;
+use App\School\Application\Exception\SchoolRelationException;
 use App\School\Domain\Entity\Teacher;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
@@ -14,12 +17,18 @@ final readonly class CreateTeacherService
     public function __construct(
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
+        private UserRepository $userRepository,
     ) {
     }
 
-    public function create(string $name): Teacher
+    public function create(string $userId): Teacher
     {
-        $teacher = (new Teacher())->setName($name);
+        $user = $this->userRepository->find($userId);
+        if (!$user instanceof User) {
+            throw SchoolRelationException::notFound('userId');
+        }
+
+        $teacher = (new Teacher())->setUser($user);
 
         $this->entityManager->persist($teacher);
         $this->entityManager->flush();

--- a/src/School/Application/Service/ListGradesService.php
+++ b/src/School/Application/Service/ListGradesService.php
@@ -29,6 +29,7 @@ final readonly class ListGradesService
         $qb = $this->gradeRepository->createQueryBuilder('grade')
             ->innerJoin('grade.exam', 'exam')
             ->innerJoin('grade.student', 'student')
+            ->innerJoin('student.user', 'studentUser')
             ->orderBy('grade.createdAt', 'DESC')
             ->setFirstResult($queryOptions->offset())
             ->setMaxResults($queryOptions->limit);
@@ -39,14 +40,15 @@ final readonly class ListGradesService
                 ->setParameter('schoolId', $school->getId());
         }
         if ($queryOptions->filters['q'] !== '') {
-            $qb->andWhere('LOWER(exam.title) LIKE LOWER(:q) OR LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+            $qb->andWhere('LOWER(exam.title) LIKE LOWER(:q) OR LOWER(studentUser.firstName) LIKE LOWER(:q) OR LOWER(studentUser.lastName) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
 
         $items = $this->viewMapper->mapGradeCollection($qb->getQuery()->getResult());
 
         $countQb = $this->gradeRepository->createQueryBuilder('grade')->select('COUNT(grade.id)')
             ->innerJoin('grade.exam', 'exam')
-            ->innerJoin('grade.student', 'student');
+            ->innerJoin('grade.student', 'student')
+            ->innerJoin('student.user', 'studentUser');
         if ($school !== null) {
             $countQb->innerJoin('exam.schoolClass', 'class')
                 ->innerJoin('class.school', 'school')
@@ -54,7 +56,7 @@ final readonly class ListGradesService
                 ->setParameter('schoolId', $school->getId());
         }
         if ($queryOptions->filters['q'] !== '') {
-            $countQb->andWhere('LOWER(exam.title) LIKE LOWER(:q) OR LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+            $countQb->andWhere('LOWER(exam.title) LIKE LOWER(:q) OR LOWER(studentUser.firstName) LIKE LOWER(:q) OR LOWER(studentUser.lastName) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
         $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
 

--- a/src/School/Application/Service/ListStudentsService.php
+++ b/src/School/Application/Service/ListStudentsService.php
@@ -37,7 +37,9 @@ final readonly class ListStudentsService
                 ->setParameter('schoolId', $school->getId());
         }
         if ($queryOptions->filters['q'] !== '') {
-            $qb->andWhere('LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+            $qb->innerJoin('student.user', 'studentUser')
+                ->andWhere('LOWER(studentUser.firstName) LIKE LOWER(:q) OR LOWER(studentUser.lastName) LIKE LOWER(:q) OR LOWER(studentUser.email) LIKE LOWER(:q)')
+                ->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
 
         $items = $this->viewMapper->mapStudentCollection($qb->getQuery()->getResult());
@@ -50,7 +52,9 @@ final readonly class ListStudentsService
                 ->setParameter('schoolId', $school->getId());
         }
         if ($queryOptions->filters['q'] !== '') {
-            $countQb->andWhere('LOWER(student.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+            $countQb->innerJoin('student.user', 'studentUser')
+                ->andWhere('LOWER(studentUser.firstName) LIKE LOWER(:q) OR LOWER(studentUser.lastName) LIKE LOWER(:q) OR LOWER(studentUser.email) LIKE LOWER(:q)')
+                ->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
         $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
 

--- a/src/School/Application/Service/ListTeachersService.php
+++ b/src/School/Application/Service/ListTeachersService.php
@@ -38,7 +38,9 @@ final readonly class ListTeachersService
                 ->setParameter('schoolId', $school->getId());
         }
         if ($queryOptions->filters['q'] !== '') {
-            $qb->andWhere('LOWER(teacher.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+            $qb->innerJoin('teacher.user', 'teacherUser')
+                ->andWhere('LOWER(teacherUser.firstName) LIKE LOWER(:q) OR LOWER(teacherUser.lastName) LIKE LOWER(:q) OR LOWER(teacherUser.email) LIKE LOWER(:q)')
+                ->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
 
         $items = $this->viewMapper->mapTeacherCollection($qb->getQuery()->getResult());
@@ -51,7 +53,9 @@ final readonly class ListTeachersService
                 ->setParameter('schoolId', $school->getId());
         }
         if ($queryOptions->filters['q'] !== '') {
-            $countQb->andWhere('LOWER(teacher.name) LIKE LOWER(:q)')->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+            $countQb->innerJoin('teacher.user', 'teacherUser')
+                ->andWhere('LOWER(teacherUser.firstName) LIKE LOWER(:q) OR LOWER(teacherUser.lastName) LIKE LOWER(:q) OR LOWER(teacherUser.email) LIKE LOWER(:q)')
+                ->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
         }
         $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
 

--- a/src/School/Application/Service/SchoolReferenceResolver.php
+++ b/src/School/Application/Service/SchoolReferenceResolver.php
@@ -7,10 +7,12 @@ namespace App\School\Application\Service;
 use App\School\Application\Exception\SchoolRelationException;
 use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\School;
+use App\School\Domain\Entity\Course;
 use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Student;
 use App\School\Domain\Entity\Teacher;
 use App\School\Infrastructure\Repository\ExamRepository;
+use App\School\Infrastructure\Repository\CourseRepository;
 use App\School\Infrastructure\Repository\SchoolClassRepository;
 use App\School\Infrastructure\Repository\StudentRepository;
 use App\School\Infrastructure\Repository\TeacherRepository;
@@ -20,6 +22,7 @@ final readonly class SchoolReferenceResolver
 {
     public function __construct(
         private SchoolClassRepository $classRepository,
+        private CourseRepository $courseRepository,
         private TeacherRepository $teacherRepository,
         private StudentRepository $studentRepository,
         private ExamRepository $examRepository,
@@ -38,6 +41,21 @@ final readonly class SchoolReferenceResolver
         }
 
         return $class;
+    }
+
+
+    public function resolveCourseInSchool(School $school, ?string $courseId, string $reference = 'courseId'): Course
+    {
+        if (!is_string($courseId) || $courseId === '') {
+            throw SchoolRelationException::unprocessable($reference . ' is required');
+        }
+
+        $course = $this->courseRepository->find($courseId);
+        if (!$course instanceof Course || $course->getSchoolClass()?->getSchool()?->getId() !== $school->getId()) {
+            throw SchoolRelationException::notFound($reference);
+        }
+
+        return $course;
     }
 
     public function resolveTeacherInSchool(School $school, ?string $teacherId, string $reference = 'teacherId'): Teacher

--- a/src/School/Application/Service/SchoolResourcePatchService.php
+++ b/src/School/Application/Service/SchoolResourcePatchService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\School\Application\Service;
 
+use App\School\Domain\Entity\Course;
 use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\Grade;
 use App\School\Domain\Entity\SchoolClass;
@@ -12,11 +13,14 @@ use App\School\Domain\Entity\Teacher;
 use App\School\Domain\Enum\ExamStatus;
 use App\School\Domain\Enum\ExamType;
 use App\School\Domain\Enum\Term;
+use App\School\Infrastructure\Repository\CourseRepository;
 use App\School\Infrastructure\Repository\ExamRepository;
 use App\School\Infrastructure\Repository\GradeRepository;
 use App\School\Infrastructure\Repository\SchoolClassRepository;
 use App\School\Infrastructure\Repository\StudentRepository;
 use App\School\Infrastructure\Repository\TeacherRepository;
+use App\User\Domain\Entity\User;
+use App\User\Infrastructure\Repository\UserRepository;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
@@ -27,6 +31,8 @@ final readonly class SchoolResourcePatchService
         private SchoolClassRepository $classRepository,
         private StudentRepository $studentRepository,
         private TeacherRepository $teacherRepository,
+        private CourseRepository $courseRepository,
+        private UserRepository $userRepository,
         private ExamRepository $examRepository,
         private GradeRepository $gradeRepository,
     ) {
@@ -76,12 +82,8 @@ final readonly class SchoolResourcePatchService
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid resource payload.');
         }
 
-        if (array_key_exists('name', $payload)) {
-            $name = trim((string)$payload['name']);
-            if ($name === '') {
-                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "name" cannot be blank.');
-            }
-            $entity->setName($name);
+        if (array_key_exists('userId', $payload)) {
+            $entity->setUser($this->resolveUser((string)$payload['userId']));
         }
 
         if (array_key_exists('classId', $payload)) {
@@ -108,12 +110,8 @@ final readonly class SchoolResourcePatchService
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid resource payload.');
         }
 
-        if (array_key_exists('name', $payload)) {
-            $name = trim((string)$payload['name']);
-            if ($name === '') {
-                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "name" cannot be blank.');
-            }
-            $entity->setName($name);
+        if (array_key_exists('userId', $payload)) {
+            $entity->setUser($this->resolveUser((string)$payload['userId']));
         }
 
         $this->teacherRepository->save($entity);
@@ -146,6 +144,18 @@ final readonly class SchoolResourcePatchService
                 throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Class not found.');
             }
             $entity->setSchoolClass($class);
+        }
+
+        if (array_key_exists('courseId', $payload)) {
+            $courseId = (string)$payload['courseId'];
+            if (!Uuid::isValid($courseId)) {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "courseId" must be a valid UUID.');
+            }
+            $course = $this->courseRepository->find($courseId);
+            if (!$course instanceof Course) {
+                throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Course not found.');
+            }
+            $entity->setCourse($course);
         }
 
         if (array_key_exists('teacherId', $payload)) {
@@ -196,6 +206,18 @@ final readonly class SchoolResourcePatchService
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid resource payload.');
         }
 
+        if (array_key_exists('courseId', $payload)) {
+            $courseId = (string)$payload['courseId'];
+            if (!Uuid::isValid($courseId)) {
+                throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "courseId" must be a valid UUID.');
+            }
+            $course = $this->courseRepository->find($courseId);
+            if (!$course instanceof Course) {
+                throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Course not found.');
+            }
+            $entity->setCourse($course);
+        }
+
         if (array_key_exists('score', $payload)) {
             if (!is_numeric($payload['score'])) {
                 throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "score" must be numeric.');
@@ -204,5 +226,19 @@ final readonly class SchoolResourcePatchService
         }
 
         $this->gradeRepository->save($entity);
+    }
+
+    private function resolveUser(string $userId): User
+    {
+        if (!Uuid::isValid($userId)) {
+            throw new HttpException(JsonResponse::HTTP_UNPROCESSABLE_ENTITY, 'Field "userId" must be a valid UUID.');
+        }
+
+        $user = $this->userRepository->find($userId);
+        if (!$user instanceof User) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'User not found.');
+        }
+
+        return $user;
     }
 }

--- a/src/School/Domain/Entity/Course.php
+++ b/src/School/Domain/Entity/Course.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'school_course')]
+#[ORM\Index(name: 'idx_school_course_class_id', columns: ['class_id'])]
+#[ORM\Index(name: 'idx_school_course_teacher_id', columns: ['teacher_id'])]
+#[ORM\UniqueConstraint(name: 'uniq_school_course_class_name', columns: ['class_id', 'name'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Course implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: SchoolClass::class, inversedBy: 'courses')]
+    #[ORM\JoinColumn(name: 'class_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?SchoolClass $schoolClass = null;
+
+    #[ORM\ManyToOne(targetEntity: Teacher::class, inversedBy: 'courses')]
+    #[ORM\JoinColumn(name: 'teacher_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Teacher $teacher = null;
+
+    #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
+    private string $name = '';
+
+    /** @var Collection<int, Exam>|ArrayCollection<int, Exam> */
+    #[ORM\OneToMany(targetEntity: Exam::class, mappedBy: 'course')]
+    private Collection|ArrayCollection $exams;
+
+    /** @var Collection<int, Grade>|ArrayCollection<int, Grade> */
+    #[ORM\OneToMany(targetEntity: Grade::class, mappedBy: 'course')]
+    private Collection|ArrayCollection $grades;
+
+    /** @var Collection<int, LearningSessionNote>|ArrayCollection<int, LearningSessionNote> */
+    #[ORM\OneToMany(targetEntity: LearningSessionNote::class, mappedBy: 'course')]
+    private Collection|ArrayCollection $learningSessionNotes;
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->exams = new ArrayCollection();
+        $this->grades = new ArrayCollection();
+        $this->learningSessionNotes = new ArrayCollection();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+    public function getSchoolClass(): ?SchoolClass
+    {
+        return $this->schoolClass;
+    }
+    public function setSchoolClass(?SchoolClass $schoolClass): self
+    {
+        $this->schoolClass = $schoolClass;
+
+        return $this;
+    }
+    public function getTeacher(): ?Teacher
+    {
+        return $this->teacher;
+    }
+    public function setTeacher(?Teacher $teacher): self
+    {
+        $this->teacher = $teacher;
+
+        return $this;
+    }
+    public function getName(): string
+    {
+        return $this->name;
+    }
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/src/School/Domain/Entity/Exam.php
+++ b/src/School/Domain/Entity/Exam.php
@@ -22,6 +22,7 @@ use Ramsey\Uuid\UuidInterface;
 #[ORM\Table(name: 'school_exam')]
 #[ORM\Index(name: 'idx_school_exam_class_id', columns: ['class_id'])]
 #[ORM\Index(name: 'idx_school_exam_teacher_id', columns: ['teacher_id'])]
+#[ORM\Index(name: 'idx_school_exam_course_id', columns: ['course_id'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Exam implements EntityInterface
 {
@@ -35,6 +36,10 @@ class Exam implements EntityInterface
     #[ORM\ManyToOne(targetEntity: SchoolClass::class, inversedBy: 'exams')]
     #[ORM\JoinColumn(name: 'class_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private ?SchoolClass $schoolClass = null;
+
+    #[ORM\ManyToOne(targetEntity: Course::class, inversedBy: 'exams')]
+    #[ORM\JoinColumn(name: 'course_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?Course $course = null;
 
     #[ORM\ManyToOne(targetEntity: Teacher::class)]
     #[ORM\JoinColumn(name: 'teacher_id', referencedColumnName: 'id', nullable: false, onDelete: 'RESTRICT')]
@@ -56,10 +61,15 @@ class Exam implements EntityInterface
     #[ORM\OneToMany(targetEntity: Grade::class, mappedBy: 'exam')]
     private Collection|ArrayCollection $grades;
 
+    /** @var Collection<int, LearningSessionNote>|ArrayCollection<int, LearningSessionNote> */
+    #[ORM\OneToMany(targetEntity: LearningSessionNote::class, mappedBy: 'exam')]
+    private Collection|ArrayCollection $learningSessionNotes;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
         $this->grades = new ArrayCollection();
+        $this->learningSessionNotes = new ArrayCollection();
     }
 
     #[Override]
@@ -74,6 +84,16 @@ class Exam implements EntityInterface
     public function setSchoolClass(?SchoolClass $schoolClass): self
     {
         $this->schoolClass = $schoolClass;
+
+        return $this;
+    }
+    public function getCourse(): ?Course
+    {
+        return $this->course;
+    }
+    public function setCourse(?Course $course): self
+    {
+        $this->course = $course;
 
         return $this;
     }

--- a/src/School/Domain/Entity/LearningSessionNote.php
+++ b/src/School/Domain/Entity/LearningSessionNote.php
@@ -14,13 +14,13 @@ use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
 use Ramsey\Uuid\UuidInterface;
 
 #[ORM\Entity]
-#[ORM\Table(name: 'school_grade')]
-#[ORM\Index(name: 'idx_school_grade_student_id', columns: ['student_id'])]
-#[ORM\Index(name: 'idx_school_grade_exam_id', columns: ['exam_id'])]
-#[ORM\Index(name: 'idx_school_grade_course_id', columns: ['course_id'])]
-#[ORM\UniqueConstraint(name: 'uniq_school_grade_exam_student', columns: ['exam_id', 'student_id'])]
+#[ORM\Table(name: 'school_learning_session_note')]
+#[ORM\Index(name: 'idx_school_lsn_student_id', columns: ['student_id'])]
+#[ORM\Index(name: 'idx_school_lsn_exam_id', columns: ['exam_id'])]
+#[ORM\Index(name: 'idx_school_lsn_course_id', columns: ['course_id'])]
+#[ORM\UniqueConstraint(name: 'uniq_school_lsn_exam_student', columns: ['exam_id', 'student_id'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
-class Grade implements EntityInterface
+class LearningSessionNote implements EntityInterface
 {
     use Timestampable;
     use Uuid;
@@ -29,20 +29,23 @@ class Grade implements EntityInterface
     #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
     private UuidInterface $id;
 
-    #[ORM\ManyToOne(targetEntity: Student::class, inversedBy: 'grades')]
+    #[ORM\ManyToOne(targetEntity: Student::class, inversedBy: 'learningSessionNotes')]
     #[ORM\JoinColumn(name: 'student_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private ?Student $student = null;
 
-    #[ORM\ManyToOne(targetEntity: Exam::class, inversedBy: 'grades')]
+    #[ORM\ManyToOne(targetEntity: Exam::class, inversedBy: 'learningSessionNotes')]
     #[ORM\JoinColumn(name: 'exam_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private ?Exam $exam = null;
 
-    #[ORM\ManyToOne(targetEntity: Course::class, inversedBy: 'grades')]
+    #[ORM\ManyToOne(targetEntity: Course::class, inversedBy: 'learningSessionNotes')]
     #[ORM\JoinColumn(name: 'course_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private ?Course $course = null;
 
     #[ORM\Column(name: 'score', type: Types::FLOAT)]
     private float $score = 0.0;
+
+    #[ORM\Column(name: 'passed', type: Types::BOOLEAN)]
+    private bool $passed = false;
 
     public function __construct()
     {
@@ -54,19 +57,11 @@ class Grade implements EntityInterface
     {
         return $this->id->toString();
     }
-    public function getStudent(): ?Student
-    {
-        return $this->student;
-    }
     public function setStudent(?Student $student): self
     {
         $this->student = $student;
 
         return $this;
-    }
-    public function getExam(): ?Exam
-    {
-        return $this->exam;
     }
     public function setExam(?Exam $exam): self
     {
@@ -74,23 +69,21 @@ class Grade implements EntityInterface
 
         return $this;
     }
-    public function getCourse(): ?Course
-    {
-        return $this->course;
-    }
     public function setCourse(?Course $course): self
     {
         $this->course = $course;
 
         return $this;
     }
-    public function getScore(): float
-    {
-        return $this->score;
-    }
     public function setScore(float $score): self
     {
         $this->score = $score;
+
+        return $this;
+    }
+    public function setPassed(bool $passed): self
+    {
+        $this->passed = $passed;
 
         return $this;
     }

--- a/src/School/Domain/Entity/SchoolClass.php
+++ b/src/School/Domain/Entity/SchoolClass.php
@@ -48,12 +48,17 @@ class SchoolClass implements EntityInterface
     #[ORM\OneToMany(targetEntity: Exam::class, mappedBy: 'schoolClass')]
     private Collection|ArrayCollection $exams;
 
+    /** @var Collection<int, Course>|ArrayCollection<int, Course> */
+    #[ORM\OneToMany(targetEntity: Course::class, mappedBy: 'schoolClass')]
+    private Collection|ArrayCollection $courses;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
         $this->students = new ArrayCollection();
         $this->teachers = new ArrayCollection();
         $this->exams = new ArrayCollection();
+        $this->courses = new ArrayCollection();
     }
 
     #[Override]
@@ -103,4 +108,13 @@ class SchoolClass implements EntityInterface
     {
         return $this->exams;
     }
+
+    /**
+     * @return Collection<int, Course>|ArrayCollection<int, Course>
+     */
+    public function getCourses(): Collection|ArrayCollection
+    {
+        return $this->courses;
+    }
 }
+

--- a/src/School/Domain/Entity/Student.php
+++ b/src/School/Domain/Entity/Student.php
@@ -7,9 +7,9 @@ namespace App\School\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
@@ -18,6 +18,8 @@ use Ramsey\Uuid\UuidInterface;
 #[ORM\Entity]
 #[ORM\Table(name: 'school_student')]
 #[ORM\Index(name: 'idx_school_student_class_id', columns: ['class_id'])]
+#[ORM\Index(name: 'idx_school_student_user_id', columns: ['user_id'])]
+#[ORM\UniqueConstraint(name: 'uniq_school_student_user_class', columns: ['user_id', 'class_id'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Student implements EntityInterface
 {
@@ -28,27 +30,51 @@ class Student implements EntityInterface
     #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
     private UuidInterface $id;
 
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?User $user = null;
+
     #[ORM\ManyToOne(targetEntity: SchoolClass::class, inversedBy: 'students')]
     #[ORM\JoinColumn(name: 'class_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
     private ?SchoolClass $schoolClass = null;
-
-    #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
-    private string $name = '';
 
     /** @var Collection<int, Grade>|ArrayCollection<int, Grade> */
     #[ORM\OneToMany(targetEntity: Grade::class, mappedBy: 'student')]
     private Collection|ArrayCollection $grades;
 
+    /** @var Collection<int, LearningSessionNote>|ArrayCollection<int, LearningSessionNote> */
+    #[ORM\OneToMany(targetEntity: LearningSessionNote::class, mappedBy: 'student')]
+    private Collection|ArrayCollection $learningSessionNotes;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
         $this->grades = new ArrayCollection();
+        $this->learningSessionNotes = new ArrayCollection();
     }
 
     #[Override]
     public function getId(): string
     {
         return $this->id->toString();
+    }
+    public function getUser(): ?User
+    {
+        return $this->user;
+    }
+    public function setUser(?User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+    public function getDisplayName(): string
+    {
+        if (!$this->user instanceof User) {
+            return '';
+        }
+
+        return trim($this->user->getFirstName() . ' ' . $this->user->getLastName());
     }
     public function getSchoolClass(): ?SchoolClass
     {
@@ -60,16 +86,6 @@ class Student implements EntityInterface
 
         return $this;
     }
-    public function getName(): string
-    {
-        return $this->name;
-    }
-    public function setName(string $name): self
-    {
-        $this->name = $name;
-
-        return $this;
-    }
 
     /**
      * @return Collection<int, Grade>|ArrayCollection<int, Grade>
@@ -77,5 +93,13 @@ class Student implements EntityInterface
     public function getGrades(): Collection|ArrayCollection
     {
         return $this->grades;
+    }
+
+    /**
+     * @return Collection<int, LearningSessionNote>|ArrayCollection<int, LearningSessionNote>
+     */
+    public function getLearningSessionNotes(): Collection|ArrayCollection
+    {
+        return $this->learningSessionNotes;
     }
 }

--- a/src/School/Domain/Entity/Teacher.php
+++ b/src/School/Domain/Entity/Teacher.php
@@ -7,9 +7,9 @@ namespace App\School\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
@@ -17,6 +17,8 @@ use Ramsey\Uuid\UuidInterface;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'school_teacher')]
+#[ORM\Index(name: 'idx_school_teacher_user_id', columns: ['user_id'])]
+#[ORM\UniqueConstraint(name: 'uniq_school_teacher_user', columns: ['user_id'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Teacher implements EntityInterface
 {
@@ -27,18 +29,24 @@ class Teacher implements EntityInterface
     #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
     private UuidInterface $id;
 
-    #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
-    private string $name = '';
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'user_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?User $user = null;
 
     /** @var Collection<int, SchoolClass>|ArrayCollection<int, SchoolClass> */
     #[ORM\ManyToMany(targetEntity: SchoolClass::class, inversedBy: 'teachers')]
     #[ORM\JoinTable(name: 'school_class_teacher')]
     private Collection|ArrayCollection $classes;
 
+    /** @var Collection<int, Course>|ArrayCollection<int, Course> */
+    #[ORM\OneToMany(targetEntity: Course::class, mappedBy: 'teacher')]
+    private Collection|ArrayCollection $courses;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
         $this->classes = new ArrayCollection();
+        $this->courses = new ArrayCollection();
     }
 
     #[Override]
@@ -46,15 +54,23 @@ class Teacher implements EntityInterface
     {
         return $this->id->toString();
     }
-    public function getName(): string
+    public function getUser(): ?User
     {
-        return $this->name;
+        return $this->user;
     }
-    public function setName(string $name): self
+    public function setUser(?User $user): self
     {
-        $this->name = $name;
+        $this->user = $user;
 
         return $this;
+    }
+    public function getDisplayName(): string
+    {
+        if (!$this->user instanceof User) {
+            return '';
+        }
+
+        return trim($this->user->getFirstName() . ' ' . $this->user->getLastName());
     }
 
     /**
@@ -63,5 +79,13 @@ class Teacher implements EntityInterface
     public function getClasses(): Collection|ArrayCollection
     {
         return $this->classes;
+    }
+
+    /**
+     * @return Collection<int, Course>|ArrayCollection<int, Course>
+     */
+    public function getCourses(): Collection|ArrayCollection
+    {
+        return $this->courses;
     }
 }

--- a/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
+++ b/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
@@ -6,8 +6,10 @@ namespace App\School\Infrastructure\DataFixtures\ORM;
 
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PlatformKey;
+use App\School\Domain\Entity\Course;
 use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\Grade;
+use App\School\Domain\Entity\LearningSessionNote;
 use App\School\Domain\Entity\School;
 use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Student;
@@ -44,6 +46,24 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
         $terms = Term::cases();
         $applicationKeys = self::APPLICATION_KEYS_BY_PLATFORM[PlatformKey::SCHOOL->value] ?? [];
 
+        $userPool = [
+            $this->getReference('User-alice', User::class),
+            $this->getReference('User-bruno', User::class),
+            $this->getReference('User-clara', User::class),
+            $this->getReference('User-bob', User::class),
+            $this->getReference('User-charlie', User::class),
+            $this->getReference('User-diana', User::class),
+            $this->getReference('User-emma', User::class),
+            $this->getReference('User-felix', User::class),
+            $this->getReference('User-grace', User::class),
+            $this->getReference('User-john-user', User::class),
+            $this->getReference('User-john-logged', User::class),
+            $this->getReference('User-john-api', User::class),
+            $this->getReference('User-john-admin', User::class),
+            $this->getReference('User-john-root', User::class),
+        ];
+        $userCursor = 0;
+
         foreach ($this->getApplicationsByPlatform(PlatformKey::SCHOOL) as $applicationIndex => $application) {
             $appKey = $applicationKeys[$applicationIndex] ?? $application->getSlug();
 
@@ -66,9 +86,9 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
 
             $classes = [];
             $classesByLabel = [
-                'small' => 'Classe A - Sciences',
-                'medium' => 'Classe B - Langues',
-                'large' => 'Classe C - Technologies',
+                'small' => 'Informatique - Grad 1',
+                'medium' => 'Informatique - Grad 2',
+                'large' => 'Informatique - Grad 3',
             ];
 
             foreach ($classesByLabel as $label => $name) {
@@ -85,9 +105,9 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
             }
             $this->addReference('SchoolClass-' . $appKey . '-1', $classes['small']);
 
-            $teacherMath = (new Teacher())->setName('Mme Martin - ' . $applicationIndex);
-            $teacherFrench = (new Teacher())->setName('M. Dubois - ' . $applicationIndex);
-            $teacherHead = (new Teacher())->setName('Dr. Principal - ' . $applicationIndex);
+            $teacherMath = (new Teacher())->setUser($this->pickUser($userPool, $userCursor));
+            $teacherFrench = (new Teacher())->setUser($this->pickUser($userPool, $userCursor));
+            $teacherHead = (new Teacher())->setUser($this->pickUser($userPool, $userCursor));
 
             $teacherMath->getClasses()->add($classes['small']);
             $teacherMath->getClasses()->add($classes['large']);
@@ -101,10 +121,28 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
             $manager->persist($teacherFrench);
             $manager->persist($teacherHead);
 
+            $teachersByLabel = [
+                'math' => $teacherMath,
+                'french' => $teacherFrench,
+                'head' => $teacherHead,
+            ];
+
             $this->addReference('Teacher-' . $appKey . '-math', $teacherMath);
             $this->addReference('Teacher-' . $appKey . '-french', $teacherFrench);
             $this->addReference('Teacher-' . $appKey . '-head', $teacherHead);
             $this->addReference('Teacher-' . $appKey . '-1', $teacherMath);
+
+            $coursesByClass = [];
+            foreach ($classes as $classLabel => $class) {
+                foreach (['Algorithmique', 'Base de Données', 'Réseaux'] as $index => $courseLabel) {
+                    $course = (new Course())
+                        ->setSchoolClass($class)
+                        ->setTeacher($index === 1 ? $teacherFrench : $teacherMath)
+                        ->setName($courseLabel . ' - ' . $classLabel . ' - ' . $applicationIndex);
+                    $manager->persist($course);
+                    $coursesByClass[$classLabel][] = $course;
+                }
+            }
 
             $students = [];
             $studentCounter = 1;
@@ -118,7 +156,7 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
                 for ($i = 1; $i <= $count; $i++) {
                     $student = (new Student())
                         ->setSchoolClass($classes[$classLabel])
-                        ->setName('Student ' . $applicationIndex . '-' . $classLabel . '-' . $i);
+                        ->setUser($this->pickUser($userPool, $userCursor));
                     $manager->persist($student);
 
                     $students[$classLabel][] = $student;
@@ -131,8 +169,10 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
             $examCounter = 1;
             foreach ($classes as $classLabel => $class) {
                 for ($i = 0; $i < 4; $i++) {
+                    $course = $coursesByClass[$classLabel][$i % count($coursesByClass[$classLabel])];
                     $exam = (new Exam())
                         ->setSchoolClass($class)
+                        ->setCourse($course)
                         ->setTeacher($i % 2 === 0 ? $teacherMath : $teacherHead)
                         ->setTitle('Examen ' . $classLabel . ' #' . ($i + 1) . ' - ' . $applicationIndex)
                         ->setType($examTypes[($applicationIndex + $i) % count($examTypes)])
@@ -150,25 +190,24 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
             foreach ($exams as $classLabel => $classExams) {
                 foreach ($classExams as $examIndex => $exam) {
                     foreach ($students[$classLabel] as $studentIndex => $student) {
-                        $score = 20.0;
-                        if ($studentIndex === 0 && $examIndex === 0) {
-                            $score = 0.0;
-                        } elseif ($studentIndex === 1 && $examIndex === 1) {
-                            $score = -1.0;
-                        } elseif ($studentIndex === 2 && $examIndex === 2) {
-                            $score = 25.0;
-                        } elseif ($studentIndex === 3 && $examIndex === 3) {
-                            $score = 9.999;
-                        } else {
-                            $score = (float)(($studentIndex + $examIndex + $applicationIndex) % 21);
-                        }
+                        $score = (float)(($studentIndex + $examIndex + $applicationIndex) % 21);
 
                         $grade = (new Grade())
                             ->setStudent($student)
                             ->setExam($exam)
+                            ->setCourse($exam->getCourse())
                             ->setScore($score);
                         $manager->persist($grade);
                         $this->addReference('Grade-' . $appKey . '-' . $gradeCounter, $grade);
+
+                        $note = (new LearningSessionNote())
+                            ->setStudent($student)
+                            ->setExam($exam)
+                            ->setCourse($exam->getCourse())
+                            ->setScore($score)
+                            ->setPassed($score >= 10.0);
+                        $manager->persist($note);
+
                         $gradeCounter++;
                     }
                 }
@@ -200,5 +239,16 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
         }
 
         return $applications;
+    }
+
+    /**
+     * @param array<int, User> $users
+     */
+    private function pickUser(array $users, int &$cursor): User
+    {
+        $user = $users[$cursor % count($users)];
+        $cursor++;
+
+        return $user;
     }
 }

--- a/src/School/Infrastructure/Repository/CourseRepository.php
+++ b/src/School/Infrastructure/Repository/CourseRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\School\Domain\Entity\Course;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends BaseRepository<Course>
+ */
+final class CourseRepository extends BaseRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Course::class);
+    }
+}

--- a/src/School/Infrastructure/Repository/LearningSessionNoteRepository.php
+++ b/src/School/Infrastructure/Repository/LearningSessionNoteRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\School\Domain\Entity\LearningSessionNote;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends BaseRepository<LearningSessionNote>
+ */
+final class LearningSessionNoteRepository extends BaseRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LearningSessionNote::class);
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
@@ -37,11 +37,12 @@ final readonly class CreateExamController
         summary: 'Créer un examen',
         tags: ['School'],
         requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
-            required: ['title', 'classId', 'teacherId', 'type', 'status', 'term'],
+            required: ['title', 'classId', 'courseId', 'teacherId', 'type', 'status', 'term'],
             properties: [
                 new OA\Property(property: 'title', type: 'string', example: 'Examen Mathematiques - Trimestre 1'),
                 new OA\Property(property: 'classId', type: 'string', format: 'uuid'),
-                new OA\Property(property: 'teacherId', type: 'string', format: 'uuid'),
+                new OA\Property(property: 'courseId', type: 'string', format: 'uuid'),
+                    new OA\Property(property: 'teacherId', type: 'string', format: 'uuid'),
                 new OA\Property(property: 'type', type: 'string', enum: ['QUIZ', 'MIDTERM', 'FINAL', 'ORAL'], example: 'QUIZ'),
                 new OA\Property(property: 'status', type: 'string', enum: ['DRAFT', 'PUBLISHED', 'CLOSED'], example: 'DRAFT'),
                 new OA\Property(property: 'term', type: 'string', enum: ['TERM_1', 'TERM_2', 'TERM_3'], example: 'TERM_1'),
@@ -67,6 +68,7 @@ final readonly class CreateExamController
         $input = new CreateExamInput();
         $input->title = (string)($payload['title'] ?? '');
         $input->classId = is_string($payload['classId'] ?? null) ? $payload['classId'] : '';
+        $input->courseId = is_string($payload['courseId'] ?? null) ? $payload['courseId'] : '';
         $input->teacherId = is_string($payload['teacherId'] ?? null) ? $payload['teacherId'] : '';
         $input->type = is_string($payload['type'] ?? null) ? $payload['type'] : '';
         $input->status = is_string($payload['status'] ?? null) ? $payload['status'] : '';
@@ -81,6 +83,7 @@ final readonly class CreateExamController
             $school,
             $input->title,
             $input->classId,
+            $input->courseId,
             $input->teacherId,
             ExamType::from($input->type),
             ExamStatus::from($input->status),

--- a/src/School/Transport/Controller/Api/V1/Input/CreateExamInput.php
+++ b/src/School/Transport/Controller/Api/V1/Input/CreateExamInput.php
@@ -18,6 +18,11 @@ final class CreateExamInput
     #[Assert\Uuid]
     public string $classId = '';
 
+
+    #[Assert\NotBlank]
+    #[Assert\Uuid]
+    public string $courseId = '';
+
     #[Assert\NotBlank]
     #[Assert\Uuid]
     public string $teacherId = '';

--- a/src/School/Transport/Controller/Api/V1/Input/CreateStudentInput.php
+++ b/src/School/Transport/Controller/Api/V1/Input/CreateStudentInput.php
@@ -9,7 +9,8 @@ use Symfony\Component\Validator\Constraints as Assert;
 final class CreateStudentInput
 {
     #[Assert\NotBlank]
-    public string $name = '';
+    #[Assert\Uuid]
+    public string $userId = '';
 
     #[Assert\NotBlank]
     #[Assert\Uuid]

--- a/src/School/Transport/Controller/Api/V1/Input/CreateTeacherInput.php
+++ b/src/School/Transport/Controller/Api/V1/Input/CreateTeacherInput.php
@@ -9,5 +9,6 @@ use Symfony\Component\Validator\Constraints as Assert;
 final class CreateTeacherInput
 {
     #[Assert\NotBlank]
-    public string $name = '';
+    #[Assert\Uuid]
+    public string $userId = '';
 }

--- a/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
+++ b/src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php
@@ -37,9 +37,9 @@ final readonly class CreateStudentController
         requestBody: new OA\RequestBody(
             required: true,
             content: new OA\JsonContent(
-                required: ['name', 'classId'],
+                required: ['userId', 'classId'],
                 properties: [
-                    new OA\Property(property: 'name', type: 'string', example: 'Alice Martin'),
+                    new OA\Property(property: 'userId', type: 'string', format: 'uuid', example: '7600e750-f92f-4f9f-883a-26404b538f66'),
                     new OA\Property(property: 'classId', type: 'string', format: 'uuid', example: '7600e750-f92f-4f9f-883a-26404b538f66'),
                 ],
             ),
@@ -61,7 +61,7 @@ final readonly class CreateStudentController
         $payload = $request->toArray();
 
         $input = new CreateStudentInput();
-        $input->name = (string)($payload['name'] ?? '');
+        $input->userId = is_string($payload['userId'] ?? null) ? $payload['userId'] : '';
         $input->classId = is_string($payload['classId'] ?? null) ? $payload['classId'] : '';
 
         $validationResponse = $this->inputValidator->validate($input);
@@ -69,7 +69,7 @@ final readonly class CreateStudentController
             return $validationResponse;
         }
 
-        $student = $this->createStudentService->create($school, $input->name, $input->classId);
+        $student = $this->createStudentService->create($school, $input->userId, $input->classId);
 
         return new JsonResponse([
             'id' => $student->getId(),

--- a/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
+++ b/src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php
@@ -43,14 +43,14 @@ final readonly class CreateTeacherController
         $payload = $request->toArray();
 
         $input = new CreateTeacherInput();
-        $input->name = (string)($payload['name'] ?? '');
+        $input->userId = is_string($payload['userId'] ?? null) ? $payload['userId'] : '';
 
         $validationResponse = $this->inputValidator->validate($input);
         if ($validationResponse instanceof JsonResponse) {
             return $validationResponse;
         }
 
-        $teacher = $this->createTeacherService->create($input->name);
+        $teacher = $this->createTeacherService->create($input->userId);
 
         return new JsonResponse([
             'id' => $teacher->getId(),


### PR DESCRIPTION
### Motivation
- Align school actors with the global `User` model so `Student` and `Teacher` are user-backed and reusable across apps. 
- Introduce `Course` and `LearningSessionNote` to model courses per class/teacher and per-student exam session notes, and to relate `Exam`/`Grade` to courses (flow: class -> course -> exam -> grade -> progression).

### Description
- Updated domain models: `Student` and `Teacher` now reference `User` instead of storing `name`, and expose `getDisplayName()` derived from the `User` profile; added DB indexes and unique constraints for `user` relationships.
- Added new entities `Course` and `LearningSessionNote` with relations: `Course` -> `SchoolClass`, optional `Teacher`, `Exam`/`Grade`/`LearningSessionNote`; `LearningSessionNote` -> `Student`, `Exam`, `Course` + `score`/`passed` fields.
- Extended `Exam` and `Grade` to include `course` relations and added collection mapping for learning session notes.
- Updated services/controllers/inputs: `CreateStudentInput`/`CreateTeacherInput` now expect `userId`; `CreateExamInput` now requires `courseId`; `Create*Service` methods validate and resolve `User`/`Course` and enforce coherence (e.g. `courseId` belongs to `classId`, teacher assigned to class).
- Adjusted list/search services and `SchoolViewMapper` to expose `userId`, user-backed display names and `courseId`/`courseName` for exams/grades, and updated query builders to join `student.user` / `teacher.user` for text search.
- Fixtures updated: `LoadSchoolData` seeds users, courses per class, exams linked to courses, grades and `LearningSessionNote` entries; added helper `pickUser()`.
- New repositories: `CourseRepository`, `LearningSessionNoteRepository` and a Doctrine migration `migrations/Version20260420110000.php` to apply schema changes (add `user_id`, `course_id`, new tables, constraints, and initial backfill logic).

### Testing
- Executed PHP lint across modified PHP files with `php -l` (all changed files linted successfully).
- Ran `php bin/console lint:container` which failed in the current environment due to missing Composer dependencies (error: "Dependencies are missing. Try running `composer install`").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6671a334883268ebf0507b3d842b9)