### PR TITLE
feat(school): add general course listing/detail endpoints

### DIFF
--- a/src/School/Application/Serializer/SchoolViewMapper.php
+++ b/src/School/Application/Serializer/SchoolViewMapper.php
@@ -6,6 +6,7 @@ namespace App\School\Application\Serializer;
 
 use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\Grade;
+use App\School\Domain\Entity\Course;
 use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Student;
 use App\School\Domain\Entity\Teacher;
@@ -100,6 +101,43 @@ final readonly class SchoolViewMapper
                 'photo' => $teacher->getUser()?->getPhoto(),
                 'firstName' => $teacher->getUser()?->getFirstName(),
                 'lastName' => $teacher->getUser()?->getLastName(),
+            ],
+        ];
+    }
+
+    /** @param array<int,Course> $courses
+     * @return array<int,array<string,mixed>>
+     */
+    public function mapCourseCollection(array $courses): array
+    {
+        $items = [];
+        foreach ($courses as $course) {
+            $items[] = $this->mapCourse($course);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function mapCourse(Course $course): array
+    {
+        return [
+            'id' => $course->getId(),
+            'name' => $course->getName(),
+            'classId' => $course->getSchoolClass()?->getId(),
+            'className' => $course->getSchoolClass()?->getName(),
+            'schoolId' => $course->getSchoolClass()?->getSchool()?->getId(),
+            'schoolName' => $course->getSchoolClass()?->getSchool()?->getName(),
+            'teacherId' => $course->getTeacher()?->getId(),
+            'teacher' => [
+                'id' => $course->getTeacher()?->getId(),
+                'name' => $course->getTeacher()?->getDisplayName(),
+                'email' => $course->getTeacher()?->getUser()?->getEmail(),
+                'photo' => $course->getTeacher()?->getUser()?->getPhoto(),
+                'firstName' => $course->getTeacher()?->getUser()?->getFirstName(),
+                'lastName' => $course->getTeacher()?->getUser()?->getLastName(),
             ],
         ];
     }

--- a/src/School/Application/Service/ListCoursesService.php
+++ b/src/School/Application/Service/ListCoursesService.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Domain\Entity\School;
+use App\School\Infrastructure\Repository\CourseRepository;
+use Symfony\Component\HttpFoundation\Request;
+
+final readonly class ListCoursesService
+{
+    public function __construct(
+        private CourseRepository $courseRepository,
+        private SchoolViewMapper $viewMapper,
+        private SchoolListRequestHelper $listRequestHelper,
+        private SchoolListResponseFactory $listResponseFactory,
+    ) {
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function list(Request $request, ?School $school = null): array
+    {
+        $queryOptions = $this->listRequestHelper->fromRequest($request, ['q']);
+
+        $qb = $this->courseRepository->createQueryBuilder('course')
+            ->innerJoin('course.schoolClass', 'class')
+            ->leftJoin('course.teacher', 'teacher')
+            ->leftJoin('teacher.user', 'teacherUser')
+            ->orderBy('course.createdAt', 'DESC')
+            ->setFirstResult($queryOptions->offset())
+            ->setMaxResults($queryOptions->limit);
+
+        if ($school !== null) {
+            $qb->innerJoin('class.school', 'school')
+                ->andWhere('school.id = :schoolId')
+                ->setParameter('schoolId', $school->getId());
+        }
+
+        if ($queryOptions->filters['q'] !== '') {
+            $qb->andWhere('LOWER(course.name) LIKE LOWER(:q) OR LOWER(teacherUser.firstName) LIKE LOWER(:q) OR LOWER(teacherUser.lastName) LIKE LOWER(:q) OR LOWER(teacherUser.email) LIKE LOWER(:q)')
+                ->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+        }
+
+        $items = $this->viewMapper->mapCourseCollection($qb->getQuery()->getResult());
+
+        $countQb = $this->courseRepository->createQueryBuilder('course')
+            ->select('COUNT(course.id)')
+            ->innerJoin('course.schoolClass', 'class')
+            ->leftJoin('course.teacher', 'teacher')
+            ->leftJoin('teacher.user', 'teacherUser');
+
+        if ($school !== null) {
+            $countQb->innerJoin('class.school', 'school')
+                ->andWhere('school.id = :schoolId')
+                ->setParameter('schoolId', $school->getId());
+        }
+
+        if ($queryOptions->filters['q'] !== '') {
+            $countQb->andWhere('LOWER(course.name) LIKE LOWER(:q) OR LOWER(teacherUser.firstName) LIKE LOWER(:q) OR LOWER(teacherUser.lastName) LIKE LOWER(:q) OR LOWER(teacherUser.email) LIKE LOWER(:q)')
+                ->setParameter('q', '%' . $queryOptions->filters['q'] . '%');
+        }
+
+        $totalItems = (int)$countQb->getQuery()->getSingleScalarResult();
+
+        return $this->listResponseFactory->create($queryOptions, $totalItems, $items, $school === null ? [] : [
+            'schoolId' => $school->getId(),
+        ]);
+    }
+}

--- a/src/School/Application/Service/SchoolResourceAccessService.php
+++ b/src/School/Application/Service/SchoolResourceAccessService.php
@@ -7,9 +7,11 @@ namespace App\School\Application\Service;
 use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\Grade;
 use App\School\Domain\Entity\School;
+use App\School\Domain\Entity\Course;
 use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Student;
 use App\School\Domain\Entity\Teacher;
+use App\School\Infrastructure\Repository\CourseRepository;
 use App\School\Infrastructure\Repository\ExamRepository;
 use App\School\Infrastructure\Repository\GradeRepository;
 use App\School\Infrastructure\Repository\SchoolClassRepository;
@@ -22,24 +24,26 @@ final readonly class SchoolResourceAccessService
         private SchoolClassRepository $classRepository,
         private StudentRepository $studentRepository,
         private TeacherRepository $teacherRepository,
+        private CourseRepository $courseRepository,
         private ExamRepository $examRepository,
         private GradeRepository $gradeRepository,
     ) {
     }
 
-    public function find(string $resource, string $id): SchoolClass|Student|Teacher|Exam|Grade|null
+    public function find(string $resource, string $id): SchoolClass|Student|Teacher|Course|Exam|Grade|null
     {
         return match ($resource) {
             'classes' => $this->classRepository->find($id),
             'students' => $this->studentRepository->find($id),
             'teachers' => $this->teacherRepository->find($id),
+            'courses' => $this->courseRepository->find($id),
             'exams' => $this->examRepository->find($id),
             'grades' => $this->gradeRepository->find($id),
             default => null,
         };
     }
 
-    public function belongsToSchool(SchoolClass|Student|Teacher|Exam|Grade $entity, School $school): bool
+    public function belongsToSchool(SchoolClass|Student|Teacher|Course|Exam|Grade $entity, School $school): bool
     {
         if ($entity instanceof SchoolClass) {
             return $entity->getSchool()?->getId() === $school->getId();
@@ -50,6 +54,10 @@ final readonly class SchoolResourceAccessService
         }
 
         if ($entity instanceof Exam) {
+            return $entity->getSchoolClass()?->getSchool()?->getId() === $school->getId();
+        }
+
+        if ($entity instanceof Course) {
             return $entity->getSchoolClass()?->getSchool()?->getId() === $school->getId();
         }
 

--- a/src/School/Application/Service/SchoolResourceViewService.php
+++ b/src/School/Application/Service/SchoolResourceViewService.php
@@ -7,6 +7,7 @@ namespace App\School\Application\Service;
 use App\School\Application\Serializer\SchoolViewMapper;
 use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\Grade;
+use App\School\Domain\Entity\Course;
 use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Student;
 use App\School\Domain\Entity\Teacher;
@@ -22,7 +23,7 @@ final readonly class SchoolResourceViewService
     ) {
     }
 
-    public function findOr404(string $resource, string $id): SchoolClass|Student|Teacher|Exam|Grade
+    public function findOr404(string $resource, string $id): SchoolClass|Student|Teacher|Course|Exam|Grade
     {
         if (!Uuid::isValid($id)) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid identifier format.');
@@ -39,12 +40,13 @@ final readonly class SchoolResourceViewService
     /**
      * @return array<string,mixed>
      */
-    public function map(SchoolClass|Student|Teacher|Exam|Grade $entity): array
+    public function map(SchoolClass|Student|Teacher|Course|Exam|Grade $entity): array
     {
         return match (true) {
             $entity instanceof SchoolClass => $this->viewMapper->mapClass($entity),
             $entity instanceof Student => $this->viewMapper->mapStudent($entity),
             $entity instanceof Teacher => $this->viewMapper->mapTeacher($entity),
+            $entity instanceof Course => $this->viewMapper->mapCourse($entity),
             $entity instanceof Exam => $this->viewMapper->mapExam($entity),
             $entity instanceof Grade => $this->viewMapper->mapGrade($entity),
         };

--- a/src/School/Transport/Controller/Api/V1/General/GetGeneralSchoolResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/General/GetGeneralSchoolResourceController.php
@@ -23,7 +23,7 @@ final readonly class GetGeneralSchoolResourceController
     }
 
     #[Route('/v1/school/general/{resource}/{id}', requirements: [
-        'resource' => 'classes|students|teachers|exams|grades',
+        'resource' => 'classes|students|teachers|courses|exams|grades',
     ], methods: [Request::METHOD_GET])]
     #[OA\Get(summary: 'Détail global d\'une ressource school (scope General en lecture seule)')]
     public function __invoke(string $resource, string $id): JsonResponse

