### PR TITLE
Add scheduler command to warm up public endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,7 @@ migrate-cron-jobs: ## Creates cron job tasks (cleanup logs, failed old messenger
 	@make exec cmd="php bin/console scheduler:cleanup-messenger-messages"
 	@make exec cmd="php bin/console scheduler:recruit-index-similar-jobs"
 	@make exec cmd="php bin/console scheduler:elastic-reindex-domains"
+	@make exec cmd="php bin/console scheduler:warmup-public-endpoints"
 
 fixtures: ## Runs all fixtures for test database without --append option (tables will be dropped and recreated)
 	@make exec cmd="php bin/console doctrine:fixtures:load --env=test --no-interaction"

--- a/src/Tool/Transport/Command/Scheduler/WarmupPublicEndpointsScheduledCommand.php
+++ b/src/Tool/Transport/Command/Scheduler/WarmupPublicEndpointsScheduledCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Command\Scheduler;
+
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Tool\Application\Service\Scheduler\Interfaces\ScheduledCommandServiceInterface;
+use App\Tool\Transport\Command\WarmupPublicEndpointsCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Create a cron job to warm up public endpoints every 30 minutes.',
+)]
+final class WarmupPublicEndpointsScheduledCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'scheduler:warmup-public-endpoints';
+
+    public function __construct(
+        private readonly ScheduledCommandServiceInterface $scheduledCommandService,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $message = $this->createScheduledCommand();
+
+        if ($input->isInteractive()) {
+            $this->getSymfonyStyle($input, $output)->success($message);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function createScheduledCommand(): string
+    {
+        $entity = $this->scheduledCommandService->findByCommand(WarmupPublicEndpointsCommand::NAME);
+
+        if ($entity !== null) {
+            return "The job WarmupPublicEndpoints is already present [id='{$entity->getId()}']";
+        }
+
+        $this->scheduledCommandService->create(
+            'Warm up public endpoints',
+            WarmupPublicEndpointsCommand::NAME,
+            '*/30 * * * *',
+            '/warmup-public-endpoints.log'
+        );
+
+        return 'The job WarmupPublicEndpoints is created';
+    }
+}


### PR DESCRIPTION
### Motivation

- Ajouter une commande scheduler qui crée automatiquement la tâche planifiée pour réchauffer les endpoints publics à intervalles réguliers afin d'éviter le cold-start et améliorer la réactivité.

### Description

- Ajout de la classe `WarmupPublicEndpointsScheduledCommand` dans `src/Tool/Transport/Command/Scheduler/` qui expose le nom `scheduler:warmup-public-endpoints` et suit le modèle des autres commandes planifiées.
- La commande crée, si absente, la tâche planifiée exécutant `app:warmup:public-endpoints` avec l'expression cron `*/30 * * * *` et le fichier de log `/warmup-public-endpoints.log`.
- Mise à jour de la cible `migrate-cron-jobs` du `Makefile` pour appeler `php bin/console scheduler:warmup-public-endpoints`.

### Testing

- Exécution de la vérification de syntaxe PHP avec `php -l src/Tool/Transport/Command/Scheduler/WarmupPublicEndpointsScheduledCommand.php`, qui a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f2ba36a0832693cd3c55e1a30a55)