### PR TITLE
refactor(api): resolve application slug via ApplicationScopeResolver in V1 controllers

### DIFF
--- a/src/Blog/Transport/Controller/Api/V1/Read/GetApplicationBlogController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Read/GetApplicationBlogController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Blog\Transport\Controller\Api\V1\Read;
 
 use App\Blog\Application\Service\BlogReadService;
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Symfony\Bundle\SecurityBundle\Security;
@@ -20,12 +21,14 @@ final readonly class GetApplicationBlogController
     public function __construct(
         private BlogReadService $blogReadService,
         private Security $security,
+        private ApplicationScopeResolver $applicationScopeResolver,
     ) {
     }
 
     #[Route('/v1/blog/feed', methods: [Request::METHOD_GET])]
-    public function __invoke(string $applicationSlug): JsonResponse
+    public function __invoke(Request $request): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $user = $this->security->getUser();
 
         return new JsonResponse($this->blogReadService->getByApplicationSlug($applicationSlug, $user instanceof User ? $user : null));

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationConversationListController.php
@@ -7,6 +7,7 @@ namespace App\Chat\Transport\Controller\Api\V1\Conversation;
 use App\Chat\Application\Service\ChatApplicationScopeValidator;
 use App\Chat\Application\Service\ConversationListService;
 use App\Chat\Domain\Entity\Chat;
+use App\General\Application\Service\ApplicationScopeResolver;
 use JsonException;
 use OpenApi\Attributes as OA;
 use Psr\Cache\InvalidArgumentException;
