### PR TITLE
test: forbid /applications/{applicationSlug} in v1 routes and enforce module-scoped prefixes

### DIFF
--- a/tests/Unit/Architecture/ApplicationScopedRouteConventionTest.php
+++ b/tests/Unit/Architecture/ApplicationScopedRouteConventionTest.php
@@ -19,9 +19,13 @@ final class ApplicationScopedRouteConventionTest extends TestCase
         'blog',
     ];
 
+    private const APPLICATION_SCOPED_SEGMENT = '/applications/{applicationSlug}';
+
     public function testV1RoutesFollowModuleScopedConvention(): void
     {
-        $violations = [];
+        $invalidModulePrefixes = [];
+        $legacyPrivatePrefixes = [];
+        $applicationScopedRoutes = [];
 
         foreach (self::MODULES as $module) {
             $moduleDir = \dirname(__DIR__, 3) . '/src/' . ucfirst($module) . '/Transport/Controller/Api/V1';
@@ -47,17 +51,18 @@ final class ApplicationScopedRouteConventionTest extends TestCase
                     }
 
                     $expectedModulePrefix = '/v1/' . $module . '/';
+                    $routeIdentity = $file->getPathname() . ' -> ' . $path;
 
                     if (!\str_starts_with($path, $expectedModulePrefix)) {
-                        $violations[] = $file->getPathname() . ' -> ' . $path . ' (expected prefix: ' . $expectedModulePrefix . '...)';
-                    }
-
-                    if (\str_contains($path, '/applications/{applicationSlug}')) {
-                        $violations[] = $file->getPathname() . ' -> ' . $path . ' (forbidden segment: /applications/{applicationSlug})';
+                        $invalidModulePrefixes[] = $routeIdentity . ' (expected prefix: ' . $expectedModulePrefix . '...)';
                     }
 
                     if (\str_starts_with($path, '/v1/private/')) {
-                        $violations[] = $file->getPathname() . ' -> ' . $path . ' (legacy private prefix: use /v1/' . $module . '/private/...)';
+                        $legacyPrivatePrefixes[] = $routeIdentity . ' (legacy private prefix: use /v1/' . $module . '/private/...)';
+                    }
+
+                    if (\str_contains($path, self::APPLICATION_SCOPED_SEGMENT)) {
+                        $applicationScopedRoutes[] = $routeIdentity;
                     }
                 }
             }
@@ -65,11 +70,24 @@ final class ApplicationScopedRouteConventionTest extends TestCase
 
         self::assertSame(
             [],
-            $violations,
-            "Routes V1 hors convention module-scoped. "
-            . "Utiliser /v1/{module}/... sans /applications/{applicationSlug}; "
-            . "passer le slug applicatif via query/header/body avec fallback sur 'general'.\n"
-            . \implode("\n", $violations),
+            $invalidModulePrefixes,
+            "Routes V1 hors convention module-scoped: utiliser explicitement le préfixe /v1/{module}/...\n"
+            . \implode("\n", $invalidModulePrefixes),
+        );
+
+        self::assertSame(
+            [],
+            $legacyPrivatePrefixes,
+            "Routes V1 avec préfixe private legacy: utiliser /v1/{module}/private/...\n"
+            . \implode("\n", $legacyPrivatePrefixes),
+        );
+
+        self::assertSame(
+            [],
+            $applicationScopedRoutes,
+            "Routes V1 interdites avec segment applicatif " . self::APPLICATION_SCOPED_SEGMENT . ".\n"
+            . "Nouvelle convention: rester en /v1/{module}/... et passer le slug applicatif via query/header/body (fallback: general).\n"
+            . \implode("\n", $applicationScopedRoutes),
         );
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure V1 routes are explicitly module-scoped with a clear `/v1/{module}/...` prefix. 
- Remove any implicit allowance for embedding application slugs in route paths and introduce an inverse rule forbidding such segments. 
- Keep explicit checks for legacy `/v1/private/...` usages to force migration to module-scoped private prefixes.

### Description
- Updated the test `tests/Unit/Architecture/ApplicationScopedRouteConventionTest.php` to introduce a constant `APPLICATION_SCOPED_SEGMENT` set to `/applications/{applicationSlug}`. 
- Replaced the single `$violations` collection with three explicit lists: `$invalidModulePrefixes`, `$legacyPrivatePrefixes`, and `$applicationScopedRoutes` to make assertions clearer. 
- Added a dedicated assertion that forbids any route containing the `APPLICATION_SCOPED_SEGMENT`. 
- Preserved and clarified the existing assertion that routes must start with the explicit module prefix `'/v1/{module}/...'` and added a separate assertion for legacy `/v1/private/...` prefixes.

### Testing
- Attempted to run `vendor/bin/phpunit tests/Unit/Architecture/ApplicationScopedRouteConventionTest.php`, but the `vendor/bin/phpunit` binary is not present in this environment so automated test execution could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e953bbee2083269418aac0d42d30dc)