### PR TITLE
CRM GitHub: store repository metrics and add rich GitHub API endpoints

### DIFF
--- a/migrations/Version20260422120000.php
+++ b/migrations/Version20260422120000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260422120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'CRM GitHub sync: store repository metrics and visibility fields.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_repository ADD visibility VARCHAR(20) DEFAULT NULL, ADD primary_language VARCHAR(120) DEFAULT NULL, ADD stars_count INT DEFAULT 0 NOT NULL, ADD forks_count INT DEFAULT 0 NOT NULL, ADD watchers_count INT DEFAULT 0 NOT NULL, ADD open_issues_count INT DEFAULT 0 NOT NULL, ADD is_archived TINYINT(1) DEFAULT 0 NOT NULL, ADD is_disabled TINYINT(1) DEFAULT 0 NOT NULL, ADD last_pushed_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)"');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_repository DROP visibility, DROP primary_language, DROP stars_count, DROP forks_count, DROP watchers_count, DROP open_issues_count, DROP is_archived, DROP is_disabled, DROP last_pushed_at');
+    }
+}

--- a/src/Crm/Application/Service/CrmGithubBootstrapSyncService.php
+++ b/src/Crm/Application/Service/CrmGithubBootstrapSyncService.php
@@ -233,11 +233,20 @@ final readonly class CrmGithubBootstrapSyncService
                     ->setName((string)($repositoryPayload['name'] ?? ''))
                     ->setFullName((string)($repositoryPayload['fullName'] ?? ''))
                     ->setDefaultBranch(isset($repositoryPayload['defaultBranch']) ? (string)$repositoryPayload['defaultBranch'] : null)
+                    ->setVisibility(isset($repositoryPayload['visibility']) ? (string)$repositoryPayload['visibility'] : null)
                     ->setIsPrivate((bool)($repositoryPayload['private'] ?? false))
+                    ->setPrimaryLanguage(isset($repositoryPayload['language']) ? (string)$repositoryPayload['language'] : null)
+                    ->setStarsCount((int)($repositoryPayload['stargazersCount'] ?? 0))
+                    ->setForksCount((int)($repositoryPayload['forksCount'] ?? 0))
+                    ->setWatchersCount((int)($repositoryPayload['watchersCount'] ?? 0))
+                    ->setOpenIssuesCount((int)($repositoryPayload['openIssuesCount'] ?? 0))
+                    ->setIsArchived((bool)($repositoryPayload['archived'] ?? false))
+                    ->setIsDisabled((bool)($repositoryPayload['disabled'] ?? false))
                     ->setHtmlUrl((string)($repositoryPayload['htmlUrl'] ?? ''))
                     ->setExternalId(isset($repositoryPayload['externalId']) ? (string)$repositoryPayload['externalId'] : null)
                     ->setSyncStatus('synced')
                     ->setLastSyncedAt(new DateTimeImmutable())
