### PR TITLE
Calendar: restreindre /private/events à l'année en cours et étendre le pull Google

### DIFF
--- a/src/Calendar/Application/Service/EventListService.php
+++ b/src/Calendar/Application/Service/EventListService.php
@@ -10,6 +10,8 @@ use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
 use App\General\Domain\Service\Interfaces\MetricsCounterInterface;
 use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use DateTimeZone;
 use JsonException;
 use Psr\Cache\InvalidArgumentException;
 use Psr\Log\LoggerInterface;
@@ -46,6 +48,21 @@ final readonly class EventListService
     public function getByUser(User $user, array $filters = [], int $page = 1, int $limit = 20): array
     {
         return $this->getList('user', $filters, $page, $limit, $user, null);
+    }
+
+    /**
+     * @param array<string, string> $filters
+     *
+     * @return array<string, mixed>
+     * @throws InvalidArgumentException
+     * @throws JsonException
+     */
+    public function getByUserForCurrentYear(User $user, array $filters = [], int $page = 1, int $limit = 20): array
+    {
+        $yearStart = new DateTimeImmutable('first day of january this year 00:00:00', new DateTimeZone('UTC'));
+        $yearEnd = new DateTimeImmutable('last day of december this year 23:59:59', new DateTimeZone('UTC'));
+
+        return $this->getList('user', $filters, $page, $limit, $user, null, $yearStart, $yearEnd);
     }
 
     /**
@@ -92,7 +109,16 @@ final readonly class EventListService
      * @throws InvalidArgumentException
      * @throws JsonException
      */
-    private function getList(string $accessContext, array $filters, int $page, int $limit, ?User $user, ?string $applicationSlug): array
+    private function getList(
+        string $accessContext,
+        array $filters,
+        int $page,
+        int $limit,
+        ?User $user,
+        ?string $applicationSlug,
+        ?DateTimeImmutable $startAtFrom = null,
+        ?DateTimeImmutable $startAtTo = null,
+    ): array
     {
         $page = max(1, $page);
         $limit = max(1, min(100, $limit));
@@ -110,6 +136,8 @@ final readonly class EventListService
             'page' => $page,
             'limit' => $limit,
             'filters' => $filters,
+            'startAtFrom' => $startAtFrom?->format(DATE_ATOM),
+            'startAtTo' => $startAtTo?->format(DATE_ATOM),
         ];
 
         $cacheKey = $user !== null
@@ -117,7 +145,7 @@ final readonly class EventListService
             : 'event_list_' . md5((string)json_encode($cachePayload, JSON_THROW_ON_ERROR));
 
         /** @var array<string, mixed> $result */
