### PR TITLE
feat(tool): add `app:warmup:public-endpoints` command with strict warmup pipeline

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -31,6 +31,7 @@ services:
             $elasticNumberOfReplicas: '%env(int:ELASTICSEARCH_NUMBER_OF_REPLICAS)%'
             $lockUserOnLoginFailureAttempts: '%env(int:LOCK_USER_ON_LOGIN_FAILURE_ATTEMPTS)%'
             $jwtBindClientFingerprint: '%env(bool:JWT_BIND_CLIENT_FINGERPRINT)%'
+            $warmupPublicEndpointsBaseUrl: '%env(default:DEFAULT_URI:APP_WARMUP_PUBLIC_ENDPOINTS_BASE_URL)%'
     _instanceof:
         App\General\Application\Rest\Interfaces\RestResourceInterface:
             tags: [ 'app.rest.resource', 'app.stopwatch' ]

--- a/src/Tool/Application/Service/Elastic/Interfaces/ReindexAllDomainsServiceInterface.php
+++ b/src/Tool/Application/Service/Elastic/Interfaces/ReindexAllDomainsServiceInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Application\Service\Elastic\Interfaces;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface ReindexAllDomainsServiceInterface
+{
+    public function reindexAllDomains(InputInterface $input, OutputInterface $output): int;
+}

