### PR TITLE
test: migrate applicationSlug test URLs to query params

### DIFF
--- a/tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php
+++ b/tests/Application/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListControllerTest.php
@@ -11,12 +11,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 final class ApplicationEventListControllerTest extends WebTestCase
 {
-    #[TestDox('GET /api/v1/calendar/applications/{applicationSlug}/events does not expose private events.')]
+    #[TestDox('GET /api/v1/calendar/events?applicationSlug={applicationSlug} does not expose private events.')]
     public function testPublicApplicationEventListDoesNotExposePrivateEvents(): void
     {
         $client = $this->getTestClient();
 
-        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/applications/crm-support-desk/events');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/events?applicationSlug=crm-support-desk');
         $response = $client->getResponse();
         $content = $response->getContent();
 
@@ -32,12 +32,12 @@ final class ApplicationEventListControllerTest extends WebTestCase
         self::assertSame(0, $responseData['pagination']['totalItems']);
     }
 
-    #[TestDox('GET /api/v1/calendar/applications/{applicationSlug}/events/me keeps owner/user access logic.')]
+    #[TestDox('GET /api/v1/calendar/events/me?applicationSlug={applicationSlug} keeps owner/user access logic.')]
     public function testPrivateApplicationEventListStillReturnsOwnerEvents(): void
     {
         $client = $this->getTestClient('john-root', 'password-root');
 
-        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/applications/crm-support-desk/events/me');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/events/me?applicationSlug=crm-support-desk');
         $response = $client->getResponse();
         $content = $response->getContent();
 
@@ -100,7 +100,7 @@ final class ApplicationEventListControllerTest extends WebTestCase
         );
         self::assertContains('John Root standalone private event #1', $privateTitles);
 
-        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/applications/crm-support-desk/events/me?limit=50');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/events/me?applicationSlug=crm-support-desk&limit=50');
         $applicationPrivateResponse = $client->getResponse();
         $applicationPrivateContent = $applicationPrivateResponse->getContent();
 

--- a/tests/Application/Calendar/Transport/Controller/Api/V1/Event/EventListingQueryCountTest.php
+++ b/tests/Application/Calendar/Transport/Controller/Api/V1/Event/EventListingQueryCountTest.php
@@ -57,7 +57,7 @@ final class EventListingQueryCountTest extends WebTestCase
     private function countSqlQueriesForListingRequest(KernelBrowser $client, string $applicationSlug): int
     {
         $client->enableProfiler();
-        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/applications/' . $applicationSlug . '/events?limit=100');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/calendar/events?applicationSlug=' . $applicationSlug . '&limit=100');
 
         $response = $client->getResponse();
         self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);

--- a/tests/Application/Calendar/Transport/Controller/Api/V1/Event/UserEventMutationControllerTest.php
+++ b/tests/Application/Calendar/Transport/Controller/Api/V1/Event/UserEventMutationControllerTest.php
@@ -95,7 +95,7 @@ final class UserEventMutationControllerTest extends WebTestCase
             'john-root',
             'password-root',
             'POST',
-            '/v1/calendar/applications/crm-support-desk/events',
+            '/v1/calendar/events?applicationSlug=crm-support-desk',
             [
                 'title' => 'application-create',
                 'startAt' => '2030-01-01T10:00:00+00:00',
@@ -107,7 +107,7 @@ final class UserEventMutationControllerTest extends WebTestCase
             'john-root',
             'password-root',
             'PATCH',
-            '/v1/calendar/applications/crm-support-desk/events/' . self::EVENT_ID,
+            '/v1/calendar/events/' . self::EVENT_ID . '?applicationSlug=crm-support-desk',
             [
                 'title' => 'application-patch',
             ],
@@ -117,7 +117,7 @@ final class UserEventMutationControllerTest extends WebTestCase
             'john-root',
             'password-root',
             'DELETE',
-            '/v1/calendar/applications/crm-support-desk/events/' . self::EVENT_ID,
+            '/v1/calendar/events/' . self::EVENT_ID . '?applicationSlug=crm-support-desk',
             null,
         ];
 
