### PR TITLE
Add warmup observability service and consecutive-failure alerting

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -33,6 +33,9 @@ services:
             $jwtBindClientFingerprint: '%env(bool:JWT_BIND_CLIENT_FINGERPRINT)%'
             $warmupPublicEndpointsBaseUrl: '%env(default:DEFAULT_URI:APP_WARMUP_PUBLIC_ENDPOINTS_BASE_URL)%'
             $warmupPublicEndpointsConfigPath: '%kernel.project_dir%/config/warmup/public_endpoints.yaml'
+            $warmupCriticalFailureWindowSeconds: '%env(int:default:7200:APP_WARMUP_CRITICAL_FAILURE_WINDOW_SECONDS)%'
+            $warmupCriticalFailureAlertThreshold: '%env(int:default:3:APP_WARMUP_CRITICAL_FAILURE_ALERT_THRESHOLD)%'
+            $warmupCriticalFailureSlackWebhook: '%env(default::APP_WARMUP_CRITICAL_FAILURE_SLACK_WEBHOOK)%'
     _instanceof:
         App\General\Application\Rest\Interfaces\RestResourceInterface:
             tags: [ 'app.rest.resource', 'app.stopwatch' ]
@@ -161,6 +164,13 @@ services:
     App\Tool\Application\Service\Warmup\WarmupPublicEndpointsConfigProvider:
         arguments:
             $configPath: '%warmupPublicEndpointsConfigPath%'
+
+
+    App\Tool\Application\Service\Warmup\WarmupPublicEndpointsObservabilityService:
+        arguments:
+            $monitoringLogger: '@monolog.logger.monitoring'
+            $appCache: '@cache.app'
+            $notifier: '@?notifier'
 
     App\Media\Application\Service\MediaUploaderService:
         arguments:

--- a/src/Tool/Application/Service/Warmup/WarmupPublicEndpointsObservabilityService.php
+++ b/src/Tool/Application/Service/Warmup/WarmupPublicEndpointsObservabilityService.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Application\Service\Warmup;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Notifier\Notification\Notification;
+use Symfony\Component\Notifier\NotifierInterface;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+use function bin2hex;
+use function microtime;
+use function parse_url;
+use function random_bytes;
+use function sprintf;
+
+final readonly class WarmupPublicEndpointsObservabilityService
+{
+    private const string CRITICAL_FAILURE_COUNTER_KEY = 'warmup:public_endpoints:critical_consecutive_failures';
+
+    public function __construct(
+        private LoggerInterface $monitoringLogger,
+        private CacheItemPoolInterface $appCache,
+        private HttpClientInterface $httpClient,
+        private ?NotifierInterface $notifier,
+        private int $warmupCriticalFailureWindowSeconds,
+        private int $warmupCriticalFailureAlertThreshold,
+        private string $warmupCriticalFailureSlackWebhook,
+    ) {
+    }
+
+    public function createRunId(): string
+    {
+        return sprintf('warmup-%d-%s', (int) (microtime(true) * 1000), bin2hex(random_bytes(4)));
+    }
+
+    public function logAttempt(
+        string $runId,
+        string $endpoint,
+        string $group,
+        int $attempt,
+        ?int $statusCode,
+        float $durationMs,
+        string $result,
+    ): void {
+        $this->monitoringLogger->info('warmup.public_endpoints.attempt', [
+            'run_id' => $runId,
+            'endpoint' => $this->sanitizeEndpoint($endpoint),
+            'group' => $group,
+            'attempt' => $attempt,
+            'status_code' => $statusCode,
+            'duration_ms' => (int) round($durationMs),
+            'result' => $result,
+        ]);
+    }
+
+    public function logRunCompleted(
+        string $runId,
+        int $criticalOk,
+        int $criticalFailed,
+        int $secondaryFailed,
+        float $totalDurationMs,
+    ): void {
+        $this->monitoringLogger->info('warmup.public_endpoints.run_completed', [
+            'run_id' => $runId,
+            'critical_ok' => $criticalOk,
+            'critical_failed' => $criticalFailed,
+            'secondary_failed' => $secondaryFailed,
+            'total_duration_ms' => (int) round($totalDurationMs),
+        ]);
+    }
+
+    public function trackCriticalFailuresAndAlert(string $runId, int $criticalFailed): void
+    {
+        if ($criticalFailed <= 0) {
+            $this->appCache->deleteItem(self::CRITICAL_FAILURE_COUNTER_KEY);
+
+            return;
+        }
+
+        $counterItem = $this->appCache->getItem(self::CRITICAL_FAILURE_COUNTER_KEY);
+        $current = $counterItem->isHit() ? (int) $counterItem->get() : 0;
+        $newValue = $current + 1;
+
+        $counterItem->set($newValue);
+        $counterItem->expiresAfter($this->warmupCriticalFailureWindowSeconds);
+        $this->appCache->save($counterItem);
+
+        if ($newValue !== $this->warmupCriticalFailureAlertThreshold) {
+            return;
+        }
+
+        $message = sprintf(
+            'Warmup public endpoints: %d consecutive runs have critical failures (run_id=%s).',
+            $newValue,
+            $runId,
+        );
+
+        $this->monitoringLogger->critical('warmup.public_endpoints.consecutive_critical_failures', [
+            'run_id' => $runId,
+            'consecutive_failures' => $newValue,
+            'window_seconds' => $this->warmupCriticalFailureWindowSeconds,
+            'threshold' => $this->warmupCriticalFailureAlertThreshold,
+        ]);
+
+        $this->sendAlert($message);
+    }
+
+    private function sendAlert(string $message): void
+    {
+        if ($this->warmupCriticalFailureSlackWebhook !== '') {
+            try {
+                $this->httpClient->request('POST', $this->warmupCriticalFailureSlackWebhook, [
+                    'json' => [
+                        'text' => $message,
+                    ],
+                ]);
+
+                return;
+            } catch (ExceptionInterface) {
+                $this->monitoringLogger->warning('warmup.public_endpoints.alert_slack_failed');
+            }
+        }
+
+        if ($this->notifier === null) {
+            return;
+        }
+
+        $notification = new Notification($message);
+        $notification->importance(Notification::IMPORTANCE_HIGH);
+
+        $this->notifier->send($notification);
+    }
+
+    private function sanitizeEndpoint(string $endpoint): string
+    {
+        $path = parse_url($endpoint, \PHP_URL_PATH);
+
+        return $path !== false ? $path : $endpoint;
+    }
+}

