### PR TITLE
Optimiser le filtrage date du pipeline, l’agrégation et la pagination

### DIFF
--- a/src/Recruit/Application/Service/PipelineBoardService.php
+++ b/src/Recruit/Application/Service/PipelineBoardService.php
@@ -7,6 +7,7 @@ namespace App\Recruit\Application\Service;
 use App\Recruit\Domain\Entity\Application;
 use App\Recruit\Domain\Entity\Recruit;
 use App\Recruit\Domain\Enum\ApplicationStatus;
+use App\Recruit\Infrastructure\Repository\ApplicationRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
@@ -69,9 +70,16 @@ readonly class PipelineBoardService
         }
 
         if ($date !== '') {
-            $queryBuilder
-                ->andWhere('DATE(application.createdAt) = :createdOn')
-                ->setParameter('createdOn', $date);
+            $startOfDay = \DateTimeImmutable::createFromFormat('!Y-m-d', $date);
+            if ($startOfDay !== false) {
+                $startOfNextDay = $startOfDay->modify('+1 day');
+
+                $queryBuilder
+                    ->andWhere('application.createdAt >= :startOfDay')
+                    ->andWhere('application.createdAt < :startOfNextDay')
+                    ->setParameter('startOfDay', $startOfDay)
+                    ->setParameter('startOfNextDay', $startOfNextDay);
+            }
         }
 
         if ($source === 'resume') {
@@ -87,12 +95,9 @@ readonly class PipelineBoardService
                 ->setParameter('tagLabel', $tag);
         }
 
-        $aggregateQueryBuilder = clone $queryBuilder;
-        $aggregateRows = $aggregateQueryBuilder
-            ->select('application.status AS status', 'COUNT(application.id) AS statusCount', 'AVG(TIMESTAMPDIFF(DAY, application.createdAt, CURRENT_TIMESTAMP())) AS avgAgingDays')
-            ->groupBy('application.status')
-            ->getQuery()
-            ->getArrayResult();
+        /** @var ApplicationRepository $applicationRepository */
+        $applicationRepository = $this->entityManager->getRepository(Application::class);
+        $aggregateRows = $applicationRepository->findPipelineStatusMetrics($queryBuilder);
 
         $queryBuilder->setFirstResult($offset)->setMaxResults($limit);
 
@@ -118,6 +123,8 @@ readonly class PipelineBoardService
 
         $columns = array_fill_keys($statusOrder, []);
 
