### PR TITLE
feat: add Mercure debug test endpoint

### DIFF
--- a/src/Tool/Transport/Controller/Api/MercureTestController.php
+++ b/src/Tool/Transport/Controller/Api/MercureTestController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tool\Transport\Controller\Api;
+
+use App\General\Application\Service\MercurePublisher;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+class MercureTestController
+{
+    #[Route('/mercure/test', name: 'mercure_test', methods: [Request::METHOD_GET])]
+    public function mercureTest(MercurePublisher $mercurePublisher): JsonResponse
+    {
+        $mercurePublisher->publish(
+            '/debug/mercure',
+            [
+                'test' => 'hello debug',
+                'time' => (new DateTimeImmutable())->format(DATE_ATOM),
+            ],
+            false,
+        );
+
+        return new JsonResponse(['ok' => true]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Fournir un endpoint simple pour vérifier la publication Mercure depuis l’application.

### Description
- Ajout du contrôleur `MercureTestController` exposant `GET /api/mercure/test` (route `mercure_test`) qui publie un message sur le topic `/debug/mercure` avec un payload de test et un timestamp ISO8601, puis renvoie `{"ok": true}`.

### Testing
- Validation syntaxique PHP exécutée via `php -l src/Tool/Transport/Controller/Api/MercureTestController.php` et passée avec succès.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e825018b848326bbd558690cae351d)