--- a/src/Tool/Application/Service/Elastic/ReindexAllDomainsService.php
+++ b/src/Tool/Application/Service/Elastic/ReindexAllDomainsService.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Application\Service\Elastic;
+
+use App\Tool\Application\Service\Elastic\Interfaces\ReindexAllDomainsServiceInterface;
+use App\Tool\Transport\Command\Elastic\ReindexBlogsCommand;
+use App\Tool\Transport\Command\Elastic\ReindexCrmIssuesCommand;
+use App\Tool\Transport\Command\Elastic\ReindexCrmRepositoriesCommand;
+use App\Tool\Transport\Command\Elastic\ReindexCrmTasksCommand;
+use App\Tool\Transport\Command\Elastic\ReindexNotificationsCommand;
+use App\Tool\Transport\Command\Elastic\ReindexPlatformsCommand;
+use App\Tool\Transport\Command\Elastic\ReindexShopProductsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ReindexAllDomainsService implements ReindexAllDomainsServiceInterface
+{
+    public function __construct(
+        private readonly ReindexBlogsCommand $reindexBlogsCommand,
+        private readonly ReindexCrmTasksCommand $reindexCrmTasksCommand,
+        private readonly ReindexCrmRepositoriesCommand $reindexCrmRepositoriesCommand,
+        private readonly ReindexCrmIssuesCommand $reindexCrmIssuesCommand,
+        private readonly ReindexShopProductsCommand $reindexShopProductsCommand,
+        private readonly ReindexPlatformsCommand $reindexPlatformsCommand,
+        private readonly ReindexNotificationsCommand $reindexNotificationsCommand,
+    ) {
+    }
+
+    public function reindexAllDomains(InputInterface $input, OutputInterface $output): int
+    {
+        $codes = [
+            $this->reindexBlogsCommand->run($input, $output),
+            $this->reindexCrmTasksCommand->run($input, $output),
+            $this->reindexCrmRepositoriesCommand->run($input, $output),
+            $this->reindexCrmIssuesCommand->run($input, $output),
+            $this->reindexShopProductsCommand->run($input, $output),
+            $this->reindexPlatformsCommand->run($input, $output),
+            $this->reindexNotificationsCommand->run($input, $output),
+        ];
+
+        foreach ($codes as $code) {
+            if ($code !== Command::SUCCESS) {
+                return Command::FAILURE;
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Tool/Transport/Command/Elastic/ReindexAllDomainsCommand.php
+++ b/src/Tool/Transport/Command/Elastic/ReindexAllDomainsCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tool\Transport\Command\Elastic;
 
+use App\Tool\Application\Service\Elastic\Interfaces\ReindexAllDomainsServiceInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,27 +19,13 @@ final class ReindexAllDomainsCommand extends Command
     final public const string NAME = 'elastic:reindex:all-domains';
 
     public function __construct(
-        private readonly ReindexBlogsCommand $reindexBlogsCommand,
-        private readonly ReindexCrmTasksCommand $reindexCrmTasksCommand,
-        private readonly ReindexCrmRepositoriesCommand $reindexCrmRepositoriesCommand,
-        private readonly ReindexCrmIssuesCommand $reindexCrmIssuesCommand,
-        private readonly ReindexShopProductsCommand $reindexShopProductsCommand,
-        private readonly ReindexPlatformsCommand $reindexPlatformsCommand,
-        private readonly ReindexNotificationsCommand $reindexNotificationsCommand,
+        private readonly ReindexAllDomainsServiceInterface $reindexAllDomainsService,
     ) {
         parent::__construct();
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $this->reindexBlogsCommand->run($input, $output);
-        $this->reindexCrmTasksCommand->run($input, $output);
-        $this->reindexCrmRepositoriesCommand->run($input, $output);
-        $this->reindexCrmIssuesCommand->run($input, $output);
-        $this->reindexShopProductsCommand->run($input, $output);
-        $this->reindexPlatformsCommand->run($input, $output);
-        $this->reindexNotificationsCommand->run($input, $output);
-
-        return Command::SUCCESS;
+        return $this->reindexAllDomainsService->reindexAllDomains($input, $output);
     }
 }

--- a/src/Tool/Transport/Command/WarmupPublicEndpointsCommand.php
+++ b/src/Tool/Transport/Command/WarmupPublicEndpointsCommand.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Command;
+
+use App\General\Application\Service\CacheInvalidationService;
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Tool\Application\Service\Elastic\Interfaces\ReindexAllDomainsServiceInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+use function array_filter;
+use function count;
+use function microtime;
+use function number_format;
+use function rtrim;
+use function sprintf;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Invalidate public caches, reindex Elasticsearch domains and warm public HTTP endpoints.',
+)]
+final class WarmupPublicEndpointsCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'app:warmup:public-endpoints';
+
+    private const float REQUEST_TIMEOUT = 2.5;
+    private const int MAX_ATTEMPTS = 2;
+
+    /**
+     * @var list<array{path: string, critical: bool}>
+     */
+    private const array ENDPOINTS = [
+        ['path' => '/api/health', 'critical' => true],
+        ['path' => '/api/version', 'critical' => true],
+        ['path' => '/api/v1/localization/language', 'critical' => true],
+        ['path' => '/api/v1/localization/locale', 'critical' => false],
+        ['path' => '/api/v1/localization/timezone', 'critical' => false],
+    ];
+
+    public function __construct(
+        private readonly CacheInvalidationService $cacheInvalidationService,
+        private readonly ReindexAllDomainsServiceInterface $reindexAllDomainsService,
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $warmupPublicEndpointsBaseUrl,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = $this->getSymfonyStyle($input, $output);
+        $totalStart = microtime(true);
+
+        $io->section('1/4 Cache invalidation');
+        $this->invalidateTargetedCaches();
+        $io->success('Targeted public caches were invalidated.');
+
+        $io->section('2/4 Elasticsearch reindex');
+        $reindexStatus = $this->reindexAllDomainsService->reindexAllDomains($input, $output);
+        if ($reindexStatus !== Command::SUCCESS) {
+            $io->error('Elasticsearch reindex step failed.');
+
+            return Command::FAILURE;
+        }
+        $io->success('Elasticsearch reindex completed.');
+
+        $io->section('3/4 HTTP endpoints warmup');
+        $results = [];
+        foreach (self::ENDPOINTS as $endpoint) {
+            $result = $this->warmEndpoint($endpoint['path'], $endpoint['critical']);
+            $results[] = $result;
+
+            $state = $result['success'] ? 'OK' : 'FAIL';
+            $io->writeln(sprintf(
+                '[%s] %s (status=%s, attempts=%d, latency=%sms)',
+                $state,
+                $result['url'],
+                $result['statusCode'] !== null ? (string) $result['statusCode'] : 'n/a',
+                $result['attempts'],
+                number_format($result['latencyMs'], 2, '.', ''),
+            ));
+        }
+
+        $io->section('4/4 Summary');
+        $successCount = count(array_filter($results, static fn (array $item): bool => $item['success']));
+        $failureCount = count($results) - $successCount;
+        $criticalFailures = count(array_filter(
+            $results,
+            static fn (array $item): bool => $item['critical'] && !$item['success']
+        ));
+
+        $totalLatencyMs = 0.0;
+        foreach ($results as $item) {
+            $totalLatencyMs += $item['latencyMs'];
+        }
+
+        $averageLatencyMs = $results !== [] ? ($totalLatencyMs / count($results)) : 0.0;
+        $durationMs = (microtime(true) - $totalStart) * 1000;
+
+        $io->definitionList(
+            ['Successes' => (string) $successCount],
+            ['Failures' => (string) $failureCount],
+            ['Critical failures' => (string) $criticalFailures],
+            ['Average latency (ms)' => number_format($averageLatencyMs, 2, '.', '')],
+            ['Total duration (ms)' => number_format($durationMs, 2, '.', '')],
+        );
+
+        if ($criticalFailures > 0) {
+            $io->error('At least one critical endpoint failed during warmup.');
+
+            return Command::FAILURE;
+        }
+
+        $io->success('Public endpoints warmup completed without critical failures.');
+
+        return Command::SUCCESS;
+    }
+
+    private function invalidateTargetedCaches(): void
+    {
+        $this->cacheInvalidationService->invalidatePublicPageCaches();
+        $this->cacheInvalidationService->invalidatePublicPlatformListCaches();
+        $this->cacheInvalidationService->invalidateBlogCaches(null);
+        $this->cacheInvalidationService->invalidateApplicationListCaches();
+        $this->cacheInvalidationService->invalidateShopProductListCaches();
+    }
+
+    /**
+     * @return array{url: string, statusCode: int|null, success: bool, critical: bool, attempts: int, latencyMs: float}
+     */
+    private function warmEndpoint(string $path, bool $critical): array
+    {
+        $url = rtrim($this->warmupPublicEndpointsBaseUrl, '/') . $path;
+        $statusCode = null;
+        $success = false;
+        $latencyMs = 0.0;
+
+        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; ++$attempt) {
+            $startedAt = microtime(true);
+            try {
+                $response = $this->httpClient->request('GET', $url, [
+                    'timeout' => self::REQUEST_TIMEOUT,
+                    'headers' => [
+                        'User-Agent' => 'warmup-bot',
+                    ],
+                ]);
+
+                $statusCode = $response->getStatusCode();
+                $latencyMs = (microtime(true) - $startedAt) * 1000;
+                if ($statusCode >= 200 && $statusCode < 400) {
+                    $success = true;
+
+                    return [
+                        'url' => $url,
+                        'statusCode' => $statusCode,
+                        'success' => $success,
+                        'critical' => $critical,
+                        'attempts' => $attempt,
+                        'latencyMs' => $latencyMs,
+                    ];
+                }
+            } catch (ExceptionInterface) {
+                $latencyMs = (microtime(true) - $startedAt) * 1000;
+            }
+        }
+
+        return [
+            'url' => $url,
+            'statusCode' => $statusCode,
+            'success' => $success,
+            'critical' => $critical,
+            'attempts' => self::MAX_ATTEMPTS,
+            'latencyMs' => $latencyMs,
+        ];
+    }
+}


