### PR TITLE
feat(crm): add GitHub commits/collaborators/actions endpoints and persist repository metrics

### DIFF
--- a/migrations/Version20260422120000.php
+++ b/migrations/Version20260422120000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260422120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'CRM GitHub sync: store repository metrics and visibility fields.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_repository ADD visibility VARCHAR(20) DEFAULT NULL, ADD primary_language VARCHAR(120) DEFAULT NULL, ADD stars_count INT DEFAULT 0 NOT NULL, ADD forks_count INT DEFAULT 0 NOT NULL, ADD watchers_count INT DEFAULT 0 NOT NULL, ADD open_issues_count INT DEFAULT 0 NOT NULL, ADD is_archived TINYINT(1) DEFAULT 0 NOT NULL, ADD is_disabled TINYINT(1) DEFAULT 0 NOT NULL, ADD last_pushed_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)"');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_repository DROP visibility, DROP primary_language, DROP stars_count, DROP forks_count, DROP watchers_count, DROP open_issues_count, DROP is_archived, DROP is_disabled, DROP last_pushed_at');
+    }
+}

--- a/src/Crm/Application/Service/CrmGithubBootstrapSyncService.php
+++ b/src/Crm/Application/Service/CrmGithubBootstrapSyncService.php
@@ -233,11 +233,20 @@ final readonly class CrmGithubBootstrapSyncService
                     ->setName((string)($repositoryPayload['name'] ?? ''))
                     ->setFullName((string)($repositoryPayload['fullName'] ?? ''))
                     ->setDefaultBranch(isset($repositoryPayload['defaultBranch']) ? (string)$repositoryPayload['defaultBranch'] : null)
+                    ->setVisibility(isset($repositoryPayload['visibility']) ? (string)$repositoryPayload['visibility'] : null)
                     ->setIsPrivate((bool)($repositoryPayload['private'] ?? false))
+                    ->setPrimaryLanguage(isset($repositoryPayload['language']) ? (string)$repositoryPayload['language'] : null)
+                    ->setStarsCount((int)($repositoryPayload['stargazersCount'] ?? 0))
+                    ->setForksCount((int)($repositoryPayload['forksCount'] ?? 0))
+                    ->setWatchersCount((int)($repositoryPayload['watchersCount'] ?? 0))
+                    ->setOpenIssuesCount((int)($repositoryPayload['openIssuesCount'] ?? 0))
+                    ->setIsArchived((bool)($repositoryPayload['archived'] ?? false))
+                    ->setIsDisabled((bool)($repositoryPayload['disabled'] ?? false))
                     ->setHtmlUrl((string)($repositoryPayload['htmlUrl'] ?? ''))
                     ->setExternalId(isset($repositoryPayload['externalId']) ? (string)$repositoryPayload['externalId'] : null)
                     ->setSyncStatus('synced')
                     ->setLastSyncedAt(new DateTimeImmutable())
