### PR TITLE
Include metadata in notifications and attach friend-request details to Mercure payload

### DIFF
--- a/src/Notification/Application/Service/NotificationPublisher.php
+++ b/src/Notification/Application/Service/NotificationPublisher.php
@@ -25,7 +25,17 @@ final readonly class NotificationPublisher
      * @throws JsonException
      * @throws ORMException
      */
-    public function publish(User $from, User $recipient, string $title, string $type, string $description = ''): void
+    /**
+     * @param array<string,mixed> $metadata
+     */
+    public function publish(
+        User $from,
+        User $recipient,
+        string $title,
+        string $type,
+        string $description = '',
+        array $metadata = [],
+    ): void
     {
         if ($from->getId() === $recipient->getId()) {
             return;
@@ -47,7 +57,8 @@ final readonly class NotificationPublisher
             'type' => $notification->getType(),
             'recipientId' => $recipient->getId(),
             'fromId' => $from->getId(),
-            'createdAt' => $notification->getCreatedAt()?->format(DATE_ATOM)
+            'createdAt' => $notification->getCreatedAt()?->format(DATE_ATOM),
+            'metadata' => $metadata,
         ]);
     }
 }

--- a/src/User/Application/Service/UserFriendService.php
+++ b/src/User/Application/Service/UserFriendService.php
@@ -83,6 +83,12 @@ readonly class UserFriendService
             title: trim($loggedInUser->getFirstName() . ' ' . $loggedInUser->getLastName()) . ' sent you a friend request',
             type: self::FRIEND_NOTIFICATION_TYPE,
             description: $this->buildUserProfileLink($loggedInUser),
+            metadata: [
+                'event' => 'friend_request_sent',
+                'friendStatus' => FriendStatus::PENDING->value,
+                'requesterId' => $loggedInUser->getId(),
+                'addresseeId' => $targetUser->getId(),
+            ],
         );
 
         if ($targetUser->getEmail() !== '') {
@@ -130,6 +136,12 @@ readonly class UserFriendService
             title: trim($loggedInUser->getFirstName() . ' ' . $loggedInUser->getLastName()) . ' accepted your friend request',
             type: self::FRIEND_NOTIFICATION_TYPE,
             description: $this->buildUserProfileLink($loggedInUser),
+            metadata: [
+                'event' => 'friend_request_accepted',
+                'friendStatus' => FriendStatus::ACCEPTED->value,
+                'requesterId' => $requester->getId(),
+                'addresseeId' => $loggedInUser->getId(),
+            ],
         );
 
         if ($requester->getEmail() !== '') {

--- a/tests/Unit/Notification/Application/Service/NotificationPublisherTest.php
+++ b/tests/Unit/Notification/Application/Service/NotificationPublisherTest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Notification\Application\Service;
 
+use App\General\Application\Service\MercurePublisher;
 use App\Notification\Application\Service\NotificationPublisher;
 use App\Notification\Domain\Entity\Notification;
 use App\Notification\Infrastructure\Repository\NotificationRepository;
 use App\User\Domain\Entity\User;
 use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Uid\UuidV7;
 
 final class NotificationPublisherTest extends TestCase
 {
@@ -19,7 +23,10 @@ final class NotificationPublisherTest extends TestCase
         $repository = $this->createMock(NotificationRepository::class);
         $repository->expects(self::never())->method('save');
 
-        $publisher = new NotificationPublisher($repository);
+        $mercurePublisher = $this->createMock(MercurePublisher::class);
+        $mercurePublisher->expects(self::never())->method('publish');
+
+        $publisher = new NotificationPublisher($repository, $mercurePublisher);
         $publisher->publish($user, $user, 'title', 'blog_notification');
     }
 
@@ -39,16 +46,40 @@ final class NotificationPublisherTest extends TestCase
                     && $notification->getDescription() === '';
             }));
 
-        $publisher = new NotificationPublisher($repository);
-        $publisher->publish($from, $recipient, 'Rami commented your post "Post title"', 'blog_notification');
+        $mercurePublisher = $this->createMock(MercurePublisher::class);
+        $mercurePublisher->expects(self::once())
+            ->method('publish')
+            ->with(
+                self::stringContains('/notifications'),
+                self::callback(static function (array $payload): bool {
+                    return ($payload['metadata']['event'] ?? null) === 'blog_comment_created';
+                }),
+            );
+
+        $publisher = new NotificationPublisher($repository, $mercurePublisher);
+        $publisher->publish(
+            $from,
+            $recipient,
+            'Rami commented your post "Post title"',
+            'blog_notification',
+            '',
+            ['event' => 'blog_comment_created'],
+        );
+
     }
 
     private function createUser(string $firstName, string $lastName): User
     {
         return (new User())
+            ->setId($this->uuid())
             ->setFirstName($firstName)
             ->setLastName($lastName)
             ->setUsername(strtolower($firstName . '.' . $lastName))
             ->setEmail(strtolower($firstName . '.' . $lastName . '@example.com'));
+    }
+
+    private function uuid(): UuidInterface
+    {
+        return Uuid::fromString((string) new UuidV7());
     }
 }


### PR DESCRIPTION
### Motivation

- Add structured metadata to real-time notifications so clients can react to specific events without parsing text.
- Surface friend-request state and participant IDs in the notification payload to support richer UI behavior.

### Description

- Extended `NotificationPublisher::publish` to accept an additional `array $metadata` parameter and include it in the Mercure payload under the `metadata` key.
- Updated the constructor usage to include `MercurePublisher` where needed and adjusted the published payload to append `'metadata' => $metadata` while keeping existing fields like `createdAt`.
- Added metadata for friend-related events in `UserFriendService` when sending and accepting requests with keys `event`, `friendStatus`, `requesterId`, and `addresseeId`.
- Updated `NotificationPublisherTest` to mock `MercurePublisher`, assert publish behavior including metadata, ensure self-notifications skip Mercure publishing, and added a UUID helper to set user IDs in tests.

### Testing

- Ran the modified unit test `tests/Unit/Notification/Application/Service/NotificationPublisherTest` which exercises persistence skip logic and payload metadata assertions, and it passed.
- Updated test suite mocks to verify `MercurePublisher::publish` is called with expected payload metadata, and those assertions succeeded when running the unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8448bbd5c832b9ca1e066e9799183)