### PR TITLE
test: enforce module-scoped V1 route convention

### DIFF
--- a/tests/Unit/Architecture/ApplicationScopedRouteConventionTest.php
+++ b/tests/Unit/Architecture/ApplicationScopedRouteConventionTest.php
@@ -19,7 +19,7 @@ final class ApplicationScopedRouteConventionTest extends TestCase
         'blog',
     ];
 
-    public function testApplicationScopedRoutesFollowOfficialConvention(): void
+    public function testV1RoutesFollowModuleScopedConvention(): void
     {
         $violations = [];
 
@@ -36,30 +36,40 @@ final class ApplicationScopedRouteConventionTest extends TestCase
                     continue;
                 }
 
-                $content = (string)\file_get_contents($file->getPathname());
+                $content = (string) \file_get_contents($file->getPathname());
                 if (!\preg_match_all("/Route\\((?:[^'\\n]*?)'([^']+)'/", $content, $matches)) {
                     continue;
                 }
 
                 foreach ($matches[1] as $path) {
-                    if (!\str_contains($path, '{applicationSlug}')) {
+                    if (!\str_starts_with($path, '/v1/')) {
                         continue;
                     }
 
-                    $expectedPrefix = '/v1/' . $module . '/applications/{applicationSlug}';
-                    if (!\str_starts_with($path, $expectedPrefix)) {
-                        $violations[] = $file->getPathname() . ' -> ' . $path;
+                    $expectedModulePrefix = '/v1/' . $module . '/';
 
-                        continue;
+                    if (!\str_starts_with($path, $expectedModulePrefix)) {
+                        $violations[] = $file->getPathname() . ' -> ' . $path . ' (expected prefix: ' . $expectedModulePrefix . '...)';
                     }
 
-                    if (\str_contains($path, '/private/applications/{applicationSlug}')) {
-                        $violations[] = $file->getPathname() . ' -> ' . $path;
+                    if (\str_contains($path, '/applications/{applicationSlug}')) {
+                        $violations[] = $file->getPathname() . ' -> ' . $path . ' (forbidden segment: /applications/{applicationSlug})';
+                    }
+
+                    if (\str_starts_with($path, '/v1/private/')) {
+                        $violations[] = $file->getPathname() . ' -> ' . $path . ' (legacy private prefix: use /v1/' . $module . '/private/...)';
                     }
                 }
             }
         }
 
-        self::assertSame([], $violations, "Routes hors convention:\n" . \implode("\n", $violations));
+        self::assertSame(
+            [],
+            $violations,
+            "Routes V1 hors convention module-scoped. "
+            . "Utiliser /v1/{module}/... sans /applications/{applicationSlug}; "
+            . "passer le slug applicatif via query/header/body avec fallback sur 'general'.\n"
+            . \implode("\n", $violations),
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- Le test d'architecture devait évoluer de la convention `/v1/{module}/applications/{applicationSlug}` vers une convention module-scoped `/v1/{module}/...` et interdire l'usage du segment `/applications/{applicationSlug}` dans les routes V1.
- Les préfixes historiques globaux `/v1/private/...` doivent être repérés comme legacy et guidés vers un pattern module-scoped `/v1/{module}/private/...`.

### Description
- Mise à jour du test `tests/Unit/Architecture/ApplicationScopedRouteConventionTest.php` et renommage de la méthode en `testV1RoutesFollowModuleScopedConvention`.
- La logique parcourt désormais uniquement les routes commençant par `/v1/` et impose le préfixe attendu `/v1/{module}/` pour chaque module.
- Ajout d'une règle explicite qui marque comme violation toute occurrence de `/applications/{applicationSlug}` dans une route V1.
- Détection des routes commençant par `/v1/private/` considérées comme legacy et message d'erreur ajusté pour recommander `slug en query/header/body + fallback general`.

### Testing
- `php -l tests/Unit/Architecture/ApplicationScopedRouteConventionTest.php` a réussi sans erreurs de syntaxe.
- Exécution de `./vendor/bin/phpunit tests/Unit/Architecture/ApplicationScopedRouteConventionTest.php` impossible dans cet environnement car le binaire PHPUnit n'est pas présent (échec dû à l'environnement, pas au test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94b23de408326ae220a0e552d86cc)