+                    ->setLastPushedAt($this->normalizeGithubDate($repositoryPayload['pushedAt'] ?? null))
                     ->setPayload($this->buildRepositoryImportPayload($repositoryPayload, null));
 
                 if (!$dryRun) {
@@ -257,11 +266,20 @@ final readonly class CrmGithubBootstrapSyncService
                     ->setName((string)($repositoryPayload['name'] ?? $existingRepository->getName()))
                     ->setFullName((string)($repositoryPayload['fullName'] ?? $existingRepository->getFullName()))
                     ->setDefaultBranch(isset($repositoryPayload['defaultBranch']) ? (string)$repositoryPayload['defaultBranch'] : null)
+                    ->setVisibility(isset($repositoryPayload['visibility']) ? (string)$repositoryPayload['visibility'] : $existingRepository->getVisibility())
                     ->setIsPrivate((bool)($repositoryPayload['private'] ?? $existingRepository->isPrivate()))
+                    ->setPrimaryLanguage(isset($repositoryPayload['language']) ? (string)$repositoryPayload['language'] : $existingRepository->getPrimaryLanguage())
+                    ->setStarsCount((int)($repositoryPayload['stargazersCount'] ?? $existingRepository->getStarsCount()))
+                    ->setForksCount((int)($repositoryPayload['forksCount'] ?? $existingRepository->getForksCount()))
+                    ->setWatchersCount((int)($repositoryPayload['watchersCount'] ?? $existingRepository->getWatchersCount()))
+                    ->setOpenIssuesCount((int)($repositoryPayload['openIssuesCount'] ?? $existingRepository->getOpenIssuesCount()))
+                    ->setIsArchived((bool)($repositoryPayload['archived'] ?? $existingRepository->isArchived()))
+                    ->setIsDisabled((bool)($repositoryPayload['disabled'] ?? $existingRepository->isDisabled()))
                     ->setHtmlUrl((string)($repositoryPayload['htmlUrl'] ?? $existingRepository->getHtmlUrl()))
                     ->setExternalId(isset($repositoryPayload['externalId']) ? (string)$repositoryPayload['externalId'] : $existingRepository->getExternalId())
                     ->setSyncStatus('synced')
                     ->setLastSyncedAt(new DateTimeImmutable())
+                    ->setLastPushedAt($this->normalizeGithubDate($repositoryPayload['pushedAt'] ?? null) ?? $existingRepository->getLastPushedAt())
                     ->setPayload($this->buildRepositoryImportPayload($repositoryPayload, $existingRepository->getPayload()));
 
                 if (!$dryRun) {
@@ -453,8 +471,17 @@ GRAPHQL, $ownerField);
                     'name' => (string)($repository['name'] ?? ''),
                     'fullName' => (string)($repository['full_name'] ?? ''),
                     'defaultBranch' => (string)($repository['default_branch'] ?? ''),
+                    'visibility' => isset($repository['visibility']) ? (string)$repository['visibility'] : null,
                     'private' => (bool)($repository['private'] ?? false),
+                    'language' => isset($repository['language']) ? (string)$repository['language'] : null,
+                    'stargazersCount' => (int)($repository['stargazers_count'] ?? 0),
+                    'forksCount' => (int)($repository['forks_count'] ?? 0),
+                    'watchersCount' => (int)($repository['watchers_count'] ?? 0),
+                    'openIssuesCount' => (int)($repository['open_issues_count'] ?? 0),
+                    'archived' => (bool)($repository['archived'] ?? false),
+                    'disabled' => (bool)($repository['disabled'] ?? false),
                     'htmlUrl' => (string)($repository['html_url'] ?? ''),
+                    'pushedAt' => isset($repository['pushed_at']) ? (string)$repository['pushed_at'] : null,
                     'owner' => (string)($repository['owner']['login'] ?? $owner),
                     'projectNodeId' => '',
                     'projectUrl' => '',
@@ -797,10 +824,32 @@ GRAPHQL, $ownerField);
         $payload['nodeId'] = (string)($repositoryPayload['nodeId'] ?? '');
         $payload['projectNodeId'] = (string)($repositoryPayload['projectNodeId'] ?? '');
         $payload['projectUrl'] = (string)($repositoryPayload['projectUrl'] ?? '');
+        $payload['visibility'] = $repositoryPayload['visibility'] ?? null;
+        $payload['language'] = $repositoryPayload['language'] ?? null;
+        $payload['stargazersCount'] = (int)($repositoryPayload['stargazersCount'] ?? 0);
+        $payload['forksCount'] = (int)($repositoryPayload['forksCount'] ?? 0);
+        $payload['watchersCount'] = (int)($repositoryPayload['watchersCount'] ?? 0);
+        $payload['openIssuesCount'] = (int)($repositoryPayload['openIssuesCount'] ?? 0);
+        $payload['archived'] = (bool)($repositoryPayload['archived'] ?? false);
+        $payload['disabled'] = (bool)($repositoryPayload['disabled'] ?? false);
+        $payload['pushedAt'] = $repositoryPayload['pushedAt'] ?? null;
         $payload['importSource'] = 'github-bootstrap';
         $payload['importedAt'] = (new DateTimeImmutable())->format(DATE_ATOM);
 
         return $payload;
