### PR TITLE
Implémenter le provisioning quiz conditionnel par plateforme

### DIFF
--- a/migrations/Version20260421110000.php
+++ b/migrations/Version20260421110000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260421110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Attach dedicated quizzes to school_exam and recruit_job entities.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE school_exam ADD quiz_id BINARY(16) DEFAULT NULL COMMENT \'(DC2Type:uuid_binary_ordered_time)\'');
+        $this->addSql('ALTER TABLE recruit_job ADD quiz_id BINARY(16) DEFAULT NULL COMMENT \'(DC2Type:uuid_binary_ordered_time)\'');
+        $this->addSql('CREATE INDEX idx_school_exam_quiz_id ON school_exam (quiz_id)');
+        $this->addSql('CREATE INDEX idx_recruit_job_quiz_id ON recruit_job (quiz_id)');
+        $this->addSql('ALTER TABLE school_exam ADD CONSTRAINT FK_F41E5E86853CD175 FOREIGN KEY (quiz_id) REFERENCES quiz (id) ON DELETE SET NULL');
+        $this->addSql('ALTER TABLE recruit_job ADD CONSTRAINT FK_75CF03EA853CD175 FOREIGN KEY (quiz_id) REFERENCES quiz (id) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE school_exam DROP FOREIGN KEY FK_F41E5E86853CD175');
+        $this->addSql('ALTER TABLE recruit_job DROP FOREIGN KEY FK_75CF03EA853CD175');
+        $this->addSql('DROP INDEX idx_school_exam_quiz_id ON school_exam');
+        $this->addSql('DROP INDEX idx_recruit_job_quiz_id ON recruit_job');
+        $this->addSql('ALTER TABLE school_exam DROP quiz_id');
+        $this->addSql('ALTER TABLE recruit_job DROP quiz_id');
+    }
+}

--- a/src/Platform/Application/Service/PluginProvisioning/QuizPluginProvisioner.php
+++ b/src/Platform/Application/Service/PluginProvisioning/QuizPluginProvisioner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Platform\Application\Service\PluginProvisioning;
 
 use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PlatformKey;
 use App\Quiz\Domain\Entity\Quiz;
 use App\Quiz\Domain\Entity\QuizQuestion;
 use App\Quiz\Domain\Enum\QuizLevel;
