### PR TITLE
Add warmup command tests and runbook

### DIFF
--- a/docs/runbook/warmup-public-endpoints.md
+++ b/docs/runbook/warmup-public-endpoints.md
@@ -1,0 +1,79 @@
+# Runbook — Warmup des endpoints publics
+
+## Commande manuelle
+
+Exécuter la commande suivante depuis le conteneur/app:
+
+```bash
+php bin/console app:warmup:public-endpoints
+```
+
+Comportement attendu:
+- invalide les caches publics ciblés,
+- relance le reindex Elasticsearch,
+- chauffe les endpoints HTTP publics (critiques puis secondaires),
+- affiche un résumé (succès/échecs/endpoints critiques).
+
+Code retour:
+- `0` si aucun endpoint **critique** n’échoue,
+- non-zéro si lock déjà pris, reindex ES en échec, ou endpoint critique en échec.
+
+## Interprétation des logs
+
+Pendant l’exécution, la sortie console affiche:
+- les sections `1/4` à `4/4`,
+- une ligne par endpoint: `[OK]` ou `[FAIL]` avec status HTTP, tentatives et latence,
+- un résumé final (succès, échecs, critical failures, latence moyenne, durée totale).
+
+Logs observabilité utiles:
+- `warmup.public_endpoints.attempt`: un log par tentative endpoint,
+- `warmup.public_endpoints.run_completed`: résumé agrégé du run,
+- `warmup.public_endpoints.consecutive_critical_failures`: seuil d’alerte atteint sur échecs critiques consécutifs.
+
+## Procédure de relance
+
+1. Vérifier la cause de l’échec (lock/ES/HTTP) dans la sortie console et les logs.
+2. Corriger le problème bloquant (cluster ES indisponible, endpoint en erreur, saturation réseau, etc.).
+3. Relancer manuellement:
+
+```bash
+php bin/console app:warmup:public-endpoints
+```
+
+4. Vérifier que:
+- le code retour est `0`,
+- `Critical failures = 0`,
+- les endpoints critiques sont en `[OK]`.
+
+## Diagnostics rapides (lock / ES / HTTP)
+
+### Lock
+Symptôme:
+- message `Another warmup process is already running.`
+- code retour non-zéro.
+
+Actions:
+- vérifier qu’un run est déjà en cours (scheduler/cron),
+- éviter les lancements concurrents,
+- relancer une fois le run actif terminé.
+
+### Elasticsearch
+Symptôme:
+- message `Elasticsearch reindex step failed.`
+- aucun warmup HTTP lancé ensuite.
+
+Actions:
+- valider la santé du cluster Elasticsearch,
+- vérifier connectivité, credentials et index cibles,
+- corriger puis relancer la commande.
+
+### HTTP endpoints
+Symptômes:
+- endpoint critique en 4xx/5xx/timeout => run en échec,
+- endpoint secondaire en échec/timeout => run peut rester OK, mais résumé avec échecs.
+
+Actions:
+- reproduire l’appel endpoint (curl),
+- vérifier gateway/reverse-proxy, logs applicatifs et délais de réponse,
+- ajuster timeout/retry/config endpoint si nécessaire,
+- relancer après correction.