@@ -37,7 +38,8 @@ readonly class ApplicationConversationListController
 {
     public function __construct(
         private ConversationListService $conversationListService,
-        private ChatApplicationScopeValidator $chatApplicationScopeValidator
+        private ChatApplicationScopeValidator $chatApplicationScopeValidator,
+        private ApplicationScopeResolver $applicationScopeResolver,
     ) {
     }
 
@@ -46,8 +48,9 @@ readonly class ApplicationConversationListController
      * @throws InvalidArgumentException
      */
     #[Route(path: '/v1/chat/chats/{chat}/conversations', methods: [Request::METHOD_GET])]
-    public function __invoke(string $applicationSlug, Chat $chat, Request $request): JsonResponse
+    public function __invoke(Chat $chat, Request $request): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $this->chatApplicationScopeValidator->validate($chat->getId(), $applicationSlug);
 
         $page = max(1, $request->query->getInt('page', 1));

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationUserConversationListController.php
@@ -6,6 +6,7 @@ namespace App\Chat\Transport\Controller\Api\V1\Conversation;
 
 use App\Chat\Application\Service\ChatApplicationScopeValidator;
 use App\Chat\Application\Service\ConversationListService;
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\User\Domain\Entity\User;
 use JsonException;
 use OpenApi\Attributes as OA;
@@ -40,7 +41,8 @@ readonly class ApplicationUserConversationListController
 {
     public function __construct(
         private ConversationListService $conversationListService,
-        private ChatApplicationScopeValidator $chatApplicationScopeValidator
+        private ChatApplicationScopeValidator $chatApplicationScopeValidator,
+        private ApplicationScopeResolver $applicationScopeResolver,
     ) {
     }
 
@@ -49,8 +51,9 @@ readonly class ApplicationUserConversationListController
      * @throws InvalidArgumentException
      */
     #[Route(path: '/v1/chat/private/chats/{chatId}/conversations', methods: [Request::METHOD_GET])]
-    public function __invoke(string $applicationSlug, string $chatId, Request $request, User $loggedInUser): JsonResponse
+    public function __invoke(string $chatId, Request $request, User $loggedInUser): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $this->chatApplicationScopeValidator->validate($chatId, $applicationSlug);
 
         $page = max(1, $request->query->getInt('page', 1));

--- a/src/Chat/Transport/Controller/Api/V1/Conversation/CreateConversationController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/CreateConversationController.php
@@ -7,6 +7,7 @@ namespace App\Chat\Transport\Controller\Api\V1\Conversation;
 use App\Chat\Application\Message\CreateConversationCommand;
 use App\Chat\Application\Service\ChatApplicationScopeValidator;
 use App\Chat\Application\Service\ConversationPayloadService;
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\General\Application\Service\OperationIdGeneratorService;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\User\Domain\Entity\User;
@@ -30,6 +31,7 @@ readonly class CreateConversationController
         private ConversationPayloadService $conversationPayloadService,
         private OperationIdGeneratorService $operationIdGeneratorService,
         private ChatApplicationScopeValidator $chatApplicationScopeValidator,
+        private ApplicationScopeResolver $applicationScopeResolver,
     ) {
     }
 
@@ -37,8 +39,9 @@ readonly class CreateConversationController
      * @throws Throwable
      */
     #[Route(path: '/v1/chat/private/chats/{chatId}/conversations', methods: [Request::METHOD_POST])]
-    public function __invoke(string $applicationSlug, string $chatId, Request $request, User $loggedInUser): JsonResponse
+    public function __invoke(string $chatId, Request $request, User $loggedInUser): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $this->chatApplicationScopeValidator->validate($chatId, $applicationSlug);
 
         $targetUserId = $this->conversationPayloadService->extractRequiredUserId($request->toArray());

--- a/src/Platform/Transport/Controller/Api/V1/Application/ApplicationViewController.php
+++ b/src/Platform/Transport/Controller/Api/V1/Application/ApplicationViewController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Platform\Transport\Controller\Api\V1\Application;
 
 use App\Configuration\Domain\Entity\Configuration;
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Domain\Entity\ApplicationPlugin;
 use App\Platform\Infrastructure\Repository\ApplicationRepository;
@@ -21,12 +22,14 @@ readonly class ApplicationViewController
 {
     public function __construct(
         private ApplicationRepository $applicationRepository,
+        private ApplicationScopeResolver $applicationScopeResolver,
     ) {
     }
 
     #[Route(path: '/v1/application/private/view', methods: [Request::METHOD_GET])]
-    public function __invoke(string $applicationSlug, ?User $loggedInUser = null): JsonResponse
+    public function __invoke(Request $request, ?User $loggedInUser = null): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $application = $this->applicationRepository->findOneBy([
             'slug' => $applicationSlug,
         ]);

--- a/src/Quiz/Transport/Controller/Api/V1/CreateQuizQuestionController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/CreateQuizQuestionController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Quiz\Transport\Controller\Api\V1;
 
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\Platform\Domain\Entity\Application;
 use App\Platform\Infrastructure\Repository\ApplicationRepository;
 use App\Quiz\Application\Message\CreateQuizQuestionCommand;
@@ -26,14 +27,20 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[OA\Tag(name: 'Quiz')]
 final class CreateQuizQuestionController
 {
+    public function __construct(
+        private readonly ApplicationScopeResolver $applicationScopeResolver,
+    ) {
+    }
+
     /**
      * @throws ExceptionInterface
      * @throws JsonException
      */
     #[Route('/v1/quiz/questions', methods: [Request::METHOD_POST])]
     #[OA\Post(summary: 'POST /v1/quiz/questions', tags: ['Quiz'])]
-    public function __invoke(string $applicationSlug, Request $request, MessageBusInterface $messageBus, User $loggedInUser, ApplicationRepository $applicationRepository, QuizRepository $quizRepository, QuizEditorAccessService $accessService): JsonResponse
+    public function __invoke(Request $request, MessageBusInterface $messageBus, User $loggedInUser, ApplicationRepository $applicationRepository, QuizRepository $quizRepository, QuizEditorAccessService $accessService): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
 
         $application = $applicationRepository->findOneBy([

--- a/src/Quiz/Transport/Controller/Api/V1/GetQuizAttemptsByApplicationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/GetQuizAttemptsByApplicationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Quiz\Transport\Controller\Api\V1;
 
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\Quiz\Domain\Entity\Quiz;
 use App\Quiz\Infrastructure\Repository\QuizAttemptRepository;
 use App\Quiz\Infrastructure\Repository\QuizRepository;
@@ -23,6 +24,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class GetQuizAttemptsByApplicationController
 {
     public function __construct(
+        private ApplicationScopeResolver $applicationScopeResolver,
         private QuizRepository $quizRepository,
         private QuizAttemptRepository $attemptRepository,
     ) {
@@ -30,8 +32,9 @@ final readonly class GetQuizAttemptsByApplicationController
 
     #[Route('/v1/quiz/attempts', methods: [Request::METHOD_GET])]
     #[OA\Get(summary: 'List current user quiz attempts by application', tags: ['Quiz'])]
-    public function __invoke(string $applicationSlug, User $loggedInUser): JsonResponse
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $quiz = $this->quizRepository->findOneByApplicationSlugWithConfiguration($applicationSlug);
         if (!$quiz instanceof Quiz) {
             throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Quiz not found for this application.');

--- a/src/Quiz/Transport/Controller/Api/V1/GetQuizByApplicationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/GetQuizByApplicationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Quiz\Transport\Controller\Api\V1;
 
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\Quiz\Application\Service\QuizReadService;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -18,9 +19,16 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[OA\Tag(name: 'Quiz')]
 final class GetQuizByApplicationController
 {
+    public function __construct(
+        private readonly ApplicationScopeResolver $applicationScopeResolver,
+    ) {
+    }
+
     #[Route('/v1/quiz', methods: [Request::METHOD_GET])]
-    public function __invoke(string $applicationSlug, Request $request, QuizReadService $quizReadService): JsonResponse
+    public function __invoke(Request $request, QuizReadService $quizReadService): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
+
         return new JsonResponse($quizReadService->getByApplicationSlug(
             $applicationSlug,
             $request->query->get('level'),

--- a/src/Quiz/Transport/Controller/Api/V1/GetQuizStatsByApplicationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/GetQuizStatsByApplicationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Quiz\Transport\Controller\Api\V1;
 
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\Quiz\Application\Service\QuizReadService;
 use OpenApi\Attributes as OA;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -18,9 +19,16 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[OA\Tag(name: 'Quiz')]
 final class GetQuizStatsByApplicationController
 {
+    public function __construct(
+        private readonly ApplicationScopeResolver $applicationScopeResolver,
+    ) {
+    }
+
     #[Route('/v1/quiz/stats', methods: [Request::METHOD_GET])]
-    public function __invoke(string $applicationSlug, QuizReadService $quizReadService): JsonResponse
+    public function __invoke(Request $request, QuizReadService $quizReadService): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
+
         return new JsonResponse($quizReadService->getStatsByApplicationSlug($applicationSlug));
     }
 }

--- a/src/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Quiz\Transport\Controller\Api\V1;
 
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\Quiz\Application\Service\QuizSubmissionService;
 use App\User\Domain\Entity\User;
 use Doctrine\ORM\Exception\ORMException;
@@ -24,6 +25,11 @@ final class SubmitQuizByApplicationController
 {
     private const string GENERAL_APPLICATION_SLUG = 'general';
 
+    public function __construct(
+        private readonly ApplicationScopeResolver $applicationScopeResolver,
+    ) {
+    }
+
     /**
      * @throws JsonException
      * @throws ORMException
@@ -31,8 +37,9 @@ final class SubmitQuizByApplicationController
      */
     #[Route('/v1/quiz/submit', methods: [Request::METHOD_POST])]
     #[OA\Post(summary: 'Submit quiz answers for an application', tags: ['Quiz'])]
-    public function __invoke(string $applicationSlug, Request $request, QuizSubmissionService $quizSubmissionService, User $loggedInUser): JsonResponse
+    public function __invoke(Request $request, QuizSubmissionService $quizSubmissionService, User $loggedInUser): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
 
         return new JsonResponse($quizSubmissionService->submitByApplicationSlug($applicationSlug, $payload, $loggedInUser));

--- a/src/School/Transport/Controller/Api/V1/Application/GetSchoolApplicationResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/Application/GetSchoolApplicationResourceController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\School\Transport\Controller\Api\V1\Application;
 
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Application\Service\SchoolResourceAccessService;
 use App\School\Application\Service\SchoolResourceViewService;
@@ -22,6 +23,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class GetSchoolApplicationResourceController
 {
     public function __construct(
+        private ApplicationScopeResolver $applicationScopeResolver,
         private SchoolApplicationScopeResolver $scopeResolver,
         private SchoolResourceAccessService $resourceAccessService,
         private SchoolResourceViewService $resourceViewService,
@@ -46,8 +48,9 @@ final readonly class GetSchoolApplicationResourceController
         ],
     )]
     #[OA\Parameter(name: 'applicationSlug', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $resource, string $id, ?User $loggedInUser): JsonResponse
+    public function __invoke(Request $request, string $resource, string $id, ?User $loggedInUser): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
         $entity = $this->resourceViewService->findOr404($resource, $id);
         if (!$this->resourceAccessService->belongsToSchool($entity, $school)) {

--- a/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
+++ b/src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\School\Transport\Controller\Api\V1\Application;
 
 use App\General\Application\Message\EntityPatched;
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\School\Application\Service\SchoolApplicationScopeResolver;
 use App\School\Application\Service\SchoolResourceAccessService;
 use App\School\Application\Service\SchoolResourcePatchService;
@@ -26,6 +27,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class PatchSchoolApplicationResourceController
 {
     public function __construct(
+        private ApplicationScopeResolver $applicationScopeResolver,
         private SchoolApplicationScopeResolver $scopeResolver,
         private SchoolResourceAccessService $resourceAccessService,
         private SchoolResourceViewService $resourceViewService,
@@ -62,9 +64,9 @@ final readonly class PatchSchoolApplicationResourceController
         ],
     )]
     #[OA\Parameter(name: 'applicationSlug', in: 'query', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $resource, string $id, Request $request, ?User $loggedInUser): JsonResponse
+    public function __invoke(string $resource, string $id, Request $request, ?User $loggedInUser): JsonResponse
     {
-        $request->attributes->set('applicationSlug', $applicationSlug);
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
         $entity = $this->resourceViewService->findOr404($resource, $id);
         if (!$this->resourceAccessService->belongsToSchool($entity, $school)) {

--- a/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php
+++ b/src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\School\Transport\Controller\Api\V1;
 
+use App\General\Application\Service\ApplicationScopeResolver;
 use App\School\Application\Serializer\SchoolApiResponseSerializer;
 use App\School\Application\Service\SchoolApplicationResourceListService;
 use App\School\Application\Service\SchoolApplicationScopeResolver;
@@ -21,6 +22,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final readonly class SchoolApplicationResourceListController
 {
     public function __construct(
+        private ApplicationScopeResolver $applicationScopeResolver,
         private SchoolApplicationScopeResolver $scopeResolver,
         private SchoolApplicationResourceListService $resourceListService,
         private SchoolApiResponseSerializer $responseSerializer,
@@ -74,8 +76,9 @@ final readonly class SchoolApplicationResourceListController
         ],
     )]
     #[OA\Parameter(name: 'applicationSlug', in: 'query', required: true, schema: new OA\Schema(type: 'string'))]
-    public function __invoke(string $applicationSlug, string $resource, ?User $loggedInUser): JsonResponse
+    public function __invoke(Request $request, string $resource, ?User $loggedInUser): JsonResponse
     {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $school = $this->scopeResolver->resolveOrCreateSchoolByApplicationSlug($applicationSlug, $loggedInUser);
         $items = $this->resourceListService->listByResource($resource, $school->getId());
 


### PR DESCRIPTION
### Motivation

- Centraliser la résolution du scope applicatif pour éviter d’exposer `applicationSlug` comme paramètre de route dans les contrôleurs V1.
- Garantir la compatibilité avec les services existants en injectant le slug résolu dans `Request->attributes` via `ApplicationScopeResolver::resolveFromRequest`.
- Appliquer ce comportement de manière cohérente aux modules demandés (Blog, Chat, Quiz, Platform, School) pour simplifier la logique d’entrée des contrôleurs.

### Description

- Les actions ont été modifiées pour utiliser `Request $request` et récupérer le slug via `ApplicationScopeResolver::resolveFromRequest($request)` au lieu d’un argument `string $applicationSlug` en signature.
- Les contrôleurs mis à jour sont `src/Blog/.../GetApplicationBlogController.php`, `src/Platform/.../ApplicationViewController.php`, plusieurs contrôleurs sous `src/Chat/.../Conversation/*`, et plusieurs contrôleurs sous `src/Quiz/...` et `src/School/...` (voir la liste des fichiers modifiés dans le diff).
- `ApplicationScopeResolver` est injecté dans les constructeurs des contrôleurs concernés et appelé en début d’action pour définir le slug résolu dans `Request->attributes` (rétro‑compatibilité avec le code existant).
- Cas particuliers gérés : endpoints de flux blog (`/v1/blog/feed`), vues privées d’application, endpoints de chat privés/publics et les endpoints school génériques qui n’utilisent pas de slug dans le path (la résolution est faite depuis la requête).

### Testing

- Exécution de vérifications de syntaxe PHP avec `php -l` sur tous les fichiers modifiés et aucun erreur détectée (tous les fichiers listés dans le diff sont passés).
- Aucune autre suite de tests automatisés n’a été exécutée dans ce changement.
- Les modifications compilent au niveau syntaxique et conservent l’injection du slug dans `Request->attributes` via le resolver pour compatibilité avec les services existants.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e954f966c08326b5dd6ab8ad2a066b)