### PR TITLE
Plan legacy route deprecation and add legacy endpoint observability

### DIFF
--- a/docs/application-slug-route-migration.md
+++ b/docs/application-slug-route-migration.md
@@ -18,6 +18,42 @@ Pour conserver la compatibilité avec les clients existants:
 3. **Phase 3**: journaliser les appels legacy (tag `legacy_route=true`) et contacter les clients restants.
 4. **Phase 4**: supprimer les routes legacy après la fenêtre de migration.
 
+## Décisions opérationnelles (validées)
+
+1. **Anciennes routes conservées temporairement (pas de suppression immédiate).**
+   - Statut: dépréciées.
+   - Signalement: en-têtes HTTP `Deprecation`, `Sunset`, `Warning`.
+   - Date de fin de support annoncée: **31 décembre 2026 à 23:59:59 GMT**.
+2. **Suivi d'usage obligatoire des endpoints legacy.**
+   - Logs structurés avec `event=shop.legacy_route.used` et `legacy_route=true`.
+   - Compteur monitoring `shop.legacy_route.usage_total` avec labels (`module`, `route`, `method`).
+3. **Communication client planifiée par lot de consommateurs.**
+   - Front web: annonce sprint N, rappel sprint N+1, bascule avant freeze release.
+   - Mobile: annonce au planning release mobile, suivi adoption par version.
+   - Intégrations externes: email + changelog + relance ciblée selon logs d'usage.
+4. **Suppression définitive après adoption.**
+   - Pré-requis: 0 appel legacy observé pendant 14 jours glissants.
+   - Action: suppression des routes legacy + retrait des couches de compatibilité + nettoyage documentation.
+
+## Plan de communication client
+
+### Cibles
+- Front web
+- Mobile (iOS/Android)
+- Intégrations externes / partenaires API
+
+### Cadence
+- **T0 (annonce)**: publication note de migration + date de sunset.
+- **T0 + 2 semaines**: rappel avec top endpoints legacy encore utilisés (basé logs/metrics).
+- **T0 + 6 semaines**: notification de pré-coupure.
+- **T0 + 8 semaines**: revue go/no-go sur la suppression (selon adoption mesurée).
+
+### Canaux
+- Changelog API
+- Message Slack/Teams équipes internes
+- Email aux intégrateurs externes
+- Ticket de suivi par client consommateur
+
 ## Recommandation technique
 Quand le slug n'est pas dérivable automatiquement, retourner `400` avec un message explicite pour forcer la migration client.
 

--- a/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Shop\Transport\Controller\Api\V1\Product;
 
 use App\General\Application\Message\EntityCreated;
+use App\Shop\Application\Monitoring\ShopMonitoringService;
 use App\Shop\Application\Service\ProductHydratorService;
 use App\Shop\Application\Service\ShopApplicationResolverService;
 use App\Shop\Domain\Entity\Product;