@@ -25,6 +26,11 @@ final readonly class QuizPluginProvisioner
 
     public function provision(Application $application): void
     {
+        $platformKey = $application->getPlatform()?->getPlatformKey();
+        if ($platformKey === PlatformKey::SCHOOL || $platformKey === PlatformKey::RECRUIT) {
+            return;
+        }
+
         $quiz = $this->quizRepository->findOneByApplication($application);
         if (!$quiz instanceof Quiz) {
             $quiz = (new Quiz())

--- a/src/Recruit/Application/Service/JobPublicDetailService.php
+++ b/src/Recruit/Application/Service/JobPublicDetailService.php
@@ -194,6 +194,7 @@ readonly class JobPublicDetailService
     {
         return [
             'id' => $job->getId(),
+            'quizId' => $job->getQuizId(),
             'slug' => $job->getSlug(),
             'title' => $job->getTitle(),
             'company' => [

--- a/src/Recruit/Application/Service/JobPublicListService.php
+++ b/src/Recruit/Application/Service/JobPublicListService.php
@@ -196,6 +196,7 @@ readonly class JobPublicListService
                 $ownerId = $job->getOwner()?->getId();
                 $jobPayload = [
                     'id' => $job->getId(),
+                    'quizId' => $job->getQuizId(),
                     'slug' => $job->getSlug(),
                     'title' => $job->getTitle(),
                     'company' => [
@@ -365,6 +366,7 @@ readonly class JobPublicListService
             foreach ($paginator as $job) {
                 $items[] = [
                     'id' => $job->getId(),
+                    'quizId' => $job->getQuizId(),
                     'slug' => $job->getSlug(),
                     'title' => $job->getTitle(),
                     'company' => [

--- a/src/Recruit/Application/Service/MyJobListService.php
+++ b/src/Recruit/Application/Service/MyJobListService.php
@@ -55,6 +55,7 @@ readonly class MyJobListService
         return [
             'createdJobs' => array_map(static fn (Job $job): array => [
                 'id' => $job->getId(),
+                'quizId' => $job->getQuizId(),
                 'slug' => $job->getSlug(),
                 'title' => $job->getTitle(),
                 'company' => $job->getCompany()?->getName() ?? '',
@@ -72,6 +73,7 @@ readonly class MyJobListService
                 'appliedAt' => $application->getCreatedAt()?->format(DATE_ATOM),
                 'job' => [
                     'id' => $application->getJob()->getId(),
+                    'quizId' => $application->getJob()->getQuizId(),
                     'slug' => $application->getJob()->getSlug(),
                     'title' => $application->getJob()->getTitle(),
                     'company' => $application->getJob()->getCompany()?->getName() ?? '',

--- a/src/Recruit/Application/Service/RecruitJobQuizProvisioningService.php
+++ b/src/Recruit/Application/Service/RecruitJobQuizProvisioningService.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Application\Service;
+
+use App\Quiz\Domain\Entity\Quiz;
+use App\Platform\Domain\Entity\Application;
+use App\Recruit\Domain\Entity\Job;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use RuntimeException;
+
+final readonly class RecruitJobQuizProvisioningService
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function provision(Job $job): Quiz
+    {
+        if ($job->getQuiz() instanceof Quiz) {
+            return $job->getQuiz();
+        }
+
+        $application = $job->getRecruit()?->getApplication();
+        if (!$application instanceof Application) {
+            throw new RuntimeException('Cannot provision job quiz without application.');
+        }
+        $owner = $application->getUser();
+        if (!$owner instanceof User) {
+            throw new RuntimeException('Cannot provision job quiz without application owner.');
+        }
+
+        $quiz = (new Quiz())
+            ->setApplication($application)
+            ->setOwner($owner)
+            ->setTitle('Quiz: ' . $job->getTitle())
+            ->setDescription('Dedicated quiz provisioned for recruit job ' . $job->getId() . '.');
+
+        $job->setQuiz($quiz);
+
+        $this->entityManager->persist($quiz);
+        $this->entityManager->persist($job);
+
+        return $quiz;
+    }
+}

--- a/src/Recruit/Domain/Entity/Job.php
+++ b/src/Recruit/Domain/Entity/Job.php
@@ -7,6 +7,7 @@ namespace App\Recruit\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\Quiz\Domain\Entity\Quiz;
 use App\Recruit\Domain\Enum\ContractType;
 use App\Recruit\Domain\Enum\ExperienceLevel;
 use App\Recruit\Domain\Enum\Schedule;
@@ -71,6 +72,10 @@ class Job implements EntityInterface
     #[ORM\JoinColumn(name: 'salary_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
     #[Groups(['Job', 'Job.salary'])]
     private ?Salary $salary = null;
+
+    #[ORM\ManyToOne(targetEntity: Quiz::class)]
+    #[ORM\JoinColumn(name: 'quiz_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Quiz $quiz = null;
 
     #[ORM\Column(name: 'location', type: Types::STRING, length: 255, options: [
         'default' => '',
@@ -263,6 +268,24 @@ class Job implements EntityInterface
     public function setSalary(?Salary $salary): self
     {
         $this->salary = $salary;
+
+        return $this;
+    }
+
+    #[Groups(['Job', 'Job.quizId'])]
+    public function getQuizId(): ?string
+    {
+        return $this->quiz?->getId();
+    }
+
+    public function getQuiz(): ?Quiz
+    {
+        return $this->quiz;
+    }
+
+    public function setQuiz(?Quiz $quiz): self
+    {
+        $this->quiz = $quiz;
 
         return $this;
     }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationController.php
@@ -8,6 +8,7 @@ use App\General\Application\Message\EntityCreated;
 use App\Recruit\Application\Security\RecruitPermissions;
 use App\Recruit\Application\Service\ApplicationJobAccessService;
 use App\Recruit\Application\Service\JobPayloadHydratorService;
+use App\Recruit\Application\Service\RecruitJobQuizProvisioningService;
 use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Infrastructure\Repository\JobRepository;
 use App\User\Domain\Entity\User;
@@ -38,6 +39,7 @@ readonly class JobCreateFromApplicationController
         private JobRepository $jobRepository,
         private MessageBusInterface $messageBus,
         private JobPayloadHydratorService $jobPayloadHydratorService,
+        private RecruitJobQuizProvisioningService $recruitJobQuizProvisioningService,
     ) {
     }
 
@@ -71,6 +73,7 @@ readonly class JobCreateFromApplicationController
             ->setTitle(trim($title));
 
         $this->jobPayloadHydratorService->applyJobFields($job, $payload);
+        $this->recruitJobQuizProvisioningService->provision($job);
 
         $this->jobRepository->save($job);
         $this->messageBus->dispatch(new EntityCreated('recruit_job', $job->getId(), context: [
@@ -83,6 +86,7 @@ readonly class JobCreateFromApplicationController
             'applicationSlug' => $application?->getSlug() ?? '',
             'slug' => $job->getSlug(),
             'title' => $job->getTitle(),
+            'quizId' => $job->getQuiz()?->getId(),
         ], JsonResponse::HTTP_CREATED);
     }
 }

--- a/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/JobPatchFromApplicationController.php
@@ -62,6 +62,7 @@ readonly class JobPatchFromApplicationController
             'recruitId' => $recruit->getId(),
             'slug' => $job->getSlug(),
             'title' => $job->getTitle(),
+            'quizId' => $job->getQuiz()?->getId(),
         ]);
     }
 }

--- a/src/School/Application/Serializer/SchoolViewMapper.php
+++ b/src/School/Application/Serializer/SchoolViewMapper.php
@@ -181,6 +181,7 @@ final readonly class SchoolViewMapper
             'type' => $exam->getType()->value,
             'status' => $exam->getStatus()->value,
             'term' => $exam->getTerm()->value,
+            'quizId' => $exam->getQuiz()?->getId(),
             'updatedAt' => $exam->getUpdatedAt()?->format(DATE_ATOM),
         ];
     }

--- a/src/School/Application/Service/CreateExamService.php
+++ b/src/School/Application/Service/CreateExamService.php
@@ -18,6 +18,7 @@ final readonly class CreateExamService
 {
     public function __construct(
         private SchoolReferenceResolver $referenceResolver,
+        private SchoolExamQuizProvisioningService $schoolExamQuizProvisioningService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -55,6 +56,11 @@ final readonly class CreateExamService
             ->setTeacher($teacher);
 
         $this->entityManager->persist($exam);
+
+        if ($type === ExamType::QUIZ) {
+            $this->schoolExamQuizProvisioningService->provision($exam);
+        }
+
         $this->entityManager->flush();
         $applicationSlug = $class->getSchool()?->getApplication()?->getSlug();
         $this->messageBus->dispatch(new EntityCreated('school_exam', $exam->getId(), context: [

--- a/src/School/Application/Service/SchoolExamQuizProvisioningService.php
+++ b/src/School/Application/Service/SchoolExamQuizProvisioningService.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\School\Application\Service;
+
+use App\Quiz\Domain\Entity\Quiz;
+use App\School\Domain\Entity\Exam;
+use App\Platform\Domain\Entity\Application;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use RuntimeException;
+
+final readonly class SchoolExamQuizProvisioningService
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function provision(Exam $exam): Quiz
+    {
+        if ($exam->getQuiz() instanceof Quiz) {
+            return $exam->getQuiz();
+        }
+
+        $application = $exam->getSchoolClass()?->getSchool()?->getApplication();
+        if (!$application instanceof Application) {
+            throw new RuntimeException('Cannot provision exam quiz without application.');
+        }
+        $owner = $application->getUser();
+        if (!$owner instanceof User) {
+            throw new RuntimeException('Cannot provision exam quiz without application owner.');
+        }
+
+        $quiz = (new Quiz())
+            ->setApplication($application)
+            ->setOwner($owner)
+            ->setTitle('Quiz: ' . $exam->getTitle())
+            ->setDescription('Dedicated quiz provisioned for school exam ' . $exam->getId() . '.');
+
+        $exam->setQuiz($quiz);
+
+        $this->entityManager->persist($quiz);
+        $this->entityManager->persist($exam);
+
+        return $quiz;
+    }
+}

--- a/src/School/Domain/Entity/Exam.php
+++ b/src/School/Domain/Entity/Exam.php
@@ -7,6 +7,7 @@ namespace App\School\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use App\Quiz\Domain\Entity\Quiz;
 use App\School\Domain\Enum\ExamStatus;
 use App\School\Domain\Enum\ExamType;
 use App\School\Domain\Enum\Term;
@@ -23,6 +24,7 @@ use Ramsey\Uuid\UuidInterface;
 #[ORM\Index(name: 'idx_school_exam_class_id', columns: ['class_id'])]
 #[ORM\Index(name: 'idx_school_exam_teacher_id', columns: ['teacher_id'])]
 #[ORM\Index(name: 'idx_school_exam_course_id', columns: ['course_id'])]
+#[ORM\Index(name: 'idx_school_exam_quiz_id', columns: ['quiz_id'])]
 #[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
 class Exam implements EntityInterface
 {
@@ -56,6 +58,10 @@ class Exam implements EntityInterface
 
     #[ORM\Column(name: 'term', type: Types::STRING, length: 32, enumType: Term::class)]
     private Term $term = Term::TERM_1;
+
+    #[ORM\ManyToOne(targetEntity: Quiz::class)]
+    #[ORM\JoinColumn(name: 'quiz_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Quiz $quiz = null;
 
     /** @var Collection<int, Grade>|ArrayCollection<int, Grade> */
     #[ORM\OneToMany(targetEntity: Grade::class, mappedBy: 'exam')]
@@ -144,6 +150,18 @@ class Exam implements EntityInterface
     public function setTerm(Term $term): self
     {
         $this->term = $term;
+
+        return $this;
+    }
+
+    public function getQuiz(): ?Quiz
+    {
+        return $this->quiz;
+    }
+
+    public function setQuiz(?Quiz $quiz): self
+    {
+        $this->quiz = $quiz;
 
         return $this;
     }

--- a/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
+++ b/src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php
@@ -92,6 +92,7 @@ final readonly class CreateExamController
 
         return new JsonResponse([
             'id' => $exam->getId(),
+            'quizId' => $exam->getQuiz()?->getId(),
         ], JsonResponse::HTTP_CREATED);
     }
 }


### PR DESCRIPTION
### Motivation
- Séparer le provisioning global d’un `Quiz` lié à l’`Application` du provisioning dédié par entité pour permettre un comportement conditionnel selon la `PlatformKey` (conserver le fallback actuel pour les plateformes autres que `SCHOOL`/`RECRUIT`).

### Description
- Empêche le provisioner plugin `QuizPluginProvisioner` de créer un quiz application-level pour les plateformes `PlatformKey::SCHOOL` et `PlatformKey::RECRUIT` en ajoutant un contrôle préalable dans `provision()`.
- Ajoute `SchoolExamQuizProvisioningService` et branche son appel dans `CreateExamService` uniquement quand `ExamType::QUIZ` afin de créer et lier un `Quiz` dédié sur `school_exam`.
- Ajoute `RecruitJobQuizProvisioningService` et l’appelle lors de la création de job (`JobCreateFromApplicationController`) pour créer et lier un `Quiz` dédié sur `recruit_job`.
- Ajoute la relation ORM `quiz_id` sur `school_exam` et `recruit_job` (getters/setters) et expose `quizId` dans les réponses des endpoints concernés et mappers (création d’exam/job, patch job, listes/détails job/exam).
- Ajoute la migration Doctrine `Version20260421110000` qui crée les colonnes `quiz_id`, les index `idx_school_exam_quiz_id` / `idx_recruit_job_quiz_id` et les FK vers `quiz(id)` avec `ON DELETE SET NULL`.

### Testing
- Vérification de syntaxe PHP sur les fichiers clés via `php -l` (fichiers modifiés + migration) et toutes les vérifications sont passées avec succès.
- Aucune autre suite de tests automatisés (unit/integration) n’a été ajoutée pour cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f920dbc08326ab9a947202f0af1e)