### PR TITLE
feat(crm): provision blogs for project and sprint creation

### DIFF
--- a/migrations/Version20260421113000.php
+++ b/migrations/Version20260421113000.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260421113000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'CRM: add optional blog relation for projects and sprints.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_project ADD blog_id BINARY(16) DEFAULT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)"');
+        $this->addSql('ALTER TABLE crm_sprint ADD blog_id BINARY(16) DEFAULT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)"');
+
+        $this->addSql('ALTER TABLE crm_project ADD CONSTRAINT FK_CE64D834DAA2FB99 FOREIGN KEY (blog_id) REFERENCES blog (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE crm_sprint ADD CONSTRAINT FK_74A6B74EDAA2FB99 FOREIGN KEY (blog_id) REFERENCES blog (id) ON DELETE SET NULL');
+
+        $this->addSql('CREATE INDEX IDX_CE64D834DAA2FB99 ON crm_project (blog_id)');
+        $this->addSql('CREATE INDEX IDX_74A6B74EDAA2FB99 ON crm_sprint (blog_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_project DROP FOREIGN KEY FK_CE64D834DAA2FB99');
+        $this->addSql('ALTER TABLE crm_sprint DROP FOREIGN KEY FK_74A6B74EDAA2FB99');
+
+        $this->addSql('DROP INDEX IDX_CE64D834DAA2FB99 ON crm_project');
+        $this->addSql('DROP INDEX IDX_74A6B74EDAA2FB99 ON crm_sprint');
+
+        $this->addSql('ALTER TABLE crm_project DROP blog_id');
+        $this->addSql('ALTER TABLE crm_sprint DROP blog_id');
+    }
+}

--- a/src/Blog/Domain/Enum/BlogType.php
+++ b/src/Blog/Domain/Enum/BlogType.php
@@ -8,6 +8,8 @@ enum BlogType: string
 {
     case GENERAL = 'general';
     case APPLICATION = 'application';
+    case PROJECT = 'project';
+    case SPRINT = 'sprint';
     case TASK = 'task';
     case TASK_REQUEST = 'task_request';
 }

--- a/src/Crm/Application/Service/CrmEntityBlogProvisioningService.php
+++ b/src/Crm/Application/Service/CrmEntityBlogProvisioningService.php
@@ -6,6 +6,8 @@ namespace App\Crm\Application\Service;
 
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Enum\BlogType;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Domain\Entity\Sprint;
 use App\Crm\Domain\Entity\Task;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Platform\Domain\Entity\Application;
@@ -19,14 +21,14 @@ use function sprintf;
 use function strtolower;
 use function trim;
 
-final readonly class CrmTaskBlogProvisioningService
+final readonly class CrmEntityBlogProvisioningService
 {
     public function __construct(
         private EntityManagerInterface $entityManager,
     ) {
     }
 
-    public function provision(Task|TaskRequest $subject): void
+    public function provision(Project|Sprint|Task|TaskRequest $subject): void
     {
         if ($subject->getBlog() instanceof Blog) {
             return;
@@ -46,12 +48,10 @@ final readonly class CrmTaskBlogProvisioningService
             return;
         }
 
-        $blogType = $subject instanceof TaskRequest ? BlogType::TASK_REQUEST : BlogType::TASK;
-
         $blog = new Blog()
             ->setApplication($application)
             ->setOwner($owner)
-            ->setType($blogType)
+            ->setType($this->resolveBlogType($subject))
             ->setTitle($this->buildTitle($subject))
             ->setSlug($this->buildUniqueSlug($subject));
 
@@ -59,13 +59,19 @@ final readonly class CrmTaskBlogProvisioningService
         $this->entityManager->persist($blog);
     }
 
-    private function resolveApplication(Task|TaskRequest $subject): ?Application
+    private function resolveApplication(Project|Sprint|Task|TaskRequest $subject): ?Application
     {
         if ($subject instanceof TaskRequest) {
             $subject = $subject->getTask();
         }
 
-        return $subject?->getProject()?->getCompany()?->getCrm()?->getApplication();
+        if ($subject instanceof Sprint) {
+            $subject = $subject->getProject();
+        }
+
+        return $subject instanceof Project
+            ? $subject->getCompany()?->getCrm()?->getApplication()
+            : $subject?->getProject()?->getCompany()?->getCrm()?->getApplication();
     }
 
     private function hasBlogPlugin(Application $application): bool
@@ -83,19 +89,41 @@ final readonly class CrmTaskBlogProvisioningService
         return false;
     }
 
