### PR TITLE
feat(school): add course creation with HTML content and file attachments

### DIFF
--- a/src/School/Application/Serializer/SchoolViewMapper.php
+++ b/src/School/Application/Serializer/SchoolViewMapper.php
@@ -131,6 +131,8 @@ final readonly class SchoolViewMapper
             'schoolId' => $course->getSchoolClass()?->getSchool()?->getId(),
             'schoolName' => $course->getSchoolClass()?->getSchool()?->getName(),
             'teacherId' => $course->getTeacher()?->getId(),
+            'contentHtml' => $course->getContentHtml(),
+            'attachments' => $course->getAttachments(),
             'teacher' => [
                 'id' => $course->getTeacher()?->getId(),
                 'name' => $course->getTeacher()?->getDisplayName(),

--- a/src/School/Application/Service/CreateCourseService.php
+++ b/src/School/Application/Service/CreateCourseService.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use App\General\Application\Message\EntityCreated;
+use App\School\Application\Exception\SchoolRelationException;
+use App\School\Domain\Entity\Course;
+use App\School\Domain\Entity\School;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final readonly class CreateCourseService
+{
+    public function __construct(
+        private SchoolReferenceResolver $referenceResolver,
+        private EntityManagerInterface $entityManager,
+        private MessageBusInterface $messageBus,
+    ) {
+    }
+
+    /**
+     * @param list<array{url: string, originalName: string, mimeType: string, size: int, extension: string}> $attachments
+     */
+    public function create(
+        School $school,
+        string $name,
+        string $classId,
+        ?string $teacherId,
+        ?string $contentHtml,
+        array $attachments,
+    ): Course {
+        $class = $this->referenceResolver->resolveClassInSchool($school, $classId);
+
+        $teacher = null;
+        if (is_string($teacherId) && $teacherId !== '') {
+            $teacher = $this->referenceResolver->resolveTeacherInSchool($school, $teacherId);
+            if (!$teacher->getClasses()->contains($class)) {
+                throw SchoolRelationException::unprocessable('teacherId is not assigned to classId');
+            }
+        }
+
+        $course = (new Course())
+            ->setSchoolClass($class)
+            ->setTeacher($teacher)
+            ->setName($name)
+            ->setContentHtml($contentHtml)
+            ->setAttachments($this->normalizeAttachments($attachments));
+
+        $this->entityManager->persist($course);
+        $this->entityManager->flush();
+
+        $this->messageBus->dispatch(new EntityCreated('school_course', $course->getId(), context: [
+            'applicationSlug' => $class->getSchool()?->getApplication()?->getSlug(),
+        ]));
+
+        return $course;
+    }
+
+    /**
+     * @param list<array{url: string, originalName: string, mimeType: string, size: int, extension: string}> $attachments
+     * @return list<array<string,mixed>>
+     */
+    private function normalizeAttachments(array $attachments): array
+    {
+        $uploadedAt = new DateTimeImmutable();
+
+        $normalized = [];
+        foreach ($attachments as $attachment) {
+            $normalized[] = [
+                'url' => $attachment['url'],
+                'originalName' => $attachment['originalName'],
+                'mimeType' => $attachment['mimeType'],
+                'size' => $attachment['size'],
+                'extension' => $attachment['extension'],
+                'uploadedAt' => $uploadedAt->format(DATE_ATOM),
+            ];
+        }
+
+        return $normalized;
+    }
+}

--- a/src/School/Application/Service/SchoolCourseAttachmentUploaderService.php
+++ b/src/School/Application/Service/SchoolCourseAttachmentUploaderService.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use App\Media\Application\Service\MediaUploadValidationPolicy;
+use App\Media\Application\Service\MediaUploaderService;
+use Random\RandomException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+
+readonly class SchoolCourseAttachmentUploaderService
+{
+    public function __construct(
+        private MediaUploaderService $mediaUploaderService,
+    ) {
+    }
+
+    /**
+     * @param list<UploadedFile> $files
+     * @return list<array{url: string, originalName: string, mimeType: string, size: int, extension: string}>
+     * @throws RandomException
+     */
+    public function upload(Request $request, array $files, string $relativeDirectory): array
+    {
+        if ($files === []) {
+            return [];
+        }
+
+        return $this->mediaUploaderService->upload(
+            $request,
+            $files,
+            $relativeDirectory,
+            new MediaUploadValidationPolicy(
+                maxSizeInBytes: 20 * 1024 * 1024,
+                allowedMimeTypes: [
+                    'application/pdf',
+                    'image/jpeg',
+                    'image/png',
+                    'image/webp',
+                    'application/msword',
+                    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+                    'application/vnd.ms-powerpoint',
+                    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+                ],
+                allowedExtensions: ['pdf', 'jpg', 'jpeg', 'png', 'webp', 'doc', 'docx', 'ppt', 'pptx'],
+            ),
+        );
+    }
+}

--- a/src/School/Domain/Entity/Course.php
+++ b/src/School/Domain/Entity/Course.php
@@ -41,6 +41,15 @@ class Course implements EntityInterface
     #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
     private string $name = '';
 
+    #[ORM\Column(name: 'content_html', type: Types::TEXT, nullable: true)]
+    private ?string $contentHtml = null;
+
+    /**
+     * @var list<array<string,mixed>>
+     */
+    #[ORM\Column(name: 'attachments', type: Types::JSON)]
+    private array $attachments = [];
+
     /** @var Collection<int, Exam>|ArrayCollection<int, Exam> */
     #[ORM\OneToMany(targetEntity: Exam::class, mappedBy: 'course')]
     private Collection|ArrayCollection $exams;
@@ -93,6 +102,46 @@ class Course implements EntityInterface
     public function setName(string $name): self
     {
         $this->name = $name;
+
+        return $this;
+    }
+
+    public function getContentHtml(): ?string
+    {
+        return $this->contentHtml;
+    }
+
+    public function setContentHtml(?string $contentHtml): self
+    {
+        $this->contentHtml = $contentHtml;
+
+        return $this;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    public function getAttachments(): array
+    {
+        return $this->attachments;
+    }
+
+    /**
+     * @param list<array<string,mixed>> $attachments
+     */
+    public function setAttachments(array $attachments): self
+    {
+        $this->attachments = $attachments;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string,mixed> $attachment
+     */
+    public function addAttachment(array $attachment): self
+    {
+        $this->attachments[] = $attachment;
 
         return $this;
     }

--- a/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
+++ b/src/School/Infrastructure/DataFixtures/ORM/LoadSchoolData.php
@@ -132,10 +132,33 @@ final class LoadSchoolData extends Fixture implements OrderedFixtureInterface
             $coursesByClass = [];
             foreach ($classes as $classLabel => $class) {
                 foreach (['Algorithmique', 'Base de Données', 'Réseaux'] as $index => $courseLabel) {
+                    $isGeneralSchool = $appKey === 'school-general-core';
+                    $normalizedClassLabel = $classLabel;
+                    $normalizedCourseLabel = strtolower(str_replace(' ', '-', $courseLabel));
+
                     $course = (new Course())
                         ->setSchoolClass($class)
                         ->setTeacher($index === 1 ? $teacherFrench : $teacherMath)
-                        ->setName($courseLabel . ' - ' . $classLabel . ' - ' . $applicationIndex);
+                        ->setName($courseLabel . ' - ' . $classLabel . ' - ' . $applicationIndex)
+                        ->setContentHtml($isGeneralSchool ? '<h2>' . $courseLabel . '</h2><p>Programme détaillé pour la classe ' . $class->getName() . '.</p><ul><li>Objectifs</li><li>Exercices</li><li>Évaluation continue</li></ul>' : null)
+                        ->setAttachments($isGeneralSchool ? [
+                            [
+                                'url' => '/uploads/school/fixtures/' . $appKey . '/' . $normalizedClassLabel . '/' . $normalizedCourseLabel . '-plan.pdf',
+                                'originalName' => $courseLabel . '-plan.pdf',
+                                'mimeType' => 'application/pdf',
+                                'size' => 124500 + ($index * 1042),
+                                'extension' => 'pdf',
+                                'uploadedAt' => '2026-01-15T08:15:00+00:00',
+                            ],
+                            [
+                                'url' => '/uploads/school/fixtures/' . $appKey . '/' . $normalizedClassLabel . '/' . $normalizedCourseLabel . '-slides.pptx',
+                                'originalName' => $courseLabel . '-slides.pptx',
+                                'mimeType' => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+                                'size' => 280900 + ($index * 2048),
+                                'extension' => 'pptx',
+                                'uploadedAt' => '2026-01-15T08:20:00+00:00',
+                            ],
+                        ] : []);
                     $manager->persist($course);
                     $coursesByClass[$classLabel][] = $course;
                 }

--- a/src/School/Transport/Controller/Api/V1/Course/CreateCourseController.php
+++ b/src/School/Transport/Controller/Api/V1/Course/CreateCourseController.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1\Course;
+
+use App\School\Application\Service\CreateCourseService;
+use App\School\Application\Service\SchoolApplicationScopeResolver;
+use App\School\Application\Service\SchoolCourseAttachmentUploaderService;
+use App\School\Transport\Controller\Api\V1\Input\CreateCourseInput;
+use App\School\Transport\Controller\Api\V1\Input\SchoolInputValidator;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function is_array;
+use function is_string;
+use function str_contains;
+use function trim;
+
+#[AsController]
+#[OA\Tag(name: 'School')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+final readonly class CreateCourseController
+{
+    public function __construct(
+        private SchoolApplicationScopeResolver $scopeResolver,
+        private CreateCourseService $createCourseService,
+        private SchoolInputValidator $inputValidator,
+        private SchoolCourseAttachmentUploaderService $attachmentUploader,
+    ) {
+    }
+
+    #[OA\Post(
+        path: '/v1/school/applications/{applicationSlug}/courses',
+        summary: 'Créer un cours avec contenu HTML et pièces jointes optionnelles',
+        tags: ['School'],
+        requestBody: new OA\RequestBody(
+            required: true,
+            content: [
+                new OA\MediaType(
+                    mediaType: 'application/json',
+                    schema: new OA\Schema(
+                        required: ['name', 'classId'],
+                        properties: [
+                            new OA\Property(property: 'name', type: 'string', example: 'Algorithmique avancée'),
+                            new OA\Property(property: 'classId', type: 'string', format: 'uuid'),
+                            new OA\Property(property: 'teacherId', type: 'string', format: 'uuid', nullable: true),
+                            new OA\Property(property: 'contentHtml', type: 'string', nullable: true, example: '<h2>Chapitre 1</h2><p>...</p>'),
+                        ],
+                    ),
+                ),
+                new OA\MediaType(
+                    mediaType: 'multipart/form-data',
+                    schema: new OA\Schema(
+                        required: ['name', 'classId'],
+                        properties: [
+                            new OA\Property(property: 'name', type: 'string'),
+                            new OA\Property(property: 'classId', type: 'string', format: 'uuid'),
+                            new OA\Property(property: 'teacherId', type: 'string', format: 'uuid', nullable: true),
+                            new OA\Property(property: 'contentHtml', type: 'string', nullable: true),
+                            new OA\Property(property: 'attachments[]', type: 'array', items: new OA\Items(type: 'string', format: 'binary')),
+                        ],
+                    ),
+                ),
+            ],
+        ),
+        responses: [
+            new OA\Response(response: 201, description: 'Cours créé'),
+            new OA\Response(response: 403, description: 'Forbidden', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError')),
+            new OA\Response(response: 404, description: 'Not found', content: new OA\JsonContent(ref: '#/components/schemas/SchoolError')),
+            new OA\Response(response: 422, description: 'Validation failed', content: new OA\JsonContent(ref: '#/components/schemas/SchoolValidationError')),
+        ],
+    )]
+    #[Route('/v1/school/applications/{applicationSlug}/courses', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/general/courses', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[Route('/v1/school/courses', methods: [Request::METHOD_POST], defaults: ['applicationSlug' => 'general'])]
+    #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
+    public function __invoke(string $applicationSlug, ?User $loggedInUser, Request $request): JsonResponse
+    {
+        $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
+        $payload = $this->extractPayload($request);
+
+        $input = new CreateCourseInput();
+        $input->name = (string)($payload['name'] ?? '');
+        $input->classId = is_string($payload['classId'] ?? null) ? $payload['classId'] : '';
+        $input->teacherId = is_string($payload['teacherId'] ?? null) ? $payload['teacherId'] : null;
+        $input->contentHtml = is_string($payload['contentHtml'] ?? null) ? $payload['contentHtml'] : null;
+
+        $validationResponse = $this->inputValidator->validate($input);
+        if ($validationResponse instanceof JsonResponse) {
+            return $validationResponse;
+        }
+
+        $uploadedAttachments = $this->attachmentUploader->upload(
+            $request,
+            $this->extractAttachments($request),
+            '/uploads/school/courses',
+        );
+
+        $course = $this->createCourseService->create(
+            $school,
+            $input->name,
+            $input->classId,
+            $input->teacherId,
+            $this->normalizeNullableString($input->contentHtml),
+            $uploadedAttachments,
+        );
+
+        return new JsonResponse([
+            'id' => $course->getId(),
+        ], JsonResponse::HTTP_CREATED);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractPayload(Request $request): array
+    {
+        $contentType = (string)$request->headers->get('Content-Type', '');
+
+        if (str_contains($contentType, 'multipart/form-data')) {
+            return $request->request->all();
+        }
+
+        return $request->toArray();
+    }
+
+    /**
+     * @return list<UploadedFile>
+     */
+    private function extractAttachments(Request $request): array
+    {
+        $attachments = $request->files->get('attachments');
+
+        if ($attachments instanceof UploadedFile) {
+            return [$attachments];
+        }
+
+        if (!is_array($attachments)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (mixed $file): ?UploadedFile => $file instanceof UploadedFile ? $file : null,
+            $attachments,
+        )));
+    }
+
+    private function normalizeNullableString(?string $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return $trimmed === '' ? null : $trimmed;
+    }
+}

--- a/src/School/Transport/Controller/Api/V1/Input/CreateCourseInput.php
+++ b/src/School/Transport/Controller/Api/V1/Input/CreateCourseInput.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Transport\Controller\Api\V1\Input;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateCourseInput
+{
+    #[Assert\NotBlank]
+    public string $name = '';
+
+    #[Assert\NotBlank]
+    #[Assert\Uuid]
+    public string $classId = '';
+
+    #[Assert\Uuid]
+    public ?string $teacherId = null;
+
+    public ?string $contentHtml = null;
+}

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolCreateReferenceValidationTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolCreateReferenceValidationTest.php
@@ -39,6 +39,16 @@ final class SchoolCreateReferenceValidationTest extends WebTestCase
         self::assertSame('SCHOOL_RELATION_NOT_FOUND', $payload['code']);
         self::assertSame([], $payload['details']);
 
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/courses', [], [], [], JSON::encode([
+            'name' => 'Cours invalide',
+            'classId' => self::UNKNOWN_UUID,
+        ]));
+        self::assertSame(Response::HTTP_NOT_FOUND, $client->getResponse()->getStatusCode());
+        $payload = $this->responsePayload($client);
+        self::assertSame('classId not found', $payload['message']);
+        self::assertSame('SCHOOL_RELATION_NOT_FOUND', $payload['code']);
+        self::assertSame([], $payload['details']);
+
         $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams', [], [], [], JSON::encode([
             'title' => 'Examen API',
             'classId' => self::UNKNOWN_UUID,
