### PR TITLE
Add locking and Elasticsearch fail-fast behavior to public endpoint warmup

### DIFF
--- a/src/Tool/Transport/Command/WarmupPublicEndpointsCommand.php
+++ b/src/Tool/Transport/Command/WarmupPublicEndpointsCommand.php
@@ -9,10 +9,13 @@ use App\General\Transport\Command\Traits\SymfonyStyleTrait;
 use App\Tool\Application\DTO\Warmup\WarmupEndpointConfig;
 use App\Tool\Application\Service\Elastic\Interfaces\ReindexAllDomainsServiceInterface;
 use App\Tool\Application\Service\Warmup\WarmupPublicEndpointsConfigProvider;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Lock\LockFactory;
 use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -41,6 +44,8 @@ final class WarmupPublicEndpointsCommand extends Command
         private readonly HttpClientInterface $httpClient,
         private readonly WarmupPublicEndpointsConfigProvider $configProvider,
         private readonly string $warmupPublicEndpointsBaseUrl,
+        private readonly LockFactory $lockFactory,
+        private readonly LoggerInterface $logger,
     ) {
         parent::__construct();
     }
@@ -49,6 +54,24 @@ final class WarmupPublicEndpointsCommand extends Command
     {
         $io = $this->getSymfonyStyle($input, $output);
         $totalStart = microtime(true);
+        $lock = $this->lockFactory->createLock(self::NAME);
+
+        if (!$lock->acquire()) {
+            $io->warning('Another warmup process is already running.');
+            $this->logger->warning('Skipped public endpoints warmup because another execution is already running.');
+
+            return Command::FAILURE;
+        }
+
+        try {
+            return $this->executeWarmup($input, $output, $io, $totalStart);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    private function executeWarmup(InputInterface $input, OutputInterface $output, SymfonyStyle $io, float $totalStart): int
+    {
 
         $config = $this->configProvider->getConfig();
 
@@ -60,6 +83,7 @@ final class WarmupPublicEndpointsCommand extends Command
         $reindexStatus = $this->reindexAllDomainsService->reindexAllDomains($input, $output);
         if ($reindexStatus !== Command::SUCCESS) {
             $io->error('Elasticsearch reindex step failed.');
+            $this->logger->error('Public endpoints warmup aborted because Elasticsearch reindex step failed.');
 
             return Command::FAILURE;
         }


### PR DESCRIPTION
### Motivation
- Prevent concurrent executions of the `app:warmup:public-endpoints` command to avoid race conditions and resource contention.
- Ensure the Elasticsearch reindex step is treated as a fail-fast prerequisite so HTTP warmup doesn't run on a bad index state.
- Keep the existing behavior where non-critical endpoint failures do not stop other warmups, while failing the command if any critical endpoint fails.

### Description
- Inject `LockFactory` and `LoggerInterface` into the command and acquire a command-level lock via `$this->lockFactory->createLock(self::NAME)`; if acquisition fails the command logs a warning and returns failure.
- Move the main flow into a new `executeWarmup()` method so the lock can be released in a `finally` block.
- Log an explicit error and return `Command::FAILURE` immediately when `reindexAllDomains()` does not return `Command::SUCCESS`.
- Preserve the existing HTTP warmup implementation, including retries and the final critical-vs-non-critical failure aggregation.

### Testing
- Ran `php -l src/Tool/Transport/Command/WarmupPublicEndpointsCommand.php` and it reported no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f38d64e8832692ba75ee49f92a5e)