--- a/tests/Application/Tool/Transport/Command/WarmupPublicEndpointsCommandTest.php
+++ b/tests/Application/Tool/Transport/Command/WarmupPublicEndpointsCommandTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Tool\Transport\Command;
+
+use App\General\Application\Service\CacheInvalidationService;
+use App\Tool\Application\Service\Elastic\Interfaces\ReindexAllDomainsServiceInterface;
+use App\Tool\Application\Service\Warmup\WarmupPublicEndpointsConfigProvider;
+use App\Tool\Application\Service\Warmup\WarmupPublicEndpointsObservabilityService;
+use App\Tool\Transport\Command\WarmupPublicEndpointsCommand;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\InMemoryStore;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class WarmupPublicEndpointsCommandTest extends TestCase
+{
+    public function testEsUnavailableSkipsHttpWarmupAndReturnsFailure(): void
+    {
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+        $cacheInvalidationService->expects($this->once())->method('invalidatePublicPageCaches');
+        $cacheInvalidationService->expects($this->once())->method('invalidatePublicPlatformListCaches');
+        $cacheInvalidationService->expects($this->once())->method('invalidateBlogCaches')->with(null);
+        $cacheInvalidationService->expects($this->once())->method('invalidateApplicationListCaches');
+        $cacheInvalidationService->expects($this->once())->method('invalidateShopProductListCaches');
+
+        $reindexService = $this->createMock(ReindexAllDomainsServiceInterface::class);
+        $reindexService->expects($this->once())
+            ->method('reindexAllDomains')
+            ->willReturn(Command::FAILURE);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->never())->method('request');
+
+        $command = $this->createCommand($cacheInvalidationService, $reindexService, $httpClient);
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('Elasticsearch reindex step failed.', $tester->getDisplay());
+    }
+
+    public function testCriticalEndpointHttp500FailsRun(): void
+    {
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+
+        $reindexService = $this->createMock(ReindexAllDomainsServiceInterface::class);
+        $reindexService->expects($this->once())
+            ->method('reindexAllDomains')
+            ->willReturn(Command::SUCCESS);
+
+        $criticalResponse = $this->createMock(ResponseInterface::class);
+        $criticalResponse->method('getStatusCode')->willReturn(500);
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->once())
+            ->method('request')
+            ->with('GET', 'https://example.test/healthz-critical', $this->anything())
+            ->willReturn($criticalResponse);
+
+        $command = $this->createCommand(
+            $cacheInvalidationService,
+            $reindexService,
+            $httpClient,
+            <<<YAML
+max_concurrency: 1
+timeout_seconds: 0.1
+retry_max: 1
+success_threshold_ms: 500
+critical:
+  - path: /healthz-critical
+secondary: []
+YAML
+        );
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('[FAIL] https://example.test/healthz-critical (status=500', $tester->getDisplay());
+        self::assertStringContainsString('At least one critical endpoint failed during warmup.', $tester->getDisplay());
+    }
+
+    public function testSecondaryTimeoutDoesNotFailRunButIsReportedInSummary(): void
+    {
+        $cacheInvalidationService = $this->createMock(CacheInvalidationService::class);
+
+        $reindexService = $this->createMock(ReindexAllDomainsServiceInterface::class);
+        $reindexService->expects($this->once())
+            ->method('reindexAllDomains')
+            ->willReturn(Command::SUCCESS);
+
+        $criticalResponse = $this->createMock(ResponseInterface::class);
+        $criticalResponse->method('getStatusCode')->willReturn(200);
+
+        $timeoutResponse = $this->createMock(ResponseInterface::class);
+        $timeoutResponse->method('getStatusCode')->willThrowException(new class ('timeout') extends \RuntimeException implements ExceptionInterface {
+        });
+
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $httpClient->expects($this->exactly(2))
+            ->method('request')
+            ->willReturnCallback(static fn (string $method, string $url): ResponseInterface => match ($url) {
+                'https://example.test/healthz-critical' => $criticalResponse,
+                'https://example.test/healthz-secondary' => $timeoutResponse,
+                default => throw new \LogicException('Unexpected URL ' . $url),
+            });
+
+        $command = $this->createCommand(
+            $cacheInvalidationService,
+            $reindexService,
+            $httpClient,
+            <<<YAML
+max_concurrency: 2
+timeout_seconds: 0.1
+retry_max: 1
+success_threshold_ms: 500
+critical:
+  - path: /healthz-critical
+secondary:
+  - path: /healthz-secondary
+YAML
+        );
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('[FAIL] https://example.test/healthz-secondary (status=n/a', $tester->getDisplay());
+        self::assertStringContainsString('Failures', $tester->getDisplay());
+        self::assertStringContainsString('Public endpoints warmup completed without critical failures.', $tester->getDisplay());
+    }
+
+    private function createCommand(
+        CacheInvalidationService $cacheInvalidationService,
+        ReindexAllDomainsServiceInterface $reindexService,
+        HttpClientInterface $httpClient,
+        string $yamlConfig = <<<YAML
+max_concurrency: 1
+timeout_seconds: 0.1
+retry_max: 1
+success_threshold_ms: 500
+critical:
+  - path: /healthz-critical
+secondary: []
+YAML,
+    ): WarmupPublicEndpointsCommand {
+        $configProvider = new WarmupPublicEndpointsConfigProvider($this->createWarmupConfigFile($yamlConfig));
+
+        $observabilityService = new WarmupPublicEndpointsObservabilityService(
+            monitoringLogger: new NullLogger(),
+            appCache: new ArrayAdapter(),
+            httpClient: $this->createMock(HttpClientInterface::class),
+            notifier: null,
+            warmupCriticalFailureWindowSeconds: 300,
+            warmupCriticalFailureAlertThreshold: 3,
+            warmupCriticalFailureSlackWebhook: '',
+        );
+
+        return new WarmupPublicEndpointsCommand(
+            cacheInvalidationService: $cacheInvalidationService,
+            reindexAllDomainsService: $reindexService,
+            httpClient: $httpClient,
+            configProvider: $configProvider,
+            warmupPublicEndpointsBaseUrl: 'https://example.test',
+            lockFactory: new LockFactory(new InMemoryStore()),
+            logger: new NullLogger(),
+            observabilityService: $observabilityService,
+        );
+    }
+
+    private function createWarmupConfigFile(string $yamlContent): string
+    {
+        $filePath = sys_get_temp_dir() . '/warmup-public-endpoints-config-' . uniqid('', true) . '.yaml';
+        file_put_contents($filePath, $yamlContent);
+
+        return $filePath;
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide automated coverage for the warmup flow to ensure ES failures block HTTP warmup and that critical vs secondary endpoints are handled correctly.
- Supply a short operational runbook so operators know how to run, interpret and recover from warmup failures.

### Description

- Add `tests/Application/Tool/Transport/Command/WarmupPublicEndpointsCommandTest.php` which introduces unit/functional tests that mock dependencies and cover three scenarios: ES unavailable (reindex failure), critical endpoint returning 500, and secondary endpoint timeout.
- Tests exercise the command via `Symfony\Component\Console\Tester\CommandTester` and create temporary YAML config files with a helper `createWarmupConfigFile`.
- Add `docs/runbook/warmup-public-endpoints.md` with manual command, log interpretation, relaunch procedure and quick diagnostics for lock/Elasticsearch/HTTP issues.
- Use in-memory lock/cache and mocked HTTP client/observability service in tests to avoid external dependencies.

### Testing

- Ran PHP lint on the new test file with `php -l tests/Application/Tool/Transport/Command/WarmupPublicEndpointsCommandTest.php`, which reported no syntax errors (success).
- Attempted to run PHPUnit for the new test suite with `php bin/phpunit tests/Application/Tool/Transport/Command/WarmupPublicEndpointsCommandTest.php`, but the `bin/phpunit` executable was not available in this environment so PHPUnit could not be executed (blocked by environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f68d1d308326ac32d23b72d89e6b)