+    }
+
+    private function normalizeGithubDate(mixed $value): ?DateTimeImmutable
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return new DateTimeImmutable(trim($value));
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/src/Crm/Application/Service/CrmGithubService.php
+++ b/src/Crm/Application/Service/CrmGithubService.php
@@ -363,6 +363,144 @@ readonly class CrmGithubService
         ];
     }
 
+    public function listCommits(Project $project, string $repoFullName, int $page = 1, int $perPage = 30, ?string $branch = null): array
+    {
+        $query = [
+            'page' => $page,
+            'per_page' => $perPage,
+        ];
+        if (is_string($branch) && trim($branch) !== '') {
+            $query['sha'] = trim($branch);
+        }
+
+        $response = $this->requestWithMeta($project, 'GET', sprintf('/repos/%s/commits', $repoFullName), [
+            'query' => $query,
+        ]);
+
+        $items = array_values(array_map(static fn (array $commit): array => [
+            'sha' => (string)($commit['sha'] ?? ''),
+            'message' => (string)($commit['commit']['message'] ?? ''),
+            'author' => (string)($commit['author']['login'] ?? $commit['commit']['author']['name'] ?? ''),
+            'date' => (string)($commit['commit']['author']['date'] ?? ''),
+            'htmlUrl' => (string)($commit['html_url'] ?? ''),
+        ], $response['data']));
+
+        return [
+            'items' => $items,
+            'pagination' => $this->buildPagination($response['meta']['link'], $page, $perPage, count($items)),
+        ];
+    }
+
+    public function getCommit(Project $project, string $repoFullName, string $sha): array
+    {
+        $commit = $this->request($project, 'GET', sprintf('/repos/%s/commits/%s', $repoFullName, trim($sha)));
+
+        return [
+            'sha' => (string)($commit['sha'] ?? ''),
+            'message' => (string)($commit['commit']['message'] ?? ''),
+            'author' => (string)($commit['author']['login'] ?? $commit['commit']['author']['name'] ?? ''),
+            'date' => (string)($commit['commit']['author']['date'] ?? ''),
+            'htmlUrl' => (string)($commit['html_url'] ?? ''),
+            'files' => array_values(array_map(static fn (array $file): array => [
+                'filename' => (string)($file['filename'] ?? ''),
+                'status' => (string)($file['status'] ?? ''),
+                'additions' => (int)($file['additions'] ?? 0),
+                'deletions' => (int)($file['deletions'] ?? 0),
+                'changes' => (int)($file['changes'] ?? 0),
+            ], is_array($commit['files'] ?? null) ? $commit['files'] : [])),
+        ];
+    }
+
+    public function listCollaborators(Project $project, string $repoFullName, int $page = 1, int $perPage = 30): array
+    {
+        $response = $this->requestWithMeta($project, 'GET', sprintf('/repos/%s/collaborators', $repoFullName), [
+            'query' => [
+                'page' => $page,
+                'per_page' => $perPage,
+            ],
+        ]);
+
+        $items = array_values(array_map(static fn (array $collaborator): array => [
+            'login' => (string)($collaborator['login'] ?? ''),
+            'type' => (string)($collaborator['type'] ?? ''),
+            'htmlUrl' => (string)($collaborator['html_url'] ?? ''),
+            'permissions' => is_array($collaborator['permissions'] ?? null) ? $collaborator['permissions'] : [],
+        ], $response['data']));
+
+        return [
+            'items' => $items,
+            'pagination' => $this->buildPagination($response['meta']['link'], $page, $perPage, count($items)),
+        ];
+    }
+
+    public function listWorkflows(Project $project, string $repoFullName, int $page = 1, int $perPage = 30): array
+    {
+        $response = $this->request($project, 'GET', sprintf('/repos/%s/actions/workflows', $repoFullName), [
+            'query' => [
+                'page' => $page,
+                'per_page' => $perPage,
+            ],
+        ]);
+        $workflows = is_array($response['workflows'] ?? null) ? $response['workflows'] : [];
+
+        return [
+            'items' => array_values(array_map(static fn (array $workflow): array => [
+                'id' => (int)($workflow['id'] ?? 0),
+                'name' => (string)($workflow['name'] ?? ''),
+                'state' => (string)($workflow['state'] ?? ''),
+                'path' => (string)($workflow['path'] ?? ''),
+                'htmlUrl' => (string)($workflow['html_url'] ?? ''),
+                'createdAt' => (string)($workflow['created_at'] ?? ''),
+                'updatedAt' => (string)($workflow['updated_at'] ?? ''),
+            ], $workflows)),
+            'pagination' => [
+                'page' => $page,
+                'limit' => $perPage,
+                'totalItems' => (int)($response['total_count'] ?? count($workflows)),
+                'totalPages' => (int)max(1, (int)ceil(((int)($response['total_count'] ?? count($workflows))) / $perPage)),
+            ],
+        ];
+    }
+
+    public function listWorkflowRuns(Project $project, string $repoFullName, ?int $workflowId = null, int $page = 1, int $perPage = 30, ?string $status = null): array
+    {
+        $path = is_int($workflowId)
+            ? sprintf('/repos/%s/actions/workflows/%d/runs', $repoFullName, $workflowId)
+            : sprintf('/repos/%s/actions/runs', $repoFullName);
+        $query = [
+            'page' => $page,
+            'per_page' => $perPage,
+        ];
+        if (is_string($status) && trim($status) !== '') {
+            $query['status'] = trim($status);
+        }
+
+        $response = $this->request($project, 'GET', $path, [
+            'query' => $query,
+        ]);
+
+        $runs = is_array($response['workflow_runs'] ?? null) ? $response['workflow_runs'] : [];
+
+        return [
+            'items' => array_values(array_map(static fn (array $run): array => [
+                'id' => (int)($run['id'] ?? 0),
+                'name' => (string)($run['name'] ?? ''),
+                'status' => (string)($run['status'] ?? ''),
+                'conclusion' => isset($run['conclusion']) ? (string)$run['conclusion'] : null,
+                'event' => (string)($run['event'] ?? ''),
+                'htmlUrl' => (string)($run['html_url'] ?? ''),
+                'createdAt' => (string)($run['created_at'] ?? ''),
+                'updatedAt' => (string)($run['updated_at'] ?? ''),
+            ], $runs)),
+            'pagination' => [
+                'page' => $page,
+                'limit' => $perPage,
+                'totalItems' => (int)($response['total_count'] ?? count($runs)),
+                'totalPages' => (int)max(1, (int)ceil(((int)($response['total_count'] ?? count($runs))) / $perPage)),
+            ],
+        ];
+    }
+
     public function getIssue(Project $project, string $repoFullName, int $number): array
     {
         $issue = $this->request($project, 'GET', sprintf('/repos/%s/issues/%d', $repoFullName, $number));

--- a/src/Crm/Domain/Entity/CrmRepository.php
+++ b/src/Crm/Domain/Entity/CrmRepository.php
@@ -54,10 +54,46 @@ class CrmRepository implements EntityInterface
     #[ORM\Column(name: 'default_branch', type: Types::STRING, length: 255, nullable: true)]
     private ?string $defaultBranch = null;
 
+    #[ORM\Column(name: 'visibility', type: Types::STRING, length: 20, nullable: true)]
+    private ?string $visibility = null;
+
     #[ORM\Column(name: 'is_private', type: Types::BOOLEAN, options: [
         'default' => false,
     ])]
     private bool $isPrivate = false;
