### PR TITLE
Add module public pages and Spanish/German fixtures

### DIFF
--- a/src/Page/Application/Service/PublicPageReadService.php
+++ b/src/Page/Application/Service/PublicPageReadService.php
@@ -20,6 +20,10 @@ use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Contracts\Cache\TagAwareCacheInterface;
 
+use function is_array;
+use function str_starts_with;
+use function substr;
+
 final readonly class PublicPageReadService
 {
     private const int TTL = 600;
@@ -71,6 +75,15 @@ final readonly class PublicPageReadService
         return $this->getPageContent('faq', $languageCode);
     }
 
+    /**
+     * @return array<string, mixed>|null
+     * @throws InvalidArgumentException
+     */
+    public function getModulePage(string $pageSlug, string $languageCode): ?array
+    {
+        return $this->getPageContent('module:' . $pageSlug, $languageCode);
+    }
+
     public function resolveLanguage(string $languageCode): ?PageLanguage
     {
         /** @var PageLanguage|null $language */
@@ -107,7 +120,7 @@ final readonly class PublicPageReadService
                 'about' => $this->readAbout($language),
                 'contact' => $this->readContact($language),
                 'faq' => $this->readFaq($language),
-                default => null,
+                default => str_starts_with($page, 'module:') ? $this->readModule($language, substr($page, 7)) : null,
             };
         });
 
@@ -164,5 +177,30 @@ final readonly class PublicPageReadService
         ]);
 
         return $entity?->getContent();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function readModule(PageLanguage $language, string $slug): ?array
+    {
+        $home = $this->readHome($language);
+        if (!is_array($home) || !isset($home['pages']) || !is_array($home['pages'])) {
+            return null;
+        }
+
+        foreach ($home['pages'] as $module) {
+            if (!is_array($module)) {
+                continue;
+            }
+
+            if (($module['slug'] ?? null) !== $slug) {
+                continue;
+            }
+
+            return $module;
+        }
+
+        return null;
     }
 }

--- a/src/Page/Infrastructure/DataFixtures/ORM/LoadPageData.php
+++ b/src/Page/Infrastructure/DataFixtures/ORM/LoadPageData.php
@@ -19,19 +19,20 @@ final class LoadPageData extends Fixture implements OrderedFixtureInterface
     #[Override]
     public function load(ObjectManager $manager): void
     {
-        $frLanguage = (new PageLanguage())
-            ->setCode('fr')
-            ->setLabel('Français');
-
-        $enLanguage = (new PageLanguage())
-            ->setCode('en')
-            ->setLabel('English');
+        $frLanguage = (new PageLanguage())->setCode('fr')->setLabel('Français');
+        $enLanguage = (new PageLanguage())->setCode('en')->setLabel('English');
+        $esLanguage = (new PageLanguage())->setCode('es')->setLabel('Español');
+        $deLanguage = (new PageLanguage())->setCode('de')->setLabel('Deutsch');
 
         $manager->persist($frLanguage);
         $manager->persist($enLanguage);
+        $manager->persist($esLanguage);
+        $manager->persist($deLanguage);
 
         $this->persistPages($manager, $frLanguage, $this->getFrenchHome(), $this->getFrenchAbout(), $this->getFrenchContact(), $this->getFrenchFaq());
         $this->persistPages($manager, $enLanguage, $this->getEnglishHome(), $this->getEnglishAbout(), $this->getEnglishContact(), $this->getEnglishFaq());
+        $this->persistPages($manager, $esLanguage, $this->getSpanishHome(), $this->getSpanishAbout(), $this->getSpanishContact(), $this->getSpanishFaq());
+        $this->persistPages($manager, $deLanguage, $this->getGermanHome(), $this->getGermanAbout(), $this->getGermanContact(), $this->getGermanFaq());
 
         $manager->flush();
     }
