### PR TITLE
Unify application slug resolution and invalid-scope error handling

### DIFF
--- a/src/Crm/Application/Service/CrmApplicationScopeResolver.php
+++ b/src/Crm/Application/Service/CrmApplicationScopeResolver.php
@@ -6,6 +6,7 @@ namespace App\Crm\Application\Service;
 
 use App\Crm\Domain\Entity\Crm;
 use App\Crm\Infrastructure\Repository\CrmRepository;
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PlatformKey;
 use Doctrine\ORM\EntityManagerInterface;
@@ -33,7 +34,7 @@ final readonly class CrmApplicationScopeResolver
             'slug' => $applicationSlug,
         ]);
         if (!$application instanceof Application) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Unknown "applicationSlug".');
+            throw ApplicationScopeResolver::createInvalidApplicationSlugException();
         }
 
         $this->assertApplicationAccess($application);
@@ -44,7 +45,7 @@ final readonly class CrmApplicationScopeResolver
     private function assertApplicationAccess(?Application $application): void
     {
         if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== PlatformKey::CRM) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid "applicationSlug" for the requested platform.');
+            throw ApplicationScopeResolver::createInvalidApplicationSlugException();
         }
     }
 }

--- a/src/General/Application/Service/ApplicationScopeResolver.php
+++ b/src/General/Application/Service/ApplicationScopeResolver.php
@@ -20,7 +20,12 @@ final readonly class ApplicationScopeResolver
     ) {
     }
 
-    public function resolveApplicationSlug(Request $request): string
+    public static function createInvalidApplicationSlugException(): HttpException
+    {
+        return new HttpException(JsonResponse::HTTP_NOT_FOUND, self::UNKNOWN_APPLICATION_SLUG_MESSAGE);
+    }
+
+    public function resolveFromRequest(Request $request): string
     {
         $resolvedSlug = $this->extractApplicationSlug($request);
         $application = $this->entityManager->getRepository(Application::class)->findOneBy([
@@ -28,7 +33,7 @@ final readonly class ApplicationScopeResolver
         ]);
 
         if (!$application instanceof Application) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, self::UNKNOWN_APPLICATION_SLUG_MESSAGE);
+            throw self::createInvalidApplicationSlugException();
         }
 
         $request->attributes->set('applicationSlug', $resolvedSlug);

--- a/src/Recruit/Application/Service/RecruitResolverService.php
+++ b/src/Recruit/Application/Service/RecruitResolverService.php
@@ -21,7 +21,7 @@ readonly class RecruitResolverService
 
     public function resolveFromRequest(Request $request): Recruit
     {
-        return $this->resolveByApplicationSlug($this->applicationScopeResolver->resolveApplicationSlug($request));
+        return $this->resolveByApplicationSlug($this->applicationScopeResolver->resolveFromRequest($request));
     }
 
     public function resolveByApplicationSlug(string $applicationSlug): Recruit

--- a/src/Shop/Application/Service/ShopApplicationResolverService.php
+++ b/src/Shop/Application/Service/ShopApplicationResolverService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shop\Application\Service;
 
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PlatformKey;
 use App\Shop\Domain\Entity\Shop;
@@ -38,7 +39,7 @@ final readonly class ShopApplicationResolverService
 
         $application = $this->shopRepository->findApplicationBySlug($applicationSlug);
         if (!$application instanceof Application) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Unknown "applicationSlug".');
+            throw ApplicationScopeResolver::createInvalidApplicationSlugException();
         }
 
         $this->assertApplicationAccess($application, PlatformKey::SHOP);
@@ -65,7 +66,7 @@ final readonly class ShopApplicationResolverService
     public function assertApplicationAccess(?Application $application, PlatformKey $platformKey): void
     {
         if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== $platformKey) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid "applicationSlug" for the requested platform.');
+            throw ApplicationScopeResolver::createInvalidApplicationSlugException();
         }
 
         $user = $this->security->getUser();

--- a/src/Shop/Transport/Controller/Api/V1/Support/ShopApplicationResolver.php
+++ b/src/Shop/Transport/Controller/Api/V1/Support/ShopApplicationResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shop\Transport\Controller\Api\V1\Support;
 
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Enum\PlatformKey;
 use App\Shop\Domain\Entity\Shop;
@@ -36,7 +37,7 @@ final readonly class ShopApplicationResolver
             'slug' => $applicationSlug,
         ]);
         if (!$application instanceof Application) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Unknown "applicationSlug".');
+            throw ApplicationScopeResolver::createInvalidApplicationSlugException();
         }
 
         $this->assertApplicationAccess($application, PlatformKey::SHOP);