-    private function buildTitle(Task|TaskRequest $subject): string
+    private function resolveBlogType(Project|Sprint|Task|TaskRequest $subject): BlogType
     {
-        if ($subject instanceof TaskRequest) {
-            return sprintf('Task Request: %s', $subject->getTitle());
-        }
-
-        return sprintf('Task: %s', $subject->getTitle());
+        return match (true) {
+            $subject instanceof Project => BlogType::PROJECT,
+            $subject instanceof Sprint => BlogType::SPRINT,
+            $subject instanceof TaskRequest => BlogType::TASK_REQUEST,
+            default => BlogType::TASK,
+        };
     }
 
-    private function buildUniqueSlug(Task|TaskRequest $subject): string
+    private function buildTitle(Project|Sprint|Task|TaskRequest $subject): string
     {
-        $prefix = $subject instanceof TaskRequest ? 'task-request' : 'task';
-        $baseSlug = $this->slugify(sprintf('%s-%s', $prefix, $subject->getTitle()));
+        return match (true) {
+            $subject instanceof Project => sprintf('Project: %s', $subject->getName()),
+            $subject instanceof Sprint => sprintf('Sprint: %s', $subject->getName()),
+            $subject instanceof TaskRequest => sprintf('Task Request: %s', $subject->getTitle()),
+            default => sprintf('Task: %s', $subject->getTitle()),
+        };
+    }
+
+    private function buildUniqueSlug(Project|Sprint|Task|TaskRequest $subject): string
+    {
+        $prefix = match (true) {
+            $subject instanceof Project => 'project',
+            $subject instanceof Sprint => 'sprint',
+            $subject instanceof TaskRequest => 'task-request',
+            default => 'task',
+        };
+
+        $name = match (true) {
+            $subject instanceof Project, $subject instanceof Sprint => $subject->getName(),
+            default => $subject->getTitle(),
+        };
+
+        $baseSlug = $this->slugify(sprintf('%s-%s', $prefix, $name));
         $slug = $baseSlug;
         $index = 1;
 
@@ -115,6 +143,6 @@ final readonly class CrmTaskBlogProvisioningService
     {
         $slug = strtolower(trim((string)preg_replace('/[^a-zA-Z0-9]+/', '-', $value), '-'));
 
-        return $slug !== '' ? $slug : 'crm-task-blog';
+        return $slug !== '' ? $slug : 'crm-entity-blog';
     }
 }

--- a/src/Crm/Domain/Entity/Project.php
+++ b/src/Crm/Domain/Entity/Project.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Domain\Entity;
 
+use App\Blog\Domain\Entity\Blog;
 use App\Crm\Domain\Enum\ProjectStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
@@ -78,6 +79,10 @@ class Project implements EntityInterface
 
     #[ORM\Column(name: 'github_token', type: Types::STRING, length: 255, nullable: true)]
     private ?string $githubToken = null;
+
+    #[ORM\OneToOne(targetEntity: Blog::class, cascade: ['persist'])]
+    #[ORM\JoinColumn(name: 'blog_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Blog $blog = null;
 
     #[ORM\Column(name: 'provisioning_status', type: Types::STRING, length: 40, options: [
         'default' => 'pending',
@@ -275,6 +280,18 @@ class Project implements EntityInterface
     public function setGithubToken(?string $githubToken): self
     {
         $this->githubToken = $githubToken;
+
+        return $this;
+    }
+
+    public function getBlog(): ?Blog
+    {
+        return $this->blog;
+    }
+
+    public function setBlog(?Blog $blog): self
+    {
+        $this->blog = $blog;
 
         return $this;
     }

--- a/src/Crm/Domain/Entity/Sprint.php
+++ b/src/Crm/Domain/Entity/Sprint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Crm\Domain\Entity;
 