@@ -67,6 +68,7 @@ final class LoadPageData extends Fixture implements OrderedFixtureInterface
     private function getFrenchHome(): array
     {
         return [
+            'pages' => $this->getPageModules('fr'),
             'featuresTitle' => 'Fonctionnalités principales',
             'metricsTitle' => 'Indicateurs de performance',
             'stepsTitle' => 'Comment ça marche',
@@ -142,6 +144,7 @@ final class LoadPageData extends Fixture implements OrderedFixtureInterface
     private function getEnglishHome(): array
     {
         return [
+            'pages' => $this->getPageModules('en'),
             'featuresTitle' => 'Key features',
             'metricsTitle' => 'Performance metrics',
             'stepsTitle' => 'How it works',
@@ -217,6 +220,7 @@ final class LoadPageData extends Fixture implements OrderedFixtureInterface
     private function getFrenchAbout(): array
     {
         return [
+            'pages' => $this->getPageModules('fr'),
             'hero' => [
                 'badge' => 'À propos',
                 'title' => 'Nous aidons les équipes à lancer plus vite',
@@ -302,6 +306,7 @@ final class LoadPageData extends Fixture implements OrderedFixtureInterface
     private function getEnglishAbout(): array
     {
         return [
+            'pages' => $this->getPageModules('en'),
             'hero' => [
                 'badge' => 'About',
                 'title' => 'We help teams launch faster',
@@ -387,6 +392,7 @@ final class LoadPageData extends Fixture implements OrderedFixtureInterface
     private function getFrenchContact(): array
     {
         return [
+            'pages' => $this->getPageModules('fr'),
             'title' => 'Contact',
             'hero' => [
                 'badge' => 'Contact',
@@ -477,6 +483,7 @@ final class LoadPageData extends Fixture implements OrderedFixtureInterface
     private function getEnglishContact(): array
     {
         return [
+            'pages' => $this->getPageModules('en'),
             'title' => 'Contact',
             'hero' => [
                 'badge' => 'Contact',
@@ -567,6 +574,7 @@ final class LoadPageData extends Fixture implements OrderedFixtureInterface
     private function getFrenchFaq(): array
     {
         return [
+            'pages' => $this->getPageModules('fr'),
             'hero' => [
                 'badge' => 'FAQ',
                 'title' => 'Questions fréquentes',
@@ -634,6 +642,7 @@ final class LoadPageData extends Fixture implements OrderedFixtureInterface
     private function getEnglishFaq(): array
     {
         return [
+            'pages' => $this->getPageModules('en'),
             'hero' => [
                 'badge' => 'FAQ',
                 'title' => 'Frequently asked questions',
@@ -693,5 +702,146 @@ final class LoadPageData extends Fixture implements OrderedFixtureInterface
                 'suggestion' => 'Try another keyword or switch category.',
             ],
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getSpanishHome(): array
+    {
+        return [
+            ...$this->getEnglishHome(),
+            'pages' => $this->getPageModules('es'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getSpanishAbout(): array
+    {
+        return [
+            ...$this->getEnglishAbout(),
+            'pages' => $this->getPageModules('es'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getSpanishContact(): array
+    {
+        return [
+            ...$this->getEnglishContact(),
+            'pages' => $this->getPageModules('es'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getSpanishFaq(): array
+    {
+        return [
+            ...$this->getEnglishFaq(),
+            'pages' => $this->getPageModules('es'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getGermanHome(): array
+    {
+        return [
+            ...$this->getEnglishHome(),
+            'pages' => $this->getPageModules('de'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getGermanAbout(): array
+    {
+        return [
+            ...$this->getEnglishAbout(),
+            'pages' => $this->getPageModules('de'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getGermanContact(): array
+    {
+        return [
+            ...$this->getEnglishContact(),
+            'pages' => $this->getPageModules('de'),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getGermanFaq(): array
+    {
+        return [
+            ...$this->getEnglishFaq(),
+            'pages' => $this->getPageModules('de'),
+        ];
+    }
+
+    /**
+     * @return list<array{slug: string, title: string, description: string}>
+     */
+    private function getPageModules(string $languageCode): array
+    {
+        return match ($languageCode) {
+            'fr' => [
+                ['slug' => 'crm', 'title' => 'CRM', 'description' => 'Gestion commerciale et relation client.'],
+                ['slug' => 'learning', 'title' => 'Learning', 'description' => 'Parcours d’apprentissage et progression.'],
+                ['slug' => 'job', 'title' => 'Job', 'description' => 'Offres, candidatures et suivi des recrutements.'],
+                ['slug' => 'school', 'title' => 'School', 'description' => 'Gestion scolaire, classes et progression des élèves.'],
+                ['slug' => 'shop', 'title' => 'Shop', 'description' => 'Catalogue produits et commandes e-commerce.'],
+                ['slug' => 'jobs-applications', 'title' => 'Jobs Applications', 'description' => 'Suivi des candidatures et statuts de recrutement.'],
+                ['slug' => 'jobs-offers', 'title' => 'Jobs Offers', 'description' => 'Gestion et publication des offres d’emploi.'],
+                ['slug' => 'learning-courses', 'title' => 'Learning Courses', 'description' => 'Catalogue des cours et parcours pédagogiques.'],
+                ['slug' => 'learning-teachers', 'title' => 'Learning Teachers', 'description' => 'Annuaire des enseignants et disponibilité.'],
+            ],
+            'es' => [
+                ['slug' => 'crm', 'title' => 'CRM', 'description' => 'Gestión comercial y relación con clientes.'],
+                ['slug' => 'learning', 'title' => 'Learning', 'description' => 'Rutas de aprendizaje y progreso.'],
+                ['slug' => 'job', 'title' => 'Job', 'description' => 'Ofertas, candidaturas y seguimiento de contratación.'],
+                ['slug' => 'school', 'title' => 'School', 'description' => 'Gestión escolar, clases y progreso de estudiantes.'],
+                ['slug' => 'shop', 'title' => 'Shop', 'description' => 'Catálogo de productos y pedidos e-commerce.'],
+                ['slug' => 'jobs-applications', 'title' => 'Jobs Applications', 'description' => 'Seguimiento de candidaturas y estado de contratación.'],
+                ['slug' => 'jobs-offers', 'title' => 'Jobs Offers', 'description' => 'Gestión y publicación de ofertas de empleo.'],
+                ['slug' => 'learning-courses', 'title' => 'Learning Courses', 'description' => 'Catálogo de cursos y rutas de aprendizaje.'],
+                ['slug' => 'learning-teachers', 'title' => 'Learning Teachers', 'description' => 'Directorio de profesores y disponibilidad.'],
+            ],
+            'de' => [
+                ['slug' => 'crm', 'title' => 'CRM', 'description' => 'Vertrieb und Kundenbeziehungen steuern.'],
+                ['slug' => 'learning', 'title' => 'Learning', 'description' => 'Lernpfade und Fortschritt verwalten.'],
+                ['slug' => 'job', 'title' => 'Job', 'description' => 'Stellen, Bewerbungen und Recruiting-Tracking.'],
+                ['slug' => 'school', 'title' => 'School', 'description' => 'Schulverwaltung, Klassen und Lernfortschritt.'],
+                ['slug' => 'shop', 'title' => 'Shop', 'description' => 'Produktkatalog und E-Commerce-Bestellungen.'],
+                ['slug' => 'jobs-applications', 'title' => 'Jobs Applications', 'description' => 'Bewerbungen und Recruiting-Status verfolgen.'],
+                ['slug' => 'jobs-offers', 'title' => 'Jobs Offers', 'description' => 'Stellenangebote verwalten und veröffentlichen.'],
+                ['slug' => 'learning-courses', 'title' => 'Learning Courses', 'description' => 'Kurskatalog und Lernpfade verwalten.'],
+                ['slug' => 'learning-teachers', 'title' => 'Learning Teachers', 'description' => 'Lehrkräfte-Verzeichnis und Verfügbarkeit.'],
+            ],
+            default => [
+                ['slug' => 'crm', 'title' => 'CRM', 'description' => 'Sales workflow and customer relationship management.'],
+                ['slug' => 'learning', 'title' => 'Learning', 'description' => 'Learning paths and progress tracking.'],
+                ['slug' => 'job', 'title' => 'Job', 'description' => 'Open positions, applications and hiring workflow.'],
+                ['slug' => 'school', 'title' => 'School', 'description' => 'School operations, classes, and learner progress.'],
+                ['slug' => 'shop', 'title' => 'Shop', 'description' => 'Product catalog and e-commerce orders.'],
+                ['slug' => 'jobs-applications', 'title' => 'Jobs Applications', 'description' => 'Track applications and hiring statuses.'],
+                ['slug' => 'jobs-offers', 'title' => 'Jobs Offers', 'description' => 'Manage and publish job offers.'],
+                ['slug' => 'learning-courses', 'title' => 'Learning Courses', 'description' => 'Course catalog and learning paths.'],
+                ['slug' => 'learning-teachers', 'title' => 'Learning Teachers', 'description' => 'Teacher directory and availability.'],
+            ],
+        };
     }
 }

--- a/src/Page/Transport/Controller/Api/V1/Public/PublicPageController.php
+++ b/src/Page/Transport/Controller/Api/V1/Public/PublicPageController.php
@@ -71,6 +71,20 @@ final readonly class PublicPageController
         return $this->jsonContentOr404($this->publicPageReadService->getFaq($languageCode), $languageCode);
     }
 
+    /**
+     * @throws InvalidArgumentException
+     */
+    #[Route(
+        path: '/v1/page/public/{pageSlug}/{languageCode}',
+        methods: [Request::METHOD_GET],
+        requirements: ['pageSlug' => 'crm|shop|jobs-applications|jobs-offers|job|school|learning-teachers|learning-courses'],
+    )]
+    #[OA\Get(security: [])]
+    public function modulePage(string $pageSlug, string $languageCode): JsonResponse
+    {
+        return $this->jsonContentOr404($this->publicPageReadService->getModulePage($pageSlug, $languageCode), $languageCode);
+    }
+
     #[Route(path: '/v1/page/public/contact', methods: [Request::METHOD_POST])]
     #[OA\Post(security: [], summary: 'Create a public contact request.')]
     #[OA\RequestBody(

--- a/tests/Application/Page/Transport/Controller/Api/V1/Public/PublicPageControllerTest.php
+++ b/tests/Application/Page/Transport/Controller/Api/V1/Public/PublicPageControllerTest.php
@@ -73,6 +73,14 @@ final class PublicPageControllerTest extends WebTestCase
                     'title' => 'Aucun résultat',
                 ],
             ]];
+        yield 'crm-fr' => ['/v1/page/public/crm', ['slug' => 'crm']];
+        yield 'shop-fr' => ['/v1/page/public/shop', ['slug' => 'shop']];
+        yield 'jobs-applications-fr' => ['/v1/page/public/jobs-applications', ['slug' => 'jobs-applications']];
+        yield 'jobs-offers-fr' => ['/v1/page/public/jobs-offers', ['slug' => 'jobs-offers']];
+        yield 'job-fr' => ['/v1/page/public/job', ['slug' => 'job']];
+        yield 'school-fr' => ['/v1/page/public/school', ['slug' => 'school']];
+        yield 'learning-teachers-fr' => ['/v1/page/public/learning-teachers', ['slug' => 'learning-teachers']];
+        yield 'learning-courses-fr' => ['/v1/page/public/learning-courses', ['slug' => 'learning-courses']];
     }
 
     /**
@@ -110,6 +118,14 @@ final class PublicPageControllerTest extends WebTestCase
                     'title' => 'No results',
                 ],
             ]];
+        yield 'crm-en' => ['/v1/page/public/crm', ['slug' => 'crm']];
+        yield 'shop-en' => ['/v1/page/public/shop', ['slug' => 'shop']];
+        yield 'jobs-applications-en' => ['/v1/page/public/jobs-applications', ['slug' => 'jobs-applications']];
+        yield 'jobs-offers-en' => ['/v1/page/public/jobs-offers', ['slug' => 'jobs-offers']];
+        yield 'job-en' => ['/v1/page/public/job', ['slug' => 'job']];
+        yield 'school-en' => ['/v1/page/public/school', ['slug' => 'school']];
+        yield 'learning-teachers-en' => ['/v1/page/public/learning-teachers', ['slug' => 'learning-teachers']];
+        yield 'learning-courses-en' => ['/v1/page/public/learning-courses', ['slug' => 'learning-courses']];
     }
 
     /**
@@ -121,6 +137,14 @@ final class PublicPageControllerTest extends WebTestCase
         yield 'about' => ['/v1/page/public/about'];
         yield 'contact' => ['/v1/page/public/contact'];
         yield 'faq' => ['/v1/page/public/faq'];
+        yield 'crm' => ['/v1/page/public/crm'];
+        yield 'shop' => ['/v1/page/public/shop'];
+        yield 'jobs-applications' => ['/v1/page/public/jobs-applications'];
+        yield 'jobs-offers' => ['/v1/page/public/jobs-offers'];
+        yield 'job' => ['/v1/page/public/job'];
+        yield 'school' => ['/v1/page/public/school'];
+        yield 'learning-teachers' => ['/v1/page/public/learning-teachers'];
+        yield 'learning-courses' => ['/v1/page/public/learning-courses'];
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Expose individual module pages (CRM, Shop, Jobs, Learning, etc.) through the public API so the frontend can fetch module metadata by slug.
- Provide a consistent `pages` list inside home/about/contact/faq payloads to support module discovery in multiple languages.
- Add Spanish (`es`) and German (`de`) page languages to the fixtures to broaden localization coverage.
- Make the public page read service able to resolve module entries from the home payload and serve them via the cache-backed API.

### Description
- Added `getModulePage(string $pageSlug, string $languageCode)` and `readModule(PageLanguage $language, string $slug)` to `PublicPageReadService`, wired into `getPageContent` using a `module:` key prefix and optimized with `str_starts_with`/`substr` imports.
- Added a new controller action `modulePage` in `PublicPageController` with route `GET /v1/page/public/{pageSlug}/{languageCode}` and a `requirements` list for supported module slugs.
- Extended `LoadPageData` fixtures to create `es` and `de` `PageLanguage` entities, persist their pages, and inject a `pages` array into all page payloads via a new `getPageModules` helper; added language-specific getters that reuse English content with localized `pages`.
- Updated tests in `PublicPageControllerTest` to include module route cases for French and English and to add those routes to the route providers.

### Testing
- Ran the application test suite with `vendor/bin/phpunit` and the updated `tests/Application/Page/Transport/Controller/Api/V1/Public/PublicPageControllerTest` which includes the new module route cases, and all tests passed.
- Verified that the new controller route responds with `HTTP 200` and returns module objects containing the expected `slug` field in the test assertions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e98d8668d0832b9dde099a2ea7a8b4)