### PR TITLE
docs: complete applicationSlug route migration updates

### DIFF
--- a/docs/application-slug-route-migration.md
+++ b/docs/application-slug-route-migration.md
@@ -44,6 +44,10 @@ Action attendue côté clients: renseigner explicitement `applicationSlug` en qu
 | `/v1/recruit/applications/{applicationSlug}/jobs` | `/v1/recruit/jobs?applicationSlug={applicationSlug}` |
 | `/v1/recruit/applications/{applicationSlug}/private/jobs` | `/v1/recruit/private/jobs?applicationSlug={applicationSlug}` |
 | `/v1/recruit/public/{applicationSlug}/jobs` | `/v1/recruit/public/jobs?applicationSlug={applicationSlug}` |
+| `/v1/recruit/private/{applicationSlug}/jobs` | `/v1/recruit/private/jobs?applicationSlug={applicationSlug}` |
+| `/v1/recruit/applications/{applicationId}/jobs/{jobId}` | `/v1/recruit/jobs/{jobId}?applicationSlug={applicationSlug}` |
+| `/v1/crm/applications/{applicationSlug}/companies` | `/v1/crm/companies?applicationSlug={applicationSlug}` |
+| `/v1/crm/applications/{applicationSlug}/tasks` | `/v1/crm/tasks?applicationSlug={applicationSlug}` |
 
 Exemple concret:
 

--- a/docs/crm-get-endpoints.md
+++ b/docs/crm-get-endpoints.md
@@ -26,3 +26,14 @@
 ## Other GET CRM endpoints (out of current refactor scope)
 - `GET /v1/crm/reports`
 - `GET /v1/crm/dashboard`
+
+
+## Migration (ancien endpoint -> nouveau endpoint)
+
+| Ancien endpoint | Nouveau endpoint |
+|---|---|
+| `GET /v1/crm/applications/{applicationSlug}/billings` | `GET /v1/crm/billings?applicationSlug={applicationSlug}` |
+| `GET /v1/crm/applications/{applicationSlug}/contacts` | `GET /v1/crm/contacts?applicationSlug={applicationSlug}` |
+| `GET /v1/crm/applications/{applicationSlug}/companies` | `GET /v1/crm/companies?applicationSlug={applicationSlug}` |
+| `GET /v1/crm/applications/{applicationSlug}/projects` | `GET /v1/crm/projects?applicationSlug={applicationSlug}` |
+| `GET /v1/crm/applications/{applicationSlug}/tasks` | `GET /v1/crm/tasks?applicationSlug={applicationSlug}` |

--- a/docs/postman/recruit-general.postman_collection.json
+++ b/docs/postman/recruit-general.postman_collection.json
@@ -53,7 +53,7 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{baseUrl}}/v1/recruit/general/jobs?page=1&limit=20&q=backend&location=lyon&workMode=Remote&contractType=CDI&experienceLevel=Senior&applicationSlug={applicationSlug}",
+          "raw": "{{baseUrl}}/v1/recruit/general/jobs?page=1&limit=20&q=backend&location=lyon&workMode=Remote&contractType=CDI&experienceLevel=Senior&applicationSlug={{applicationSlug}}",
           "host": [
             "{{baseUrl}}"
           ],
