### PR TITLE
feat(mercure): allow public publishes without JWT

### DIFF
--- a/compose-staging.yaml
+++ b/compose-staging.yaml
@@ -140,11 +140,10 @@ services:
         restart: always
         environment:
             SERVER_NAME: ':80'
-            MERCURE_PUBLISHER_JWT_KEY: ${MERCURE_JWT_SECRET}
-            MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_JWT_SECRET}
             MERCURE_EXTRA_DIRECTIVES: |
                 cors_origins *
                 anonymous
+                publish_origins *
         ports:
             - "${MERCURE_PORT}:80"
         networks:

--- a/compose.yaml
+++ b/compose.yaml
@@ -156,11 +156,10 @@ services:
         restart: always
         environment:
             SERVER_NAME: ':80'
-            MERCURE_PUBLISHER_JWT_KEY: ${MERCURE_JWT_SECRET}
-            MERCURE_SUBSCRIBER_JWT_KEY: ${MERCURE_JWT_SECRET}
             MERCURE_EXTRA_DIRECTIVES: |
                 cors_origins *
                 anonymous
+                publish_origins *
         ports:
             - "${MERCURE_PORT}:80"
         networks:

--- a/src/General/Application/Service/MercurePublisher.php
+++ b/src/General/Application/Service/MercurePublisher.php
@@ -19,8 +19,6 @@ final readonly class MercurePublisher
         private LoggerInterface $logger,
         #[Autowire('%env(string:MERCURE_PUBLISH_URL)%')]
         private string $mercurePublishUrl,
-        #[Autowire('%env(string:MERCURE_JWT_SECRET)%')]
-        private string $mercureJwtSecret,
     ) {
     }
 
@@ -43,7 +41,6 @@ final readonly class MercurePublisher
 
         try {
             $this->httpClient->request('POST', $this->mercurePublishUrl, [
-                'auth_bearer' => $this->mercureJwtSecret,
                 'body' => $payload,
             ])->getStatusCode();
         } catch (ExceptionInterface $exception) {


### PR DESCRIPTION
### Motivation
- Allow the app (e.g. a Nuxt frontend) to publish to Mercure without providing a JWT, by making hub accepts public publishes.
- Simplify backend publishing so the server no longer needs to sign requests with a Mercure JWT when publishing updates.

### Description
- Removed Mercure hub JWT environment keys from `compose.yaml` and `compose-staging.yaml` and added `publish_origins *` to `MERCURE_EXTRA_DIRECTIVES` so the hub accepts public publishes (keeps `anonymous`).
- Stopped injecting and using the `MERCURE_JWT_SECRET` in `src/General/Application/Service/MercurePublisher.php` and removed the `'auth_bearer'` header from the HTTP `POST` used to publish updates.
- Affects Docker compose hub configuration and the Symfony `MercurePublisher` service.

### Testing
- Ran `php -l src/General/Application/Service/MercurePublisher.php` and it reported no syntax errors (success).
- Attempted `docker compose -f compose.yaml config` and `docker compose -f compose-staging.yaml config` but they failed in this environment with `docker: command not found` (could not validate generated compose locally).
- No additional automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e80d948c548326bded8b3b53bfcff8)