+use App\Blog\Domain\Entity\Blog;
 use App\Crm\Domain\Enum\SprintStatus;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
@@ -53,6 +54,10 @@ class Sprint implements EntityInterface
         'default' => SprintStatus::PLANNED->value,
     ])]
     private SprintStatus $status = SprintStatus::PLANNED;
+
+    #[ORM\OneToOne(targetEntity: Blog::class, cascade: ['persist'])]
+    #[ORM\JoinColumn(name: 'blog_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Blog $blog = null;
 
     /** @var Collection<int, Task>|ArrayCollection<int, Task> */
     #[ORM\OneToMany(targetEntity: Task::class, mappedBy: 'sprint')]
@@ -149,6 +154,18 @@ class Sprint implements EntityInterface
     public function setStatus(SprintStatus $status): self
     {
         $this->status = $status;
+
+        return $this;
+    }
+
+    public function getBlog(): ?Blog
+    {
+        return $this->blog;
+    }
+
+    public function setBlog(?Blog $blog): self
+    {
+        $this->blog = $blog;
 
         return $this;
     }

--- a/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/CreateProjectController.php
@@ -6,6 +6,7 @@ namespace App\Crm\Transport\Controller\Api\V1\Project;
 
 use App\Crm\Application\Message\ProjectCreated;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmEntityBlogProvisioningService;
 use App\Crm\Domain\Entity\Project;
 use App\Crm\Domain\Enum\ProjectStatus;
 use App\Crm\Infrastructure\Repository\CompanyRepository;
@@ -36,6 +37,7 @@ final readonly class CreateProjectController
         private CompanyRepository $companyRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
+        private CrmEntityBlogProvisioningService $crmEntityBlogProvisioningService,
         private ValidatorInterface $validator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
@@ -186,6 +188,7 @@ final readonly class CreateProjectController
         }
 
         $this->entityManager->persist($project);
+        $this->crmEntityBlogProvisioningService->provision($project);
         $this->entityManager->flush();
 
         $this->messageBus->dispatch(new ProjectCreated($project->getId(), $applicationSlug));

--- a/src/Crm/Transport/Controller/Api/V1/Sprint/CreateSprintController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Sprint/CreateSprintController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Crm\Transport\Controller\Api\V1\Sprint;
 
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmEntityBlogProvisioningService;
 use App\Crm\Domain\Entity\Sprint;
 use App\Crm\Domain\Enum\SprintStatus;
 use App\Crm\Infrastructure\Repository\ProjectRepository;
@@ -34,6 +35,7 @@ final readonly class CreateSprintController
         private ProjectRepository $projectRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
+        private CrmEntityBlogProvisioningService $crmEntityBlogProvisioningService,
         private ValidatorInterface $validator,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
@@ -160,6 +162,7 @@ final readonly class CreateSprintController
         }
 
         $this->entityManager->persist($sprint);