@@ -72,6 +82,17 @@ final class SchoolCreateReferenceValidationTest extends WebTestCase
 
         $campusClassId = $this->firstResourceId($client, '/v1/school/applications/school-campus-core/classes');
         $courseTeacherId = $this->firstResourceId($client, '/v1/school/applications/school-course-flow/teachers');
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/courses', [], [], [], JSON::encode([
+            'name' => 'Cours incoherent',
+            'classId' => $campusClassId,
+            'teacherId' => $courseTeacherId,
+        ]));
+        self::assertSame(Response::HTTP_UNPROCESSABLE_ENTITY, $client->getResponse()->getStatusCode());
+        $payload = $this->responsePayload($client);
+        self::assertSame('teacherId is not assigned to classId', $payload['message']);
+        self::assertSame('SCHOOL_RELATION_UNPROCESSABLE', $payload['code']);
+        self::assertSame([], $payload['details']);
 
         $client->request('POST', self::API_URL_PREFIX . '/v1/school/applications/school-campus-core/exams', [], [], [], JSON::encode([
             'title' => 'Examen incoherent',

--- a/tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php
+++ b/tests/Application/School/Transport/Controller/Api/V1/SchoolCrudValidationPaginationTest.php
@@ -112,6 +112,38 @@ final class SchoolCrudValidationPaginationTest extends WebTestCase
         self::assertSame(Response::HTTP_NO_CONTENT, $client->getResponse()->getStatusCode());
     }
 
+    #[TestDox('School general scope allows course creation with HTML content.')]
+    public function testSchoolGeneralCourseCreateRoute(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/school/general/classes?page=1&limit=1');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $classId = JSON::decode((string)$client->getResponse()->getContent(), true)['items'][0]['id'];
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/school/general/teachers?page=1&limit=1');
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $teacherId = JSON::decode((string)$client->getResponse()->getContent(), true)['items'][0]['id'];
+
+        $client->request('POST', self::API_URL_PREFIX . '/v1/school/general/courses', [], [], [], JSON::encode([
+            'name' => 'Course General API',
+            'classId' => $classId,
+            'teacherId' => $teacherId,
+            'contentHtml' => '<h2>Lesson</h2><p>Test content</p>',
+        ]));
+        self::assertSame(Response::HTTP_CREATED, $client->getResponse()->getStatusCode());
+        $courseId = JSON::decode((string)$client->getResponse()->getContent(), true)['id'];
+
+        $client->request('GET', self::API_URL_PREFIX . '/v1/school/general/courses/' . $courseId);
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        $courseDetail = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        self::assertSame('Course General API', $courseDetail['name']);
+        self::assertSame('<h2>Lesson</h2><p>Test content</p>', $courseDetail['contentHtml']);
+        self::assertArrayHasKey('attachments', $courseDetail);
+        self::assertIsArray($courseDetail['attachments']);
+    }
+
     #[TestDox('School general scope exposes courses listing and detail endpoints with rich payload.')]
     public function testSchoolGeneralCoursesListAndDetailRoutes(): void
     {

--- a/tests/Unit/School/Application/Serializer/SchoolViewMapperTest.php
+++ b/tests/Unit/School/Application/Serializer/SchoolViewMapperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\School\Application\Serializer;
 
 use App\School\Application\Serializer\SchoolViewMapper;
+use App\School\Domain\Entity\Course;
 use App\School\Domain\Entity\Exam;
 use App\School\Domain\Entity\SchoolClass;
 use App\School\Domain\Entity\Teacher;
@@ -32,5 +33,32 @@ final class SchoolViewMapperTest extends TestCase
         self::assertSame('FINAL', $result[0]['type']);
         self::assertSame('PUBLISHED', $result[0]['status']);
         self::assertSame('TERM_2', $result[0]['term']);
+    }
+
+    public function testMapCourseIncludesHtmlContentAndAttachments(): void
+    {
+        $schoolClass = (new SchoolClass())->setName('Classe B - Informatique');
+        $teacher = (new Teacher())->setName('M. Dupont');
+        $course = (new Course())
+            ->setName('Algorithmique avancée')
+            ->setSchoolClass($schoolClass)
+            ->setTeacher($teacher)
+            ->setContentHtml('<h2>Chapitre 1</h2><p>Introduction</p>')
+            ->setAttachments([
+                [
+                    'url' => '/uploads/school/courses/intro.pdf',
+                    'originalName' => 'intro.pdf',
+                    'mimeType' => 'application/pdf',
+                    'size' => 12345,
+                    'extension' => 'pdf',
+                    'uploadedAt' => '2026-01-15T08:15:00+00:00',
+                ],
+            ]);
+
+        $result = (new SchoolViewMapper())->mapCourse($course);
+
+        self::assertSame('<h2>Chapitre 1</h2><p>Introduction</p>', $result['contentHtml']);
+        self::assertCount(1, $result['attachments']);
+        self::assertSame('/uploads/school/courses/intro.pdf', $result['attachments'][0]['url']);
     }
 }


### PR DESCRIPTION
### Motivation

- Permettre la création de `Course` avec contenu HTML riche et pièces jointes afin d'enrichir le module School et les payloads retournés par les endpoints.
- Gérer l'upload sécurisé de fichiers (pdf/images/doc/ppt) pour les cours et normaliser les métadonnées d'attachement pour usage en front/back.

### Description

- Ajout d'un nouvel endpoint de création de cours `POST /v1/school/applications/{applicationSlug}/courses` avec alias `/v1/school/general/courses` et `/v1/school/courses`, supportant `application/json` et `multipart/form-data` (fichier(s) via `attachments[]`).
- Nouveau DTO d'entrée `CreateCourseInput` et contrôleur `CreateCourseController` qui valident le payload, gèrent l'upload et appellent le service métier.
- Nouveau service métier `CreateCourseService` qui résout les références, vérifie la cohérence `teacher/class`, persiste l'entité `Course` et dispatche l'événement `EntityCreated`.
- Nouveau service d'upload `SchoolCourseAttachmentUploaderService` reposant sur `MediaUploaderService` avec une politique de validation (extensions mime autorisées, taille maxi 20MB).
- Extension de l'entité `Course` pour stocker `content_html` (`TEXT`) et `attachments` (`JSON`) avec getters/setters et méthode `addAttachment`.
- Mise à jour du mapper `SchoolViewMapper::mapCourse()` pour exposer `contentHtml` et `attachments` dans les réponses API.
- Enrichissement des fixtures `LoadSchoolData` pour peupler les cours du scope `school-general-core` avec contenu HTML et exemples de pièces jointes.
- Ajout/extension de tests pour couvrir le mapping (`SchoolViewMapperTest`) et les validations/création de cours (tests d'intégration School existing tests étendus).

### Testing

- Syntaxe PHP vérifiée avec `php -l` sur les fichiers créés/modifiés et aucune erreur détectée (checks exécutés pour les nouveaux fichiers du module School).
- Tentative d'exécution des suites PHPunit ciblées a échoué dans cet environnement car `./vendor/bin/phpunit` est absent, donc les tests d'intégration unitaires n'ont pas été lancés ici.
- Les changements incluent des tests unitaires/functional ajoutés (voir `tests/Unit/School/...` et `tests/Application/School/...`) qui sont prêts à être exécutés dans CI où `vendor` est disponible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67ec511188326ba6b47adc92eb058)