### PR TITLE
calendar: default Google sync range to current year

### DIFF
--- a/src/Calendar/Application/Service/GoogleCalendarSyncService.php
+++ b/src/Calendar/Application/Service/GoogleCalendarSyncService.php
@@ -10,6 +10,7 @@ use App\Calendar\Domain\Enum\EventVisibility;
 use App\Calendar\Infrastructure\Repository\EventRepository;
 use App\User\Domain\Entity\User;
 use DateTimeImmutable;
+use DateTimeZone;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
@@ -33,6 +34,11 @@ final readonly class GoogleCalendarSyncService
         ?DateTimeImmutable $timeMin = null,
         ?DateTimeImmutable $timeMax = null,
     ): array {
+        if (!$timeMin instanceof DateTimeImmutable && !$timeMax instanceof DateTimeImmutable) {
+            $timeMin = new DateTimeImmutable('first day of january this year 00:00:00', new DateTimeZone('UTC'));
+            $timeMax = new DateTimeImmutable('last day of december this year 23:59:59', new DateTimeZone('UTC'));
+        }
+
         $pulled = $this->pullGoogleEvents($user, $accessToken, $calendarId, $timeMin, $timeMax);
 
         $pushed = 0;

--- a/tests/Unit/Calendar/Application/Service/GoogleCalendarSyncServiceTest.php
+++ b/tests/Unit/Calendar/Application/Service/GoogleCalendarSyncServiceTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Calendar\Application\Service;
+
+use App\Calendar\Application\Service\GoogleCalendarSyncService;
+use App\Calendar\Infrastructure\Repository\EventRepository;
+use App\User\Domain\Entity\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class GoogleCalendarSyncServiceTest extends TestCase
+{
+    public function testSyncBidirectionalUsesCurrentYearWindowWhenNoTimeRangeIsProvided(): void
+    {
+        $eventRepository = $this->createMock(EventRepository::class);
+        $eventRepository->expects(self::once())
+            ->method('findByUser')
+            ->willReturn([]);
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->expects(self::once())->method('getStatusCode')->willReturn(200);
+        $response->expects(self::once())->method('toArray')->with(false)->willReturn(['items' => []]);
+
+        $currentYear = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y');
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('request')
+            ->with(
+                'GET',
+                'https://www.googleapis.com/calendar/v3/calendars/primary/events',
+                self::callback(static function (array $options) use ($currentYear): bool {
+                    $query = $options['query'] ?? [];
+
+                    return ($query['timeMin'] ?? null) === sprintf('%s-01-01T00:00:00+00:00', $currentYear)
+                        && ($query['timeMax'] ?? null) === sprintf('%s-12-31T23:59:59+00:00', $currentYear);
+                }),
+            )
+            ->willReturn($response);
+
+        $service = new GoogleCalendarSyncService($eventRepository, $httpClient);
+
+        $user = $this->createMock(User::class);
+        $service->syncBidirectional($user, 'token');
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure Google Calendar bidirectional sync pulls a reasonable default window when the client omits `timeMin` and `timeMax`, namely the full current year in UTC.

### Description
- Set a default time window in `GoogleCalendarSyncService::syncBidirectional` to the start and end of the current UTC year when neither `timeMin` nor `timeMax` is provided (`YYYY-01-01T00:00:00+00:00` to `YYYY-12-31T23:59:59+00:00`).
- Add `DateTimeZone` import and use UTC when constructing the default `DateTimeImmutable` values.
- The default window is passed to the existing `pullGoogleEvents` call so remote pulls use the year-range by default.
- Add a unit test at `tests/Unit/Calendar/Application/Service/GoogleCalendarSyncServiceTest.php` that asserts the HTTP client request includes the `timeMin`/`timeMax` parameters for the current year.

### Testing
- Ran `php -l src/Calendar/Application/Service/GoogleCalendarSyncService.php` and `php -l tests/Unit/Calendar/Application/Service/GoogleCalendarSyncServiceTest.php` with no syntax errors.
- Added the unit test `tests/Unit/Calendar/Application/Service/GoogleCalendarSyncServiceTest.php` which verifies the default-year query parameters are sent to the Google API.
- Attempted to run `vendor/bin/phpunit tests/Unit/Calendar/Application/Service/GoogleCalendarSyncServiceTest.php` but PHPUnit is not available in this environment, so the test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e69eeb8a648326ae479fe1073c673b)