### PR TITLE
feat(tool): externalize public warmup endpoints configuration

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -32,6 +32,7 @@ services:
             $lockUserOnLoginFailureAttempts: '%env(int:LOCK_USER_ON_LOGIN_FAILURE_ATTEMPTS)%'
             $jwtBindClientFingerprint: '%env(bool:JWT_BIND_CLIENT_FINGERPRINT)%'
             $warmupPublicEndpointsBaseUrl: '%env(default:DEFAULT_URI:APP_WARMUP_PUBLIC_ENDPOINTS_BASE_URL)%'
+            $warmupPublicEndpointsConfigPath: '%kernel.project_dir%/config/warmup/public_endpoints.yaml'
     _instanceof:
         App\General\Application\Rest\Interfaces\RestResourceInterface:
             tags: [ 'app.rest.resource', 'app.stopwatch' ]
@@ -156,6 +157,10 @@ services:
     App\Tool\Transport\Serializer\ExternalMessageSerializer:
         arguments:
             $serializer: '@app.serializer.external_message'
+
+    App\Tool\Application\Service\Warmup\WarmupPublicEndpointsConfigProvider:
+        arguments:
+            $configPath: '%warmupPublicEndpointsConfigPath%'
 
     App\Media\Application\Service\MediaUploaderService:
         arguments:

--- a/config/warmup/public_endpoints.yaml
+++ b/config/warmup/public_endpoints.yaml
@@ -1,0 +1,11 @@
+critical:
+  - path: '/api/health'
+  - path: '/api/version'
+  - path: '/api/v1/localization/language'
+secondary:
+  - path: '/api/v1/localization/locale'
+  - path: '/api/v1/localization/timezone'
+max_concurrency: 3
+timeout_seconds: 2.5
+retry_max: 2
+success_threshold_ms: 600

--- a/src/Tool/Application/DTO/Warmup/WarmupEndpointConfig.php
+++ b/src/Tool/Application/DTO/Warmup/WarmupEndpointConfig.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Application\DTO\Warmup;
+
+final readonly class WarmupEndpointConfig
+{
+    public function __construct(
+        public string $path,
+        public bool $critical,
+        public ?float $successThresholdMs,
+    ) {
+    }
+}

--- a/src/Tool/Application/DTO/Warmup/WarmupPublicEndpointsConfig.php
+++ b/src/Tool/Application/DTO/Warmup/WarmupPublicEndpointsConfig.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Application\DTO\Warmup;
+
+final readonly class WarmupPublicEndpointsConfig
+{
+    /**
+     * @param list<WarmupEndpointConfig> $endpoints
+     */
+    public function __construct(
+        public array $endpoints,
+        public int $maxConcurrency,
+        public float $timeoutSeconds,
+        public int $retryMax,
+        public ?float $successThresholdMs,
+    ) {
+    }
+}

