### PR TITLE
Add migration/connect plugin fixtures and wire CRM general connectors

### DIFF
--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php
@@ -685,6 +685,51 @@ final class LoadApplicationData extends Fixture implements OrderedFixtureInterfa
                         ],
                     ],
                 ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000038',
+                    'reference' => 'Plugin-Connect-Github',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000038',
+                            'key' => 'plugin.connect.github.general',
+                            'value' => [
+                                'enabled' => true,
+                                'provider' => 'github',
+                                'syncRepositories' => true,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000039',
+                    'reference' => 'Plugin-Connect-Gitlab',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000039',
+                            'key' => 'plugin.connect.gitlab.general',
+                            'value' => [
+                                'enabled' => true,
+                                'provider' => 'gitlab',
+                                'syncPipelines' => true,
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'uuid' => '62000000-0000-1000-8000-000000000040',
+                    'reference' => 'Plugin-Connect-Azure',
+                    'configurations' => [
+                        [
+                            'uuid' => '63000000-0000-1000-8000-000000000040',
+                            'key' => 'plugin.connect.azure.general',
+                            'value' => [
+                                'enabled' => true,
+                                'provider' => 'azure-devops',
+                                'syncBoards' => true,
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ],
         [

--- a/src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php
+++ b/src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php
@@ -76,6 +76,60 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
             'private' => false,
             'description' => 'Gamified quiz module with categories, difficulty levels and answer scoring.',
         ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000007',
+            'key' => 'Migration-Shopify',
+            'pluginKey' => 'language',
+            'name' => 'Migration Shopify',
+            'enabled' => true,
+            'private' => false,
+            'description' => 'Assistant de migration des catalogues et commandes Shopify vers l application cible.',
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000008',
+            'key' => 'Migration-OroEcommerce',
+            'pluginKey' => 'language',
+            'name' => 'Migration OroEcommerce',
+            'enabled' => true,
+            'private' => false,
+            'description' => 'Outils de migration des donnees OroCommerce incluant clients, prix et historiques.',
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000009',
+            'key' => 'Migration-Shopware',
+            'pluginKey' => 'language',
+            'name' => 'Migration Shopware',
+            'enabled' => true,
+            'private' => false,
+            'description' => 'Connecteur de migration Shopware avec reprise des contenus, stocks et medias.',
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000010',
+            'key' => 'Connect-Github',
+            'pluginKey' => 'chat',
+            'name' => 'Connect Github',
+            'enabled' => true,
+            'private' => false,
+            'description' => 'Connexion Github pour synchroniser repositories, issues et pull requests.',
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000011',
+            'key' => 'Connect-Gitlab',
+            'pluginKey' => 'chat',
+            'name' => 'Connect Gitlab',
+            'enabled' => true,
+            'private' => false,
+            'description' => 'Connexion Gitlab pour suivre pipelines CI/CD, merge requests et projets.',
+        ],
+        [
+            'uuid' => '50000000-0000-1000-8000-000000000012',
+            'key' => 'Connect-Azure',
+            'pluginKey' => 'chat',
+            'name' => 'Connect Azure',
+            'enabled' => true,
+            'private' => false,
+            'description' => 'Connexion Azure DevOps pour boards, repositories et deploiements cloud.',
+        ],
     ];
     /**
      * @var array<non-empty-string, non-empty-string>
@@ -90,6 +144,12 @@ final class LoadPluginData extends Fixture implements OrderedFixtureInterface
         'CRM Assistant' => '50000000-0000-1000-8000-000000000001',
         'Analytics Booster' => '50000000-0000-1000-8000-000000000002',
         'Knowledge Base Connector' => '50000000-0000-1000-8000-000000000005',
+        'Migration Shopify' => '50000000-0000-1000-8000-000000000007',
+        'Migration OroEcommerce' => '50000000-0000-1000-8000-000000000008',
+        'Migration Shopware' => '50000000-0000-1000-8000-000000000009',
+        'Connect Github' => '50000000-0000-1000-8000-000000000010',
+        'Connect Gitlab' => '50000000-0000-1000-8000-000000000011',
+        'Connect Azure' => '50000000-0000-1000-8000-000000000012',
     ];
 
     /**


### PR DESCRIPTION
### Motivation
- Enable migration and SCM/CI connectors in fixtures so applications can reference and configure them in tests and local data seeding.
- Provide deterministic UUIDs for the new plugins so other fixtures and tests can resolve them by name.
- Enable CRM general scope to include the three connector plugins so CRM features depending on repository/board sync are present in fixture data.

### Description
- Added six new plugin fixtures to `LoadPluginData.php`: `Migration Shopify`, `Migration OroEcommerce`, `Migration Shopware`, `Connect Github`, `Connect Gitlab`, and `Connect Azure`, each with UUIDs, keys, names and descriptions.
- Exposed UUID mappings for the new plugins in `LoadPluginData::$uuids` so they can be referenced by name like existing plugins.
- Updated `crm-general-core` entry in `LoadApplicationData.php` to include `Plugin-Connect-Github`, `Plugin-Connect-Gitlab`, and `Plugin-Connect-Azure` application plugin entries with dedicated configuration payloads.

### Testing
- Ran `php -l src/Platform/Infrastructure/DataFixtures/ORM/LoadPluginData.php` and the file had no syntax errors.
- Ran `php -l src/Platform/Infrastructure/DataFixtures/ORM/LoadApplicationData.php` and the file had no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98e2584b4832bb09b685a3e8f2a37)