### PR TITLE
Improve Google Calendar error handling and surface insufficient-scope warnings

### DIFF
--- a/src/Calendar/Application/Service/GoogleCalendarSyncService.php
+++ b/src/Calendar/Application/Service/GoogleCalendarSyncService.php
@@ -12,6 +12,7 @@ use App\User\Domain\Entity\User;
 use DateTimeImmutable;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Throwable;
 
@@ -33,12 +34,29 @@ final readonly class GoogleCalendarSyncService
         ?DateTimeImmutable $timeMax = null,
     ): array {
         $pulled = $this->pullGoogleEvents($user, $accessToken, $calendarId, $timeMin, $timeMax);
-        $pushed = $this->pushLocalEvents($user, $accessToken, $calendarId);
 
-        return [
+        $pushed = 0;
+        $warnings = [];
+        try {
+            $pushed = $this->pushLocalEvents($user, $accessToken, $calendarId);
+        } catch (HttpExceptionInterface $exception) {
+            if (!$this->isInsufficientScopeError($exception)) {
+                throw $exception;
+            }
+
+            $warnings[] = 'Google token does not include write scope. Local events were not pushed to Google Calendar.';
+        }
+
+        $result = [
             'pulledFromGoogle' => $pulled,
             'pushedToGoogle' => $pushed,
         ];
+
+        if ($warnings !== []) {
+            $result['warnings'] = $warnings;
+        }
+
+        return $result;
     }
 
     public function pushLocalEvent(Event $event): void
@@ -243,10 +261,51 @@ final readonly class GoogleCalendarSyncService
         }
 
         if ($status < 200 || $status >= 300) {
-            throw new HttpException(JsonResponse::HTTP_BAD_GATEWAY, 'Google Calendar request failed with status ' . $status . '.');
+            $googleMessage = $this->extractGoogleErrorMessage($data);
+            $message = 'Google Calendar request failed with status ' . $status . '.';
+            if ($googleMessage !== null) {
+                $message .= ' Google says: ' . $googleMessage;
+            }
+
+            $httpStatus = match ($status) {
+                JsonResponse::HTTP_UNAUTHORIZED,
+                JsonResponse::HTTP_FORBIDDEN,
+                JsonResponse::HTTP_NOT_FOUND => $status,
+                default => JsonResponse::HTTP_BAD_GATEWAY,
+            };
+
+            throw new HttpException($httpStatus, $message);
         }
 
         return is_array($data) ? $data : [];
+    }
+
+    private function extractGoogleErrorMessage(mixed $data): ?string
+    {
+        if (!is_array($data)) {
+            return null;
+        }
+
+        $error = $data['error'] ?? null;
+        if (!is_array($error)) {
+            return null;
+        }
+
+        $message = $error['message'] ?? null;
+        if (is_string($message) && trim($message) !== '') {
+            return trim($message);
+        }
+
+        return null;
+    }
+
+    private function isInsufficientScopeError(HttpExceptionInterface $exception): bool
+    {
+        if ($exception->getStatusCode() !== JsonResponse::HTTP_FORBIDDEN) {
+            return false;
+        }
+
+        return str_contains(strtolower($exception->getMessage()), 'insufficient authentication scopes');
     }
 
     private function parseGoogleDateTime(mixed $value): ?DateTimeImmutable

--- a/src/Calendar/Transport/Controller/Api/V1/Event/SyncPrivateGoogleEventController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/SyncPrivateGoogleEventController.php
@@ -39,6 +39,9 @@ use Throwable;
     responses: [
         new OA\Response(response: 200, description: 'Synchronisation terminée'),
         new OA\Response(response: 400, description: 'Payload invalide'),
+        new OA\Response(response: 401, description: 'Token Google invalide ou expiré'),
+        new OA\Response(response: 403, description: 'Permissions Google insuffisantes'),
+        new OA\Response(response: 404, description: 'Calendrier Google introuvable'),
         new OA\Response(response: 502, description: 'Erreur Google Calendar'),
     ]
 )]


### PR DESCRIPTION
### Motivation
- Improve robustness and observability when calling the Google Calendar API by surfacing Google's error messages in responses.
- Avoid failing a full bidirectional sync when the provided Google token lacks write scope, and instead return a warning while continuing to pull events.
- Make API documentation clearer by adding explicit OpenAPI responses for common Google error statuses.

### Description
- Update `GoogleCalendarSyncService::syncBidirectional` to catch `HttpExceptionInterface` from push operations and continue when the error is an insufficient-scope case, adding a warning instead of failing the whole sync.
- Add `extractGoogleErrorMessage` to parse and include Google's error message from response payloads, and change `requestGoogle` to map certain status codes (`401`, `403`, `404`) to corresponding HTTP responses instead of always returning `502` while appending Google's message when available.
- Add `isInsufficientScopeError` helper to detect the "insufficient authentication scopes" error and import `HttpExceptionInterface`.
- Extend OpenAPI responses in `SyncPrivateGoogleEventController` to include `401`, `403`, and `404` responses for clearer API documentation.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e698c2f778832685ce9e375342fc04)