### PR TITLE
feat(application-list): expose calendarId and chatId in list responses

### DIFF
--- a/src/Platform/Application/Service/ApplicationListService.php
+++ b/src/Platform/Application/Service/ApplicationListService.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Platform\Application\Service;
 
+use App\Calendar\Infrastructure\Repository\CalendarRepository;
+use App\Chat\Infrastructure\Repository\ChatRepository;
 use App\Configuration\Domain\Entity\Configuration;
 use App\General\Application\Service\CacheKeyConventionService;
 use App\General\Domain\Service\Interfaces\ElasticsearchServiceInterface;
@@ -24,6 +26,8 @@ readonly class ApplicationListService
 {
     public function __construct(
         private ApplicationRepositoryInterface $applicationRepository,
+        private CalendarRepository $calendarRepository,
+        private ChatRepository $chatRepository,
         private CacheInterface $cache,
         private ElasticsearchServiceInterface $elasticsearchService,
         private CacheKeyConventionService $cacheKeyConventionService,
@@ -103,6 +107,9 @@ readonly class ApplicationListService
             $items = [];
             /** @var Application $application */
             foreach ($query->getResult() as $application) {
+                $calendar = $this->calendarRepository->findOneByApplication($application);
+                $chat = $this->chatRepository->findOneByApplication($application);
+
                 $pluginKeys = [];
                 foreach ($application->getApplicationPlugins() as $applicationPlugin) {
                     $pluginKey = $applicationPlugin->getPlugin()?->getPluginKeyValue();
@@ -122,6 +129,8 @@ readonly class ApplicationListService
                     'platformId' => $application->getPlatform()?->getId(),
                     'platformName' => $application->getPlatform()?->getName(),
                     'platformKey' => $application->getPlatform()?->getPlatformKeyValue(),
+                    'calendarId' => $calendar?->getId(),
+                    'chatId' => $chat?->getId(),
                     'pluginKeys' => array_keys($pluginKeys),
                     'plugins' => array_map(static fn (ApplicationPlugin $applicationPlugin) => [
                         'id' => $applicationPlugin->getId(),

--- a/src/Platform/Transport/Controller/Api/V1/Application/PrivateApplicationListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Application/PrivateApplicationListController.php
@@ -43,9 +43,58 @@ readonly class PrivateApplicationListController
                 description: 'Liste filtrée et paginée avec indicateur de propriété (isOwner).',
                 content: new JsonContent(
                     properties: [
-                        new Property(property: 'items', type: 'array', items: new OA\Items(type: 'object')),
-                        new Property(property: 'pagination', type: 'object'),
-                        new Property(property: 'filters', type: 'object'),
+                        new Property(
+                            property: 'items',
+                            type: 'array',
+                            items: new OA\Items(
+                                properties: [
+                                    new Property(property: 'id', type: 'string', example: 'fcb1f1e0-5f6f-4f5b-b7f2-4f5c64f42ea9'),
+                                    new Property(property: 'title', type: 'string', example: 'CRM Lite'),
+                                    new Property(property: 'slug', type: 'string', example: 'crm-lite'),
+                                    new Property(property: 'description', type: 'string', example: 'Application CRM pour équipes commerciales'),
+                                    new Property(property: 'photo', type: 'string', nullable: true),
+                                    new Property(property: 'status', type: 'string', example: 'active'),
+                                    new Property(property: 'private', type: 'boolean', example: true),
+                                    new Property(property: 'platformId', type: 'string', nullable: true),
+                                    new Property(property: 'platformName', type: 'string', example: 'CRM'),
+                                    new Property(property: 'platformKey', type: 'string', example: 'crm'),
+                                    new Property(property: 'calendarId', type: 'string', nullable: true, example: '6fdcb5de-57ac-4863-afec-1dd8bb3ef8f6'),
+                                    new Property(property: 'chatId', type: 'string', nullable: true, example: 'e233f52e-2dc3-4de5-bc5c-f65c1db4191e'),
+                                    new Property(property: 'pluginKeys', type: 'array', items: new OA\Items(type: 'string', example: 'analytics')),
+                                    new Property(
+                                        property: 'author',
+                                        properties: [
+                                            new Property(property: 'id', type: 'string', nullable: true),
+                                            new Property(property: 'firstName', type: 'string'),
+                                            new Property(property: 'lastName', type: 'string'),
+                                            new Property(property: 'photo', type: 'string'),
+                                        ],
+                                        type: 'object',
+                                    ),
+                                    new Property(property: 'createdAt', type: 'string', example: '2026-03-06T09:00:00+00:00', nullable: true),
+                                    new Property(property: 'isOwner', type: 'boolean', example: true),
+                                ],
+                                type: 'object',
+                            ),
+                        ),
+                        new Property(
+                            property: 'pagination',
+                            properties: [
+                                new Property(property: 'page', type: 'integer', example: 1),
+                                new Property(property: 'limit', type: 'integer', example: 10),
+                                new Property(property: 'totalItems', type: 'integer', example: 2),
+                                new Property(property: 'totalPages', type: 'integer', example: 1),
+                            ],
+                            type: 'object',
+                        ),
+                        new Property(
+                            property: 'filters',
+                            properties: [
+                                new Property(property: 'title', type: 'string', example: 'crm'),
+                                new Property(property: 'platformKey', type: 'string', example: 'crm'),
+                            ],
+                            type: 'object',
+                        ),
                     ],
                     type: 'object',
                 ),

--- a/src/Platform/Transport/Controller/Api/V1/Application/PublicApplicationListController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Application/PublicApplicationListController.php
@@ -57,6 +57,8 @@ readonly class PublicApplicationListController
                                     new Property(property: 'platformId', type: 'string'),
                                     new Property(property: 'platformName', type: 'string', example: 'Shop'),
                                     new Property(property: 'platformKey', type: 'string', example: 'shop'),
+                                    new Property(property: 'calendarId', type: 'string', nullable: true, example: '6fdcb5de-57ac-4863-afec-1dd8bb3ef8f6'),
+                                    new Property(property: 'chatId', type: 'string', nullable: true, example: 'e233f52e-2dc3-4de5-bc5c-f65c1db4191e'),
                                     new Property(property: 'pluginKeys', type: 'array', items: new OA\Items(type: 'string', example: 'analytics')),
                                     new Property(
                                         property: 'author',


### PR DESCRIPTION
### Motivation
- Les réponses de la liste d’applications doivent exposer les références aux ressources associées `calendar` et `chat` pour permettre aux clients d’afficher ou de lier ces entités. 
- Les champs doivent rester `null` lorsque le plugin correspondant n’est pas activé ou que la ressource est absente.

### Description
- Injection des repositories `CalendarRepository` et `ChatRepository` dans `ApplicationListService` via le constructeur.
- Pour chaque application dans la boucle de normalisation, récupération de `findOneByApplication($application)` sur `CalendarRepository` et `ChatRepository` et affectation à des variables locales.
- Ajout des clés `calendarId` et `chatId` (valeur `null` si absent) dans chaque item retourné par le service (`'calendarId' => $calendar?->getId()`, `'chatId' => $chat?->getId()`).
- Mise à jour des schémas OpenAPI dans `src/Platform/Transport/Controller/Api/V1/Application/PublicApplicationListController.php` et `src/Platform/Transport/Controller/Api/V1/Application/PrivateApplicationListController.php` pour inclure `calendarId` et `chatId` dans les items de réponse.

### Testing
- Vérification de la syntaxe PHP avec `php -l src/Platform/Application/Service/ApplicationListService.php`, `php -l src/Platform/Transport/Controller/Api/V1/Application/PublicApplicationListController.php` et `php -l src/Platform/Transport/Controller/Api/V1/Application/PrivateApplicationListController.php`, toutes réussies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f5c111948326ad381c926c23fe32)