+                    ->setLastPushedAt($this->normalizeGithubDate($repositoryPayload['pushedAt'] ?? null))
                     ->setPayload($this->buildRepositoryImportPayload($repositoryPayload, null));
 
                 if (!$dryRun) {
@@ -257,11 +266,20 @@ final readonly class CrmGithubBootstrapSyncService
                     ->setName((string)($repositoryPayload['name'] ?? $existingRepository->getName()))
                     ->setFullName((string)($repositoryPayload['fullName'] ?? $existingRepository->getFullName()))
                     ->setDefaultBranch(isset($repositoryPayload['defaultBranch']) ? (string)$repositoryPayload['defaultBranch'] : null)
+                    ->setVisibility(isset($repositoryPayload['visibility']) ? (string)$repositoryPayload['visibility'] : $existingRepository->getVisibility())
                     ->setIsPrivate((bool)($repositoryPayload['private'] ?? $existingRepository->isPrivate()))
+                    ->setPrimaryLanguage(isset($repositoryPayload['language']) ? (string)$repositoryPayload['language'] : $existingRepository->getPrimaryLanguage())
+                    ->setStarsCount((int)($repositoryPayload['stargazersCount'] ?? $existingRepository->getStarsCount()))
+                    ->setForksCount((int)($repositoryPayload['forksCount'] ?? $existingRepository->getForksCount()))
+                    ->setWatchersCount((int)($repositoryPayload['watchersCount'] ?? $existingRepository->getWatchersCount()))
+                    ->setOpenIssuesCount((int)($repositoryPayload['openIssuesCount'] ?? $existingRepository->getOpenIssuesCount()))
+                    ->setIsArchived((bool)($repositoryPayload['archived'] ?? $existingRepository->isArchived()))
+                    ->setIsDisabled((bool)($repositoryPayload['disabled'] ?? $existingRepository->isDisabled()))
                     ->setHtmlUrl((string)($repositoryPayload['htmlUrl'] ?? $existingRepository->getHtmlUrl()))
                     ->setExternalId(isset($repositoryPayload['externalId']) ? (string)$repositoryPayload['externalId'] : $existingRepository->getExternalId())
                     ->setSyncStatus('synced')
                     ->setLastSyncedAt(new DateTimeImmutable())
+                    ->setLastPushedAt($this->normalizeGithubDate($repositoryPayload['pushedAt'] ?? null) ?? $existingRepository->getLastPushedAt())
                     ->setPayload($this->buildRepositoryImportPayload($repositoryPayload, $existingRepository->getPayload()));
 
                 if (!$dryRun) {
@@ -453,8 +471,17 @@ GRAPHQL, $ownerField);
                     'name' => (string)($repository['name'] ?? ''),
                     'fullName' => (string)($repository['full_name'] ?? ''),
                     'defaultBranch' => (string)($repository['default_branch'] ?? ''),
+                    'visibility' => isset($repository['visibility']) ? (string)$repository['visibility'] : null,
                     'private' => (bool)($repository['private'] ?? false),
+                    'language' => isset($repository['language']) ? (string)$repository['language'] : null,
+                    'stargazersCount' => (int)($repository['stargazers_count'] ?? 0),
+                    'forksCount' => (int)($repository['forks_count'] ?? 0),
+                    'watchersCount' => (int)($repository['watchers_count'] ?? 0),
+                    'openIssuesCount' => (int)($repository['open_issues_count'] ?? 0),
+                    'archived' => (bool)($repository['archived'] ?? false),
+                    'disabled' => (bool)($repository['disabled'] ?? false),
                     'htmlUrl' => (string)($repository['html_url'] ?? ''),
+                    'pushedAt' => isset($repository['pushed_at']) ? (string)$repository['pushed_at'] : null,
                     'owner' => (string)($repository['owner']['login'] ?? $owner),
                     'projectNodeId' => '',
                     'projectUrl' => '',
@@ -797,10 +824,32 @@ GRAPHQL, $ownerField);
         $payload['nodeId'] = (string)($repositoryPayload['nodeId'] ?? '');
         $payload['projectNodeId'] = (string)($repositoryPayload['projectNodeId'] ?? '');
         $payload['projectUrl'] = (string)($repositoryPayload['projectUrl'] ?? '');
+        $payload['visibility'] = $repositoryPayload['visibility'] ?? null;
+        $payload['language'] = $repositoryPayload['language'] ?? null;
+        $payload['stargazersCount'] = (int)($repositoryPayload['stargazersCount'] ?? 0);
+        $payload['forksCount'] = (int)($repositoryPayload['forksCount'] ?? 0);
+        $payload['watchersCount'] = (int)($repositoryPayload['watchersCount'] ?? 0);
+        $payload['openIssuesCount'] = (int)($repositoryPayload['openIssuesCount'] ?? 0);
+        $payload['archived'] = (bool)($repositoryPayload['archived'] ?? false);
+        $payload['disabled'] = (bool)($repositoryPayload['disabled'] ?? false);
+        $payload['pushedAt'] = $repositoryPayload['pushedAt'] ?? null;
         $payload['importSource'] = 'github-bootstrap';
         $payload['importedAt'] = (new DateTimeImmutable())->format(DATE_ATOM);
 
         return $payload;