@@ -115,7 +115,7 @@
         "method": "GET",
         "header": [],
         "url": {
-          "raw": "{{baseUrl}}/v1/recruit/general/jobs/{{jobSlug}}?applicationSlug={applicationSlug}",
+          "raw": "{{baseUrl}}/v1/recruit/general/jobs/{{jobSlug}}?applicationSlug={{applicationSlug}}",
           "host": [
             "{{baseUrl}}"
           ],
@@ -155,7 +155,7 @@
           }
         ],
         "url": {
-          "raw": "{{baseUrl}}/v1/recruit/general/private/me/jobs?applicationSlug={applicationSlug}",
+          "raw": "{{baseUrl}}/v1/recruit/general/private/me/jobs?applicationSlug={{applicationSlug}}",
           "host": [
             "{{baseUrl}}"
           ],
@@ -196,7 +196,7 @@
           }
         ],
         "url": {
-          "raw": "{{baseUrl}}/v1/recruit/general/private/me/resumes?applicationSlug={applicationSlug}",
+          "raw": "{{baseUrl}}/v1/recruit/general/private/me/resumes?applicationSlug={{applicationSlug}}",
           "host": [
             "{{baseUrl}}"
           ],
@@ -236,7 +236,7 @@
           }
         ],
         "url": {
-          "raw": "{{baseUrl}}/v1/recruit/general/applicants?applicationSlug={applicationSlug}",
+          "raw": "{{baseUrl}}/v1/recruit/general/applicants?applicationSlug={{applicationSlug}}",
           "host": [
             "{{baseUrl}}"
           ],
@@ -275,7 +275,7 @@
           }
         ],
         "url": {
-          "raw": "{{baseUrl}}/v1/recruit/general/private/job-applications?jobId={{jobId}}&applicationSlug={applicationSlug}",
+          "raw": "{{baseUrl}}/v1/recruit/general/private/job-applications?jobId={{jobId}}&applicationSlug={{applicationSlug}}",
           "host": [
             "{{baseUrl}}"
           ],
@@ -327,7 +327,7 @@
           "raw": "{\n  \"experiences\": [{\"title\": \"Backend Developer\", \"description\": \"Symfony API\"}],\n  \"skills\": [{\"title\": \"PHP\", \"description\": \"8.x\"}],\n  \"languages\": [{\"title\": \"French\", \"description\": \"Native\"}]\n}"
         },
         "url": {
-          "raw": "{{baseUrl}}/v1/recruit/general/resumes?applicationSlug={applicationSlug}",
+          "raw": "{{baseUrl}}/v1/recruit/general/resumes?applicationSlug={{applicationSlug}}",
           "host": [
             "{{baseUrl}}"
           ],
@@ -386,7 +386,7 @@
           ]
         },
         "url": {
-          "raw": "{{baseUrl}}/v1/recruit/general/resumes?applicationSlug={applicationSlug}",
+          "raw": "{{baseUrl}}/v1/recruit/general/resumes?applicationSlug={{applicationSlug}}",
           "host": [
             "{{baseUrl}}"
           ],
@@ -433,7 +433,7 @@
           "raw": "{\n  \"resumeId\": \"{{resumeId}}\",\n  \"coverLetter\": \"Je suis motivé pour ce poste.\"\n}"
         },
         "url": {
-          "raw": "{{baseUrl}}/v1/recruit/general/applicants?applicationSlug={applicationSlug}",
+          "raw": "{{baseUrl}}/v1/recruit/general/applicants?applicationSlug={{applicationSlug}}",
           "host": [
             "{{baseUrl}}"
           ],
@@ -479,7 +479,7 @@
           "raw": "{\n  \"applicantId\": \"{{applicantId}}\",\n  \"jobId\": \"{{jobId}}\"\n}"
         },
         "url": {
-          "raw": "{{baseUrl}}/v1/recruit/general/applications?applicationSlug={applicationSlug}",
+          "raw": "{{baseUrl}}/v1/recruit/general/applications?applicationSlug={{applicationSlug}}",
           "host": [
             "{{baseUrl}}"
           ],
@@ -525,7 +525,7 @@
           "raw": "{\n  \"status\": \"INTERVIEW_PLANNED\",\n  \"comment\": \"Profil validé, entretien planifié.\"\n}"
         },
         "url": {
-          "raw": "{{baseUrl}}/v1/recruit/general/private/applications/{{applicationId}}/status?applicationSlug={applicationSlug}",
+          "raw": "{{baseUrl}}/v1/recruit/general/private/applications/{{applicationId}}/status?applicationSlug={{applicationSlug}}",
           "host": [
             "{{baseUrl}}"
           ],
@@ -559,7 +559,7 @@
       "name": "Recruit V1 - endpoints ajoutés (hors /general)",
       "item": [
         {
-          "name": "GET /v1/recruit/private/analytics?applicationSlug={applicationSlug}",
+          "name": "GET /v1/recruit/private/analytics?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "GET",
             "header": [
@@ -569,7 +569,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/analytics?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/analytics?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -597,7 +597,7 @@
           ]
         },
         {
-          "name": "POST /v1/recruit/applicants?applicationSlug={applicationSlug}",
+          "name": "POST /v1/recruit/applicants?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "POST",
             "header": [
@@ -611,7 +611,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/applicants?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/applicants?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -642,7 +642,7 @@
           ]
         },
         {
-          "name": "POST /v1/recruit/applications?applicationSlug={applicationSlug}",
+          "name": "POST /v1/recruit/applications?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "POST",
             "header": [
@@ -656,7 +656,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/applications?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/applications?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -687,7 +687,7 @@
           ]
         },
         {
-          "name": "GET /v1/recruit/private/applications/{applicationId}/status-history?applicationSlug={applicationSlug}",
+          "name": "GET /v1/recruit/private/applications/{applicationId}/status-history?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "GET",
             "header": [
@@ -697,7 +697,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/applications/{{applicationId}}/status-history?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/applications/{{applicationId}}/status-history?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -727,7 +727,7 @@
           ]
         },
         {
-          "name": "GET /v1/recruit/private/job-applications?applicationSlug={applicationSlug}",
+          "name": "GET /v1/recruit/private/job-applications?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "GET",
             "header": [
@@ -737,7 +737,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/job-applications?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/job-applications?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -765,7 +765,7 @@
           ]
         },
         {
-          "name": "GET /v1/recruit/private/pipeline?applicationSlug={applicationSlug}",
+          "name": "GET /v1/recruit/private/pipeline?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "GET",
             "header": [
@@ -775,7 +775,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/pipeline?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/pipeline?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -817,7 +817,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/applications/{{applicationId}}/interviews?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/applications/{{applicationId}}/interviews?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -861,7 +861,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/interviews/{{interviewId}}?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/interviews/{{interviewId}}?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -900,7 +900,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/applications/{{applicationId}}/interviews?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/applications/{{applicationId}}/interviews?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -944,7 +944,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/interviews/{{interviewId}}?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/interviews/{{interviewId}}?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -987,7 +987,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/applications/{{applicationId}}/decision-summary?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/applications/{{applicationId}}/decision-summary?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1017,7 +1017,7 @@
           ]
         },
         {
-          "name": "POST /v1/recruit/jobs?applicationSlug={applicationSlug}",
+          "name": "POST /v1/recruit/jobs?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "POST",
             "header": [
@@ -1031,7 +1031,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/jobs?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/jobs?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1062,7 +1062,7 @@
           ]
         },
         {
-          "name": "DELETE /v1/recruit/jobs?applicationSlug={applicationSlug}/{jobId}",
+          "name": "DELETE /v1/recruit/jobs/{jobId}?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "DELETE",
             "header": [
@@ -1072,7 +1072,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/jobs/{{jobId}}?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/jobs/{{jobId}}?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1100,7 +1100,7 @@
           ]
         },
         {
-          "name": "PATCH /v1/recruit/jobs?applicationSlug={applicationSlug}/{jobId}",
+          "name": "PATCH /v1/recruit/jobs/{jobId}?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "PATCH",
             "header": [
@@ -1114,7 +1114,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/jobs/{{jobId}}?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/jobs/{{jobId}}?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1146,7 +1146,7 @@
           ]
         },
         {
-          "name": "PATCH /v1/recruit/private/jobs/{jobId}?applicationSlug={applicationSlug}",
+          "name": "PATCH /v1/recruit/private/jobs/{jobId}?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "PATCH",
             "header": [
@@ -1160,7 +1160,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/jobs/{{jobId}}?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/jobs/{{jobId}}?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1193,7 +1193,7 @@
           ]
         },
         {
-          "name": "GET /v1/recruit/private/me/jobs?applicationSlug={applicationSlug}",
+          "name": "GET /v1/recruit/private/me/jobs?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "GET",
             "header": [
@@ -1203,7 +1203,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/me/jobs?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/me/jobs?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1232,7 +1232,7 @@
           ]
         },
         {
-          "name": "GET /v1/recruit/private/jobs?applicationSlug={applicationSlug}",
+          "name": "GET /v1/recruit/private/jobs?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "GET",
             "header": [
@@ -1242,7 +1242,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/jobs?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/jobs?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1270,7 +1270,7 @@
           ]
         },
         {
-          "name": "GET /v1/recruit/private/jobs?applicationSlug={applicationSlug}/stats",
+          "name": "GET /v1/recruit/private/jobs/stats?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "GET",
             "header": [
@@ -1280,7 +1280,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/jobs/stats?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/jobs/stats?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1309,12 +1309,12 @@
           ]
         },
         {
-          "name": "GET /v1/recruit/public/jobs/{jobSlug}?applicationSlug={applicationSlug}",
+          "name": "GET /v1/recruit/public/jobs/{jobSlug}?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/public/jobs/{{jobSlug}}?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/public/jobs/{{jobSlug}}?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1343,12 +1343,12 @@
           ]
         },
         {
-          "name": "GET /v1/recruit/public/jobs?applicationSlug={applicationSlug}",
+          "name": "GET /v1/recruit/public/jobs?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/public/jobs?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/public/jobs?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1376,7 +1376,7 @@
           ]
         },
         {
-          "name": "POST /v1/recruit/private/applications/{applicationId}/offers?applicationSlug={applicationSlug}",
+          "name": "POST /v1/recruit/private/applications/{applicationId}/offers?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "POST",
             "header": [
@@ -1390,7 +1390,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/applications/{{applicationId}}/offers?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/applications/{{applicationId}}/offers?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1424,7 +1424,7 @@
           ]
         },
         {
-          "name": "POST /v1/recruit/private/offers/{offerId}/send?applicationSlug={applicationSlug}",
+          "name": "POST /v1/recruit/private/offers/{offerId}/send?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "POST",
             "header": [
@@ -1438,7 +1438,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/offers/{{offerId}}/send?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/offers/{{offerId}}/send?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1472,7 +1472,7 @@
           ]
         },
         {
-          "name": "POST /v1/recruit/private/offers/{offerId}/accept?applicationSlug={applicationSlug}",
+          "name": "POST /v1/recruit/private/offers/{offerId}/accept?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "POST",
             "header": [
@@ -1486,7 +1486,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/offers/{{offerId}}/accept?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/offers/{{offerId}}/accept?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1520,7 +1520,7 @@
           ]
         },
         {
-          "name": "POST /v1/recruit/private/offers/{offerId}/decline?applicationSlug={applicationSlug}",
+          "name": "POST /v1/recruit/private/offers/{offerId}/decline?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "POST",
             "header": [
@@ -1534,7 +1534,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/offers/{{offerId}}/decline?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/offers/{{offerId}}/decline?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1568,7 +1568,7 @@
           ]
         },
         {
-          "name": "POST /v1/recruit/private/offers/{offerId}/withdraw?applicationSlug={applicationSlug}",
+          "name": "POST /v1/recruit/private/offers/{offerId}/withdraw?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "POST",
             "header": [
@@ -1582,7 +1582,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/offers/{{offerId}}/withdraw?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/offers/{{offerId}}/withdraw?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1616,7 +1616,7 @@
           ]
         },
         {
-          "name": "DELETE /v1/recruit/private/me/resumes/{resumeId}?applicationSlug={applicationSlug}",
+          "name": "DELETE /v1/recruit/private/me/resumes/{resumeId}?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "DELETE",
             "header": [
@@ -1626,7 +1626,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/me/resumes/{{resumeId}}?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/me/resumes/{{resumeId}}?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1656,7 +1656,7 @@
           ]
         },
         {
-          "name": "GET /v1/recruit/private/me/resumes?applicationSlug={applicationSlug}",
+          "name": "GET /v1/recruit/private/me/resumes?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "GET",
             "header": [
@@ -1666,7 +1666,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/me/resumes?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/me/resumes?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1695,7 +1695,7 @@
           ]
         },
         {
-          "name": "PATCH /v1/recruit/private/me/resumes/{resumeId}?applicationSlug={applicationSlug}",
+          "name": "PATCH /v1/recruit/private/me/resumes/{resumeId}?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "PATCH",
             "header": [
@@ -1709,7 +1709,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/private/me/resumes/{{resumeId}}?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/private/me/resumes/{{resumeId}}?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],
@@ -1743,7 +1743,7 @@
           ]
         },
         {
-          "name": "POST /v1/recruit/resumes?applicationSlug={applicationSlug}",
+          "name": "POST /v1/recruit/resumes?applicationSlug={{applicationSlug}}",
           "request": {
             "method": "POST",
             "header": [
@@ -1757,7 +1757,7 @@
               }
             ],
             "url": {
-              "raw": "{{baseUrl}}/v1/recruit/resumes?applicationSlug={applicationSlug}",
+              "raw": "{{baseUrl}}/v1/recruit/resumes?applicationSlug={{applicationSlug}}",
               "host": [
                 "{{baseUrl}}"
               ],

--- a/docs/recruit.md
+++ b/docs/recruit.md
@@ -257,11 +257,13 @@ curl -X POST "http://localhost/api/v1/recruit/jobs?applicationSlug=my-app" \
 ```
 
 ### 2.5 Mettre à jour partiellement un job d'une application
-`PATCH /v1/recruit/applications/{applicationId}/jobs/{jobId}`
+`PATCH /v1/recruit/jobs/{jobId}`
 
 Path params:
-- `applicationId` (UUID)
 - `jobId` (UUID)
+
+Query params:
+- `applicationSlug` (string, requis)
 
 Body patchable:
 - `title`, `location`, `summary`, `missionTitle`, `missionDescription`
@@ -271,7 +273,7 @@ Body patchable:
 
 Exemple:
 ```bash
-curl -X PATCH "http://localhost/api/v1/recruit/applications/<applicationId>/jobs/<jobId>" \
+curl -X PATCH "http://localhost/api/v1/recruit/jobs/<jobId>?applicationSlug=my-app" \
   -H "Accept: application/json" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer <JWT_TOKEN>" \
@@ -279,15 +281,17 @@ curl -X PATCH "http://localhost/api/v1/recruit/applications/<applicationId>/jobs
 ```
 
 ### 2.6 Supprimer un job d'une application
-`DELETE /v1/recruit/applications/{applicationId}/jobs/{jobId}`
+`DELETE /v1/recruit/jobs/{jobId}`
 
 Path params:
-- `applicationId` (UUID)
 - `jobId` (UUID)
+
+Query params:
+- `applicationSlug` (string, requis)
 
 Exemple:
 ```bash
-curl -X DELETE "http://localhost/api/v1/recruit/applications/<applicationId>/jobs/<jobId>" \
+curl -X DELETE "http://localhost/api/v1/recruit/jobs/<jobId>?applicationSlug=my-app" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer <JWT_TOKEN>"
 ```
@@ -468,7 +472,7 @@ Conserver le token dans `JWT_TOKEN`.
 ### Étape 2 — Lister les jobs privés
 
 ```bash
-curl -X GET "http://localhost/api/v1/recruit/private/recruit-talent-core/jobs?page=1&limit=20" \
+curl -X GET "http://localhost/api/v1/recruit/private/jobs?applicationSlug=recruit-talent-core&page=1&limit=20" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer ${JWT_TOKEN}"
 ```
@@ -478,7 +482,7 @@ Vérifier qu'au moins un job est présent et récupérer un `jobId`.
 ### Étape 3 — Vérifier les candidatures multi-statuts
 
 ```bash
-curl -X GET "http://localhost/api/v1/recruit/applications/recruit-talent-core/private/job-applications?jobId={jobId}" \
+curl -X GET "http://localhost/api/v1/recruit/private/job-applications?applicationSlug=recruit-talent-core&jobId={jobId}" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer ${JWT_TOKEN}"
 ```
@@ -505,7 +509,7 @@ Vérifier:
 Choisir une `applicationId` en `OFFER_SENT`:
 
 ```bash
-curl -X GET "http://localhost/api/v1/recruit/applications/recruit-talent-core/private/applications/{applicationId}/status-history" \
+curl -X GET "http://localhost/api/v1/recruit/private/applications/{applicationId}/status-history?applicationSlug=recruit-talent-core" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer ${JWT_TOKEN}"
 ```
@@ -540,9 +544,9 @@ Permissions fonctionnelles:
 |---|---|---:|---:|---:|
 | `POST/PATCH/DELETE /v1/recruit/private/interviews/...` | `RECRUIT_INTERVIEW_MANAGE` | ✅ | ✅ | ❌ |
 | `GET /v1/recruit/private/applications/{id}/interviews` | `RECRUIT_INTERVIEW_VIEW` | ✅ | ✅ | ✅ |
-| `PATCH /v1/recruit/applications/{slug}/private/applications/{id}/status` | `RECRUIT_APPLICATION_STATUS_TRANSITION` | ✅ | ✅ | ❌ |
-| `GET /v1/recruit/applications/{slug}/private/applications/{id}/status-history` | `RECRUIT_APPLICATION_STATUS_HISTORY_VIEW` | ✅ | ✅ | ✅ |
-| `POST/PATCH/DELETE /v1/recruit/applications/{slug}/jobs/...` (offers) | `RECRUIT_OFFER_MANAGE` | ✅ | ✅ | ❌ |
+| `PATCH /v1/recruit/private/applications/{id}/status?applicationSlug={applicationSlug}` | `RECRUIT_APPLICATION_STATUS_TRANSITION` | ✅ | ✅ | ❌ |
+| `GET /v1/recruit/private/applications/{id}/status-history?applicationSlug={applicationSlug}` | `RECRUIT_APPLICATION_STATUS_HISTORY_VIEW` | ✅ | ✅ | ✅ |
+| `POST/PATCH/DELETE /v1/recruit/jobs/... ?applicationSlug={applicationSlug}` | `RECRUIT_OFFER_MANAGE` | ✅ | ✅ | ❌ |
 | Lecture de données sensibles (`CV`, `notes`, `feedback/comment`) | `RECRUIT_SENSITIVE_DATA_VIEW` | ✅ | ✅ | ❌ |
 
 ### Règles de confidentialité appliquées
@@ -559,6 +563,10 @@ Permissions fonctionnelles:
 
 ## Migration client (ancienne URL -> nouvelle URL)
 
-- `GET /v1/recruit/public/{applicationSlug}/jobs` -> `GET /v1/recruit/public/jobs?applicationSlug={applicationSlug}`
-- `GET /v1/recruit/private/{applicationSlug}/jobs` -> `GET /v1/recruit/private/jobs?applicationSlug={applicationSlug}`
-- `POST /v1/recruit/applications/{applicationSlug}/jobs` -> `POST /v1/recruit/jobs?applicationSlug={applicationSlug}`
+| Ancien endpoint | Nouveau endpoint |
+|---|---|
+| `GET /v1/recruit/public/{applicationSlug}/jobs` | `GET /v1/recruit/public/jobs?applicationSlug={applicationSlug}` |
+| `GET /v1/recruit/private/{applicationSlug}/jobs` | `GET /v1/recruit/private/jobs?applicationSlug={applicationSlug}` |
+| `POST /v1/recruit/applications/{applicationSlug}/jobs` | `POST /v1/recruit/jobs?applicationSlug={applicationSlug}` |
+| `PATCH /v1/recruit/applications/{applicationId}/jobs/{jobId}` | `PATCH /v1/recruit/jobs/{jobId}?applicationSlug={applicationSlug}` |
+| `DELETE /v1/recruit/applications/{applicationId}/jobs/{jobId}` | `DELETE /v1/recruit/jobs/{jobId}?applicationSlug={applicationSlug}` |

--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -239,6 +239,9 @@ Réponse: `204 No Content`.
 
 ## Migration client (applicationSlug en query)
 
-Exemple de bascule :
-- Avant: `/v1/school/applications/school-crm/classes`
-- Après: `/v1/school/classes?applicationSlug=school-crm`
+| Ancien endpoint | Nouveau endpoint |
+|---|---|
+| `/v1/school/applications/{applicationSlug}/classes` | `/v1/school/classes?applicationSlug={applicationSlug}` |
+| `/v1/recruit/public/{applicationSlug}/jobs` | `/v1/recruit/public/jobs?applicationSlug={applicationSlug}` |
+| `/v1/recruit/private/{applicationSlug}/jobs` | `/v1/recruit/private/jobs?applicationSlug={applicationSlug}` |
+| `/v1/crm/applications/{applicationSlug}/companies` | `/v1/crm/companies?applicationSlug={applicationSlug}` |


### PR DESCRIPTION
### Motivation
- Standardize the migration from slug-in-path routes to query/header-scoped `applicationSlug` and update documentation and Postman collections accordingly.
- Ensure examples, E2E snippets and endpoint inventories consistently show the new `?applicationSlug=...` usage and provide a clear legacy → new endpoint mapping for clients.

### Description
- Updated migration guide in `docs/application-slug-route-migration.md` to include an expanded "ancienne URL → nouvelle URL" table and additional Recruit/CRM rows and examples.
- Added a migration mapping table to `docs/crm-get-endpoints.md` to list legacy CRM GET endpoints and their `?applicationSlug=` equivalents.
- Reworked `docs/recruit.md` to replace slug-in-path endpoints with query-style endpoints (e.g. `PATCH/DELETE /v1/recruit/jobs/{jobId}?applicationSlug=...`), adjusted examples and the RBAC/migration matrix, and added the legacy→new endpoint table.
- Updated `docs/swagger.md` to include a migration table and harmonized examples, and fixed `docs/postman/recruit-general.postman_collection.json` to use `{{applicationSlug}}` as a query parameter in `raw` URLs and request names.

### Testing
- Validated Postman JSON parsing with `python`/`json.load(...)` for all `docs/postman/*.json` files and it succeeded.
- Ran `rg`/grep checks to detect any OpenAPI annotations or paths still referencing `applicationSlug` in the path and the checks returned no hits for `name: 'applicationSlug', in: 'path'` and no OA paths containing `{applicationSlug}`.
- Verified the adjusted doc snippets and examples by searching updated docs for legacy patterns and confirming the presence of the new migration tables and corrected example URLs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9563379e88326bd266a582031daf6)