### PR TITLE
feat(page): add public contact submission endpoint and email notification

### DIFF
--- a/migrations/Version20260421130000.php
+++ b/migrations/Version20260421130000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260421130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Page: add storage for public contact requests.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE page_public_contact_request (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", first_name VARCHAR(100) NOT NULL, last_name VARCHAR(100) NOT NULL, email VARCHAR(190) NOT NULL, type VARCHAR(100) NOT NULL, message LONGTEXT NOT NULL, created_at DATETIME NOT NULL COMMENT "(DC2Type:datetime_immutable)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE INDEX idx_page_public_contact_request_email ON page_public_contact_request (email)');
+        $this->addSql('CREATE INDEX idx_page_public_contact_request_created_at ON page_public_contact_request (created_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE page_public_contact_request');
+    }
+}

--- a/src/Page/Application/Service/PublicContactMutationService.php
+++ b/src/Page/Application/Service/PublicContactMutationService.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Application\Service;
+
+use App\General\Domain\Service\Interfaces\MailerServiceInterface;
+use App\Page\Domain\Entity\PublicContactRequest;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Throwable;
+use Twig\Environment as Twig;
+
+final readonly class PublicContactMutationService
+{
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+        private MailerServiceInterface $mailerService,
+        private Twig $twig,
+        #[Autowire('%env(resolve:APP_SENDER_EMAIL)%')]
+        private string $appSenderEmail,
+        #[Autowire('%env(resolve:SITE_CONTACT_EMAIL)%')]
+        private string $siteContactEmail,
+    ) {
+    }
+
+    /**
+     * @param array<string, string> $payload
+     * @throws Throwable
+     */
+    public function create(array $payload): PublicContactRequest
+    {
+        $contactRequest = (new PublicContactRequest())
+            ->setFirstName($payload['firstName'])
+            ->setLastName($payload['lastName'])
+            ->setEmail($payload['email'])
+            ->setType($payload['type'])
+            ->setMessage($payload['message']);
+
+        $this->entityManager->persist($contactRequest);
+        $this->entityManager->flush();
+
+        $body = $this->twig->render('Emails/public_contact_request.html.twig', [
+            'contactRequest' => $contactRequest,
+        ]);
+
+        $this->mailerService->sendMail(
+            'Nouveau message du formulaire de contact',
+            $this->appSenderEmail,
+            $this->siteContactEmail,
+            $body,
+        );
+
+        return $contactRequest;
+    }
+}

--- a/src/Page/Domain/Entity/PublicContactRequest.php
+++ b/src/Page/Domain/Entity/PublicContactRequest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Page\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'page_public_contact_request')]
+#[ORM\Index(name: 'idx_page_public_contact_request_email', columns: ['email'])]
+#[ORM\Index(name: 'idx_page_public_contact_request_created_at', columns: ['created_at'])]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class PublicContactRequest implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'first_name', type: Types::STRING, length: 100)]
+    private string $firstName = '';
+
+    #[ORM\Column(name: 'last_name', type: Types::STRING, length: 100)]
+    private string $lastName = '';
+
+    #[ORM\Column(name: 'email', type: Types::STRING, length: 190)]
+    private string $email = '';
+
+    #[ORM\Column(name: 'type', type: Types::STRING, length: 100)]
+    private string $type = '';
+
+    #[ORM\Column(name: 'message', type: Types::TEXT)]
+    private string $message = '';
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getFirstName(): string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(string $firstName): self
+    {
+        $this->firstName = trim($firstName);
+
+        return $this;
+    }
+
+    public function getLastName(): string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(string $lastName): self
+    {
+        $this->lastName = trim($lastName);
+
+        return $this;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = trim($email);
+
+        return $this;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = trim($type);
+
+        return $this;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function setMessage(string $message): self
+    {
+        $this->message = trim($message);
+
+        return $this;
+    }
+}

--- a/src/Page/Transport/Controller/Api/V1/Public/PublicPageController.php
+++ b/src/Page/Transport/Controller/Api/V1/Public/PublicPageController.php
@@ -4,14 +4,22 @@ declare(strict_types=1);
 
 namespace App\Page\Transport\Controller\Api\V1\Public;
 
+use App\Page\Application\Service\PublicContactMutationService;
 use App\Page\Application\Service\PublicPageReadService;
+use JsonException;
 use OpenApi\Attributes as OA;
 use Psr\Cache\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Attribute\Route;
+
+use function filter_var;
+use function sprintf;
+use function trim;
 
 #[AsController]
 #[OA\Tag(name: 'Page Public')]
@@ -19,6 +27,7 @@ final readonly class PublicPageController
 {
     public function __construct(
         private PublicPageReadService $publicPageReadService,
+        private PublicContactMutationService $publicContactMutationService,
     ) {
     }
 
@@ -62,6 +71,41 @@ final readonly class PublicPageController
         return $this->jsonContentOr404($this->publicPageReadService->getFaq($languageCode), $languageCode);
     }
 
