### PR TITLE
Centralize platform orchestration alias mapping in blog/quiz provisioning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -364,3 +364,16 @@ Note: You can find git flow detail example [here](https://danielkummer.github.io
 
 ## License
 [The MIT License (MIT)](LICENSE)
+
+## Platform orchestration guardrails (blog/quiz provisioning)
+To avoid product ambiguity when orchestration metadata is interpreted from configuration keys, use the business mapping below:
+
+- `learning` -> `PlatformKey::SCHOOL`
+- `job` -> `PlatformKey::RECRUIT`
+
+Implementation rule:
+- Mapping is centralized in `PlatformBusinessKeyResolver` and must be reused by blog/quiz provisioning flows.
+- Do not duplicate `if/else` mappings in controllers, fixtures, or plugin provisioners.
+
+Regression rule:
+- Any new orchestration alias must be added to the centralized resolver first, with unit tests, before being consumed by provisioning logic.

--- a/src/Platform/Application/Service/PlatformBusinessKeyResolver.php
+++ b/src/Platform/Application/Service/PlatformBusinessKeyResolver.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Platform\Application\Service;
+
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\ApplicationPlugin;
+use App\Platform\Domain\Enum\PlatformKey;
+
+use function explode;
+use function in_array;
+use function strtolower;
+
+final class PlatformBusinessKeyResolver
+{
+    /**
+     * @var array<string, PlatformKey>
+     */
+    private const array ORCHESTRATION_ALIAS_MAP = [
+        'learning' => PlatformKey::SCHOOL,
+        'job' => PlatformKey::RECRUIT,
+    ];
+
+    public function resolve(Application $application): ?PlatformKey
+    {
+        $platformKey = $application->getPlatform()?->getPlatformKey();
+        if (in_array($platformKey, [PlatformKey::SCHOOL, PlatformKey::RECRUIT], true)) {
+            return $platformKey;
+        }
+
+        $resolvedFromConfigurations = $this->resolveFromApplicationConfigurations($application);
+        if ($resolvedFromConfigurations instanceof PlatformKey) {
+            return $resolvedFromConfigurations;
+        }
+
+        return $platformKey;
+    }
+
+    private function resolveFromApplicationConfigurations(Application $application): ?PlatformKey
+    {
+        foreach ($application->getConfigurations() as $configuration) {
+            $resolved = $this->resolveFromConfigurationKey($configuration->getConfigurationKey());
+            if ($resolved instanceof PlatformKey) {
+                return $resolved;
+            }
+        }
+
+        foreach ($application->getApplicationPlugins() as $applicationPlugin) {
+            if (!$applicationPlugin instanceof ApplicationPlugin) {
+                continue;
+            }
+
+            foreach ($applicationPlugin->getConfigurations() as $configuration) {
+                $resolved = $this->resolveFromConfigurationKey($configuration->getConfigurationKey());
+                if ($resolved instanceof PlatformKey) {
+                    return $resolved;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveFromConfigurationKey(string $configurationKey): ?PlatformKey
+    {
+        $segments = explode('.', $configurationKey);
+        $alias = strtolower((string)end($segments));
+
+        if ($alias === '') {
+            return null;
+        }
+
+        return self::ORCHESTRATION_ALIAS_MAP[$alias] ?? null;
+    }
+}

--- a/src/Platform/Application/Service/PluginProvisioning/BlogPluginProvisioner.php
+++ b/src/Platform/Application/Service/PluginProvisioning/BlogPluginProvisioner.php
@@ -11,10 +11,13 @@ use App\Blog\Domain\Enum\BlogType;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
 use App\Blog\Infrastructure\Repository\BlogRepository;
 use App\Blog\Infrastructure\Repository\BlogTagRepository;
+use App\Platform\Application\Service\PlatformBusinessKeyResolver;
 use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PlatformKey;
 use Doctrine\ORM\EntityManagerInterface;
 
 use function iconv;
+use function in_array;
 use function is_string;
 use function preg_replace;
 use function strlen;
@@ -29,11 +32,17 @@ final readonly class BlogPluginProvisioner
         private BlogPostRepository $blogPostRepository,
         private BlogTagRepository $blogTagRepository,
         private EntityManagerInterface $entityManager,
+        private PlatformBusinessKeyResolver $platformBusinessKeyResolver,
     ) {
     }
 
     public function provision(Application $application): void
     {
+        $platformKey = $this->platformBusinessKeyResolver->resolve($application);
+        if (in_array($platformKey, [PlatformKey::SCHOOL, PlatformKey::RECRUIT], true)) {
+            return;
+        }
+
         $blog = $this->blogRepository->findOneByApplication($application);
         if (!$blog instanceof Blog) {
             $blogSlug = $this->generateUniqueBlogSlug($application);

--- a/src/Platform/Application/Service/PluginProvisioning/QuizPluginProvisioner.php
+++ b/src/Platform/Application/Service/PluginProvisioning/QuizPluginProvisioner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Platform\Application\Service\PluginProvisioning;
 
 use App\Platform\Domain\Entity\Application;
+use App\Platform\Application\Service\PlatformBusinessKeyResolver;
 use App\Platform\Domain\Enum\PlatformKey;
 use App\Quiz\Domain\Entity\Quiz;
 use App\Quiz\Domain\Entity\QuizQuestion;
@@ -21,12 +22,13 @@ final readonly class QuizPluginProvisioner
         private QuizQuestionRepository $quizQuestionRepository,
         private QuizCategoryRepository $quizCategoryRepository,
         private EntityManagerInterface $entityManager,
+        private PlatformBusinessKeyResolver $platformBusinessKeyResolver,
     ) {
     }
 
     public function provision(Application $application): void
     {
-        $platformKey = $application->getPlatform()?->getPlatformKey();
+        $platformKey = $this->platformBusinessKeyResolver->resolve($application);
         if ($platformKey === PlatformKey::SCHOOL || $platformKey === PlatformKey::RECRUIT) {
             return;
         }

--- a/tests/Unit/Platform/Application/Service/PlatformBusinessKeyResolverTest.php
+++ b/tests/Unit/Platform/Application/Service/PlatformBusinessKeyResolverTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Platform\Application\Service;
+
+use App\Configuration\Domain\Entity\Configuration;
+use App\Platform\Application\Service\PlatformBusinessKeyResolver;
+use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Entity\ApplicationPlugin;
+use App\Platform\Domain\Entity\Platform;
+use App\Platform\Domain\Enum\PlatformKey;
+use PHPUnit\Framework\TestCase;
+
+final class PlatformBusinessKeyResolverTest extends TestCase
+{
+    public function testResolveReturnsNativeBusinessPlatformWhenAlreadySchool(): void
+    {
+        $platform = (new Platform())->setPlatformKey(PlatformKey::SCHOOL);
+        $application = (new Application())->setPlatform($platform);
+
+        $resolver = new PlatformBusinessKeyResolver();
+
+        self::assertSame(PlatformKey::SCHOOL, $resolver->resolve($application));
+    }
+
+    public function testResolveMapsLearningAliasToSchool(): void
+    {
+        $application = (new Application())
+            ->setPlatform((new Platform())->setPlatformKey(PlatformKey::CRM));
+
+        $application->addConfiguration(
+            (new Configuration())->setConfigurationKey('application.general.learning')->setConfigurationValue([]),
+        );
+
+        $resolver = new PlatformBusinessKeyResolver();
+
+        self::assertSame(PlatformKey::SCHOOL, $resolver->resolve($application));
+    }
+
+    public function testResolveMapsJobAliasToRecruitFromPluginConfiguration(): void
+    {
+        $application = (new Application())
+            ->setPlatform((new Platform())->setPlatformKey(PlatformKey::SHOP));
+
+        $applicationPlugin = new ApplicationPlugin();
+        $applicationPlugin->addConfiguration(
+            (new Configuration())->setConfigurationKey('plugin.blog.job')->setConfigurationValue([]),
+        );
+        $application->addApplicationPlugin($applicationPlugin);
+
+        $resolver = new PlatformBusinessKeyResolver();
+
+        self::assertSame(PlatformKey::RECRUIT, $resolver->resolve($application));
+    }
+}

--- a/tests/Unit/Platform/Application/Service/PluginProvisioning/BlogPluginProvisionerTest.php
+++ b/tests/Unit/Platform/Application/Service/PluginProvisioning/BlogPluginProvisionerTest.php
@@ -10,8 +10,10 @@ use App\Blog\Domain\Entity\BlogTag;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
 use App\Blog\Infrastructure\Repository\BlogRepository;
 use App\Blog\Infrastructure\Repository\BlogTagRepository;
+use App\Platform\Application\Service\PlatformBusinessKeyResolver;
 use App\Platform\Application\Service\PluginProvisioning\BlogPluginProvisioner;
 use App\Platform\Domain\Entity\Application;
+use App\Platform\Domain\Enum\PlatformKey;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -53,11 +55,15 @@ final class BlogPluginProvisionerTest extends TestCase
                 $persisted[] = $entity;
             });
 
+        $platformBusinessKeyResolver = $this->createMock(PlatformBusinessKeyResolver::class);
+        $platformBusinessKeyResolver->method('resolve')->willReturn(null);
+
         $provisioner = new BlogPluginProvisioner(
             blogRepository: $blogRepository,
             blogPostRepository: $blogPostRepository,
             blogTagRepository: $blogTagRepository,
             entityManager: $entityManager,
+            platformBusinessKeyResolver: $platformBusinessKeyResolver,
         );
 
         $provisioner->provision($application);
@@ -96,17 +102,44 @@ final class BlogPluginProvisionerTest extends TestCase
                 $persisted[] = $entity;
             });
 
+        $platformBusinessKeyResolver = $this->createMock(PlatformBusinessKeyResolver::class);
+        $platformBusinessKeyResolver->method('resolve')->willReturn(null);
+
         $provisioner = new BlogPluginProvisioner(
             blogRepository: $blogRepository,
             blogPostRepository: $blogPostRepository,
             blogTagRepository: $blogTagRepository,
             entityManager: $entityManager,
+            platformBusinessKeyResolver: $platformBusinessKeyResolver,
         );
 
         $provisioner->provision($application);
 
         $blog = self::findPersistedEntity($persisted, Blog::class);
         self::assertMatchesRegularExpression('/^app-[a-f0-9]{8}-blog$/', $blog->getSlug());
+    }
+
+    public function testProvisionSkipsBootstrapForSchoolAndRecruitBusinessPlatforms(): void
+    {
+        $application = (new Application())
+            ->setTitle('Learning App')
+            ->setUser(new User());
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('persist');
+
+        $platformBusinessKeyResolver = $this->createMock(PlatformBusinessKeyResolver::class);
+        $platformBusinessKeyResolver->method('resolve')->willReturn(PlatformKey::SCHOOL);
+
+        $provisioner = new BlogPluginProvisioner(
+            blogRepository: $this->createMock(BlogRepository::class),
+            blogPostRepository: $this->createMock(BlogPostRepository::class),
+            blogTagRepository: $this->createMock(BlogTagRepository::class),
+            entityManager: $entityManager,
+            platformBusinessKeyResolver: $platformBusinessKeyResolver,
+        );
+
+        $provisioner->provision($application);
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Avoid ambiguous interpretation of orchestration aliases (e.g. `learning`, `job`) spread across code and fixtures by centralizing the business mapping. 
- Ensure blog/quiz provisioning uses a single source of truth to prevent product regressions when orchestration metadata is present in configuration keys.

### Description
- Add `PlatformBusinessKeyResolver` to centralize mapping and resolution of orchestration aliases with explicit mapping: `learning -> PlatformKey::SCHOOL` and `job -> PlatformKey::RECRUIT`, with resolution that prefers native platform keys and then falls back to application/plugin configuration keys (`src/Platform/Application/Service/PlatformBusinessKeyResolver.php`).
- Reuse the resolver from provisioning flows by injecting it into `BlogPluginProvisioner` and `QuizPluginProvisioner` and stop in-provisioner ad-hoc mappings; blog/quiz provisioning now short-circuits (no bootstrap content) when the resolved business key is `SCHOOL` or `RECRUIT` (`src/Platform/Application/Service/PluginProvisioning/BlogPluginProvisioner.php`, `src/Platform/Application/Service/PluginProvisioning/QuizPluginProvisioner.php`).
- Update unit tests: adapt existing `BlogPluginProvisionerTest` to the new dependency and add `PlatformBusinessKeyResolverTest` which covers native platform, `learning` alias via application config and `job` alias via plugin config (`tests/Unit/Platform/Application/Service/PluginProvisioning/BlogPluginProvisionerTest.php`, `tests/Unit/Platform/Application/Service/PlatformBusinessKeyResolverTest.php`).
- Document orchestration guardrails and the mapping in `readme.md` to prevent duplication and enforce adding aliases to the centralized resolver first.

### Testing
- Ran syntax checks with `php -l` on the modified files and they all passed. 
- Added unit tests for the resolver and updated blog provisioner tests; tests are included under `tests/Unit/...` but full `phpunit` execution could not be performed in this environment because `./vendor/bin/phpunit` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7fa998af08326b2e238afbb6e96db)