--- a/src/Tool/Application/Service/Warmup/WarmupPublicEndpointsConfigProvider.php
+++ b/src/Tool/Application/Service/Warmup/WarmupPublicEndpointsConfigProvider.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Application\Service\Warmup;
+
+use App\Tool\Application\DTO\Warmup\WarmupEndpointConfig;
+use App\Tool\Application\DTO\Warmup\WarmupPublicEndpointsConfig;
+use InvalidArgumentException;
+use Symfony\Component\Yaml\Yaml;
+
+use function array_key_exists;
+use function is_array;
+use function is_int;
+use function is_numeric;
+use function is_string;
+
+final class WarmupPublicEndpointsConfigProvider
+{
+    public function __construct(private readonly string $configPath)
+    {
+    }
+
+    public function getConfig(): WarmupPublicEndpointsConfig
+    {
+        $rawConfig = Yaml::parseFile($this->configPath);
+        if (!is_array($rawConfig)) {
+            throw new InvalidArgumentException('Warmup public endpoints config must be a YAML map.');
+        }
+
+        $criticalEndpoints = $this->parseEndpointList($rawConfig, 'critical', true);
+        $secondaryEndpoints = $this->parseEndpointList($rawConfig, 'secondary', false);
+
+        return new WarmupPublicEndpointsConfig(
+            endpoints: [...$criticalEndpoints, ...$secondaryEndpoints],
+            maxConcurrency: $this->readPositiveInt($rawConfig, 'max_concurrency'),
+            timeoutSeconds: $this->readPositiveFloat($rawConfig, 'timeout_seconds'),
+            retryMax: $this->readPositiveInt($rawConfig, 'retry_max'),
+            successThresholdMs: $this->readOptionalPositiveFloat($rawConfig, 'success_threshold_ms'),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $rawConfig
+     *
+     * @return list<WarmupEndpointConfig>
+     */
+    private function parseEndpointList(array $rawConfig, string $key, bool $critical): array
+    {
+        $value = $rawConfig[$key] ?? null;
+        if (!is_array($value)) {
+            throw new InvalidArgumentException(sprintf('Warmup config key "%s" must be a list.', $key));
+        }
+
+        $endpoints = [];
+        foreach ($value as $index => $endpointData) {
+            if (!is_array($endpointData)) {
+                throw new InvalidArgumentException(sprintf('Warmup endpoint "%s[%d]" must be an object.', $key, $index));
+            }
+
+            $path = $endpointData['path'] ?? null;
+            if (!is_string($path) || $path === '') {
+                throw new InvalidArgumentException(sprintf('Warmup endpoint "%s[%d].path" must be a non-empty string.', $key, $index));
+            }
+
+            $successThresholdMs = $this->readOptionalPositiveFloat($endpointData, 'success_threshold_ms');
+
+            $endpoints[] = new WarmupEndpointConfig(
+                path: $path,
+                critical: $critical,
+                successThresholdMs: $successThresholdMs,
+            );
+        }
+
+        return $endpoints;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function readPositiveInt(array $data, string $key): int
+    {
+        $value = $data[$key] ?? null;
+        if (!is_int($value) || $value < 1) {
+            throw new InvalidArgumentException(sprintf('Warmup config key "%s" must be a positive integer.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function readPositiveFloat(array $data, string $key): float
+    {
+        $value = $data[$key] ?? null;
+        if (!is_numeric($value) || (float) $value <= 0.0) {
+            throw new InvalidArgumentException(sprintf('Warmup config key "%s" must be a positive number.', $key));
+        }
+
+        return (float) $value;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function readOptionalPositiveFloat(array $data, string $key): ?float
+    {
+        if (!array_key_exists($key, $data) || $data[$key] === null) {
+            return null;
+        }
+
+        $value = $data[$key];
+        if (!is_numeric($value) || (float) $value <= 0.0) {
+            throw new InvalidArgumentException(sprintf('Warmup config key "%s" must be a positive number when provided.', $key));
+        }
+
+        return (float) $value;
+    }
+}

--- a/src/Tool/Transport/Command/WarmupPublicEndpointsCommand.php
+++ b/src/Tool/Transport/Command/WarmupPublicEndpointsCommand.php
@@ -6,14 +6,18 @@ namespace App\Tool\Transport\Command;
 
 use App\General\Application\Service\CacheInvalidationService;
 use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Tool\Application\DTO\Warmup\WarmupEndpointConfig;
 use App\Tool\Application\Service\Elastic\Interfaces\ReindexAllDomainsServiceInterface;
+use App\Tool\Application\Service\Warmup\WarmupPublicEndpointsConfigProvider;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
+use function array_chunk;
 use function array_filter;
 use function count;
 use function microtime;
@@ -31,24 +35,11 @@ final class WarmupPublicEndpointsCommand extends Command
 
     final public const string NAME = 'app:warmup:public-endpoints';
 
-    private const float REQUEST_TIMEOUT = 2.5;
-    private const int MAX_ATTEMPTS = 2;
-
-    /**
-     * @var list<array{path: string, critical: bool}>
-     */
-    private const array ENDPOINTS = [
-        ['path' => '/api/health', 'critical' => true],
-        ['path' => '/api/version', 'critical' => true],
-        ['path' => '/api/v1/localization/language', 'critical' => true],
-        ['path' => '/api/v1/localization/locale', 'critical' => false],
-        ['path' => '/api/v1/localization/timezone', 'critical' => false],
-    ];
-
     public function __construct(
         private readonly CacheInvalidationService $cacheInvalidationService,
         private readonly ReindexAllDomainsServiceInterface $reindexAllDomainsService,
         private readonly HttpClientInterface $httpClient,
+        private readonly WarmupPublicEndpointsConfigProvider $configProvider,
         private readonly string $warmupPublicEndpointsBaseUrl,
     ) {
         parent::__construct();
@@ -58,6 +49,8 @@ final class WarmupPublicEndpointsCommand extends Command
     {
         $io = $this->getSymfonyStyle($input, $output);
         $totalStart = microtime(true);
+
+        $config = $this->configProvider->getConfig();
 
         $io->section('1/4 Cache invalidation');
         $this->invalidateTargetedCaches();
@@ -73,11 +66,8 @@ final class WarmupPublicEndpointsCommand extends Command
         $io->success('Elasticsearch reindex completed.');
 
         $io->section('3/4 HTTP endpoints warmup');
-        $results = [];
-        foreach (self::ENDPOINTS as $endpoint) {
-            $result = $this->warmEndpoint($endpoint['path'], $endpoint['critical']);
-            $results[] = $result;
-
+        $results = $this->warmEndpoints($config->endpoints, $config->maxConcurrency, $config->timeoutSeconds, $config->retryMax, $config->successThresholdMs);
+        foreach ($results as $result) {
             $state = $result['success'] ? 'OK' : 'FAIL';
             $io->writeln(sprintf(
                 '[%s] %s (status=%s, attempts=%d, latency=%sms)',
@@ -134,51 +124,89 @@ final class WarmupPublicEndpointsCommand extends Command
     }
 
     /**
-     * @return array{url: string, statusCode: int|null, success: bool, critical: bool, attempts: int, latencyMs: float}
+     * @param list<WarmupEndpointConfig> $endpoints
+     *
+     * @return list<array{url: string, statusCode: int|null, success: bool, critical: bool, attempts: int, latencyMs: float}>
      */
-    private function warmEndpoint(string $path, bool $critical): array
+    private function warmEndpoints(array $endpoints, int $maxConcurrency, float $timeoutSeconds, int $retryMax, ?float $globalSuccessThresholdMs): array
     {
-        $url = rtrim($this->warmupPublicEndpointsBaseUrl, '/') . $path;
-        $statusCode = null;
-        $success = false;
-        $latencyMs = 0.0;
+        $resultsByPath = [];
 
-        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; ++$attempt) {
-            $startedAt = microtime(true);
-            try {
-                $response = $this->httpClient->request('GET', $url, [
-                    'timeout' => self::REQUEST_TIMEOUT,
-                    'headers' => [
-                        'User-Agent' => 'warmup-bot',
-                    ],
-                ]);
+        for ($attempt = 1; $attempt <= $retryMax; ++$attempt) {
+            $remaining = [];
+            foreach ($endpoints as $endpoint) {
+                if (!isset($resultsByPath[$endpoint->path]) || !$resultsByPath[$endpoint->path]['success']) {
+                    $remaining[] = $endpoint;
+                }
+            }
 
-                $statusCode = $response->getStatusCode();
-                $latencyMs = (microtime(true) - $startedAt) * 1000;
-                if ($statusCode >= 200 && $statusCode < 400) {
-                    $success = true;
+            if ($remaining === []) {
+                break;
+            }
 
-                    return [
+            foreach (array_chunk($remaining, $maxConcurrency) as $chunk) {
+                $responses = [];
+                foreach ($chunk as $endpoint) {
+                    $url = rtrim($this->warmupPublicEndpointsBaseUrl, '/') . $endpoint->path;
+                    $responses[$endpoint->path] = [
+                        'endpoint' => $endpoint,
                         'url' => $url,
+                        'startedAt' => microtime(true),
+                        'response' => $this->httpClient->request('GET', $url, [
+                            'timeout' => $timeoutSeconds,
+                            'headers' => [
+                                'User-Agent' => 'warmup-bot',
+                            ],
+                        ]),
+                    ];
+                }
+
+                foreach ($responses as $path => $responseData) {
+                    $endpoint = $responseData['endpoint'];
+                    $statusCode = null;
+                    $success = false;
+                    $latencyMs = 0.0;
+
+                    try {
+                        $response = $responseData['response'];
+                        if ($response instanceof ResponseInterface) {
+                            $statusCode = $response->getStatusCode();
+                        }
+                        $latencyMs = (microtime(true) - $responseData['startedAt']) * 1000;
+                        $successThresholdMs = $endpoint->successThresholdMs ?? $globalSuccessThresholdMs;
+
+                        $success = $statusCode !== null
+                            && $statusCode >= 200
+                            && $statusCode < 400
+                            && ($successThresholdMs === null || $latencyMs <= $successThresholdMs);
+                    } catch (ExceptionInterface) {
+                        $latencyMs = (microtime(true) - $responseData['startedAt']) * 1000;
+                    }
+
+                    $resultsByPath[$path] = [
+                        'url' => $responseData['url'],
                         'statusCode' => $statusCode,
                         'success' => $success,
-                        'critical' => $critical,
+                        'critical' => $endpoint->critical,
                         'attempts' => $attempt,
                         'latencyMs' => $latencyMs,
                     ];
                 }
-            } catch (ExceptionInterface) {
-                $latencyMs = (microtime(true) - $startedAt) * 1000;
             }
         }
 
-        return [
-            'url' => $url,
-            'statusCode' => $statusCode,
-            'success' => $success,
-            'critical' => $critical,
-            'attempts' => self::MAX_ATTEMPTS,
-            'latencyMs' => $latencyMs,
-        ];
+        $orderedResults = [];
+        foreach ($endpoints as $endpoint) {
+            $orderedResults[] = $resultsByPath[$endpoint->path] ?? [
+                'url' => rtrim($this->warmupPublicEndpointsBaseUrl, '/') . $endpoint->path,
+                'statusCode' => null,
+                'success' => false,
+                'critical' => $endpoint->critical,
+                'attempts' => $retryMax,
+                'latencyMs' => 0.0,
+            ];
+        }
+
+        return $orderedResults;
     }
 }


### PR DESCRIPTION
### Motivation

- Make the warmup command configurable instead of using hardcoded endpoints and constants so runtime behavior (lists, concurrency, timeout, retries, latency thresholds) can be adjusted without code changes.

### Description

- Add `config/warmup/public_endpoints.yaml` to declare `critical`, `secondary`, `max_concurrency`, `timeout_seconds`, `retry_max` and `success_threshold_ms` (global or per-endpoint).
- Add DTOs `WarmupEndpointConfig` and `WarmupPublicEndpointsConfig` and a `WarmupPublicEndpointsConfigProvider` service that parses and validates the YAML into typed objects.
- Update `WarmupPublicEndpointsCommand` to consume the config provider and drive warmup behavior (batching via `max_concurrency`, per-request `timeout_seconds`, `retry_max`, and latency checks using `success_threshold_ms`).
- Wire DI in `config/services.yaml` by adding `$warmupPublicEndpointsConfigPath` and registering `WarmupPublicEndpointsConfigProvider` with the config path.

### Testing

- Ran `php -l` on the modified/added PHP files (`WarmupPublicEndpointsCommand.php`, `WarmupPublicEndpointsConfigProvider.php`, `WarmupEndpointConfig.php`, `WarmupPublicEndpointsConfig.php`) and they reported no syntax errors.
- Ran `php bin/console lint:yaml config/warmup/public_endpoints.yaml` which could not complete in this environment due to missing project dependencies and returned `Dependencies are missing. Try running "composer install".` (environmental failure, not YAML syntax verified by CI here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f159383c8326a44b83139678ed72)