--- a/src/School/Transport/Controller/Api/V1/General/ListGeneralCoursesController.php
+++ b/src/School/Transport/Controller/Api/V1/General/ListGeneralCoursesController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1\General;
+
+use App\School\Application\Service\ListCoursesService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+final readonly class ListGeneralCoursesController
+{
+    public function __construct(
+        private ListCoursesService $listCoursesService,
+    ) {
+    }
+
+    #[Route('/v1/school/general/courses', methods: [Request::METHOD_GET], defaults: ['applicationSlug' => 'general'])]
+    #[OA\Get(summary: 'Lister globalement les cours school (scope General en lecture seule)')]
+    public function __invoke(Request $request): JsonResponse
+    {
+        return new JsonResponse($this->listCoursesService->list($request));
+    }
+}

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php
@@ -111,4 +111,31 @@ final class SchoolCrudValidationPaginationTest extends WebTestCase
         $client->request('DELETE', self::API_URL_PREFIX . '/v1/school/general/classes/' . $classId);
         self::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
     }
+
+    #[TestDox('School general scope exposes courses listing and detail endpoints with rich payload.')]
+    public function testSchoolGeneralCoursesListAndDetailRoutes(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/school/general/courses?page=1&limit=5');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $listPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+        self::assertArrayHasKey('items', $listPayload);
+        self::assertNotEmpty($listPayload['items']);
+
+        $firstCourse = $listPayload['items'][0];
+        self::assertArrayHasKey('id', $firstCourse);
+        self::assertArrayHasKey('name', $firstCourse);
+        self::assertArrayHasKey('classId', $firstCourse);
+        self::assertArrayHasKey('schoolId', $firstCourse);
+        self::assertArrayHasKey('teacher', $firstCourse);
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/school/general/courses/' . $firstCourse['id']);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $detailPayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        self::assertSame($firstCourse['id'], $detailPayload['id']);
+        self::assertArrayHasKey('teacherId', $detailPayload);
+        self::assertArrayHasKey('teacher', $detailPayload);
+    }
 }