+    }
+
+    private function normalizeGithubDate(mixed $value): ?DateTimeImmutable
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return new DateTimeImmutable(trim($value));
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     /**

--- a/src/Crm/Application/Service/CrmGithubService.php
+++ b/src/Crm/Application/Service/CrmGithubService.php
@@ -330,6 +330,68 @@ readonly class CrmGithubService
         ];
     }
 
+    public function createPullRequest(Project $project, string $repoFullName, string $title, string $head, string $base, ?string $body = null, bool $draft = false): array
+    {
+        $payload = [
+            'title' => trim($title),
+            'head' => trim($head),
+            'base' => trim($base),
+            'draft' => $draft,
+        ];
+        if (is_string($body) && trim($body) !== '') {
+            $payload['body'] = trim($body);
+        }
+
+        return $this->request($project, 'POST', sprintf('/repos/%s/pulls', $repoFullName), [
+            'json' => $payload,
+        ]);
+    }
+
+    public function patchPullRequest(
+        Project $project,
+        string $repoFullName,
+        int $number,
+        ?string $title = null,
+        ?string $body = null,
+        ?string $state = null,
+        ?string $base = null,
+        ?bool $maintainerCanModify = null,
+    ): array {
+        $payload = array_filter([
+            'title' => is_string($title) ? trim($title) : null,
+            'body' => $body,
+            'state' => is_string($state) ? trim($state) : null,
+            'base' => is_string($base) ? trim($base) : null,
+            'maintainer_can_modify' => $maintainerCanModify,
+        ], static fn (mixed $value): bool => $value !== null);
+
+        return $this->request($project, 'PATCH', sprintf('/repos/%s/pulls/%d', $repoFullName, $number), [
+            'json' => $payload,
+        ]);
+    }
+
+    public function listPullRequestCommits(Project $project, string $repoFullName, int $number, int $page = 1, int $perPage = 30): array
+    {
+        $response = $this->requestWithMeta($project, 'GET', sprintf('/repos/%s/pulls/%d/commits', $repoFullName, $number), [
+            'query' => [
+                'page' => $page,
+                'per_page' => $perPage,
+            ],
+        ]);
+
+        $items = array_values(array_map(static fn (array $commit): array => [
+            'sha' => (string)($commit['sha'] ?? ''),
+            'message' => (string)($commit['commit']['message'] ?? ''),
+            'author' => (string)($commit['author']['login'] ?? $commit['commit']['author']['name'] ?? ''),
+            'htmlUrl' => (string)($commit['html_url'] ?? ''),
+        ], $response['data']));
+
+        return [
+            'items' => $items,
+            'pagination' => $this->buildPagination($response['meta']['link'], $page, $perPage, count($items)),
+        ];
+    }
+
     public function listIssues(Project $project, string $repoFullName, string $state = 'open', int $page = 1, int $perPage = 30): array
     {
         $response = $this->requestWithMeta($project, 'GET', sprintf('/repos/%s/issues', $repoFullName), [
@@ -360,6 +422,144 @@ readonly class CrmGithubService
         return [
             'items' => $items,
             'pagination' => $this->buildPagination($response['meta']['link'], $page, $perPage, count($items)),
+        ];
+    }
+
+    public function listCommits(Project $project, string $repoFullName, int $page = 1, int $perPage = 30, ?string $branch = null): array
+    {
+        $query = [
+            'page' => $page,
+            'per_page' => $perPage,
+        ];
+        if (is_string($branch) && trim($branch) !== '') {
+            $query['sha'] = trim($branch);
+        }
+
+        $response = $this->requestWithMeta($project, 'GET', sprintf('/repos/%s/commits', $repoFullName), [
+            'query' => $query,
+        ]);
+
+        $items = array_values(array_map(static fn (array $commit): array => [
+            'sha' => (string)($commit['sha'] ?? ''),
+            'message' => (string)($commit['commit']['message'] ?? ''),
+            'author' => (string)($commit['author']['login'] ?? $commit['commit']['author']['name'] ?? ''),
+            'date' => (string)($commit['commit']['author']['date'] ?? ''),
+            'htmlUrl' => (string)($commit['html_url'] ?? ''),
+        ], $response['data']));
+
+        return [
+            'items' => $items,
+            'pagination' => $this->buildPagination($response['meta']['link'], $page, $perPage, count($items)),
+        ];
+    }
+
+    public function getCommit(Project $project, string $repoFullName, string $sha): array
+    {
+        $commit = $this->request($project, 'GET', sprintf('/repos/%s/commits/%s', $repoFullName, trim($sha)));
+
+        return [
+            'sha' => (string)($commit['sha'] ?? ''),
+            'message' => (string)($commit['commit']['message'] ?? ''),
+            'author' => (string)($commit['author']['login'] ?? $commit['commit']['author']['name'] ?? ''),
+            'date' => (string)($commit['commit']['author']['date'] ?? ''),
+            'htmlUrl' => (string)($commit['html_url'] ?? ''),
+            'files' => array_values(array_map(static fn (array $file): array => [
+                'filename' => (string)($file['filename'] ?? ''),
+                'status' => (string)($file['status'] ?? ''),
+                'additions' => (int)($file['additions'] ?? 0),
+                'deletions' => (int)($file['deletions'] ?? 0),
+                'changes' => (int)($file['changes'] ?? 0),
+            ], is_array($commit['files'] ?? null) ? $commit['files'] : [])),
+        ];
+    }
+
+    public function listCollaborators(Project $project, string $repoFullName, int $page = 1, int $perPage = 30): array
+    {
+        $response = $this->requestWithMeta($project, 'GET', sprintf('/repos/%s/collaborators', $repoFullName), [
+            'query' => [
+                'page' => $page,
+                'per_page' => $perPage,
+            ],
+        ]);
+
+        $items = array_values(array_map(static fn (array $collaborator): array => [
+            'login' => (string)($collaborator['login'] ?? ''),
+            'type' => (string)($collaborator['type'] ?? ''),
+            'htmlUrl' => (string)($collaborator['html_url'] ?? ''),
+            'permissions' => is_array($collaborator['permissions'] ?? null) ? $collaborator['permissions'] : [],
+        ], $response['data']));
+
+        return [
+            'items' => $items,
+            'pagination' => $this->buildPagination($response['meta']['link'], $page, $perPage, count($items)),
+        ];
+    }
+
+    public function listWorkflows(Project $project, string $repoFullName, int $page = 1, int $perPage = 30): array
+    {
+        $response = $this->request($project, 'GET', sprintf('/repos/%s/actions/workflows', $repoFullName), [
+            'query' => [
+                'page' => $page,
+                'per_page' => $perPage,
+            ],
+        ]);
+        $workflows = is_array($response['workflows'] ?? null) ? $response['workflows'] : [];
+
+        return [
+            'items' => array_values(array_map(static fn (array $workflow): array => [
+                'id' => (int)($workflow['id'] ?? 0),
+                'name' => (string)($workflow['name'] ?? ''),
+                'state' => (string)($workflow['state'] ?? ''),
+                'path' => (string)($workflow['path'] ?? ''),
+                'htmlUrl' => (string)($workflow['html_url'] ?? ''),
+                'createdAt' => (string)($workflow['created_at'] ?? ''),
+                'updatedAt' => (string)($workflow['updated_at'] ?? ''),
+            ], $workflows)),
+            'pagination' => [
+                'page' => $page,
+                'limit' => $perPage,
+                'totalItems' => (int)($response['total_count'] ?? count($workflows)),
+                'totalPages' => (int)max(1, (int)ceil(((int)($response['total_count'] ?? count($workflows))) / $perPage)),
+            ],
+        ];
+    }
+
+    public function listWorkflowRuns(Project $project, string $repoFullName, ?int $workflowId = null, int $page = 1, int $perPage = 30, ?string $status = null): array
+    {
+        $path = is_int($workflowId)
+            ? sprintf('/repos/%s/actions/workflows/%d/runs', $repoFullName, $workflowId)
+            : sprintf('/repos/%s/actions/runs', $repoFullName);
+        $query = [
+            'page' => $page,
+            'per_page' => $perPage,
+        ];
+        if (is_string($status) && trim($status) !== '') {
+            $query['status'] = trim($status);
+        }
+
+        $response = $this->request($project, 'GET', $path, [
+            'query' => $query,
+        ]);
+
+        $runs = is_array($response['workflow_runs'] ?? null) ? $response['workflow_runs'] : [];
+
+        return [
+            'items' => array_values(array_map(static fn (array $run): array => [
+                'id' => (int)($run['id'] ?? 0),
+                'name' => (string)($run['name'] ?? ''),
+                'status' => (string)($run['status'] ?? ''),
+                'conclusion' => isset($run['conclusion']) ? (string)$run['conclusion'] : null,
+                'event' => (string)($run['event'] ?? ''),
+                'htmlUrl' => (string)($run['html_url'] ?? ''),
+                'createdAt' => (string)($run['created_at'] ?? ''),
+                'updatedAt' => (string)($run['updated_at'] ?? ''),
+            ], $runs)),
+            'pagination' => [
+                'page' => $page,
+                'limit' => $perPage,
+                'totalItems' => (int)($response['total_count'] ?? count($runs)),
+                'totalPages' => (int)max(1, (int)ceil(((int)($response['total_count'] ?? count($runs))) / $perPage)),
+            ],
         ];
     }
 
@@ -519,6 +719,55 @@ GRAPHQL, [
             'json' => [
                 'state' => strtolower(trim($state)),
             ],
+        ]);
+    }
+
+    public function patchIssue(
+        Project $project,
+        string $repoFullName,
+        int $number,
+        ?string $title = null,
+        ?string $body = null,
+        ?string $state = null,
+        ?string $stateReason = null,
+        ?array $labels = null,
+        ?array $assignees = null,
+        ?int $milestone = null,
+    ): array {
+        $payload = array_filter([
+            'title' => is_string($title) ? trim($title) : null,
+            'body' => $body,
+            'state' => is_string($state) ? trim($state) : null,
+            'state_reason' => is_string($stateReason) ? trim($stateReason) : null,
+            'labels' => $labels,
+            'assignees' => $assignees,
+            'milestone' => $milestone,
+        ], static fn (mixed $value): bool => $value !== null);
+
+        return $this->request($project, 'PATCH', sprintf('/repos/%s/issues/%d', $repoFullName, $number), [
+            'json' => $payload,
+        ]);
+    }
+
+    public function patchRepository(
+        Project $project,
+        string $repoFullName,
+        ?string $name = null,
+        ?string $description = null,
+        ?bool $private = null,
+        ?string $defaultBranch = null,
+        ?bool $archived = null,
+    ): array {
+        $payload = array_filter([
+            'name' => is_string($name) ? trim($name) : null,
+            'description' => $description,
+            'private' => $private,
+            'default_branch' => is_string($defaultBranch) ? trim($defaultBranch) : null,
+            'archived' => $archived,
+        ], static fn (mixed $value): bool => $value !== null);
+
+        return $this->request($project, 'PATCH', sprintf('/repos/%s', trim($repoFullName)), [
+            'json' => $payload,
         ]);
     }
 

--- a/src/Crm/Domain/Entity/CrmRepository.php
+++ b/src/Crm/Domain/Entity/CrmRepository.php
@@ -54,10 +54,46 @@ class CrmRepository implements EntityInterface
     #[ORM\Column(name: 'default_branch', type: Types::STRING, length: 255, nullable: true)]
     private ?string $defaultBranch = null;
 
+    #[ORM\Column(name: 'visibility', type: Types::STRING, length: 20, nullable: true)]
+    private ?string $visibility = null;
+
     #[ORM\Column(name: 'is_private', type: Types::BOOLEAN, options: [
         'default' => false,
     ])]
     private bool $isPrivate = false;
+
+    #[ORM\Column(name: 'primary_language', type: Types::STRING, length: 120, nullable: true)]
+    private ?string $primaryLanguage = null;
+
+    #[ORM\Column(name: 'stars_count', type: Types::INTEGER, options: [
+        'default' => 0,
+    ])]
+    private int $starsCount = 0;
+
+    #[ORM\Column(name: 'forks_count', type: Types::INTEGER, options: [
+        'default' => 0,
+    ])]
+    private int $forksCount = 0;
+
+    #[ORM\Column(name: 'watchers_count', type: Types::INTEGER, options: [
+        'default' => 0,
+    ])]
+    private int $watchersCount = 0;
+
+    #[ORM\Column(name: 'open_issues_count', type: Types::INTEGER, options: [
+        'default' => 0,
+    ])]
+    private int $openIssuesCount = 0;
+
+    #[ORM\Column(name: 'is_archived', type: Types::BOOLEAN, options: [
+        'default' => false,
+    ])]
+    private bool $isArchived = false;
+
+    #[ORM\Column(name: 'is_disabled', type: Types::BOOLEAN, options: [
+        'default' => false,
+    ])]
+    private bool $isDisabled = false;
 
     #[ORM\Column(name: 'html_url', type: Types::STRING, length: 1024, nullable: true)]
     private ?string $htmlUrl = null;
@@ -67,6 +103,9 @@ class CrmRepository implements EntityInterface
 
     #[ORM\Column(name: 'last_synced_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?DateTimeImmutable $lastSyncedAt = null;
+
+    #[ORM\Column(name: 'last_pushed_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?DateTimeImmutable $lastPushedAt = null;
 
     #[ORM\Column(name: 'sync_status', type: Types::STRING, length: 40, options: [
         'default' => 'pending',
@@ -165,6 +204,18 @@ class CrmRepository implements EntityInterface
         return $this;
     }
 
+    public function getVisibility(): ?string
+    {
+        return $this->visibility;
+    }
+
+    public function setVisibility(?string $visibility): self
+    {
+        $this->visibility = $visibility;
+
+        return $this;
+    }
+
     public function isPrivate(): bool
     {
         return $this->isPrivate;
@@ -173,6 +224,90 @@ class CrmRepository implements EntityInterface
     public function setIsPrivate(bool $isPrivate): self
     {
         $this->isPrivate = $isPrivate;
+
+        return $this;
+    }
+
+    public function getPrimaryLanguage(): ?string
+    {
+        return $this->primaryLanguage;
+    }
+
+    public function setPrimaryLanguage(?string $primaryLanguage): self
+    {
+        $this->primaryLanguage = $primaryLanguage;
+
+        return $this;
+    }
+
+    public function getStarsCount(): int
+    {
+        return $this->starsCount;
+    }
+
+    public function setStarsCount(int $starsCount): self
+    {
+        $this->starsCount = $starsCount;
+
+        return $this;
+    }
+
+    public function getForksCount(): int
+    {
+        return $this->forksCount;
+    }
+
+    public function setForksCount(int $forksCount): self
+    {
+        $this->forksCount = $forksCount;
+
+        return $this;
+    }
+
+    public function getWatchersCount(): int
+    {
+        return $this->watchersCount;
+    }
+
+    public function setWatchersCount(int $watchersCount): self
+    {
+        $this->watchersCount = $watchersCount;
+
+        return $this;
+    }
+
+    public function getOpenIssuesCount(): int
+    {
+        return $this->openIssuesCount;
+    }
+
+    public function setOpenIssuesCount(int $openIssuesCount): self
+    {
+        $this->openIssuesCount = $openIssuesCount;
+
+        return $this;
+    }
+
+    public function isArchived(): bool
+    {
+        return $this->isArchived;
+    }
+
+    public function setIsArchived(bool $isArchived): self
+    {
+        $this->isArchived = $isArchived;
+
+        return $this;
+    }
+
+    public function isDisabled(): bool
+    {
+        return $this->isDisabled;
+    }
+
+    public function setIsDisabled(bool $isDisabled): self
+    {
+        $this->isDisabled = $isDisabled;
 
         return $this;
     }
@@ -209,6 +344,18 @@ class CrmRepository implements EntityInterface
     public function setLastSyncedAt(?DateTimeImmutable $lastSyncedAt): self
     {
         $this->lastSyncedAt = $lastSyncedAt;
+
+        return $this;
+    }
+
+    public function getLastPushedAt(): ?DateTimeImmutable
+    {
+        return $this->lastPushedAt;
+    }
+
+    public function setLastPushedAt(?DateTimeImmutable $lastPushedAt): self
+    {
+        $this->lastPushedAt = $lastPushedAt;
 
         return $this;
     }

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubPullRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubPullRequestController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CreateGithubPullRequestRequest;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class CreateProjectGithubPullRequestController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+        private CrmRequestHandler $crmRequestHandler,
+        private CrmGithubApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/general/projects/{project}/github/pull-requests', methods: [Request::METHOD_POST])]
+    public function __invoke(Project $project, Request $request): JsonResponse
+    {
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $input = $this->crmRequestHandler->mapAndValidate($payload, CreateGithubPullRequestRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
+        }
+
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->createPullRequest(
+                $project,
+                (string)$input->repository,
+                (string)$input->title,
+                (string)$input->head,
+                (string)$input->base,
+                $input->body,
+                (bool)($input->draft ?? false),
+            ),
+            JsonResponse::HTTP_CREATED,
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubCommitController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubCommitController.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+final readonly class GetProjectGithubCommitController
+{
+    public function __construct(private CrmGithubService $crmGithubService)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/commits/{sha}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/commits/{sha}', methods: [Request::METHOD_GET])]
+    public function __invoke(Project $project, string $sha, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->getCommit(
+            $project,
+            (string)$request->query->get('repo', ''),
+            $sha,
+        ));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubActionsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubActionsController.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+final readonly class ListProjectGithubActionsController
+{
+    public function __construct(private CrmGithubService $crmGithubService)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/actions/workflows', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/actions/workflows', methods: [Request::METHOD_GET])]
+    public function workflows(Project $project, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->listWorkflows(
+            $project,
+            (string)$request->query->get('repo', ''),
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+        ));
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/actions/runs', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/actions/runs', methods: [Request::METHOD_GET])]
+    public function runs(Project $project, Request $request): JsonResponse
+    {
+        $workflowId = $request->query->get('workflowId');
+
+        return new JsonResponse($this->crmGithubService->listWorkflowRuns(
+            $project,
+            (string)$request->query->get('repo', ''),
+            $workflowId !== null ? (int)$workflowId : null,
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+            $request->query->get('status') !== null ? (string)$request->query->get('status') : null,
+        ));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCollaboratorsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCollaboratorsController.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+final readonly class ListProjectGithubCollaboratorsController
+{
+    public function __construct(private CrmGithubService $crmGithubService)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/collaborators', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/collaborators', methods: [Request::METHOD_GET])]
+    public function __invoke(Project $project, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->listCollaborators(
+            $project,
+            (string)$request->query->get('repo', ''),
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+        ));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCommitsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCommitsController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+final readonly class ListProjectGithubCommitsController
+{
+    public function __construct(private CrmGithubService $crmGithubService)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/commits', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/commits', methods: [Request::METHOD_GET])]
+    public function __invoke(Project $project, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->listCommits(
+            $project,
+            (string)$request->query->get('repo', ''),
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+            $request->query->get('branch') !== null ? (string)$request->query->get('branch') : null,
+        ));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestCommitsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestCommitsController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+final readonly class ListProjectGithubPullRequestCommitsController
+{
+    public function __construct(private CrmGithubService $crmGithubService)
+    {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests/{number}/commits', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/general/projects/{project}/github/pull-requests/{number}/commits', methods: [Request::METHOD_GET])]
+    public function __invoke(Project $project, int $number, Request $request): JsonResponse
+    {
+        return new JsonResponse($this->crmGithubService->listPullRequestCommits(
+            $project,
+            (string)$request->query->get('repo', ''),
+            $number,
+            max(1, $request->query->getInt('page', 1)),
+            max(1, min(100, $request->query->getInt('limit', 30))),
+        ));
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubIssueController.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use App\Crm\Transport\Request\PatchGithubIssueRequest;
+use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class PatchProjectGithubIssueController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+        private CrmRequestHandler $crmRequestHandler,
+        private CrmGithubApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/issues/{number}/patch', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/crm/general/projects/{project}/github/issues/{number}/patch', methods: [Request::METHOD_PATCH])]
+    public function __invoke(Project $project, int $number, Request $request): JsonResponse
+    {
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $input = $this->crmRequestHandler->mapAndValidate($payload, PatchGithubIssueRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
+        }
+
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->patchIssue(
+                $project,
+                (string)$input->repository,
+                $number,
+                $input->title,
+                $input->body,
+                $input->state,
+                $input->stateReason,
+                $input->labels,
+                $input->assignees,
+                $input->milestone,
+            ),
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubPullRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubPullRequestController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use App\Crm\Transport\Request\PatchGithubPullRequestRequest;
+use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class PatchProjectGithubPullRequestController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+        private CrmRequestHandler $crmRequestHandler,
+        private CrmGithubApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/pull-requests/{number}', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/crm/general/projects/{project}/github/pull-requests/{number}', methods: [Request::METHOD_PATCH])]
+    public function __invoke(Project $project, int $number, Request $request): JsonResponse
+    {
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $input = $this->crmRequestHandler->mapAndValidate($payload, PatchGithubPullRequestRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
+        }
+
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->patchPullRequest(
+                $project,
+                (string)$input->repository,
+                $number,
+                $input->title,
+                $input->body,
+                $input->state,
+                $input->base,
+                $input->maintainerCanModify,
+            ),
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubRepositoryController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Project\Github;
+
+use App\Crm\Application\Service\CrmGithubService;
+use App\Crm\Domain\Entity\Project;
+use App\Crm\Transport\Request\CrmGithubApiErrorResponseFactory;
+use App\Crm\Transport\Request\CrmRequestHandler;
+use App\Crm\Transport\Request\PatchGithubRepositoryRequest;
+use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm Github')]
+#[IsGranted(Role::CRM_ADMIN->value)]
+final readonly class PatchProjectGithubRepositoryController
+{
+    use HandlesGithubApiExceptions;
+
+    public function __construct(
+        private CrmGithubService $crmGithubService,
+        private CrmRequestHandler $crmRequestHandler,
+        private CrmGithubApiErrorResponseFactory $errorResponseFactory,
+    ) {
+    }
+
+    #[Route('/v1/crm/applications/{applicationSlug}/projects/{project}/github/repositories/patch', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/crm/general/projects/{project}/github/repositories/patch', methods: [Request::METHOD_PATCH])]
+    public function __invoke(Project $project, Request $request): JsonResponse
+    {
+        $payload = $this->crmRequestHandler->decodeJson($request);
+        if ($payload instanceof JsonResponse) {
+            return $payload;
+        }
+
+        $input = $this->crmRequestHandler->mapAndValidate($payload, PatchGithubRepositoryRequest::class);
+        if ($input instanceof JsonResponse) {
+            return $input;
+        }
+
+        return $this->withGithubApiErrors(fn (): JsonResponse => new JsonResponse(
+            $this->crmGithubService->patchRepository(
+                $project,
+                (string)$input->repository,
+                $input->name,
+                $input->description,
+                $input->private,
+                $input->defaultBranch,
+                $input->archived,
+            ),
+        ), $this->errorResponseFactory);
+    }
+}

--- a/src/Crm/Transport/Request/CreateGithubPullRequestRequest.php
+++ b/src/Crm/Transport/Request/CreateGithubPullRequestRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class CreateGithubPullRequestRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Regex(pattern: '/^[^\s\/]+\/[^\s\/]+$/', message: 'Repository must be in the "owner/name" format.')]
+    public ?string $repository = null;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 255)]
+    public ?string $title = null;
+
+    #[Assert\NotBlank]
+    public ?string $head = null;
+
+    #[Assert\NotBlank]
+    public ?string $base = null;
+
+    public ?string $body = null;
+
+    public ?bool $draft = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->repository = isset($payload['repository']) ? trim((string)$payload['repository']) : null;
+        $request->title = isset($payload['title']) ? trim((string)$payload['title']) : null;
+        $request->head = isset($payload['head']) ? trim((string)$payload['head']) : null;
+        $request->base = isset($payload['base']) ? trim((string)$payload['base']) : null;
+        $request->body = isset($payload['body']) ? (string)$payload['body'] : null;
+        $request->draft = isset($payload['draft']) ? (bool)$payload['draft'] : null;
+
+        return $request;
+    }
+}

--- a/src/Crm/Transport/Request/PatchGithubIssueRequest.php
+++ b/src/Crm/Transport/Request/PatchGithubIssueRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class PatchGithubIssueRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Regex(pattern: '/^[^\s\/]+\/[^\s\/]+$/', message: 'Repository must be in the "owner/name" format.')]
+    public ?string $repository = null;
+
+    #[Assert\Length(max: 255)]
+    public ?string $title = null;
+
+    public ?string $body = null;
+
+    #[Assert\Choice(choices: ['open', 'closed'])]
+    public ?string $state = null;
+
+    #[Assert\Choice(choices: ['completed', 'reopened', 'not_planned'])]
+    public ?string $stateReason = null;
+
+    /** @var list<string>|null */
+    public ?array $labels = null;
+
+    /** @var list<string>|null */
+    public ?array $assignees = null;
+
+    public ?int $milestone = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->repository = isset($payload['repository']) ? trim((string)$payload['repository']) : null;
+        $request->title = isset($payload['title']) ? trim((string)$payload['title']) : null;
+        $request->body = isset($payload['body']) ? (string)$payload['body'] : null;
+        $request->state = isset($payload['state']) ? trim((string)$payload['state']) : null;
+        $request->stateReason = isset($payload['stateReason']) ? trim((string)$payload['stateReason']) : null;
+        $request->labels = isset($payload['labels']) && is_array($payload['labels']) ? array_values(array_map(static fn (mixed $value): string => (string)$value, $payload['labels'])) : null;
+        $request->assignees = isset($payload['assignees']) && is_array($payload['assignees']) ? array_values(array_map(static fn (mixed $value): string => (string)$value, $payload['assignees'])) : null;
+        $request->milestone = isset($payload['milestone']) ? (int)$payload['milestone'] : null;
+
+        return $request;
+    }
+}