@@ -125,7 +125,7 @@ final class UserEventMutationControllerTest extends WebTestCase
             'john-root',
             'password-root',
             'POST',
-            '/v1/calendar/applications/crm-support-desk/events/' . self::EVENT_ID . '/cancel',
+            '/v1/calendar/events/' . self::EVENT_ID . '/cancel?applicationSlug=crm-support-desk',
             null,
         ];
     }
@@ -155,14 +155,14 @@ final class UserEventMutationControllerTest extends WebTestCase
             '/v1/calendar/private/events/{eventId}/cancel' => [
                 'post' => 'calendar_private_event_cancel',
             ],
-            '/v1/calendar/applications/{applicationSlug}/events' => [
+            '/v1/calendar/events' => [
                 'post' => 'calendar_application_event_create',
             ],
-            '/v1/calendar/applications/{applicationSlug}/events/{eventId}' => [
+            '/v1/calendar/events/{eventId}' => [
                 'patch' => 'calendar_application_event_patch',
                 'delete' => 'calendar_application_event_delete',
             ],
-            '/v1/calendar/applications/{applicationSlug}/events/{eventId}/cancel' => [
+            '/v1/calendar/events/{eventId}/cancel' => [
                 'post' => 'calendar_application_event_cancel',
             ],
         ];

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Application/ApplicationCreateControllerTest.php
@@ -21,7 +21,7 @@ class ApplicationCreateControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that POST /v1/recruit/applications/{applicationSlug}/applications rejects a job from another application.')]
+    #[TestDox('Test that POST /v1/recruit/applications?applicationSlug={applicationSlug} rejects a job from another application.')]
     public function testThatCreateRejectsJobApplicationSlugMismatch(): void
     {
         $rootContext = $this->getApplicantAndApplicationSlugForUsername('john-root');
@@ -39,7 +39,7 @@ class ApplicationCreateControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that POST /v1/recruit/applications/{applicationSlug}/applications rejects duplicate active applications for same applicant and job.')]
+    #[TestDox('Test that POST /v1/recruit/applications?applicationSlug={applicationSlug} rejects duplicate active applications for same applicant and job.')]
     public function testThatCreateRejectsDuplicateActiveApplication(): void
     {
         [$applicationSlug, $applicantId, $jobId] = $this->createDedicatedContextForUsername('john-root');

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobCreateFromApplicationControllerTest.php
@@ -18,7 +18,7 @@ class JobCreateFromApplicationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that `POST /v1/recruit/applications/{applicationSlug}/jobs` creates a job for owner without requiring matchScore.')]
+    #[TestDox('Test that `POST /v1/recruit/jobs?applicationSlug={applicationSlug}` creates a job for owner without requiring matchScore.')]
     public function testThatCreateFromApplicationCreatesJobWithoutMatchScore(): void
     {
         $applicationSlug = $this->getApplicationSlugForUsername('john-root');
@@ -48,7 +48,7 @@ class JobCreateFromApplicationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that `POST /v1/recruit/applications/{applicationSlug}/jobs` returns forbidden if application is not owned by logged user.')]
+    #[TestDox('Test that `POST /v1/recruit/jobs?applicationSlug={applicationSlug}` returns forbidden if application is not owned by logged user.')]
     public function testThatCreateFromApplicationRejectsForeignApplication(): void
     {
         $applicationSlug = $this->getApplicationSlugForUsername('john-root');

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobPatchDeleteFromApplicationControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/JobPatchDeleteFromApplicationControllerTest.php
@@ -20,7 +20,7 @@ class JobPatchDeleteFromApplicationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that PATCH /v1/recruit/applications/{applicationSlug}/jobs/{jobId} updates job for owner.')]
+    #[TestDox('Test that PATCH /v1/recruit/jobs/{jobId}?applicationSlug={applicationSlug} updates job for owner.')]
     public function testThatPatchFromApplicationUpdatesJob(): void
     {
         [$applicationSlug, $jobId] = $this->getApplicationSlugAndJobIdForUsername('john-root');
@@ -44,7 +44,7 @@ class JobPatchDeleteFromApplicationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that PATCH /v1/recruit/applications/{applicationSlug}/jobs/{jobId} returns bad request for unknown application slug.')]
+    #[TestDox('Test that PATCH /v1/recruit/jobs/{jobId}?applicationSlug={applicationSlug} returns bad request for unknown application slug.')]
     public function testThatPatchFromApplicationRejectsUnknownApplicationSlug(): void
     {
         $client = $this->getTestClient('john-root', 'password-root');
@@ -58,7 +58,7 @@ class JobPatchDeleteFromApplicationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that PATCH /v1/recruit/applications/{applicationSlug}/jobs/{jobId} returns not found for missing job.')]
+    #[TestDox('Test that PATCH /v1/recruit/jobs/{jobId}?applicationSlug={applicationSlug} returns not found for missing job.')]
     public function testThatPatchFromApplicationReturnsNotFoundWhenJobIsMissing(): void
     {
         [$applicationSlug] = $this->getApplicationSlugAndJobIdForUsername('john-root');
@@ -74,7 +74,7 @@ class JobPatchDeleteFromApplicationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that PATCH /v1/recruit/applications/{applicationSlug}/jobs/{jobId} forbids non owner.')]
+    #[TestDox('Test that PATCH /v1/recruit/jobs/{jobId}?applicationSlug={applicationSlug} forbids non owner.')]
     public function testThatPatchFromApplicationRejectsForeignApplication(): void
     {
         [$applicationSlug, $jobId] = $this->getApplicationSlugAndJobIdForUsername('john-root');
@@ -90,7 +90,7 @@ class JobPatchDeleteFromApplicationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that DELETE /v1/recruit/applications/{applicationSlug}/jobs/{jobId} deletes job for owner.')]
+    #[TestDox('Test that DELETE /v1/recruit/jobs/{jobId}?applicationSlug={applicationSlug} deletes job for owner.')]
     public function testThatDeleteFromApplicationDeletesJob(): void
     {
         [$applicationSlug, $jobId] = $this->createDedicatedJobForUser('john-root');
@@ -110,7 +110,7 @@ class JobPatchDeleteFromApplicationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that DELETE /v1/recruit/applications/{applicationSlug}/jobs/{jobId} returns bad request for unknown application slug.')]
+    #[TestDox('Test that DELETE /v1/recruit/jobs/{jobId}?applicationSlug={applicationSlug} returns bad request for unknown application slug.')]
     public function testThatDeleteFromApplicationRejectsUnknownApplicationSlug(): void
     {
         $client = $this->getTestClient('john-root', 'password-root');
@@ -122,7 +122,7 @@ class JobPatchDeleteFromApplicationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that DELETE /v1/recruit/applications/{applicationSlug}/jobs/{jobId} returns forbidden for foreign application.')]
+    #[TestDox('Test that DELETE /v1/recruit/jobs/{jobId}?applicationSlug={applicationSlug} returns forbidden for foreign application.')]
     public function testThatDeleteFromApplicationRejectsForeignApplication(): void
     {
         [$applicationSlug, $jobId] = $this->createDedicatedJobForUser('john-root');
@@ -136,7 +136,7 @@ class JobPatchDeleteFromApplicationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
-    #[TestDox('Test that DELETE /v1/recruit/applications/{applicationSlug}/jobs/{jobId} returns not found for missing job.')]
+    #[TestDox('Test that DELETE /v1/recruit/jobs/{jobId}?applicationSlug={applicationSlug} returns not found for missing job.')]
     public function testThatDeleteFromApplicationReturnsNotFoundWhenJobIsMissing(): void
     {
         [$applicationSlug] = $this->getApplicationSlugAndJobIdForUsername('john-root');

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PrivateJobListControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PrivateJobListControllerTest.php
@@ -31,7 +31,7 @@ use function trim;
 
 class PrivateJobListControllerTest extends WebTestCase
 {
-    #[TestDox('Test that `GET /v1/recruit/applications/{applicationSlug}/private/jobs` requires authentication.')]
+    #[TestDox('Test that `GET /v1/recruit/private/jobs?applicationSlug={applicationSlug}` requires authentication.')]
     public function testThatPrivateJobListRequiresAuthentication(): void
     {
         [$applicationSlug] = $this->getFixtureContext();
@@ -42,7 +42,7 @@ class PrivateJobListControllerTest extends WebTestCase
         self::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
     }
 
-    #[TestDox('Test that `GET /v1/recruit/applications/{applicationSlug}/private/jobs` returns computed matchScore from user resume skills.')]
+    #[TestDox('Test that `GET /v1/recruit/private/jobs?applicationSlug={applicationSlug}` returns computed matchScore from user resume skills.')]
     public function testThatPrivateJobListReturnsComputedMatchScoreFromResumeSkills(): void
     {
         [$applicationSlug, $jobId, $expectedMatchScore] = $this->getFixtureContext();
@@ -74,7 +74,7 @@ class PrivateJobListControllerTest extends WebTestCase
         self::assertSame($expectedMatchScore, $jobPayload['matchScore']);
     }
 
-    #[TestDox('Test that `GET /v1/recruit/applications/{applicationSlug}/private/jobs` keeps the expected payload structure.')]
+    #[TestDox('Test that `GET /v1/recruit/private/jobs?applicationSlug={applicationSlug}` keeps the expected payload structure.')]
     public function testThatPrivateJobListKeepsExpectedPayloadStructure(): void
     {
         [$applicationSlug] = $this->getFixtureContext();

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PrivateJobStatsControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PrivateJobStatsControllerTest.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PrivateJobStatsControllerTest extends WebTestCase
 {
-    #[TestDox('Test that GET /v1/recruit/applications/{applicationSlug}/private/jobs/stats returns aggregate statistics for owner.')]
+    #[TestDox('Test that GET /v1/recruit/private/jobs/stats?applicationSlug={applicationSlug} returns aggregate statistics for owner.')]
     public function testThatPrivateJobStatsReturnsAggregates(): void
     {
         $applicationSlug = $this->getApplicationSlug();

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobDetailControllerTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PublicJobDetailControllerTest extends WebTestCase
 {
-    #[TestDox('Test that GET /v1/recruit/applications/{applicationSlug}/public/jobs/{jobSlug} returns job detail and similar jobs list.')]
+    #[TestDox('Test that GET /v1/recruit/public/jobs/{jobSlug}?applicationSlug={applicationSlug} returns job detail and similar jobs list.')]
     public function testThatPublicJobDetailReturnsJobAndSimilarJobsList(): void
     {
         [$applicationSlug, $jobSlug, $jobId, $similarJobSlug, $similarJobId] = $this->getApplicationSlugAndJobDetails();

--- a/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobListControllerTest.php
+++ b/tests/Application/Recruit/Transport/Controller/Api/V1/Job/PublicJobListControllerTest.php
@@ -17,7 +17,7 @@ use function count;
 
 class PublicJobListControllerTest extends WebTestCase
 {
-    #[TestDox('Test that `GET /v1/recruit/applications/{applicationSlug}/public/jobs` filters by experienceLevel.')]
+    #[TestDox('Test that `GET /v1/recruit/public/jobs?applicationSlug={applicationSlug}` filters by experienceLevel.')]
     public function testThatPublicJobListFiltersByExperienceLevel(): void
     {
         [$applicationSlug, $referenceJob] = $this->getFixtureContext();
@@ -44,7 +44,7 @@ class PublicJobListControllerTest extends WebTestCase
         }
     }
 
-    #[TestDox('Test that `GET /v1/recruit/applications/{applicationSlug}/public/jobs` filters by yearsExperience range intersection.')]
+    #[TestDox('Test that `GET /v1/recruit/public/jobs?applicationSlug={applicationSlug}` filters by yearsExperience range intersection.')]
     public function testThatPublicJobListFiltersByYearsExperienceIntersection(): void
     {
         [$applicationSlug, $referenceJob] = $this->getFixtureContext();
@@ -75,7 +75,7 @@ class PublicJobListControllerTest extends WebTestCase
         }
     }
 
-    #[TestDox('Test that `GET /v1/recruit/applications/{applicationSlug}/public/jobs` keeps the expected job payload structure.')]
+    #[TestDox('Test that `GET /v1/recruit/public/jobs?applicationSlug={applicationSlug}` keeps the expected job payload structure.')]
     public function testThatPublicJobListKeepsExpectedPayloadStructure(): void
     {
         [$applicationSlug] = $this->getFixtureContext();

--- a/tests/Application/Scoped/ScopedApplicationRoutesTest.php
+++ b/tests/Application/Scoped/ScopedApplicationRoutesTest.php
@@ -16,6 +16,8 @@ final class ScopedApplicationRoutesTest extends WebTestCase
         $ownerClient = $this->getTestClient('john-root', 'password-root');
         $ownerClient->request('GET', self::API_URL_PREFIX . '/v1/crm/companies?applicationSlug=crm-sales-hub');
         self::assertSame(Response::HTTP_OK, $ownerClient->getResponse()->getStatusCode());
+        $ownerPayload = $this->decodeResponse($ownerClient->getResponse());
+        self::assertSame('crm-sales-hub', $ownerPayload['meta']['applicationSlug'] ?? null);
 
         $forbiddenClient = $this->getTestClient('john-user', 'password-user');
         $forbiddenClient->request('GET', self::API_URL_PREFIX . '/v1/crm/companies?applicationSlug=crm-sales-hub');
@@ -56,5 +58,8 @@ final class ScopedApplicationRoutesTest extends WebTestCase
         $invalidClient->request('GET', self::API_URL_PREFIX . '/v1/school/classes?applicationSlug=not-found-slug');
 
         self::assertSame(Response::HTTP_NOT_FOUND, $invalidClient->getResponse()->getStatusCode());
+        $payload = $this->decodeResponse($invalidClient->getResponse());
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('message', $payload);
     }
 }


### PR DESCRIPTION
### Motivation
- Aligner les tests sur la nouvelle convention de routage qui passe le slug applicatif via query string (`?applicationSlug=...`) au lieu d’un segment `/applications/{applicationSlug}` pour éviter les routes applicatives interdites et clarifier la documentation.
- Renforcer la couverture des cas de scope applicatif pour vérifier le comportement sur slug absent (fallback `general`), slug valide (filtre appliqué) et slug invalide (erreur standard).

### Description
- Migré les tests Calendar de chemins segmentés vers des requêtes avec `?applicationSlug=...` pour les endpoints de listing et de mutation (`tests/Application/Calendar/...`).
- Mis à jour les assertions OpenAPI dans `UserEventMutationControllerTest` pour correspondre aux nouvelles paths documentées (`/v1/calendar/events`, `/v1/calendar/events/{eventId}`, etc.).
- Converti les `TestDox` et références dans plusieurs tests Recruit pour utiliser `?applicationSlug={applicationSlug}` et harmoniser la documentation des tests (`tests/Application/Recruit/...`).
- Modifié `EventListingQueryCountTest` pour appeler `GET /v1/calendar/events?applicationSlug=...` et ajouté vérifications supplémentaires dans `ScopedApplicationRoutesTest` (assertion sur `meta.applicationSlug` pour slug valide et payload `message` pour slug invalide).

### Testing
- Lint PHP sur les fichiers modifiés via `php -l` a réussi pour tous les fichiers touchés.
- Recherche `rg -n "/applications/{applicationSlug}" tests` montre qu’il ne reste plus d’occurrences non intentionnelles (la constante d’architecture reste volontairement présente).
- Exécution de `vendor/bin/phpunit ...` a été tentée mais impossible dans cet environnement car `composer install` échoue (verrouillage / lockfile incohérent, package manquant dans `composer.lock`).
- Tentative de `composer install --no-interaction --prefer-dist` a échoué à cause d’une incohérence de `composer.lock` (`doctrine/doctrine-fixtures-bundle` manquant), donc les tests fonctionnels/contract ne pouvaient pas être exécutés ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9575d9a988326b3fa0464cd337f78)