@@ -47,7 +48,7 @@ final readonly class ShopApplicationResolver
     private function assertApplicationAccess(?Application $application, PlatformKey $platformKey): void
     {
         if (!$application instanceof Application || $application->getPlatform()?->getPlatformKey() !== $platformKey) {
-            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Invalid "applicationSlug" for the requested platform.');
+            throw ApplicationScopeResolver::createInvalidApplicationSlugException();
         }
 
         $user = $this->security->getUser();

--- a/tests/Unit/General/Application/Service/ApplicationScopeResolverTest.php
+++ b/tests/Unit/General/Application/Service/ApplicationScopeResolverTest.php
@@ -14,28 +14,39 @@ use Symfony\Component\HttpFoundation\Request;
 
 final class ApplicationScopeResolverTest extends TestCase
 {
-    public function testResolveApplicationSlugTrimsQueryValue(): void
+    public function testResolveFromRequestUsesGeneralWhenSlugIsAbsent(): void
+    {
+        $request = new Request();
+        $resolver = $this->createResolverExpectingLookup(ApplicationScopeResolver::DEFAULT_APPLICATION_SLUG, true);
+
+        $slug = $resolver->resolveFromRequest($request);
+
+        self::assertSame(ApplicationScopeResolver::DEFAULT_APPLICATION_SLUG, $slug);
+        self::assertSame(ApplicationScopeResolver::DEFAULT_APPLICATION_SLUG, $request->attributes->get('applicationSlug'));
+    }
+
+    public function testResolveFromRequestUsesGeneralWhenSlugIsEmpty(): void
+    {
+        $request = new Request(['applicationSlug' => '   ']);
+        $resolver = $this->createResolverExpectingLookup(ApplicationScopeResolver::DEFAULT_APPLICATION_SLUG, true);
+
+        $slug = $resolver->resolveFromRequest($request);
+
+        self::assertSame(ApplicationScopeResolver::DEFAULT_APPLICATION_SLUG, $slug);
+    }
+
+    public function testResolveFromRequestReturnsTrimmedValidSlug(): void
     {
         $request = new Request(['applicationSlug' => '  recruit-general-core  ']);
         $resolver = $this->createResolverExpectingLookup('recruit-general-core', true);
 
-        $slug = $resolver->resolveApplicationSlug($request);
+        $slug = $resolver->resolveFromRequest($request);
 
         self::assertSame('recruit-general-core', $slug);
         self::assertSame('recruit-general-core', $request->attributes->get('applicationSlug'));
     }
 
-    public function testResolveApplicationSlugFallsBackToGeneralWhenEmpty(): void
-    {
-        $request = new Request(['applicationSlug' => '   ']);
-        $resolver = $this->createResolverExpectingLookup(ApplicationScopeResolver::DEFAULT_APPLICATION_SLUG, true);
-
-        $slug = $resolver->resolveApplicationSlug($request);
-
-        self::assertSame(ApplicationScopeResolver::DEFAULT_APPLICATION_SLUG, $slug);
-    }
-
-    public function testResolveApplicationSlugThrowsWhenUnknown(): void
+    public function testResolveFromRequestThrowsWhenSlugIsInvalid(): void
     {
         $request = new Request(['applicationSlug' => 'unknown-scope']);
         $resolver = $this->createResolverExpectingLookup('unknown-scope', false);
@@ -44,15 +55,15 @@ final class ApplicationScopeResolverTest extends TestCase
         $this->expectExceptionCode(404);
         $this->expectExceptionMessage(ApplicationScopeResolver::UNKNOWN_APPLICATION_SLUG_MESSAGE);
 
-        $resolver->resolveApplicationSlug($request);
+        $resolver->resolveFromRequest($request);
     }
 
-    public function testResolveApplicationSlugUsesGeneralFromHeadersWhenMissingInQuery(): void
+    public function testResolveFromRequestUsesHeaderWhenMissingInQuery(): void
     {
         $request = new Request(server: ['HTTP_X_APPLICATION_SLUG' => '   general   ']);
         $resolver = $this->createResolverExpectingLookup('general', true);
 
-        $slug = $resolver->resolveApplicationSlug($request);
+        $slug = $resolver->resolveFromRequest($request);
 
         self::assertSame('general', $slug);
     }


### PR DESCRIPTION
### Motivation

- Centraliser la logique de lecture/normalisation/validation du `applicationSlug` depuis la requête en un service partagé pour éviter la duplication et les différences de comportement.
- Uniformiser le comportement par défaut (`trim`, fallback sur `general`) et le message/code HTTP retourné pour un `applicationSlug` invalide.
- Fournir une seule entrée publique pour résoudre un scope depuis un `Request` afin d'harmoniser l'usage par les autres resolvers.

### Description

- Ajouté `createInvalidApplicationSlugException()` et renommé l’entrée publique en `resolveFromRequest(Request $request): string` dans `src/General/Application/Service/ApplicationScopeResolver.php` pour extraire, `trim`, fallback sur `general`, valider l'existence et stocker l'attribut `applicationSlug` dans la `Request`.
- Mis à jour `src/Recruit/Application/Service/RecruitResolverService.php` pour utiliser `resolveFromRequest(...)` comme unique point d'entrée.
- Standardisé l'utilisation de l'exception partagée (`ApplicationScopeResolver::createInvalidApplicationSlugException()`) dans `src/Crm/Application/Service/CrmApplicationScopeResolver.php`, `src/Shop/Application/Service/ShopApplicationResolverService.php` et `src/Shop/Transport/Controller/Api/V1/Support/ShopApplicationResolver.php` pour les cas de slug inconnu ou hors plateforme.
- Ajouté/ajusté les tests unitaires dédiés dans `tests/Unit/General/Application/Service/ApplicationScopeResolverTest.php` couvrant les cas: slug absent, slug vide, slug valide (trimming), slug invalide et fallback depuis header.

### Testing

- Exécuté des vérifications de syntaxe PHP avec `php -l` sur les fichiers modifiés et le fichier de test, et toutes les vérifications sont passées.
- Le fichier de tests unitaires `tests/Unit/General/Application/Service/ApplicationScopeResolverTest.php` a été ajouté/ajusté pour couvrir les scénarios demandés mais n'a pas été exécuté par PHPUnit dans cet environnement.
- Tentative d'exécuter `vendor/bin/phpunit tests/Unit/General/Application/Service/ApplicationScopeResolverTest.php` a échoué car `vendor/bin/phpunit` est absent dans l'environnement d'exécution (tests unitaires non lancés ici).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e952d27be883269ec92c359cae4417)