### PR DESCRIPTION
### Motivation
- Fournir une commande CLI unique pour exécuter un warmup contrôlé des endpoints publics en respectant l’ordre strict demandé (invalidation cache → reindex ES → warm HTTP → résumé). 
- Réutiliser la logique existante de reindexation Elasticsearch via un service dédié pour éviter la duplication et permettre la réutilisation depuis la nouvelle commande.

### Description
- Ajout de la commande `app:warmup:public-endpoints` dans `src/Tool/Transport/Command/WarmupPublicEndpointsCommand.php` qui exécute 4 étapes dans l’ordre : ciblage d’invalidation de caches via `CacheInvalidationService`, reindex via le service `ReindexAllDomainsServiceInterface`, warmup HTTP interne (GET, timeout court, retries limités, `User-Agent: warmup-bot`) et affichage d’un résumé (succès/échecs/échecs critiques/latence moyenne/durée totale). 
- Création de `ReindexAllDomainsServiceInterface` et `ReindexAllDomainsService` dans `src/Tool/Application/Service/Elastic/` pour factoriser la séquence de reindex des domaines. 
- Refactor de `src/Tool/Transport/Command/Elastic/ReindexAllDomainsCommand.php` pour déléguer la logique au service dédié afin de réutiliser la séquence depuis la commande de warmup. 
- Ajout d’un bind DI ` $warmupPublicEndpointsBaseUrl` dans `config/services.yaml` lié à l’env variable `APP_WARMUP_PUBLIC_ENDPOINTS_BASE_URL` avec fallback sur `DEFAULT_URI`.
- La commande retourne un code non-zéro (`Command::FAILURE`) si au moins un endpoint marqué comme critique échoue.

### Testing
- `php -l` a été exécuté sur les fichiers modifiés et `config/services.yaml` et a réussi pour tous les fichiers concernés. (succès)
- Exécution de `php bin/console app:warmup:public-endpoints --help` impossible dans cet environnement à cause de dépendances manquantes (`composer install` requis) donc le comportement runtime n’a pas été vérifié ici (échec environnemental).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7eff41658832686a59b1405b3163d)