### PR TITLE
feat: centraliser la résolution du scope applicatif

### DIFF
--- a/src/General/Application/Service/ApplicationScopeResolver.php
+++ b/src/General/Application/Service/ApplicationScopeResolver.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\General\Application\Service;
+
+use App\Platform\Domain\Entity\Application;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+final readonly class ApplicationScopeResolver
+{
+    public const string DEFAULT_APPLICATION_SLUG = 'general';
+    public const string UNKNOWN_APPLICATION_SLUG_MESSAGE = 'Unknown "applicationSlug".';
+
+    public function __construct(
+        private EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function resolveApplicationSlug(Request $request): string
+    {
+        $resolvedSlug = $this->extractApplicationSlug($request);
+        $application = $this->entityManager->getRepository(Application::class)->findOneBy([
+            'slug' => $resolvedSlug,
+        ]);
+
+        if (!$application instanceof Application) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, self::UNKNOWN_APPLICATION_SLUG_MESSAGE);
+        }
+
+        $request->attributes->set('applicationSlug', $resolvedSlug);
+
+        return $resolvedSlug;
+    }
+
+    private function extractApplicationSlug(Request $request): string
+    {
+        $applicationSlug = trim((string) ($request->query->get('applicationSlug')
+            ?? $request->headers->get('X-Application-Slug')
+            ?? $request->headers->get('Application-Slug')
+            ?? $request->attributes->get('applicationSlug')
+            ?? ''));
+
+        if ($applicationSlug === '') {
+            return self::DEFAULT_APPLICATION_SLUG;
+        }
+
+        return $applicationSlug;
+    }
+}

--- a/src/Recruit/Application/Service/RecruitResolverService.php
+++ b/src/Recruit/Application/Service/RecruitResolverService.php
@@ -4,16 +4,24 @@ declare(strict_types=1);
 
 namespace App\Recruit\Application\Service;
 
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\Recruit\Domain\Entity\Recruit;
 use App\Recruit\Domain\Repository\Interfaces\RecruitRepositoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 readonly class RecruitResolverService
 {
     public function __construct(
         private RecruitRepositoryInterface $recruitRepository,
+        private ApplicationScopeResolver $applicationScopeResolver,
     ) {
+    }
+
+    public function resolveFromRequest(Request $request): Recruit
+    {
+        return $this->resolveByApplicationSlug($this->applicationScopeResolver->resolveApplicationSlug($request));
     }
 
     public function resolveByApplicationSlug(string $applicationSlug): Recruit
@@ -21,7 +29,7 @@ readonly class RecruitResolverService
         $recruit = $this->recruitRepository->findOneByApplicationSlug($applicationSlug);
 
         if (!$recruit instanceof Recruit) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "applicationSlug".');
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, ApplicationScopeResolver::UNKNOWN_APPLICATION_SLUG_MESSAGE);
         }
 
         return $recruit;

--- a/src/Recruit/Transport/Controller/Api/V1/Analytics/PrivateRecruitAnalyticsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Analytics/PrivateRecruitAnalyticsController.php
@@ -40,9 +40,10 @@ readonly class PrivateRecruitAnalyticsController
     #[OA\Parameter(name: 'to', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'date-time'))]
     #[OA\Parameter(name: 'jobId', in: 'query', required: false, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'format', in: 'query', required: false, schema: new OA\Schema(type: 'string', enum: ['json', 'csv']))]
-    public function __invoke(string $applicationSlug, Request $request, User $loggedInUser): Response
+    public function __invoke(Request $request, User $loggedInUser): Response
     {
-        $recruit = $this->recruitResolverService->resolveByApplicationSlug($applicationSlug);
+        $recruit = $this->recruitResolverService->resolveFromRequest($request);
+        $applicationSlug = (string) $request->attributes->get('applicationSlug', '');
 
         if ($recruit->getApplication()?->getUser()?->getId() !== $loggedInUser->getId()) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot access analytics for this application.');

--- a/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateController.php
@@ -59,9 +59,9 @@ readonly class ApplicationCreateController
             new OA\Response(response: 400, description: 'Payload invalide.'),
         ],
     )]
-    public function __invoke(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {
-        $request->attributes->set('applicationSlug', $applicationSlug);
+        $recruit = $this->recruitResolverService->resolveFromRequest($request);
         /** @var array<string, mixed> $payload */
         $payload = $request->toArray();
 
@@ -88,7 +88,6 @@ readonly class ApplicationCreateController
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unknown "jobId".');
         }
 
-        $recruit = $this->recruitResolverService->resolveByApplicationSlug($applicationSlug);
         if ($job->getRecruit()?->getId() !== $recruit->getId()) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'The given job does not belong to this application.');
         }

--- a/src/Recruit/Transport/Controller/Api/V1/Application/PrivatePipelineController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Application/PrivatePipelineController.php
@@ -41,9 +41,9 @@ readonly class PrivatePipelineController
             new OA\Parameter(name: 'tags', in: 'query', required: false, schema: new OA\Schema(type: 'string', description: 'Label du tag job.')),
         ],
     )]