+        $now = new \DateTimeImmutable();
+
         foreach ($paginator as $application) {
             if (!$application instanceof Application) {
                 continue;
@@ -132,7 +139,7 @@ readonly class PipelineBoardService
                 'id' => $application->getId(),
                 'status' => $status,
                 'createdAt' => $application->getCreatedAt()?->format(DATE_ATOM),
-                'agingDays' => max(0, (int)$application->getCreatedAt()?->diff(new \DateTimeImmutable())->days),
+                'agingDays' => max(0, (int)$application->getCreatedAt()?->diff($now)->days),
                 'source' => $applicant->getResume() !== null ? 'resume' : 'manual',
                 'job' => [
                     'id' => $job->getId(),
@@ -148,6 +155,8 @@ readonly class PipelineBoardService
             ];
         }
 
+        $total = count($paginator);
+
         return [
             'columns' => array_values(array_map(static fn (string $status) => [
                 'status' => $status,
@@ -157,8 +166,8 @@ readonly class PipelineBoardService
             'pagination' => [
                 'page' => $page,
                 'limit' => $limit,
-                'total' => count($paginator),
-                'pages' => (int)ceil(max(1, count($paginator)) / $limit),
+                'total' => $total,
+                'pages' => (int)ceil(max(1, $total) / $limit),
             ],
             'filters' => [
                 'jobId' => $jobId,

--- a/src/Recruit/Infrastructure/Repository/ApplicationRepository.php
+++ b/src/Recruit/Infrastructure/Repository/ApplicationRepository.php
@@ -15,6 +15,7 @@ use App\Recruit\Domain\Repository\Interfaces\ApplicationRepositoryInterface;
 use DateInterval;
 use DateTimeImmutable;
 use Doctrine\DBAL\LockMode;
+use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -215,6 +216,68 @@ class ApplicationRepository extends BaseRepository implements ApplicationReposit
             ApplicationStatus::OFFER_SENT->value => $offerCount,
             ApplicationStatus::HIRED->value => $hiredCount,
         ];
+    }
+
+    /**
+     * @return list<array{status: string, statusCount: int, avgAgingDays: float}>
+     */
+    public function findPipelineStatusMetrics(QueryBuilder $pipelineQueryBuilder): array
+    {
+        $aggregateQueryBuilder = clone $pipelineQueryBuilder;
+
+        try {
+            $rows = $aggregateQueryBuilder
+                ->select(
+                    'application.status AS status',
+                    'COUNT(application.id) AS statusCount',
+                    'AVG(TIMESTAMPDIFF(DAY, application.createdAt, CURRENT_TIMESTAMP())) AS avgAgingDays'
+                )
+                ->groupBy('application.status')
+                ->getQuery()
+                ->getArrayResult();
+
+            return array_map(static fn (array $row): array => [
+                'status' => (string)($row['status'] ?? ''),
+                'statusCount' => (int)($row['statusCount'] ?? 0),
+                'avgAgingDays' => round((float)($row['avgAgingDays'] ?? 0), 2),
+            ], $rows);
+        } catch (\Throwable) {
+            $rows = (clone $pipelineQueryBuilder)
+                ->select('application.status AS status', 'application.createdAt AS createdAt')
+                ->getQuery()
+                ->getArrayResult();
+
+            $now = new DateTimeImmutable();
+            $counts = [];
+            $agingSums = [];
+
+            foreach ($rows as $row) {
+                $status = (string)($row['status'] ?? '');
+                if ($status === '') {
+                    continue;
+                }
+
+                $counts[$status] = ($counts[$status] ?? 0) + 1;
+
+                $createdAt = $row['createdAt'] ?? null;
+                if (!$createdAt instanceof DateTimeImmutable) {
+                    continue;
+                }
+
+                $agingSums[$status] = ($agingSums[$status] ?? 0.0) + max(0, (float)$createdAt->diff($now)->days);
+            }
+
+            $result = [];
+            foreach ($counts as $status => $count) {
+                $result[] = [
+                    'status' => $status,
+                    'statusCount' => $count,
+                    'avgAgingDays' => round(($agingSums[$status] ?? 0.0) / max(1, $count), 2),
+                ];
+            }
+
+            return $result;
+        }
     }
 
     /**

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Application/PrivatePipelineControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Application/PrivatePipelineControllerTest.php
@@ -15,6 +15,7 @@ use App\Recruit\Domain\Enum\ApplicationStatus;
 use App\Tests\TestCase\WebTestCase;
 use App\User\Domain\Entity\User;
 use DateTime;
+use DateTimeImmutable;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\HttpFoundation\Response;
@@ -81,6 +82,24 @@ class PrivatePipelineControllerTest extends WebTestCase
         self::assertCount(1, $filteredCandidates);
         self::assertSame($jobId, $filteredCandidates[0]['job']['id'] ?? null);
         self::assertSame('manual', $filteredCandidates[0]['source'] ?? null);
+
+        $filterDate = (new DateTimeImmutable('-3 days'))->format('Y-m-d');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/recruit/private/' . $applicationSlug . '/pipeline?date=' . $filterDate . '&limit=10&page=1');
+        $datePayload = JSON::decode((string)$client->getResponse()->getContent(), true);
+
+        self::assertSame($filterDate, $datePayload['filters']['date'] ?? null);
+        self::assertSame(1, $datePayload['pagination']['total'] ?? null);
+        self::assertSame(1, $datePayload['pagination']['pages'] ?? null);
+
+        $dateFilteredCandidates = [];
+        foreach ($datePayload['columns'] as $column) {
+            foreach ($column['candidates'] ?? [] as $candidate) {
+                $dateFilteredCandidates[] = $candidate;
+            }
+        }
+
+        self::assertCount(1, $dateFilteredCandidates);
+        self::assertStringStartsWith($filterDate, (string)($dateFilteredCandidates[0]['createdAt'] ?? ''));
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Éviter des patterns coûteux en SQL et PHP dans `PipelineBoardService::getPipeline()` en rendant le filtrage date index-friendly, en réduisant les recomptages et en stabilisant le calcul d'ancienneté des candidatures.
- Rendre l'agrégation de métriques (`AVG(TIMESTAMPDIFF(...))`) robuste face aux différences de SGBD en ajoutant un fallback côté PHP si l'expression SQL n'est pas supportée.
- Verrouiller le comportement via un test fonctionnel pour `date + pagination` afin d'éviter régressions futures.

### Description
- Remplacement de `DATE(application.createdAt) = :createdOn` par un intervalle indexable en utilisant `application.createdAt >= :startOfDay` et `application.createdAt < :startOfNextDay` avec parsing défensif via `DateTimeImmutable::createFromFormat('!Y-m-d', $date)` dans `PipelineBoardService`.
- Extraction de l'agrégation des métriques vers `ApplicationRepository::findPipelineStatusMetrics()` qui tente l'agrégation SQL `AVG(TIMESTAMPDIFF(...))` et, en cas d'exception, calcule un fallback en PHP (compte + moyenne d'agingDays) en parcourant les `createdAt` récupérés.
- Optimisations PHP dans `getPipeline()`: création d'un seul `DateTimeImmutable $now` avant la boucle et réutilisation de `$total = count($paginator)` pour `pagination.total` et le calcul de `pagination.pages`.
- Ajout d'un cas dans le test fonctionnel `PrivatePipelineControllerTest` pour couvrir explicitement le filtrage par `date` combiné à la pagination et vérifier la présence/format du `createdAt` filtré.

### Testing
- Exécution de vérifications de syntaxe PHP avec `php -l` sur les fichiers modifiés (`PipelineBoardService`, `ApplicationRepository`, test) : succès pour tous les fichiers.
- Exécution ciblée de la suite PHPUnit n'a pas pu être effectuée en raison de l'absence du binaire PHPUnit dans l'environnement (`./vendor/bin/phpunit` / `bin/phpunit` non trouvés), donc le test fonctionnel ajouté n'a pas été lancé ici.
- Aucun échec de compilation/syntaxe constaté après modifications.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e845ef102c832bac9a5d936f5e2dec)