### PR TITLE
refactor(recruit): centralize public job payload mapping

### DIFF
--- a/src/Recruit/Application/Service/JobPublicListService.php
+++ b/src/Recruit/Application/Service/JobPublicListService.php
@@ -193,46 +193,15 @@ readonly class JobPublicListService
             /** @var Job $job */
             foreach ($paginator as $job) {
                 $jobIds[] = $job->getId();
-                $ownerId = $job->getOwner()?->getId();
-                $jobPayload = [
-                    'id' => $job->getId(),
-                    'quizId' => $job->getQuizId(),
-                    'slug' => $job->getSlug(),
-                    'title' => $job->getTitle(),
-                    'company' => [
-                        'name' => $job->getCompany()?->getName() ?? '',
-                        'logo' => $job->getCompany()?->getLogo() ?? '',
-                        'sector' => $job->getCompany()?->getSector() ?? '',
-                        'size' => $job->getCompany()?->getSize() ?? '',
-                    ],
-                    'location' => $job->getLocation(),
-                    'contractType' => $job->getContractTypeValue(),
-                    'workMode' => $job->getWorkModeValue(),
-                    'schedule' => $job->getScheduleValue(),
-                    'experienceLevel' => $job->getExperienceLevelValue(),
-                    'yearsExperienceMin' => $job->getYearsExperienceMin(),
-                    'yearsExperienceMax' => $job->getYearsExperienceMax(),
-                    'salary' => [
-                        'min' => $job->getSalary()?->getMin() ?? 0,
-                        'max' => $job->getSalary()?->getMax() ?? 0,
-                        'currency' => $job->getSalary()?->getCurrency() ?? 'EUR',
-                        'period' => $job->getSalary()?->getPeriod() ?? 'year',
-                    ],
-                    'postedAtLabel' => $this->buildPostedAtLabel($job->getCreatedAt()),
-                    'summary' => $job->getSummary(),
+                $jobPayload = $this->buildJobPayload($job, [
+                    'mode' => 'connected',
                     'matchScore' => $userSkillKeywords === []
                         ? $job->getMatchScore()
                         : $this->computeMatchScore($job, $userSkillKeywords),
-                    'badges' => array_map(static fn ($badge): string => $badge->getLabel(), $job->getBadges()->toArray()),
-                    'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $job->getTags()->toArray()),
-                    'missionTitle' => $job->getMissionTitle(),
-                    'missionDescription' => $job->getMissionDescription(),
-                    'responsibilities' => $job->getResponsibilities(),
-                    'profile' => $job->getProfile(),
-                    'benefits' => $job->getBenefits(),
-                ];
+                ]);
 
                 if ($loggedInUser instanceof User) {
+                    $ownerId = $job->getOwner()?->getId();
                     $jobPayload['owner'] = $ownerId !== null && $ownerId === $loggedInUser->getId();
                 }
 
@@ -364,41 +333,9 @@ readonly class JobPublicListService
             $items = [];
             /** @var Job $job */
             foreach ($paginator as $job) {
-                $items[] = [
-                    'id' => $job->getId(),
-                    'quizId' => $job->getQuizId(),
-                    'slug' => $job->getSlug(),
-                    'title' => $job->getTitle(),
-                    'company' => [
-                        'name' => $job->getCompany()?->getName() ?? '',
-                        'logo' => $job->getCompany()?->getLogo() ?? '',
-                        'sector' => $job->getCompany()?->getSector() ?? '',
-                        'size' => $job->getCompany()?->getSize() ?? '',
-                    ],
-                    'location' => $job->getLocation(),
-                    'contractType' => $job->getContractTypeValue(),
-                    'workMode' => $job->getWorkModeValue(),
-                    'schedule' => $job->getScheduleValue(),
-                    'experienceLevel' => $job->getExperienceLevelValue(),
-                    'yearsExperienceMin' => $job->getYearsExperienceMin(),
-                    'yearsExperienceMax' => $job->getYearsExperienceMax(),
-                    'salary' => [
-                        'min' => $job->getSalary()?->getMin() ?? 0,
-                        'max' => $job->getSalary()?->getMax() ?? 0,
-                        'currency' => $job->getSalary()?->getCurrency() ?? 'EUR',
-                        'period' => $job->getSalary()?->getPeriod() ?? 'year',
-                    ],
-                    'postedAtLabel' => $this->buildPostedAtLabel($job->getCreatedAt()),
-                    'summary' => $job->getSummary(),
-                    'matchScore' => $job->getMatchScore(),
-                    'badges' => array_map(static fn ($badge): string => $badge->getLabel(), $job->getBadges()->toArray()),
-                    'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $job->getTags()->toArray()),
-                    'missionTitle' => $job->getMissionTitle(),
-                    'missionDescription' => $job->getMissionDescription(),
-                    'responsibilities' => $job->getResponsibilities(),
-                    'profile' => $job->getProfile(),
-                    'benefits' => $job->getBenefits(),
-                ];
+                $items[] = $this->buildJobPayload($job, [
+                    'mode' => 'general',
+                ]);
             }
 
             return [
@@ -418,6 +355,54 @@ readonly class JobPublicListService
         ];
 
         return $result;
+    }
+
+    /**
+     * @param array<string, mixed>|null $context
+     *
+     * @return array<string, mixed>
+     */
+    private function buildJobPayload(Job $job, ?array $context = null): array
+    {
+        $mode = is_string($context['mode'] ?? null) ? $context['mode'] : 'general';
+
+        return [
+            'id' => $job->getId(),
+            'quizId' => $job->getQuizId(),
+            'slug' => $job->getSlug(),
+            'title' => $job->getTitle(),
+            'company' => [
+                'name' => $job->getCompany()?->getName() ?? '',
+                'logo' => $job->getCompany()?->getLogo() ?? '',
+                'sector' => $job->getCompany()?->getSector() ?? '',
+                'size' => $job->getCompany()?->getSize() ?? '',
+            ],
+            'location' => $job->getLocation(),
+            'contractType' => $job->getContractTypeValue(),
+            'workMode' => $job->getWorkModeValue(),
+            'schedule' => $job->getScheduleValue(),
+            'experienceLevel' => $job->getExperienceLevelValue(),
+            'yearsExperienceMin' => $job->getYearsExperienceMin(),
+            'yearsExperienceMax' => $job->getYearsExperienceMax(),
+            'salary' => [
+                'min' => $job->getSalary()?->getMin() ?? 0,
+                'max' => $job->getSalary()?->getMax() ?? 0,
+                'currency' => $job->getSalary()?->getCurrency() ?? 'EUR',
+                'period' => $job->getSalary()?->getPeriod() ?? 'year',
+            ],
+            'postedAtLabel' => $this->buildPostedAtLabel($job->getCreatedAt()),
+            'summary' => $job->getSummary(),
+            'matchScore' => $mode === 'connected' && isset($context['matchScore'])
+                ? (int)$context['matchScore']
+                : $job->getMatchScore(),
+            'badges' => array_map(static fn ($badge): string => $badge->getLabel(), $job->getBadges()->toArray()),
+            'tags' => array_map(static fn ($tag): string => $tag->getLabel(), $job->getTags()->toArray()),
+            'missionTitle' => $job->getMissionTitle(),
+            'missionDescription' => $job->getMissionDescription(),
+            'responsibilities' => $job->getResponsibilities(),
+            'profile' => $job->getProfile(),
+            'benefits' => $job->getBenefits(),
+        ];
     }
 
     private function buildPostedAtLabel(?DateTimeImmutable $createdAt): string

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobsControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobsControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\Recruit\Transport\Controller\Api\V1\General;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ListGeneralJobsControllerTest extends WebTestCase
+{
+    #[TestDox('Test that `GET /v1/recruit/general/jobs` keeps the expected payload structure.')]
+    public function testThatGeneralJobsListKeepsExpectedPayloadStructure(): void
+    {
+        $client = $this->getTestClient();
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/general/jobs?limit=1');
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload['items'] ?? null);
+        self::assertNotEmpty($payload['items']);
+
+        $item = $payload['items'][0];
+        self::assertIsArray($item);
+        self::assertArrayHasKey('missionTitle', $item);
+        self::assertArrayHasKey('missionDescription', $item);
+        self::assertArrayHasKey('responsibilities', $item);
+        self::assertArrayHasKey('benefits', $item);
+        self::assertArrayHasKey('matchScore', $item);
+        self::assertArrayNotHasKey('owner', $item);
+        self::assertArrayNotHasKey('apply', $item);
+    }
+}

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PrivateJobListControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PrivateJobListControllerTest.php
@@ -58,11 +58,11 @@ class PrivateJobListControllerTest extends WebTestCase
 
         $payload = JSON::decode($content, true);
 
