### PR TITLE
Improve Google Calendar sync error propagation

### DIFF
--- a/src/Calendar/Application/Service/GoogleCalendarSyncService.php
+++ b/src/Calendar/Application/Service/GoogleCalendarSyncService.php
@@ -243,10 +243,42 @@ final readonly class GoogleCalendarSyncService
         }
 
         if ($status < 200 || $status >= 300) {
-            throw new HttpException(JsonResponse::HTTP_BAD_GATEWAY, 'Google Calendar request failed with status ' . $status . '.');
+            $googleMessage = $this->extractGoogleErrorMessage($data);
+            $message = 'Google Calendar request failed with status ' . $status . '.';
+            if ($googleMessage !== null) {
+                $message .= ' Google says: ' . $googleMessage;
+            }
+
+            $httpStatus = match ($status) {
+                JsonResponse::HTTP_UNAUTHORIZED,
+                JsonResponse::HTTP_FORBIDDEN,
+                JsonResponse::HTTP_NOT_FOUND => $status,
+                default => JsonResponse::HTTP_BAD_GATEWAY,
+            };
+
+            throw new HttpException($httpStatus, $message);
         }
 
         return is_array($data) ? $data : [];
+    }
+
+    private function extractGoogleErrorMessage(mixed $data): ?string
+    {
+        if (!is_array($data)) {
+            return null;
+        }
+
+        $error = $data['error'] ?? null;
+        if (!is_array($error)) {
+            return null;
+        }
+
+        $message = $error['message'] ?? null;
+        if (is_string($message) && trim($message) !== '') {
+            return trim($message);
+        }
+
+        return null;
     }
 
     private function parseGoogleDateTime(mixed $value): ?DateTimeImmutable

--- a/src/Calendar/Transport/Controller/Api/V1/Event/SyncPrivateGoogleEventController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/SyncPrivateGoogleEventController.php
@@ -39,6 +39,9 @@ use Throwable;
     responses: [
         new OA\Response(response: 200, description: 'Synchronisation terminée'),
         new OA\Response(response: 400, description: 'Payload invalide'),
+        new OA\Response(response: 401, description: 'Token Google invalide ou expiré'),
+        new OA\Response(response: 403, description: 'Permissions Google insuffisantes'),
+        new OA\Response(response: 404, description: 'Calendrier Google introuvable'),
         new OA\Response(response: 502, description: 'Erreur Google Calendar'),
     ]
 )]


### PR DESCRIPTION
### Motivation
- The sync code previously converted all non-2xx Google responses into a generic `502`, which hides useful Google error statuses and messages.
- Expose more precise failure semantics (e.g. invalid token, missing permissions, missing calendar) to help clients and debugging.

### Description
- Enhance `requestGoogle` to extract `error.message` from Google responses and append it to the thrown exception message when present.
- Preserve Google HTTP statuses `401`, `403` and `404` by mapping them through instead of always returning `502`, and keep other non-2xx responses as `502`.
- Add a new helper `extractGoogleErrorMessage` to parse the Google error payload.
- Update the OpenAPI annotations for the `/v1/calendar/private/events/google/sync` endpoint to list `401`, `403` and `404` responses.

### Testing
- Ran syntax checks with `php -l src/Calendar/Application/Service/GoogleCalendarSyncService.php` and `php -l src/Calendar/Transport/Controller/Api/V1/Event/SyncPrivateGoogleEventController.php`, both succeeded.
- No automated unit tests were added or run as part of this change; only the above static/syntax validations were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e698c2f778832685ce9e375342fc04)