### PR TITLE
feat(blog): add Mercure notifications for reactions/comments and blog changes

### DIFF
--- a/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogCommentCommandHandler.php
@@ -78,6 +78,15 @@ final readonly class CreateBlogCommentCommandHandler
 
         $this->commentRepository->save($comment);
         $this->blogNotificationService->notifyCommentCreated($comment);
+        $this->blogNotificationService->publishBlogEvent(
+            $post,
+            $command->parentCommentId === null ? 'blog.comment.created' : 'blog.comment.reply.created',
+            [
+                'commentId' => $comment->getId(),
+                'parentCommentId' => $comment->getParent()?->getId(),
+                'actorUserId' => $user->getId(),
+            ],
+        );
 
         $affectedUserIds = array_values(array_filter(array_unique([
             $command->actorUserId,

--- a/src/Blog/Application/MessageHandler/CreateBlogPostCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogPostCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Application\MessageHandler;
 
 use App\Blog\Application\Message\CreateBlogPostCommand;
+use App\Blog\Application\Service\BlogNotificationService;
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
@@ -27,6 +28,7 @@ final readonly class CreateBlogPostCommandHandler
         private BlogPostRepository $postRepository,
         private BlogRepository $blogRepository,
         private UserRepository $userRepository,
+        private BlogNotificationService $blogNotificationService,
         private CacheInvalidationService $cacheInvalidationService,
     ) {
     }
@@ -81,6 +83,10 @@ final readonly class CreateBlogPostCommandHandler
             ->setSharedUrl($command->sharedUrl)
             ->setParentPost($parentPost)
             ->setIsPinned($command->isPinned));
+        $this->blogNotificationService->publishBlogEvent($post, 'blog.post.created', [
+            'actorUserId' => $user->getId(),
+            'parentPostId' => $parentPost?->getId(),
+        ]);
 
         $affectedUserIds = array_values(array_filter(array_unique([$command->actorUserId, $blog->getOwner()->getId(), $parentPost?->getAuthor()->getId()]), static fn (?string $userId): bool => $userId !== null && $userId !== ''));
         $this->cacheInvalidationService->invalidateBlogCaches($blog->getApplication()?->getSlug(), $affectedUserIds);

--- a/src/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogPostReactionCommandHandler.php
@@ -55,6 +55,11 @@ final readonly class CreateBlogPostReactionCommandHandler
         if ($existingReaction instanceof BlogReaction) {
             $existingReaction->setType($command->type);
             $this->reactionRepository->save($existingReaction);
+            $this->blogNotificationService->publishBlogEvent($post, 'blog.post.reaction.updated', [
+                'reactionId' => $existingReaction->getId(),
+                'reactionType' => $command->type->value,
+                'actorUserId' => $user->getId(),
+            ]);
 
             $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
 
@@ -86,6 +91,11 @@ final readonly class CreateBlogPostReactionCommandHandler
 
             $existingReaction->setType($command->type);
             $this->reactionRepository->save($existingReaction);
+            $this->blogNotificationService->publishBlogEvent($post, 'blog.post.reaction.updated', [
+                'reactionId' => $existingReaction->getId(),
+                'reactionType' => $command->type->value,
+                'actorUserId' => $user->getId(),
+            ]);
 
             $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
 
@@ -93,6 +103,11 @@ final readonly class CreateBlogPostReactionCommandHandler
         }
 
         $this->blogNotificationService->notifyPostReactionCreated($post, $user, $command->type->value);
+        $this->blogNotificationService->publishBlogEvent($post, 'blog.post.reaction.created', [
+            'reactionId' => $reaction->getId(),
+            'reactionType' => $command->type->value,
+            'actorUserId' => $user->getId(),
+        ]);
         $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
 
         return $reaction->getId();

--- a/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogReactionCommandHandler.php
@@ -57,6 +57,12 @@ final readonly class CreateBlogReactionCommandHandler
         if ($existingReaction instanceof BlogReaction) {
             $existingReaction->setType($command->type);
             $this->reactionRepository->save($existingReaction);
+            $this->blogNotificationService->publishBlogEvent($comment->getPost(), 'blog.comment.reaction.updated', [
+                'reactionId' => $existingReaction->getId(),
+                'commentId' => $comment->getId(),
+                'reactionType' => $command->type->value,
+                'actorUserId' => $user->getId(),
+            ]);
 
             $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
 
@@ -88,6 +94,12 @@ final readonly class CreateBlogReactionCommandHandler
 
             $existingReaction->setType($command->type);
             $this->reactionRepository->save($existingReaction);
+            $this->blogNotificationService->publishBlogEvent($comment->getPost(), 'blog.comment.reaction.updated', [
+                'reactionId' => $existingReaction->getId(),
+                'commentId' => $comment->getId(),
+                'reactionType' => $command->type->value,
+                'actorUserId' => $user->getId(),
+            ]);
 
             $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
 
@@ -95,6 +107,12 @@ final readonly class CreateBlogReactionCommandHandler
         }
 
         $this->blogNotificationService->notifyReactionCreated($comment, $user, $command->type->value);
+        $this->blogNotificationService->publishBlogEvent($comment->getPost(), 'blog.comment.reaction.created', [
+            'reactionId' => $reaction->getId(),
+            'commentId' => $comment->getId(),
+            'reactionType' => $command->type->value,
+            'actorUserId' => $user->getId(),
+        ]);
         $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
 
         return $reaction->getId();

--- a/src/Blog/Application/MessageHandler/DeleteBlogCommentCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/DeleteBlogCommentCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Application\MessageHandler;
 
 use App\Blog\Application\Message\DeleteBlogCommentCommand;
+use App\Blog\Application\Service\BlogNotificationService;
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Infrastructure\Repository\BlogCommentRepository;
 use App\General\Application\Service\CacheInvalidationService;
@@ -19,6 +20,7 @@ final readonly class DeleteBlogCommentCommandHandler
 {
     public function __construct(
         private BlogCommentRepository $commentRepository,
+        private BlogNotificationService $blogNotificationService,
         private CacheInvalidationService $cacheInvalidationService
     ) {
     }
@@ -40,6 +42,11 @@ final readonly class DeleteBlogCommentCommandHandler
         }
 
         $applicationSlug = $comment->getPost()->getBlog()->getApplication()?->getSlug();
+        $this->blogNotificationService->publishBlogEvent($comment->getPost(), 'blog.comment.deleted', [
+            'commentId' => $comment->getId(),
+            'parentCommentId' => $comment->getParent()?->getId(),
+            'actorUserId' => $command->actorUserId,
+        ]);
         $this->commentRepository->remove($comment);
         $affectedUserIds = array_values(array_filter(array_unique([$command->actorUserId, $comment->getAuthor()->getId(), $comment->getPost()->getAuthor()->getId(), $comment->getParent()?->getAuthor()->getId()]), static fn (?string $userId): bool => $userId !== null && $userId !== ''));
         $this->cacheInvalidationService->invalidateBlogCaches($applicationSlug, $affectedUserIds);

--- a/src/Blog/Application/MessageHandler/DeleteBlogPostCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/DeleteBlogPostCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Application\MessageHandler;
 
 use App\Blog\Application\Message\DeleteBlogPostCommand;
+use App\Blog\Application\Service\BlogNotificationService;
 use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
 use App\General\Application\Service\CacheInvalidationService;
@@ -19,6 +20,7 @@ final readonly class DeleteBlogPostCommandHandler
 {
     public function __construct(
         private BlogPostRepository $postRepository,
+        private BlogNotificationService $blogNotificationService,
         private CacheInvalidationService $cacheInvalidationService
     ) {
     }
@@ -40,6 +42,10 @@ final readonly class DeleteBlogPostCommandHandler
         }
 
         $applicationSlug = $post->getBlog()->getApplication()?->getSlug();
+        $this->blogNotificationService->publishBlogEvent($post, 'blog.post.deleted', [
+            'actorUserId' => $command->actorUserId,
+            'deletedPostId' => $post->getId(),
+        ]);
         $this->postRepository->remove($post);
         $affectedUserIds = array_values(array_filter(array_unique([$command->actorUserId, $post->getAuthor()->getId()]), static fn (?string $userId): bool => $userId !== null && $userId !== ''));
         $this->cacheInvalidationService->invalidateBlogCaches($applicationSlug, $affectedUserIds);

--- a/src/Blog/Application/MessageHandler/DeleteBlogReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/DeleteBlogReactionCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Application\MessageHandler;
 
 use App\Blog\Application\Message\DeleteBlogReactionCommand;
+use App\Blog\Application\Service\BlogNotificationService;
 use App\Blog\Domain\Entity\BlogReaction;
 use App\Blog\Infrastructure\Repository\BlogReactionRepository;
 use App\General\Application\Service\CacheInvalidationService;
@@ -19,6 +20,7 @@ final readonly class DeleteBlogReactionCommandHandler
 {
     public function __construct(
         private BlogReactionRepository $reactionRepository,
+        private BlogNotificationService $blogNotificationService,
         private CacheInvalidationService $cacheInvalidationService
     ) {
     }
@@ -39,7 +41,15 @@ final readonly class DeleteBlogReactionCommandHandler
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'Only reaction owner can delete.');
         }
 
-        $applicationSlug = $reaction->getPost()?->getBlog()->getApplication()?->getSlug();
+        $post = $reaction->getPost() ?? $reaction->getComment()?->getPost();
+        $applicationSlug = $post?->getBlog()->getApplication()?->getSlug();
+        if ($post !== null) {
+            $this->blogNotificationService->publishBlogEvent($post, 'blog.reaction.deleted', [
+                'reactionId' => $reaction->getId(),
+                'commentId' => $reaction->getComment()?->getId(),
+                'actorUserId' => $command->actorUserId,
+            ]);
+        }
         $this->reactionRepository->remove($reaction);
         $affectedUserIds = array_values(array_filter(array_unique([$command->actorUserId, $reaction->getAuthor()->getId(), $reaction->getPost()?->getAuthor()->getId(), $reaction->getComment()?->getAuthor()->getId(), $reaction->getComment()?->getParent()?->getAuthor()->getId()]), static fn (?string $userId): bool => $userId !== null && $userId !== ''));
         $this->cacheInvalidationService->invalidateBlogCaches($applicationSlug, $affectedUserIds);

--- a/src/Blog/Application/MessageHandler/PatchBlogCommentCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/PatchBlogCommentCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Application\MessageHandler;
 
 use App\Blog\Application\Message\PatchBlogCommentCommand;
+use App\Blog\Application\Service\BlogNotificationService;
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Infrastructure\Repository\BlogCommentRepository;
 use App\General\Application\Service\CacheInvalidationService;
@@ -19,6 +20,7 @@ final readonly class PatchBlogCommentCommandHandler
 {
     public function __construct(
         private BlogCommentRepository $commentRepository,
+        private BlogNotificationService $blogNotificationService,
         private CacheInvalidationService $cacheInvalidationService
     ) {
     }
@@ -44,6 +46,11 @@ final readonly class PatchBlogCommentCommandHandler
             ->setFilePath($command->filePath);
 
         $this->commentRepository->save($comment);
+        $this->blogNotificationService->publishBlogEvent($comment->getPost(), 'blog.comment.updated', [
+            'commentId' => $comment->getId(),
+            'parentCommentId' => $comment->getParent()?->getId(),
+            'actorUserId' => $command->actorUserId,
+        ]);
         $affectedUserIds = array_values(array_filter(array_unique([$command->actorUserId, $comment->getAuthor()->getId(), $comment->getPost()->getAuthor()->getId(), $comment->getParent()?->getAuthor()->getId()]), static fn (?string $userId): bool => $userId !== null && $userId !== ''));
         $this->cacheInvalidationService->invalidateBlogCaches($comment->getPost()->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
     }

--- a/src/Blog/Application/MessageHandler/PatchBlogPostCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/PatchBlogPostCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Application\MessageHandler;
 
 use App\Blog\Application\Message\PatchBlogPostCommand;
+use App\Blog\Application\Service\BlogNotificationService;
 use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
 use App\General\Application\Service\CacheInvalidationService;
@@ -19,6 +20,7 @@ final readonly class PatchBlogPostCommandHandler
 {
     public function __construct(
         private BlogPostRepository $postRepository,
+        private BlogNotificationService $blogNotificationService,
         private CacheInvalidationService $cacheInvalidationService
     ) {
     }
@@ -61,6 +63,9 @@ final readonly class PatchBlogPostCommandHandler
         }
 
         $this->postRepository->save($post);
+        $this->blogNotificationService->publishBlogEvent($post, 'blog.post.updated', [
+            'actorUserId' => $command->actorUserId,
+        ]);
         $affectedUserIds = array_values(array_filter(array_unique([$command->actorUserId, $post->getAuthor()->getId()]), static fn (?string $userId): bool => $userId !== null && $userId !== ''));
         $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
     }

--- a/src/Blog/Application/MessageHandler/PatchBlogReactionCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/PatchBlogReactionCommandHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Application\MessageHandler;
 
 use App\Blog\Application\Message\PatchBlogReactionCommand;
+use App\Blog\Application\Service\BlogNotificationService;
 use App\Blog\Domain\Entity\BlogReaction;
 use App\Blog\Infrastructure\Repository\BlogReactionRepository;
 use App\General\Application\Service\CacheInvalidationService;
@@ -19,6 +20,7 @@ final readonly class PatchBlogReactionCommandHandler
 {
     public function __construct(
         private BlogReactionRepository $reactionRepository,
+        private BlogNotificationService $blogNotificationService,
         private CacheInvalidationService $cacheInvalidationService
     ) {
     }
@@ -41,7 +43,15 @@ final readonly class PatchBlogReactionCommandHandler
 
         $reaction->setType($command->type);
         $this->reactionRepository->save($reaction);
-        $post = $reaction->getPost();
+        $post = $reaction->getPost() ?? $reaction->getComment()?->getPost();
+        if ($post !== null) {
+            $this->blogNotificationService->publishBlogEvent($post, 'blog.reaction.updated', [
+                'reactionId' => $reaction->getId(),
+                'reactionType' => $reaction->getType()->value,
+                'commentId' => $reaction->getComment()?->getId(),
+                'actorUserId' => $command->actorUserId,
+            ]);
+        }
         $affectedUserIds = array_values(array_filter(array_unique([$command->actorUserId, $reaction->getAuthor()->getId(), $post?->getAuthor()->getId(), $reaction->getComment()?->getAuthor()->getId(), $reaction->getComment()?->getParent()?->getAuthor()->getId()]), static fn (?string $userId): bool => $userId !== null && $userId !== ''));
         $this->cacheInvalidationService->invalidateBlogCaches($post?->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
     }

--- a/src/Blog/Application/Service/BlogNotificationService.php
+++ b/src/Blog/Application/Service/BlogNotificationService.php
@@ -6,9 +6,11 @@ namespace App\Blog\Application\Service;
 
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Domain\Entity\BlogPost;
+use App\General\Application\Service\MercurePublisher;
 use App\Notification\Application\Service\NotificationPublisher;
 use App\User\Domain\Entity\User;
 
+use DateTimeImmutable;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
 use JsonException;
@@ -18,10 +20,35 @@ use function trim;
 final readonly class BlogNotificationService
 {
     public const string BLOG_NOTIFICATION_TYPE = 'blog_notification';
+    public const string BLOG_EVENT_TYPE = 'blog_event';
 
     public function __construct(
-        private NotificationPublisher $notificationPublisher
+        private NotificationPublisher $notificationPublisher,
+        private MercurePublisher $mercurePublisher,
     ) {
+    }
+
+    /**
+     * @param array<string, mixed> $extra
+     * @throws JsonException
+     */
+    public function publishBlogEvent(BlogPost $post, string $event, array $extra = []): void
+    {
+        $blog = $post->getBlog();
+        $scope = $blog->getApplication()?->getSlug() ?? 'general';
+        $payload = array_merge([
+            'type' => self::BLOG_EVENT_TYPE,
+            'event' => $event,
+            'blogId' => $blog->getId(),
+            'blogSlug' => $blog->getSlug(),
+            'scope' => $scope,
+            'postId' => $post->getId(),
+            'occurredAt' => (new DateTimeImmutable())->format(DATE_ATOM),
+        ], $extra);
+
+        $this->mercurePublisher->publish('/blogs/' . $blog->getId() . '/events', $payload);
+        $this->mercurePublisher->publish('/blogs/scopes/' . $scope . '/events', $payload);
+        $this->mercurePublisher->publish('/blogs/' . $blog->getId() . '/posts/' . $post->getId() . '/events', $payload);
     }
 
     public function notifyCommentCreated(BlogComment $comment): void


### PR DESCRIPTION
### Motivation
- Fournir des notifications temps réel via Mercure pour toutes les mutations du blog (post, comment, reaction) afin que le front (Nuxt) puisse se mettre à jour sans polling.
- Centraliser et standardiser le format des événements envoyés pour faciliter l'abonnement côté client et la normalisation des payloads.

### Description
- Ajout de la méthode `publishBlogEvent()` dans `BlogNotificationService` qui construit un payload standard (`type`, `event`, `blogId`, `blogSlug`, `scope`, `postId`, `occurredAt`, ...) et publie sur trois topics: `/blogs/{blogId}/events`, `/blogs/scopes/{scope}/events`, et `/blogs/{blogId}/posts/{postId}/events` via `MercurePublisher`.
- Injection de `MercurePublisher` dans `BlogNotificationService` et définition d'un nouveau `BLOG_EVENT_TYPE` constant.
- Appels à `publishBlogEvent()` ajoutés dans les handlers concernés pour publier des événements sur: post créé/modifié/supprimé, commentaire créé/réponse/modifié/supprimé, et réaction créée/modifiée/supprimée (pour post et commentaire), avec des champs d’événement spécifiques (`reactionId`, `commentId`, `actorUserId`, ...).
- Ajustements mineurs dans handlers pour retrouver le `post` quand une réaction appartient à un commentaire, et usage de `DateTimeImmutable` pour `occurredAt`.
- Fichiers modifiés principaux: `BlogNotificationService.php` et plusieurs MessageHandler sous `src/Blog/Application/MessageHandler/` (création, patch et suppression pour posts/comments/reactions).

### Testing
- Lint PHP: `php -l` exécuté sur les fichiers modifiés (service + handlers) et toutes les vérifications de syntaxe sont passées avec succès.
- Aucune autre suite de tests automatisés (unit/integration) n'a été lancée dans ce patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7eae156f883269f750b48fd3f8604)