--- a/src/Tool/Transport/Command/WarmupPublicEndpointsCommand.php
+++ b/src/Tool/Transport/Command/WarmupPublicEndpointsCommand.php
@@ -9,6 +9,7 @@ use App\General\Transport\Command\Traits\SymfonyStyleTrait;
 use App\Tool\Application\DTO\Warmup\WarmupEndpointConfig;
 use App\Tool\Application\Service\Elastic\Interfaces\ReindexAllDomainsServiceInterface;
 use App\Tool\Application\Service\Warmup\WarmupPublicEndpointsConfigProvider;
+use App\Tool\Application\Service\Warmup\WarmupPublicEndpointsObservabilityService;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -46,6 +47,7 @@ final class WarmupPublicEndpointsCommand extends Command
         private readonly string $warmupPublicEndpointsBaseUrl,
         private readonly LockFactory $lockFactory,
         private readonly LoggerInterface $logger,
+        private readonly WarmupPublicEndpointsObservabilityService $observabilityService,
     ) {
         parent::__construct();
     }
@@ -74,6 +76,7 @@ final class WarmupPublicEndpointsCommand extends Command
     {
 
         $config = $this->configProvider->getConfig();
+        $runId = $this->observabilityService->createRunId();
 
         $io->section('1/4 Cache invalidation');
         $this->invalidateTargetedCaches();
@@ -90,7 +93,7 @@ final class WarmupPublicEndpointsCommand extends Command
         $io->success('Elasticsearch reindex completed.');
 
         $io->section('3/4 HTTP endpoints warmup');
-        $results = $this->warmEndpoints($config->endpoints, $config->maxConcurrency, $config->timeoutSeconds, $config->retryMax, $config->successThresholdMs);
+        $results = $this->warmEndpoints($runId, $config->endpoints, $config->maxConcurrency, $config->timeoutSeconds, $config->retryMax, $config->successThresholdMs);
         foreach ($results as $result) {
             $state = $result['success'] ? 'OK' : 'FAIL';
             $io->writeln(sprintf(
@@ -110,6 +113,14 @@ final class WarmupPublicEndpointsCommand extends Command
             $results,
             static fn (array $item): bool => $item['critical'] && !$item['success']
         ));
+        $criticalOk = count(array_filter(
+            $results,
+            static fn (array $item): bool => $item['critical'] && $item['success']
+        ));
+        $secondaryFailures = count(array_filter(
+            $results,
+            static fn (array $item): bool => !$item['critical'] && !$item['success']
+        ));
 
         $totalLatencyMs = 0.0;
         foreach ($results as $item) {
@@ -118,6 +129,9 @@ final class WarmupPublicEndpointsCommand extends Command
 
         $averageLatencyMs = $results !== [] ? ($totalLatencyMs / count($results)) : 0.0;
         $durationMs = (microtime(true) - $totalStart) * 1000;
+
+        $this->observabilityService->logRunCompleted($runId, $criticalOk, $criticalFailures, $secondaryFailures, $durationMs);
+        $this->observabilityService->trackCriticalFailuresAndAlert($runId, $criticalFailures);
 
         $io->definitionList(
             ['Successes' => (string) $successCount],
@@ -152,7 +166,7 @@ final class WarmupPublicEndpointsCommand extends Command
      *
      * @return list<array{url: string, statusCode: int|null, success: bool, critical: bool, attempts: int, latencyMs: float}>
      */
-    private function warmEndpoints(array $endpoints, int $maxConcurrency, float $timeoutSeconds, int $retryMax, ?float $globalSuccessThresholdMs): array
+    private function warmEndpoints(string $runId, array $endpoints, int $maxConcurrency, float $timeoutSeconds, int $retryMax, ?float $globalSuccessThresholdMs): array
     {
         $resultsByPath = [];
 
@@ -190,6 +204,7 @@ final class WarmupPublicEndpointsCommand extends Command
                     $statusCode = null;
                     $success = false;
                     $latencyMs = 0.0;
+                    $result = 'transport_error';
 
                     try {
                         $response = $responseData['response'];
@@ -198,14 +213,33 @@ final class WarmupPublicEndpointsCommand extends Command
                         }
                         $latencyMs = (microtime(true) - $responseData['startedAt']) * 1000;
                         $successThresholdMs = $endpoint->successThresholdMs ?? $globalSuccessThresholdMs;
+                        $isFastEnough = $successThresholdMs === null || $latencyMs <= $successThresholdMs;
 
                         $success = $statusCode !== null
                             && $statusCode >= 200
                             && $statusCode < 400
-                            && ($successThresholdMs === null || $latencyMs <= $successThresholdMs);
+                            && $isFastEnough;
+
+                        if ($success) {
+                            $result = 'success';
+                        } elseif ($statusCode === null || $statusCode < 200 || $statusCode >= 400) {
+                            $result = 'http_error';
+                        } else {
+                            $result = 'slow_response';
+                        }
                     } catch (ExceptionInterface) {
                         $latencyMs = (microtime(true) - $responseData['startedAt']) * 1000;
                     }
+
+                    $this->observabilityService->logAttempt(
+                        runId: $runId,
+                        endpoint: $path,
+                        group: $endpoint->critical ? 'critical' : 'secondary',
+                        attempt: $attempt,
+                        statusCode: $statusCode,
+                        durationMs: $latencyMs,
+                        result: $result,
+                    );
 
                     $resultsByPath[$path] = [
                         'url' => $responseData['url'],


### PR DESCRIPTION
### Motivation
- Centraliser l’observabilité du warmup des endpoints publics en ajoutant des logs structurés par tentative et un résumé de run afin d’avoir métriques et traces dans le channel `monitoring`.
- Compter les échecs critiques consécutifs avec une fenêtre glissante pour détecter régressions récurrentes et déclencher des alertes lorsque le seuil configuré est atteint.
- Prendre en charge les canaux d’alerte disponibles (Slack webhook si configuré, fallback via `Notifier`) tout en évitant de logger des secrets ou query strings.

### Description
- Ajout du service `WarmupPublicEndpointsObservabilityService` avec les méthodes `createRunId()`, `logAttempt()`, `logRunCompleted()` et `trackCriticalFailuresAndAlert()` qui persistent un compteur dans `cache.app` et envoient une alerte via Slack webhook ou `Notifier` au seuil configuré.
- Les logs d’essai sont envoyés sur le channel `monitoring` avec les champs `run_id`, `endpoint` (sanitizé pour n’exposer que le path), `group`, `attempt`, `status_code`, `duration_ms` et `result`, et le log de fin de run contient `critical_ok`, `critical_failed`, `secondary_failed`, `total_duration_ms`.
- Intégration dans `WarmupPublicEndpointsCommand`: génération de `runId`, appel de `logAttempt()` à chaque tentative d’endpoint, et appel de `logRunCompleted()` + `trackCriticalFailuresAndAlert()` en fin de run.
- Configuration DI mise à jour dans `config/services.yaml` pour binder les nouveaux paramètres env `APP_WARMUP_CRITICAL_FAILURE_WINDOW_SECONDS`, `APP_WARMUP_CRITICAL_FAILURE_ALERT_THRESHOLD`, `APP_WARMUP_CRITICAL_FAILURE_SLACK_WEBHOOK` et pour déclarer le nouveau service avec `@monolog.logger.monitoring` et `@cache.app`.

### Testing
- Syntax checks passed: `php -l src/Tool/Application/Service/Warmup/WarmupPublicEndpointsObservabilityService.php` returned no syntax errors.
- Syntax checks passed: `php -l src/Tool/Transport/Command/WarmupPublicEndpointsCommand.php` returned no syntax errors.
- Syntax checks passed: `php -l config/services.yaml` returned no syntax errors.
- Container lint attempted with `php bin/console lint:container --no-debug` but failed in this environment because Composer dependencies are not installed (error: "Dependencies are missing. Try running \"composer install\".").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f4ffe64883269b0b56f8dc47d60f)