-        self::assertArrayHasKey('jobs', $payload);
-        self::assertIsArray($payload['jobs']);
+        self::assertArrayHasKey('items', $payload);
+        self::assertIsArray($payload['items']);
 
         $jobPayload = null;
-        foreach ($payload['jobs'] as $job) {
+        foreach ($payload['items'] as $job) {
             if (($job['id'] ?? null) === $jobId) {
                 $jobPayload = $job;
                 break;
@@ -72,6 +72,35 @@ class PrivateJobListControllerTest extends WebTestCase
         self::assertIsArray($jobPayload);
         self::assertArrayHasKey('matchScore', $jobPayload);
         self::assertSame($expectedMatchScore, $jobPayload['matchScore']);
+    }
+
+    #[TestDox('Test that `GET /v1/recruit/applications/{applicationSlug}/private/jobs` keeps the expected payload structure.')]
+    public function testThatPrivateJobListKeepsExpectedPayloadStructure(): void
+    {
+        [$applicationSlug] = $this->getFixtureContext();
+
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/applications/' . $applicationSlug . '/private/jobs?limit=1');
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload['items'] ?? null);
+        self::assertNotEmpty($payload['items']);
+
+        $item = $payload['items'][0];
+        self::assertIsArray($item);
+        self::assertArrayHasKey('missionTitle', $item);
+        self::assertArrayHasKey('missionDescription', $item);
+        self::assertArrayHasKey('responsibilities', $item);
+        self::assertArrayHasKey('benefits', $item);
+        self::assertArrayHasKey('matchScore', $item);
+        self::assertArrayHasKey('owner', $item);
+        self::assertArrayHasKey('apply', $item);
     }
 
     /**

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobListControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobListControllerTest.php
@@ -75,6 +75,35 @@ class PublicJobListControllerTest extends WebTestCase
         }
     }
 
+    #[TestDox('Test that `GET /v1/recruit/applications/{applicationSlug}/public/jobs` keeps the expected job payload structure.')]
+    public function testThatPublicJobListKeepsExpectedPayloadStructure(): void
+    {
+        [$applicationSlug] = $this->getFixtureContext();
+
+        $client = $this->getTestClient();
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/applications/' . $applicationSlug . '/public/jobs?limit=1');
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload['items'] ?? null);
+        self::assertNotEmpty($payload['items']);
+
+        $item = $payload['items'][0];
+        self::assertIsArray($item);
+        self::assertArrayHasKey('missionTitle', $item);
+        self::assertArrayHasKey('missionDescription', $item);
+        self::assertArrayHasKey('responsibilities', $item);
+        self::assertArrayHasKey('benefits', $item);
+        self::assertArrayHasKey('matchScore', $item);
+        self::assertArrayNotHasKey('owner', $item);
+        self::assertArrayNotHasKey('apply', $item);
+    }
+
     /**
      * @return array{0: string, 1: Job}
      */


### PR DESCRIPTION
### Motivation
- Réduire la duplication et centraliser la transformation `Job -> array` observée dans `getList()` et `getGeneralList()` en extrayant les champs communs (notamment `missionTitle`, `missionDescription`, `responsibilities`, `benefits`).
- Préserver le contrat API et la logique métier existante pour les variantes connecté/général notamment autour de `matchScore`, `owner` et `apply`.

### Description
- Extraction d'une méthode privée `buildJobPayload(Job $job, ?array $context = null): array` dans `src/Recruit/Application/Service/JobPublicListService.php` qui assemble le payload partagé et gère les variantes via le paramètre `context` (`mode: 'connected'|'general'` et `matchScore`).
- `getList()` utilise désormais `buildJobPayload` en `mode = 'connected'` et continue d'appliquer la logique existante (calcul ou usage natif de `matchScore`, puis enrichissement `owner` / `apply`).
- `getGeneralList()` utilise désormais `buildJobPayload` en `mode = 'general'` et conserve le `matchScore` natif.
- Ajout / mise à jour de tests d'intégration ciblés pour verrouiller la forme JSON retournée: `tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobListControllerTest.php`, `tests/Application/Recruit/Transport/Controller/Api/V1/Job/PrivateJobListControllerTest.php` et nouveau `tests/Application/Recruit/Transport/Controller/Api/V1/General/ListGeneralJobsControllerTest.php`.

### Testing
- Syntax checks `php -l` were executed on the modified service and added/updated tests and returned no syntax errors (`php -l src/Recruit/Application/Service/JobPublicListService.php` and the three test files succeeded). 
- Attempt to run the test suite with `phpunit` failed in this environment because the project PHPUnit binary/dependencies are not available (`./vendor/bin/phpunit` missing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e84217c7e4832b9310daebb7f48d9b)