### PR DESCRIPTION
### Motivation

- Exposer les cours dans le scope `general` avec un payload riche (classe, école, enseignant, etc.) afin que les consommateurs API puissent lire les courses avec le maximum d'attributs sans être liés à une application spécifique.
- Réutiliser les conventions de listing/pagination/filtre déjà présentes pour les autres ressources `school` (students, teachers, exams, grades).

### Description

- Ajout de l'endpoint général `GET /v1/school/general/courses` via `ListGeneralCoursesController` et du service `ListCoursesService` qui supporte pagination et filtre `q` pour la recherche par nom/enseignant.
- Ajout des méthodes de sérialisation `mapCourse` et `mapCourseCollection` dans `SchoolViewMapper` pour renvoyer un payload détaillé (`id`, `name`, `classId`, `className`, `schoolId`, `schoolName`, `teacherId`, `teacher` avec détails utilisateur).
- Extension de la résolution/mapping des ressources pour supporter `courses` dans `SchoolResourceAccessService` et `SchoolResourceViewService`, et mise à jour de la route générique de détail pour accepter `courses` (`/v1/school/general/courses/{id}`).
- Ajout d'une couverture d'intégration dans `tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php` pour vérifier la liste et le détail des courses (présence des attributs riches).

### Testing

- `php -l` a été exécuté avec succès sur les fichiers modifiés (`SchoolViewMapper`, `ListCoursesService`, `SchoolResourceAccessService`, `SchoolResourceViewService`, `ListGeneralCoursesController`, `GetGeneralSchoolResourceController`, et le test modifié) et n'a retourné aucune erreur de syntaxe.
- Tentative d'exécution de PHPUnit a échoué dans cet environnement car `./vendor/bin/phpunit` est introuvable (dépendances `vendor` absentes), donc les tests fonctionnels n'ont pas été lancés ici.
- Les nouveaux/édités fichiers sources et le test d'intégration ont été ajoutés et sont prêts pour exécution dans l'environnement CI où les dépendances sont installées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67891302083269cee6dc755bc63da)