+
+    #[ORM\Column(name: 'primary_language', type: Types::STRING, length: 120, nullable: true)]
+    private ?string $primaryLanguage = null;
+
+    #[ORM\Column(name: 'stars_count', type: Types::INTEGER, options: [
+        'default' => 0,
+    ])]
+    private int $starsCount = 0;
+
+    #[ORM\Column(name: 'forks_count', type: Types::INTEGER, options: [
+        'default' => 0,
+    ])]
+    private int $forksCount = 0;
+
+    #[ORM\Column(name: 'watchers_count', type: Types::INTEGER, options: [
+        'default' => 0,
+    ])]
+    private int $watchersCount = 0;
+
+    #[ORM\Column(name: 'open_issues_count', type: Types::INTEGER, options: [
+        'default' => 0,
+    ])]
+    private int $openIssuesCount = 0;
+
+    #[ORM\Column(name: 'is_archived', type: Types::BOOLEAN, options: [
+        'default' => false,
+    ])]
+    private bool $isArchived = false;
+
+    #[ORM\Column(name: 'is_disabled', type: Types::BOOLEAN, options: [
+        'default' => false,
+    ])]
+    private bool $isDisabled = false;
 
     #[ORM\Column(name: 'html_url', type: Types::STRING, length: 1024, nullable: true)]
     private ?string $htmlUrl = null;