-    public function __invoke(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {
-        $recruit = $this->recruitResolverService->resolveByApplicationSlug($applicationSlug);
+        $recruit = $this->recruitResolverService->resolveFromRequest($request);
 
         if ($recruit->getApplication()?->getUser()?->getId() !== $loggedInUser->getId()) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot access pipeline for this application.');

--- a/src/Recruit/Transport/Controller/Api/V1/Job/PrivateJobStatsController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Job/PrivateJobStatsController.php
@@ -29,9 +29,9 @@ readonly class PrivateJobStatsController
 
     #[Route(path: '/v1/recruit/private/jobs/stats', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, User $loggedInUser): JsonResponse
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {
-        $recruit = $this->recruitResolverService->resolveByApplicationSlug($applicationSlug);
+        $recruit = $this->recruitResolverService->resolveFromRequest($request);
 
         if ($recruit->getApplication()?->getUser()?->getId() !== $loggedInUser->getId()) {
             throw new HttpException(JsonResponse::HTTP_FORBIDDEN, 'You cannot access stats for this application.');

--- a/tests/Unit/General/Application/Service/ApplicationScopeResolverTest.php
+++ b/tests/Unit/General/Application/Service/ApplicationScopeResolverTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\General\Application\Service;
+
+use App\General\Application\Service\ApplicationScopeResolver;
+use App\Platform\Domain\Entity\Application;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ApplicationScopeResolverTest extends TestCase
+{
+    public function testResolveApplicationSlugTrimsQueryValue(): void
+    {
+        $request = new Request(['applicationSlug' => '  recruit-general-core  ']);
+        $resolver = $this->createResolverExpectingLookup('recruit-general-core', true);
+
+        $slug = $resolver->resolveApplicationSlug($request);
+
+        self::assertSame('recruit-general-core', $slug);
+        self::assertSame('recruit-general-core', $request->attributes->get('applicationSlug'));
+    }
+
+    public function testResolveApplicationSlugFallsBackToGeneralWhenEmpty(): void
+    {
+        $request = new Request(['applicationSlug' => '   ']);
+        $resolver = $this->createResolverExpectingLookup(ApplicationScopeResolver::DEFAULT_APPLICATION_SLUG, true);
+
+        $slug = $resolver->resolveApplicationSlug($request);
+
+        self::assertSame(ApplicationScopeResolver::DEFAULT_APPLICATION_SLUG, $slug);
+    }
+
+    public function testResolveApplicationSlugThrowsWhenUnknown(): void
+    {
+        $request = new Request(['applicationSlug' => 'unknown-scope']);
+        $resolver = $this->createResolverExpectingLookup('unknown-scope', false);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(404);
+        $this->expectExceptionMessage(ApplicationScopeResolver::UNKNOWN_APPLICATION_SLUG_MESSAGE);
+
+        $resolver->resolveApplicationSlug($request);
+    }
+
+    public function testResolveApplicationSlugUsesGeneralFromHeadersWhenMissingInQuery(): void
+    {
+        $request = new Request(server: ['HTTP_X_APPLICATION_SLUG' => '   general   ']);
+        $resolver = $this->createResolverExpectingLookup('general', true);
+
+        $slug = $resolver->resolveApplicationSlug($request);
+
+        self::assertSame('general', $slug);
+    }
+
+    private function createResolverExpectingLookup(string $expectedSlug, bool $exists): ApplicationScopeResolver
+    {
+        $repository = $this->createMock(ObjectRepository::class);
+        $repository
+            ->expects(self::once())
+            ->method('findOneBy')
+            ->with(['slug' => $expectedSlug])
+            ->willReturn($exists ? new Application() : null);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager
+            ->expects(self::once())
+            ->method('getRepository')
+            ->with(Application::class)
+            ->willReturn($repository);
+
+        return new ApplicationScopeResolver($entityManager);
+    }
+}


### PR DESCRIPTION
### Motivation
- Centraliser la résolution du slug applicatif pour avoir un comportement unique (lecture depuis query/header/attributes, trim, fallback `general`).
- Valider l’existence de l’application avant d’appeler la logique métier pour éviter duplications et messages d’erreur divergents.
- Harmoniser les erreurs métier liées au scope (message `Unknown "applicationSlug".` et code 404).

### Description
- Ajout du service transverse `App\General\Application\Service\ApplicationScopeResolver` qui extrait le `applicationSlug` depuis la requête, applique le fallback `general`, valide l’existence de l’application et réinjecte le slug dans les attributs de la requête (`src/General/Application/Service/ApplicationScopeResolver.php`).
- Adaptation de `RecruitResolverService` pour exposer `resolveFromRequest(Request $request)` et réutiliser la constante d’erreur partagée, plus validation via le resolver (`src/Recruit/Application/Service/RecruitResolverService.php`).
- Remplacement dans les contrôleurs Recruit ciblés de l’appel direct `resolveByApplicationSlug($applicationSlug)` par `resolveFromRequest($request)` afin d’utiliser le resolver centralisé (`PrivateJobStatsController`, `PrivatePipelineController`, `ApplicationCreateController`, `PrivateRecruitAnalyticsController`).
- Ajout de tests unitaires dédiés pour le resolver couvrant trim, fallback vers `general`, header-based resolution et slug inconnu (`tests/Unit/General/Application/Service/ApplicationScopeResolverTest.php`).

### Testing
- Validation syntaxique avec `php -l` sur les fichiers modifiés/ajoutés (tous OK).
- Nouveau test unitaire ajouté `tests/Unit/General/Application/Service/ApplicationScopeResolverTest.php` (tests écrits et syntaxiquement valides).
- Exécution de `./vendor/bin/phpunit tests/Unit/General/Application/Service/ApplicationScopeResolverTest.php` non réalisée car l’environnement CI local n’a pas `vendor/` installé (dépendances PHPUnit absentes); donc tests unitaires non exécutés ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e94f7604608326870f8ec74efe6758)