--- a/src/Crm/Transport/Request/PatchGithubPullRequestRequest.php
+++ b/src/Crm/Transport/Request/PatchGithubPullRequestRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class PatchGithubPullRequestRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Regex(pattern: '/^[^\s\/]+\/[^\s\/]+$/', message: 'Repository must be in the "owner/name" format.')]
+    public ?string $repository = null;
+
+    #[Assert\Length(max: 255)]
+    public ?string $title = null;
+
+    public ?string $body = null;
+
+    #[Assert\Choice(choices: ['open', 'closed'])]
+    public ?string $state = null;
+
+    public ?string $base = null;
+
+    public ?bool $maintainerCanModify = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->repository = isset($payload['repository']) ? trim((string)$payload['repository']) : null;
+        $request->title = isset($payload['title']) ? trim((string)$payload['title']) : null;
+        $request->body = isset($payload['body']) ? (string)$payload['body'] : null;
+        $request->state = isset($payload['state']) ? trim((string)$payload['state']) : null;
+        $request->base = isset($payload['base']) ? trim((string)$payload['base']) : null;
+        $request->maintainerCanModify = isset($payload['maintainerCanModify']) ? (bool)$payload['maintainerCanModify'] : null;
+
+        return $request;
+    }
+}

--- a/src/Crm/Transport/Request/PatchGithubRepositoryRequest.php
+++ b/src/Crm/Transport/Request/PatchGithubRepositoryRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Request;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class PatchGithubRepositoryRequest
+{
+    #[Assert\NotBlank]
+    #[Assert\Regex(pattern: '/^[^\s\/]+\/[^\s\/]+$/', message: 'Repository must be in the "owner/name" format.')]
+    public ?string $repository = null;
+
+    #[Assert\Length(max: 255)]
+    public ?string $name = null;
+
+    public ?string $description = null;
+
+    public ?bool $private = null;
+
+    public ?string $defaultBranch = null;
+
+    public ?bool $archived = null;
+
+    public static function fromArray(array $payload): self
+    {
+        $request = new self();
+        $request->repository = isset($payload['repository']) ? trim((string)$payload['repository']) : null;
+        $request->name = isset($payload['name']) ? trim((string)$payload['name']) : null;
+        $request->description = isset($payload['description']) ? (string)$payload['description'] : null;
+        $request->private = isset($payload['private']) ? (bool)$payload['private'] : null;
+        $request->defaultBranch = isset($payload['defaultBranch']) ? trim((string)$payload['defaultBranch']) : null;
+        $request->archived = isset($payload['archived']) ? (bool)$payload['archived'] : null;
+
+        return $request;
+    }
+}