@@ -67,6 +103,9 @@ class CrmRepository implements EntityInterface
 
     #[ORM\Column(name: 'last_synced_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?DateTimeImmutable $lastSyncedAt = null;
+
+    #[ORM\Column(name: 'last_pushed_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $lastPushedAt = null;
 
     #[ORM\Column(name: 'sync_status', type: Types::STRING, length: 40, options: [
         'default' => 'pending',
@@ -165,6 +204,18 @@ class CrmRepository implements EntityInterface
         return $this;
     }
 
+    public function getVisibility(): ?string
+    {
+        return $this->visibility;
+    }
+
+    public function setVisibility(?string $visibility): self
+    {
+        $this->visibility = $visibility;
+
+        return $this;
+    }
+
     public function isPrivate(): bool
     {
         return $this->isPrivate;
@@ -173,6 +224,90 @@ class CrmRepository implements EntityInterface
     public function setIsPrivate(bool $isPrivate): self
     {
         $this->isPrivate = $isPrivate;
+
+        return $this;
+    }
+
+    public function getPrimaryLanguage(): ?string
+    {
+        return $this->primaryLanguage;
+    }
+
+    public function setPrimaryLanguage(?string $primaryLanguage): self
+    {
+        $this->primaryLanguage = $primaryLanguage;
+
+        return $this;
+    }
+
+    public function getStarsCount(): int
+    {
+        return $this->starsCount;
+    }
+
+    public function setStarsCount(int $starsCount): self
+    {
+        $this->starsCount = $starsCount;
+
+        return $this;
+    }
+
+    public function getForksCount(): int
+    {
+        return $this->forksCount;
+    }
+
+    public function setForksCount(int $forksCount): self
+    {
+        $this->forksCount = $forksCount;
+
+        return $this;
+    }
+
+    public function getWatchersCount(): int
+    {
+        return $this->watchersCount;
+    }
+
+    public function setWatchersCount(int $watchersCount): self
+    {
+        $this->watchersCount = $watchersCount;
+
+        return $this;
+    }
+
+    public function getOpenIssuesCount(): int
+    {
+        return $this->openIssuesCount;
+    }
+
+    public function setOpenIssuesCount(int $openIssuesCount): self
+    {
+        $this->openIssuesCount = $openIssuesCount;
+
+        return $this;
+    }
+
+    public function isArchived(): bool
+    {
+        return $this->isArchived;
+    }
+
+    public function setIsArchived(bool $isArchived): self
+    {
+        $this->isArchived = $isArchived;
+
+        return $this;
+    }
+
+    public function isDisabled(): bool
+    {
+        return $this->isDisabled;
+    }
+
+    public function setIsDisabled(bool $isDisabled): self
+    {
+        $this->isDisabled = $isDisabled;
 
         return $this;
     }
@@ -209,6 +344,18 @@ class CrmRepository implements EntityInterface
     public function setLastSyncedAt(?DateTimeImmutable $lastSyncedAt): self
     {
         $this->lastSyncedAt = $lastSyncedAt;
+
+        return $this;
+    }
+
+    public function getLastPushedAt(): ?DateTimeImmutable
+    {
+        return $this->lastPushedAt;
+    }
+
+    public function setLastPushedAt(?DateTimeImmutable $lastPushedAt): self
+    {
+        $this->lastPushedAt = $lastPushedAt;
 
         return $this;
     }

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubCommitController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubCommitController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+final readonly class GetProjectGithubCommitController
+{
+    public function __construct(private CrmGithubService $crmGithubService)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/commits/{sha}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/commits/{sha}', methods: [Request::METHOD_GET])]
+    public function __invoke(Project $project, string $sha, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->getCommit(
+            $project,
+            (string)$request->query->get('repo', ''),
+            $sha,
+        ));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubActionsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubActionsController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+final readonly class ListProjectGithubActionsController
+{
+    public function __construct(private CrmGithubService $crmGithubService)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/actions/workflows', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/actions/workflows', methods: [Request::METHOD_GET])]
+    public function workflows(Project $project, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->listWorkflows(
+            $project,
+            (string)$request->query->get('repo', ''),
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+        ));
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/actions/runs', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/actions/runs', methods: [Request::METHOD_GET])]
+    public function runs(Project $project, Request $request): JsonResponse
+    {
+        $workflowId = $request->query->get('workflowId');
+
+        return new JsonResponse($this->crmGithubService->listWorkflowRuns(
+            $project,
+            (string)$request->query->get('repo', ''),
+            $workflowId !== null ? (int)$workflowId : null,
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+            $request->query->get('status') !== null ? (string)$request->query->get('status') : null,
+        ));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCollaboratorsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCollaboratorsController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+final readonly class ListProjectGithubCollaboratorsController
+{
+    public function __construct(private CrmGithubService $crmGithubService)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/collaborators', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/collaborators', methods: [Request::METHOD_GET])]
+    public function __invoke(Project $project, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->listCollaborators(
+            $project,
+            (string)$request->query->get('repo', ''),
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+        ));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCommitsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCommitsController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+final readonly class ListProjectGithubCommitsController
+{
+    public function __construct(private CrmGithubService $crmGithubService)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/commits', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/commits', methods: [Request::METHOD_GET])]
+    public function __invoke(Project $project, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->listCommits(
+            $project,
+            (string)$request->query->get('repo', ''),
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+            $request->query->get('branch') !== null ? (string)$request->query->get('branch') : null,
+        ));
+    }
+}


