### PR TITLE
Include metadata and sender info in notification payloads and update friend notifications

### DIFF
--- a/src/Notification/Application/Service/NotificationPublisher.php
+++ b/src/Notification/Application/Service/NotificationPublisher.php
@@ -24,8 +24,16 @@ final readonly class NotificationPublisher
      * @throws OptimisticLockException
      * @throws JsonException
      * @throws ORMException
+     * @param array<string,mixed> $metadata
      */
-    public function publish(User $from, User $recipient, string $title, string $type, string $description = ''): void
+    public function publish(
+        User $from,
+        User $recipient,
+        string $title,
+        string $type,
+        string $description = '',
+        array $metadata = [],
+    ): void
     {
         if ($from->getId() === $recipient->getId()) {
             return;
@@ -47,7 +55,13 @@ final readonly class NotificationPublisher
             'type' => $notification->getType(),
             'recipientId' => $recipient->getId(),
             'fromId' => $from->getId(),
-            'createdAt' => $notification->getCreatedAt()?->format(DATE_ATOM)
+            'fromPhoto' => $from->getPhoto(),
+            'from' => [
+                'id' => $from->getId(),
+                'photo' => $from->getPhoto(),
+            ],
+            'createdAt' => $notification->getCreatedAt()?->format(DATE_ATOM),
+            'metadata' => $metadata,
         ]);
     }
 }

--- a/src/User/Application/Service/UserFriendService.php
+++ b/src/User/Application/Service/UserFriendService.php
@@ -83,6 +83,12 @@ readonly class UserFriendService
             title: trim($loggedInUser->getFirstName() . ' ' . $loggedInUser->getLastName()) . ' sent you a friend request',
             type: self::FRIEND_NOTIFICATION_TYPE,
             description: $this->buildUserProfileLink($loggedInUser),
+            metadata: [
+                'event' => 'friend_request_sent',
+                'friendStatus' => FriendStatus::PENDING->value,
+                'requesterId' => $loggedInUser->getId(),
+                'addresseeId' => $targetUser->getId(),
+            ],
         );
 
         if ($targetUser->getEmail() !== '') {
@@ -130,6 +136,12 @@ readonly class UserFriendService
             title: trim($loggedInUser->getFirstName() . ' ' . $loggedInUser->getLastName()) . ' accepted your friend request',
             type: self::FRIEND_NOTIFICATION_TYPE,
             description: $this->buildUserProfileLink($loggedInUser),
+            metadata: [
+                'event' => 'friend_request_accepted',
+                'friendStatus' => FriendStatus::ACCEPTED->value,
+                'requesterId' => $requester->getId(),
+                'addresseeId' => $loggedInUser->getId(),
+            ],
         );
 
         if ($requester->getEmail() !== '') {

--- a/tests/Unit/Notification/Application/Service/NotificationPublisherTest.php
+++ b/tests/Unit/Notification/Application/Service/NotificationPublisherTest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Notification\Application\Service;
 
+use App\General\Application\Service\MercurePublisher;
 use App\Notification\Application\Service\NotificationPublisher;
 use App\Notification\Domain\Entity\Notification;
 use App\Notification\Infrastructure\Repository\NotificationRepository;
 use App\User\Domain\Entity\User;
 use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Uid\UuidV7;
 
 final class NotificationPublisherTest extends TestCase
 {
@@ -19,7 +23,10 @@ final class NotificationPublisherTest extends TestCase
         $repository = $this->createMock(NotificationRepository::class);
         $repository->expects(self::never())->method('save');
 
-        $publisher = new NotificationPublisher($repository);
+        $mercurePublisher = $this->createMock(MercurePublisher::class);
+        $mercurePublisher->expects(self::never())->method('publish');
+
+        $publisher = new NotificationPublisher($repository, $mercurePublisher);
         $publisher->publish($user, $user, 'title', 'blog_notification');
     }
 
@@ -39,16 +46,43 @@ final class NotificationPublisherTest extends TestCase
                     && $notification->getDescription() === '';
             }));
 
-        $publisher = new NotificationPublisher($repository);
-        $publisher->publish($from, $recipient, 'Rami commented your post "Post title"', 'blog_notification');
+        $mercurePublisher = $this->createMock(MercurePublisher::class);
+        $mercurePublisher->expects(self::once())
+            ->method('publish')
+            ->with(
+                self::stringContains('/notifications'),
+                self::callback(static function (array $payload) use ($from): bool {
+                    return ($payload['metadata']['event'] ?? null) === 'blog_comment_created'
+                        && ($payload['fromId'] ?? null) === $from->getId()
+                        && ($payload['fromPhoto'] ?? '') !== ''
+                        && ($payload['from']['id'] ?? null) === $from->getId()
+                        && ($payload['from']['photo'] ?? '') !== '';
+                }),
+            );
+
+        $publisher = new NotificationPublisher($repository, $mercurePublisher);
+        $publisher->publish(
+            $from,
+            $recipient,
+            'Rami commented your post "Post title"',
+            'blog_notification',
+            '',
+            ['event' => 'blog_comment_created'],
+        );
     }
 
     private function createUser(string $firstName, string $lastName): User
     {
         return (new User())
+            ->setId($this->uuid())
             ->setFirstName($firstName)
             ->setLastName($lastName)
             ->setUsername(strtolower($firstName . '.' . $lastName))
             ->setEmail(strtolower($firstName . '.' . $lastName . '@example.com'));
+    }
+
+    private function uuid(): UuidInterface
+    {
+        return Uuid::fromString((string) new UuidV7());
     }
 }


### PR DESCRIPTION
### Motivation
- Enrich notification payloads with sender information and arbitrary metadata to support richer frontend behavior and event handling.
- Surface the sender photo and structured `from` data so clients can render notifications without extra lookups.
- Tag friend request lifecycle events with structured metadata for easier client-side handling.

### Description
- Updated `NotificationPublisher::publish` signature to accept an additional `array $metadata` parameter and added a `@param array<string,mixed> $metadata` docblock.
- Included `fromPhoto`, a structured `from` sub-array, and `metadata` in the Mercure publish payload, and preserved `createdAt` formatting.
- Added metadata when publishing friend-related notifications in the friend request flow with `event`, `friendStatus`, `requesterId`, and `addresseeId` fields.
- Updated `NotificationPublisherTest` to mock `MercurePublisher`, assert the `publish` call and payload contents (including `metadata` and `from` fields), and added a `uuid()` helper using `Ramsey\uuid` and `UuidV7` for test user IDs.

### Testing
- Ran `tests/Unit/Notification/Application/Service/NotificationPublisherTest.php` (unit tests) which exercised both the self-notification skip and publish-with-metadata scenarios, and they passed under `phpunit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8448bbd5c832b9ca1e066e9799183)