-        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($accessContext, $user, $applicationSlug, $filters, $page, $limit): array {
+        $result = $this->cache->get($cacheKey, function (ItemInterface $item) use ($accessContext, $user, $applicationSlug, $filters, $page, $limit, $startAtFrom, $startAtTo): array {
             $item->expiresAfter(120);
             if ($user !== null && method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->tagPrivateEvents($user->getId()));
@@ -140,8 +168,8 @@ final readonly class EventListService
             }
 
             if ($accessContext === 'user') {
-                $events = $this->eventRepository->findByUser($user, $filters, $page, $limit, $esIds);
-                $totalItems = $this->eventRepository->countByUser($user, $filters, $esIds);
+                $events = $this->eventRepository->findByUser($user, $filters, $page, $limit, $esIds, $startAtFrom, $startAtTo);
+                $totalItems = $this->eventRepository->countByUser($user, $filters, $esIds, $startAtFrom, $startAtTo);
             } elseif ($accessContext === 'application_private') {
                 $events = $this->eventRepository->findByApplicationSlugAndUser($applicationSlug, $user, $filters, $page, $limit, $esIds);
                 $totalItems = $this->eventRepository->countByApplicationSlugAndUser($applicationSlug, $user, $filters, $esIds);

--- a/src/Calendar/Application/Service/GoogleCalendarSyncService.php
+++ b/src/Calendar/Application/Service/GoogleCalendarSyncService.php
@@ -36,7 +36,6 @@ final readonly class GoogleCalendarSyncService
     ): array {
         if (!$timeMin instanceof DateTimeImmutable && !$timeMax instanceof DateTimeImmutable) {
             $timeMin = new DateTimeImmutable('first day of january this year 00:00:00', new DateTimeZone('UTC'));
-            $timeMax = new DateTimeImmutable('last day of december this year 23:59:59', new DateTimeZone('UTC'));
         }
 
         $pulled = $this->pullGoogleEvents($user, $accessToken, $calendarId, $timeMin, $timeMax);

--- a/src/Calendar/Domain/Repository/Interfaces/EventRepositoryInterface.php
+++ b/src/Calendar/Domain/Repository/Interfaces/EventRepositoryInterface.php
@@ -6,15 +6,30 @@ namespace App\Calendar\Domain\Repository\Interfaces;
 
 use App\Calendar\Domain\Entity\Event;
 use App\User\Domain\Entity\User;
+use DateTimeImmutable;
 
 interface EventRepositoryInterface
 {
     /**
      * @return array<int, Event>
      */
-    public function findByUser(User $user, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array;
+    public function findByUser(
+        User $user,
+        array $filters = [],
+        int $page = 1,
+        int $limit = 20,
+        ?array $esIds = null,
+        ?DateTimeImmutable $startAtFrom = null,
+        ?DateTimeImmutable $startAtTo = null,
+    ): array;
 
-    public function countByUser(User $user, array $filters = [], ?array $esIds = null): int;
+    public function countByUser(
+        User $user,
+        array $filters = [],
+        ?array $esIds = null,
+        ?DateTimeImmutable $startAtFrom = null,
+        ?DateTimeImmutable $startAtTo = null,
+    ): int;
 
     /**
      * @return array<int, Event>

--- a/src/Calendar/Infrastructure/Repository/EventRepository.php
+++ b/src/Calendar/Infrastructure/Repository/EventRepository.php
@@ -53,11 +53,23 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
         return $event;
     }
 
-    public function findByUser(User $user, array $filters = [], int $page = 1, int $limit = 20, ?array $esIds = null): array
+    public function findByUser(
+        User $user,
+        array $filters = [],
+        int $page = 1,
+        int $limit = 20,
+        ?array $esIds = null,
+        ?DateTimeImmutable $startAtFrom = null,
+        ?DateTimeImmutable $startAtTo = null,
+    ): array
     {
         $offset = max(0, ($page - 1) * $limit);
 
-        return $this->applyListFilters($this->createBaseQueryBuilder(), $filters, $esIds)
+        return $this->applyTimeWindow(
+            $this->applyListFilters($this->createBaseQueryBuilder(), $filters, $esIds),
+            $startAtFrom,
+            $startAtTo,
+        )
             ->andWhere('event.user = :user OR calendar.user = :user')
             ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
             ->orderBy('event.startAt', 'ASC')
@@ -67,9 +79,19 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
             ->getResult();
     }
 
-    public function countByUser(User $user, array $filters = [], ?array $esIds = null): int
+    public function countByUser(
+        User $user,
+        array $filters = [],
+        ?array $esIds = null,
+        ?DateTimeImmutable $startAtFrom = null,
+        ?DateTimeImmutable $startAtTo = null,
+    ): int
     {
-        return (int)$this->applyListFilters($this->createCountQueryBuilder(), $filters, $esIds)
+        return (int)$this->applyTimeWindow(
+            $this->applyListFilters($this->createCountQueryBuilder(), $filters, $esIds),
+            $startAtFrom,
+            $startAtTo,
+        )
             ->andWhere('event.user = :user OR calendar.user = :user')
             ->setParameter('user', $user->getId(), UuidBinaryOrderedTimeType::NAME)
             ->getQuery()
@@ -207,6 +229,26 @@ class EventRepository extends BaseRepository implements EventRepositoryInterface
             $queryBuilder
                 ->andWhere('LOWER(event.location) LIKE LOWER(:location)')
                 ->setParameter('location', '%' . $filters['location'] . '%');
+        }
+
+        return $queryBuilder;
+    }
+
+    private function applyTimeWindow(
+        QueryBuilder $queryBuilder,
+        ?DateTimeImmutable $startAtFrom,
+        ?DateTimeImmutable $startAtTo,
+    ): QueryBuilder {
+        if ($startAtFrom instanceof DateTimeImmutable) {
+            $queryBuilder
+                ->andWhere('event.startAt >= :startAtFrom')
+                ->setParameter('startAtFrom', $startAtFrom);
+        }
+
+        if ($startAtTo instanceof DateTimeImmutable) {
+            $queryBuilder
+                ->andWhere('event.startAt <= :startAtTo')
+                ->setParameter('startAtTo', $startAtTo);
         }
 
         return $queryBuilder;

--- a/src/Calendar/Transport/Controller/Api/V1/Event/UserEventListController.php
+++ b/src/Calendar/Transport/Controller/Api/V1/Event/UserEventListController.php
@@ -59,6 +59,6 @@ readonly class UserEventListController
             'location' => trim((string)$request->query->get('location', '')),
         ];
 
-        return new JsonResponse($this->eventListService->getByUser($loggedInUser, $filters, $page, $limit));
+        return new JsonResponse($this->eventListService->getByUserForCurrentYear($loggedInUser, $filters, $page, $limit));
     }
 }

--- a/tests/Unit/Calendar/Application/Service/EventListServiceTest.php
+++ b/tests/Unit/Calendar/Application/Service/EventListServiceTest.php
@@ -88,8 +88,8 @@ final class EventListServiceTest extends TestCase
     {
         $user = $this->mockUser();
         $repo = $this->createMock(EventRepositoryInterface::class);
-        $repo->expects(self::once())->method('findByUser')->with(self::anything(), self::anything(), 1, 20, null)->willReturn([]);
-        $repo->expects(self::once())->method('countByUser')->with(self::anything(), self::anything(), null)->willReturn(0);
+        $repo->expects(self::once())->method('findByUser')->with(self::anything(), self::anything(), 1, 20, null, null, null)->willReturn([]);
+        $repo->expects(self::once())->method('countByUser')->with(self::anything(), self::anything(), null, null, null)->willReturn(0);
 
         $elastic = $this->createMock(ElasticsearchServiceInterface::class);
         $elastic->expects(self::once())->method('search')->willThrowException(new \RuntimeException('ES down'));
@@ -122,8 +122,8 @@ final class EventListServiceTest extends TestCase
     {
         $user = $this->mockUser();
         $repo = $this->createMock(EventRepositoryInterface::class);
-        $repo->expects(self::once())->method('findByUser')->with(self::anything(), self::anything(), 2, 20, null)->willReturn([]);
-        $repo->expects(self::once())->method('countByUser')->with(self::anything(), self::anything(), null)->willReturn(1450);
+        $repo->expects(self::once())->method('findByUser')->with(self::anything(), self::anything(), 2, 20, null, null, null)->willReturn([]);
+        $repo->expects(self::once())->method('countByUser')->with(self::anything(), self::anything(), null, null, null)->willReturn(1450);
 
         $elastic = $this->createMock(ElasticsearchServiceInterface::class);
         $elastic->expects(self::once())->method('search')->willReturn([
@@ -275,6 +275,45 @@ final class EventListServiceTest extends TestCase
         $service->getByUser($user, [
             'title' => 'foo',
         ], 1, 20);
+    }
+
+    public function testGetByUserForCurrentYearAppliesYearBoundaries(): void
+    {
+        $user = $this->mockUser();
+        $repo = $this->createMock(EventRepositoryInterface::class);
+        $repo->expects(self::once())
+            ->method('findByUser')
+            ->with(
+                self::anything(),
+                self::anything(),
+                1,
+                20,
+                null,
+                self::callback(static fn ($value): bool => $value instanceof \DateTimeImmutable && $value->format(DATE_ATOM) === (new \DateTimeImmutable('first day of january this year 00:00:00', new \DateTimeZone('UTC')))->format(DATE_ATOM)),
+                self::callback(static fn ($value): bool => $value instanceof \DateTimeImmutable && $value->format(DATE_ATOM) === (new \DateTimeImmutable('last day of december this year 23:59:59', new \DateTimeZone('UTC')))->format(DATE_ATOM)),
+            )
+            ->willReturn([]);
+        $repo->expects(self::once())
+            ->method('countByUser')
+            ->willReturn(0);
+
+        $elastic = $this->createMock(ElasticsearchServiceInterface::class);
+
+        $item = $this->createMock(ItemInterface::class);
+        $item->expects(self::once())->method('expiresAfter')->with(120);
+
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects(self::once())->method('get')->willReturnCallback(static function (string $key, callable $callback) use ($item): array {
+            return $callback($item);
+        });
+
+        $cacheKeyConvention = $this->createMock(CacheKeyConventionService::class);
+        $cacheKeyConvention->expects(self::once())->method('buildPrivateEventKey')->willReturn('private_event_key');
+        $cacheKeyConvention->expects(self::never())->method('tagPrivateEvents');
+        $cacheKeyConvention->expects(self::never())->method('tagPublicEventsByApplication');
+
+        $service = new EventListService($repo, $cache, $elastic, $cacheKeyConvention, $this->createMock(LoggerInterface::class), $this->createMock(MetricsCounterInterface::class));
+        $service->getByUserForCurrentYear($user, [], 1, 20);
     }
 
     private function mockUser(): User

--- a/tests/Unit/Calendar/Application/Service/GoogleCalendarSyncServiceTest.php
+++ b/tests/Unit/Calendar/Application/Service/GoogleCalendarSyncServiceTest.php
@@ -36,7 +36,7 @@ final class GoogleCalendarSyncServiceTest extends TestCase
                     $query = $options['query'] ?? [];
 
                     return ($query['timeMin'] ?? null) === sprintf('%s-01-01T00:00:00+00:00', $currentYear)
-                        && ($query['timeMax'] ?? null) === sprintf('%s-12-31T23:59:59+00:00', $currentYear);
+                        && !isset($query['timeMax']);
                 }),
             )
             ->willReturn($response);


### PR DESCRIPTION
### Motivation
- Restreindre `GET /v1/calendar/private/events` pour qu'il retourne seulement les événements de l'année en cours afin de réduire le scope des listes privées.
- Lors de la synchronisation Google, permettre le pull d'événements futurs en ne limitant plus la borne haute par défaut pour inclure les événements à venir.

### Description
- Ajout de `EventListService::getByUserForCurrentYear(...)` et branchement du contrôleur `UserEventListController` pour appeler cette méthode à la place de `getByUser` pour l'endpoint privé `GET /v1/calendar/private/events`.
- Ajout d'une fenêtre temporelle optionnelle (`startAtFrom` / `startAtTo`) propagée de `EventListService` vers le repository pour filtrer `event.startAt` et incluse dans la clé de cache pour éviter les collisions de cache.
- Extension de l'interface `EventRepositoryInterface` et implémentation Doctrine `EventRepository` pour accepter les bornes temporelles optionnelles et application via la nouvelle méthode `applyTimeWindow(...)` qui ajoute `event.startAt >=` / `<=`.
- Modification de `GoogleCalendarSyncService::syncBidirectional(...)` pour ne plus définir une `timeMax` par défaut (seule `timeMin` par défaut au 1er janvier UTC de l'année courante est conservée), afin d'inclure les événements futurs lors du pull depuis Google.

### Testing
- Les fichiers modifiés ont été vérifiés avec `php -l` et n'affichent pas d'erreurs de syntaxe (`php -l` sur les fichiers listés : OK).
- Les tests unitaires concernés ont été mis à jour (`tests/Unit/Calendar/...`) pour prendre en compte la nouvelle signature repository et le comportement annuel et Google, mais l'exécution de `./vendor/bin/phpunit ...` a échoué dans cet environnement car `vendor/bin/phpunit` est absent.
- Les assertions unitaires éditées couvrent la pagination/caching existants et ajoutent une vérification que `getByUserForCurrentYear` transmet bien les bornes annuelles au repository et que la requête Google n'inclut plus `timeMax` par défaut.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6a39816a88326a2952b74fc07f405)