### PR DESCRIPTION
### Motivation
- Étendre l'intégration GitHub du CRM pour couvrir commits, collaborateurs et GitHub Actions afin d'exposer ces données via l'API REST (scopée application et `/general`).
- Persister des métadonnées de dépôt (visibilité, langage, stats, état, date push) pour améliorer la synchronisation, le reporting et les recherches futures.

### Description
- Ajout de nouveaux endpoints controllers pour lister/consulter les commits, lister les collaborateurs et lister workflows/runs d'Actions (scopes application + général) dans `src/Crm/Transport/Controller/Api/V1/Project/Github/*.php`.
- Extension de `CrmGithubService` avec `listCommits`, `getCommit`, `listCollaborators`, `listWorkflows` et `listWorkflowRuns` pour normaliser les réponses GitHub et fournir pagination/meta.
- Enrichissement de `CrmGithubBootstrapSyncService` pour collecter et mapper `visibility`, `language`, `stargazers_count`, `forks_count`, `watchers_count`, `open_issues_count`, `archived`, `disabled` et `pushed_at` et les stocker dans le payload et l'entité CRM.
- Ajout de nouveaux champs persistés dans l'entité `CrmRepository` (`visibility`, `primary_language`, `stars_count`, `forks_count`, `watchers_count`, `open_issues_count`, `is_archived`, `is_disabled`, `last_pushed_at`) avec getters/setters.
- Migration Doctrine `migrations/Version20260422120000.php` pour ajouter les colonnes correspondantes à la table `crm_repository`.

### Testing
- Exécution de vérification syntaxique `php -l` sur tous les fichiers ajoutés/modifiés réussie (pas d'erreurs de syntaxe). 
- Les nouveaux controllers et services ont été ajoutés et leurs fichiers PHP sont valides selon `php -l`.
- L'exécution des tests unitaires via `vendor/bin/phpunit --filter CrmGithub --testdox` n'a pas pu être lancée dans cet environnement car `vendor/bin/phpunit` est absent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86c0252d8832b94f8bd6f9a9734a0)