+        $this->crmEntityBlogProvisioningService->provision($sprint);
         $this->entityManager->flush();
         $this->messageBus->dispatch(new EntityCreated('crm_sprint', $sprint->getId(), context: [
             'applicationSlug' => $applicationSlug,

--- a/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/CreateTaskController.php
@@ -10,7 +10,7 @@ use App\Crm\Application\Exception\CrmOutOfScopeException;
 use App\Crm\Application\Exception\CrmReferenceNotFoundException;
 use App\Crm\Application\Service\CreateTaskHandler;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
-use App\Crm\Application\Service\CrmTaskBlogProvisioningService;
+use App\Crm\Application\Service\CrmEntityBlogProvisioningService;
 use App\Crm\Transport\Request\CrmApiErrorResponseFactory;
 use App\Crm\Transport\Request\CrmDateParser;
 use App\Crm\Transport\Request\CrmRequestHandler;
@@ -34,7 +34,7 @@ final readonly class CreateTaskController
     public function __construct(
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
-        private CrmTaskBlogProvisioningService $crmTaskBlogProvisioningService,
+        private CrmEntityBlogProvisioningService $crmEntityBlogProvisioningService,
         private CrmRequestHandler $crmRequestHandler,
         private CrmDateParser $crmDateParser,
         private CreateTaskHandler $createTaskHandler,
@@ -140,7 +140,7 @@ final readonly class CreateTaskController
         }
 
         $this->entityManager->persist($task);
-        $this->crmTaskBlogProvisioningService->provision($task);
+        $this->crmEntityBlogProvisioningService->provision($task);
         $this->entityManager->flush();
         $this->messageBus->dispatch(new EntityCreated('crm_task', $task->getId(), context: [
             'applicationSlug' => $applicationSlug,

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
@@ -6,7 +6,7 @@ namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
 
 use App\Crm\Application\Message\ProvisionTaskRequestGithubIssue;
 use App\Crm\Application\Service\CrmApplicationScopeResolver;
-use App\Crm\Application\Service\CrmTaskBlogProvisioningService;
+use App\Crm\Application\Service\CrmEntityBlogProvisioningService;
 use App\Crm\Domain\Entity\TaskRequest;
 use App\Crm\Domain\Enum\TaskRequestStatus;
 use App\Crm\Infrastructure\Repository\CrmProjectRepositoryRepository;
@@ -38,7 +38,7 @@ final readonly class CreateTaskRequestController
         private CrmProjectRepositoryRepository $crmProjectRepositoryRepository,
         private CrmApplicationScopeResolver $scopeResolver,
         private CrmApiErrorResponseFactory $errorResponseFactory,
-        private CrmTaskBlogProvisioningService $crmTaskBlogProvisioningService,
+        private CrmEntityBlogProvisioningService $crmEntityBlogProvisioningService,
         private CrmRequestHandler $crmRequestHandler,
         private CrmDateParser $crmDateParser,
         private EntityManagerInterface $entityManager,
@@ -142,7 +142,7 @@ final readonly class CreateTaskRequestController
         }
 
         $this->entityManager->persist($taskRequest);
-        $this->crmTaskBlogProvisioningService->provision($taskRequest);
+        $this->crmEntityBlogProvisioningService->provision($taskRequest);
         $this->entityManager->flush();
         $this->messageBus->dispatch(new ProvisionTaskRequestGithubIssue($taskRequest->getId()));
         $this->messageBus->dispatch(new EntityCreated('crm_task_request', $taskRequest->getId(), context: [


### PR DESCRIPTION
### Motivation
- Permettre la création automatique d’un `Blog` pour les entités CRM `Project` et `Sprint` lorsque le plugin blog est actif, en cohérence avec l’existant pour `Task`/`TaskRequest`.

### Description
- Ajout d’une relation `OneToOne` nullable `blog` avec `cascade: ['persist']` et `onDelete: 'SET NULL'` dans `src/Crm/Domain/Entity/Project.php` et `src/Crm/Domain/Entity/Sprint.php` avec getters/setters correspondants.
- Ajout d’une migration Doctrine `migrations/Version20260421113000.php` qui ajoute les colonnes `blog_id`, les clés étrangères `ON DELETE SET NULL` et les index sur `crm_project` et `crm_sprint`.
- Remplacement/évolution du service ciblé `CrmTaskBlogProvisioningService` en un service métier générique `CrmEntityBlogProvisioningService` qui supporte `Project|Sprint|Task|TaskRequest` et qui conserve les garde-fous (idempotence, uniquement plateforme CRM, vérification du plugin BLOG, slug unique, type/titre adaptés).
- Branchement du nouveau service dans les contrôleurs de création `CreateProjectController` et `CreateSprintController`, et remplacement des références dans `CreateTaskController` et `CreateTaskRequestController`, ainsi que l’extension de l’enum `BlogType` avec `PROJECT` et `SPRINT`.

### Testing
- Exécution de vérifications de syntaxe PHP avec `php -l` sur les fichiers modifiés et sur la migration (`src/Crm/Application/Service/CrmEntityBlogProvisioningService.php`, `src/Crm/Domain/Entity/Project.php`, `src/Crm/Domain/Entity/Sprint.php`, les contrôleurs modifiés, `src/Blog/Domain/Enum/BlogType.php` et `migrations/Version20260421113000.php`) et toutes les vérifications sont passées.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f6b1c0c883268901f18edaa1817b)