### PR DESCRIPTION
### Motivation

- Capture additional repository metadata (visibility, language, stars/forks/watchers, issue counts, archive/disabled flags and last push time) in the CRM to improve sync fidelity and reporting.
- Extend GitHub integration to support additional API operations (commits, commit details, collaborators, workflows/runs, pull request creation/patching, issue and repository patching) for richer automation and UI features.
- Provide HTTP endpoints and request DTOs to expose the new operations from the transport layer with consistent validation.

### Description

- Added a Doctrine migration `Version20260422120000` which adds repository columns: `visibility`, `primary_language`, `stars_count`, `forks_count`, `watchers_count`, `open_issues_count`, `is_archived`, `is_disabled`, and `last_pushed_at`.
- Extended `CrmRepository` entity with new fields, Doctrine mappings and corresponding getters/setters for all new columns including `lastPushedAt` and metric counters.
- Updated `CrmGithubBootstrapSyncService` to collect and persist the new repository fields during bootstrap sync, to include them in repository payloads and to normalize GitHub date strings with `normalizeGithubDate`.
- Added many new methods to `CrmGithubService` to support `createPullRequest`, `patchPullRequest`, `listPullRequestCommits`, `listCommits`, `getCommit`, `listCollaborators`, `listWorkflows`, `listWorkflowRuns`, `patchIssue`, and `patchRepository`, plus pagination helpers for those endpoints.
- Introduced new controllers under `App\Crm\Transport\Controller\Api\V1\Project\Github` to expose endpoints for commits, commit details, pull request creation/patching, listing pull request commits, listing commits, listing collaborators, listing actions/workflows and runs, and patching issues and repositories.
- Added request DTOs with validation for incoming payloads: `CreateGithubPullRequestRequest`, `PatchGithubIssueRequest`, `PatchGithubPullRequestRequest`, and `PatchGithubRepositoryRequest`.

### Testing

- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e86c0252d8832b94f8bd6f9a9734a0)