+    #[Route(path: '/v1/page/public/contact', methods: [Request::METHOD_POST])]
+    #[OA\Post(security: [], summary: 'Create a public contact request.')]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['firstName', 'lastName', 'email', 'type', 'message'],
+            properties: [
+                new OA\Property(property: 'firstName', type: 'string', example: 'John'),
+                new OA\Property(property: 'lastName', type: 'string', example: 'Doe'),
+                new OA\Property(property: 'email', type: 'string', format: 'email', example: 'john.doe@example.com'),
+                new OA\Property(property: 'type', type: 'string', example: 'support'),
+                new OA\Property(property: 'message', type: 'string', example: 'Hello, I need help with my account.'),
+            ],
+        ),
+    )]
+    #[OA\Response(response: Response::HTTP_CREATED, description: 'Contact request created.')]
+    #[OA\Response(response: Response::HTTP_BAD_REQUEST, description: 'Invalid payload.')]
+    public function createContact(Request $request): JsonResponse
+    {
+        try {
+            /** @var array<string, mixed> $payload */
+            $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new BadRequestHttpException('Invalid JSON payload.');
+        }
+
+        $normalizedPayload = $this->normalizeContactPayload($payload);
+        $contactRequest = $this->publicContactMutationService->create($normalizedPayload);
+
+        return new JsonResponse([
+            'id' => $contactRequest->getId(),
+            'status' => 'created',
+        ], Response::HTTP_CREATED);
+    }
+
     /**
      * @param array<string, mixed>|null $content
      */
@@ -76,5 +120,32 @@ final readonly class PublicPageController
         }
 
         return new JsonResponse($content);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return array{firstName: string, lastName: string, email: string, type: string, message: string}
+     */
+    private function normalizeContactPayload(array $payload): array
+    {
+        $normalizedPayload = [
+            'firstName' => trim((string)($payload['firstName'] ?? '')),
+            'lastName' => trim((string)($payload['lastName'] ?? '')),
+            'email' => trim((string)($payload['email'] ?? '')),
+            'type' => trim((string)($payload['type'] ?? '')),
+            'message' => trim((string)($payload['message'] ?? '')),
+        ];
+
+        foreach ($normalizedPayload as $field => $value) {
+            if ($value === '') {
+                throw new BadRequestHttpException(sprintf('%s is required.', $field));
+            }
+        }
+
+        if (filter_var($normalizedPayload['email'], FILTER_VALIDATE_EMAIL) === false) {
+            throw new BadRequestHttpException('email must be valid.');
+        }
+
+        return $normalizedPayload;
     }
 }

--- a/templates/Emails/public_contact_request.html.twig
+++ b/templates/Emails/public_contact_request.html.twig
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Nouveau message de contact</title>
+</head>
+<body style="font-family:Arial,sans-serif;background:#f7f9fc;padding:24px;color:#1f2937;">
+<div style="max-width:680px;margin:0 auto;background:#ffffff;border-radius:10px;padding:24px;border:1px solid #e5e7eb;">
+    <h1 style="font-size:22px;margin:0 0 16px;">Nouveau message depuis le formulaire public</h1>
+    <p style="margin:0 0 16px;">Un visiteur a soumis une demande de contact.</p>
+
+    <table style="width:100%;border-collapse:collapse;">
+        <tr>
+            <td style="padding:8px 0;font-weight:600;width:180px;">Prénom</td>
+            <td style="padding:8px 0;">{{ contactRequest.firstName }}</td>
+        </tr>
+        <tr>
+            <td style="padding:8px 0;font-weight:600;">Nom</td>
+            <td style="padding:8px 0;">{{ contactRequest.lastName }}</td>
+        </tr>
+        <tr>
+            <td style="padding:8px 0;font-weight:600;">Email</td>
+            <td style="padding:8px 0;">{{ contactRequest.email }}</td>
+        </tr>
+        <tr>
+            <td style="padding:8px 0;font-weight:600;">Type</td>
+            <td style="padding:8px 0;">{{ contactRequest.type }}</td>
+        </tr>
+        <tr>
+            <td style="padding:8px 0;font-weight:600;vertical-align:top;">Message</td>
+            <td style="padding:8px 0;white-space:pre-line;">{{ contactRequest.message }}</td>
+        </tr>
+    </table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a public API endpoint to allow visitors to submit contact requests and have them persisted for later handling.  
- Notify the site contact via email using the existing mailer/Twig stack and the `SITE_CONTACT_EMAIL` env var to centralize handling of incoming contact messages.

### Description
- Add `PublicContactRequest` entity under `src/Page/Domain/Entity` to store `firstName`, `lastName`, `email`, `type`, `message` and timestamps.  
- Add `PublicContactMutationService` under `src/Page/Application/Service` to persist the entity and send a notification email using `MailerServiceInterface`, `APP_SENDER_EMAIL` and `SITE_CONTACT_EMAIL`.  
- Add a public POST endpoint `POST /v1/page/public/contact` in `PublicPageController` with JSON parsing and validation for `firstName`, `lastName`, `email`, `type` and `message`.  
- Add Twig email template `templates/Emails/public_contact_request.html.twig` and a Doctrine migration `migrations/Version20260421130000.php` to create the `page_public_contact_request` table and indexes.

### Testing
- Ran PHP syntax checks with `php -l` against `src/Page/Domain/Entity/PublicContactRequest.php`, `src/Page/Application/Service/PublicContactMutationService.php`, `src/Page/Transport/Controller/Api/V1/Public/PublicPageController.php` and `migrations/Version20260421130000.php`, all of which reported no syntax errors.  
- Attempted `php bin/console lint:twig templates/Emails/public_contact_request.html.twig` which failed in the container due to missing dependencies and suggests running `composer install` (environment issue, not a template syntax confirmation failure).  
- No automated unit tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7fa40db5083269d6748f9af217053)