@@ -32,13 +33,15 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class CreateProductController
 {
-    private const LEGACY_ROUTE_WARNING = 'Deprecated endpoint: use /v1/shop/legacy/products instead.';
+    private const LEGACY_ROUTE_WARNING = 'Deprecated endpoint: use /v1/shop/products?applicationSlug={applicationSlug} instead.';
+    private const LEGACY_ROUTE_COUNTER = 'shop.legacy_route.usage_total';
 
     public function __construct(
         private ProductHydratorService $productHydratorService,
         private ProductInputValidator $productInputValidator,
         private ShopApplicationResolverService $shopApplicationResolverService,
         private ShopRepository $shopRepository,
+        private ShopMonitoringService $shopMonitoringService,
         private EntityManagerInterface $entityManager,
         private MessageBusInterface $messageBus,
     ) {
@@ -57,6 +60,25 @@ final readonly class CreateProductController
     )]
     public function __invoke(Request $request): JsonResponse
     {
+        $this->shopMonitoringService->logStructured(
+            'shop.legacy_route.used',
+            'Legacy shop product create endpoint called.',
+            [
+                'legacy_route' => true,
+                'route' => '/v1/shop/legacy/products',
+                'method' => Request::METHOD_POST,
+                'replacement' => '/v1/shop/products?applicationSlug={applicationSlug}',
+                'sunset_at' => '2026-12-31T23:59:59Z',
+                'user_agent' => $request->headers->get('User-Agent'),
+            ],
+            'info'
+        );
+        $this->shopMonitoringService->incrementCounter(self::LEGACY_ROUTE_COUNTER, [
+            'module' => 'shop',
+            'route' => '/v1/shop/legacy/products',
+            'method' => Request::METHOD_POST,
+        ]);
+
         try {
             $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException) {

--- a/src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php
+++ b/src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Shop\Transport\Controller\Api\V1\Product;
 
+use App\Shop\Application\Monitoring\ShopMonitoringService;
 use App\Shop\Application\Service\ProductListService;
 use JsonException;
 use OpenApi\Attributes as OA;
@@ -20,10 +21,12 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
 final readonly class ListProductsController
 {
-    private const LEGACY_ROUTE_WARNING = 'Deprecated endpoint: use /v1/shop/legacy/products instead.';
+    private const LEGACY_ROUTE_WARNING = 'Deprecated endpoint: use /v1/shop/products?applicationSlug={applicationSlug} instead.';
+    private const LEGACY_ROUTE_COUNTER = 'shop.legacy_route.usage_total';
 
     public function __construct(
-        private ProductListService $productListService
+        private ProductListService $productListService,
+        private ShopMonitoringService $shopMonitoringService,
     ) {
     }
 
@@ -39,6 +42,25 @@ final readonly class ListProductsController
     )]
     public function __invoke(Request $request): JsonResponse
     {
+        $this->shopMonitoringService->logStructured(
+            'shop.legacy_route.used',
+            'Legacy shop product list endpoint called.',
+            [
+                'legacy_route' => true,
+                'route' => '/v1/shop/legacy/products',
+                'method' => Request::METHOD_GET,
+                'replacement' => '/v1/shop/products?applicationSlug={applicationSlug}',
+                'sunset_at' => '2026-12-31T23:59:59Z',
+                'user_agent' => $request->headers->get('User-Agent'),
+            ],
+            'info'
+        );
+        $this->shopMonitoringService->incrementCounter(self::LEGACY_ROUTE_COUNTER, [
+            'module' => 'shop',
+            'route' => '/v1/shop/legacy/products',
+            'method' => Request::METHOD_GET,
+        ]);
+
         $response = new JsonResponse($this->productListService->getList($request));
         $response->headers->set('Deprecation', 'true');
         $response->headers->set('Sunset', 'Wed, 31 Dec 2026 23:59:59 GMT');


### PR DESCRIPTION
### Motivation

- Provide an operational migration plan for legacy API routes that balances backward compatibility and a clear sunset strategy. 
- Ensure we can measure and track remaining usage of legacy endpoints to drive client outreach and final removal. 

### Description

- Documented the operational decisions and client communication plan in `docs/application-slug-route-migration.md` including temporary retention, sunset date (`2026-12-31T23:59:59Z`), and criteria for final removal. 
- Instrumented legacy Shop product endpoints by adding structured logs via `ShopMonitoringService::logStructured` with `event=shop.legacy_route.used` and `legacy_route=true`. 
- Added a monitoring counter `shop.legacy_route.usage_total` (via `ShopMonitoringService::incrementCounter`) with labels (`module`, `route`, `method`) on both `GET /v1/shop/legacy/products` and `POST /v1/shop/legacy/products`. 
- Updated deprecation warning message to point to the canonical endpoint `/v1/shop/products?applicationSlug={applicationSlug}` in both `ListProductsController` and `CreateProductController`. 

### Testing

- Ran PHP syntax checks with `php -l` for `src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php` and `src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php` which reported no syntax errors. 
- Attempted to run `./vendor/bin/phpunit tests/Application/Shop/Transport/Controller/Api/V1/ShopMutationControllerTest.php` but local test runner dependencies are not installed (`./vendor/bin/phpunit` missing), so full PHPUnit run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e95a1696348326bd48d2f0c53bb582)