### PR TITLE
Add module CRUD role model and endpoint access-control policies

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -59,8 +59,17 @@ security:
         ROLE_CRM_MANAGER: [ROLE_CRM_SUPPORT, ROLE_CRM_MARKETING, ROLE_CRM_SALES]
         ROLE_CRM_ADMIN: [ROLE_CRM_MANAGER]
         ROLE_CRM_OWNER: [ROLE_CRM_ADMIN]
-        ROLE_ADMIN: [ROLE_USER]
+        ROLE_ADMIN: [ROLE_USER, ROLE_CRM_OWNER, ROLE_SHOP_MANAGER, ROLE_SCHOOL_MANAGER, ROLE_JOB_MANAGER]
         ROLE_ROOT: [ROLE_ADMIN]
+        ROLE_SHOP_VIEWER: [ROLE_USER]
+        ROLE_SHOP_EDITOR: [ROLE_SHOP_VIEWER]
+        ROLE_SHOP_MANAGER: [ROLE_SHOP_EDITOR]
+        ROLE_SCHOOL_VIEWER: [ROLE_USER]
+        ROLE_SCHOOL_EDITOR: [ROLE_SCHOOL_VIEWER]
+        ROLE_SCHOOL_MANAGER: [ROLE_SCHOOL_EDITOR]
+        ROLE_JOB_VIEWER: [ROLE_USER]
+        ROLE_JOB_EDITOR: [ROLE_JOB_VIEWER]
+        ROLE_JOB_MANAGER: [ROLE_JOB_EDITOR]
 
     access_decision_manager:
         strategy: unanimous
@@ -71,6 +80,18 @@ security:
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }
         - { path: ^/command-scheduler, roles: ROLE_ADMIN }
+        - { path: ^/api/v1/crm, roles: ROLE_CRM_OWNER, methods: [DELETE] }
+        - { path: ^/api/v1/crm, roles: ROLE_CRM_MANAGER, methods: [POST, PUT, PATCH] }
+        - { path: ^/api/v1/crm, roles: ROLE_CRM_VIEWER, methods: [GET] }
+        - { path: ^/api/v1/shop, roles: ROLE_SHOP_MANAGER, methods: [DELETE] }
+        - { path: ^/api/v1/shop, roles: ROLE_SHOP_EDITOR, methods: [POST, PUT, PATCH] }
+        - { path: ^/api/v1/shop, roles: ROLE_SHOP_VIEWER, methods: [GET] }
+        - { path: ^/api/v1/school, roles: ROLE_SCHOOL_MANAGER, methods: [DELETE] }
+        - { path: ^/api/v1/school, roles: ROLE_SCHOOL_EDITOR, methods: [POST, PUT, PATCH] }
+        - { path: ^/api/v1/school, roles: ROLE_SCHOOL_VIEWER, methods: [GET] }
+        - { path: ^/api/v1/recruit, roles: ROLE_JOB_MANAGER, methods: [DELETE] }
+        - { path: ^/api/v1/recruit, roles: ROLE_JOB_EDITOR, methods: [POST, PUT, PATCH] }
+        - { path: ^/api/v1/recruit, roles: ROLE_JOB_VIEWER, methods: [GET] }
 
 when@test:
     security:

--- a/src/Role/Domain/Enum/Role.php
+++ b/src/Role/Domain/Enum/Role.php
@@ -26,6 +26,15 @@ enum Role: string
     case CRM_SUPPORT = 'ROLE_CRM_SUPPORT';
     case CRM_MARKETING = 'ROLE_CRM_MARKETING';
     case CRM_VIEWER = 'ROLE_CRM_VIEWER';
+    case SHOP_VIEWER = 'ROLE_SHOP_VIEWER';
+    case SHOP_EDITOR = 'ROLE_SHOP_EDITOR';
+    case SHOP_MANAGER = 'ROLE_SHOP_MANAGER';
+    case SCHOOL_VIEWER = 'ROLE_SCHOOL_VIEWER';
+    case SCHOOL_EDITOR = 'ROLE_SCHOOL_EDITOR';
+    case SCHOOL_MANAGER = 'ROLE_SCHOOL_MANAGER';
+    case JOB_VIEWER = 'ROLE_JOB_VIEWER';
+    case JOB_EDITOR = 'ROLE_JOB_EDITOR';
+    case JOB_MANAGER = 'ROLE_JOB_MANAGER';
 
     public function label(): string
     {
@@ -45,6 +54,15 @@ enum Role: string
             self::CRM_SUPPORT => 'CRM support',
             self::CRM_MARKETING => 'CRM marketing',
             self::CRM_VIEWER => 'CRM viewers',
+            self::SHOP_VIEWER => 'Shop viewers',
+            self::SHOP_EDITOR => 'Shop editors',
+            self::SHOP_MANAGER => 'Shop managers',
+            self::SCHOOL_VIEWER => 'School viewers',
+            self::SCHOOL_EDITOR => 'School editors',
+            self::SCHOOL_MANAGER => 'School managers',
+            self::JOB_VIEWER => 'Job viewers',
+            self::JOB_EDITOR => 'Job editors',
+            self::JOB_MANAGER => 'Job managers',
         };
     }
 }


### PR DESCRIPTION
### Motivation
- Introduce a clear CRUD-oriented permission model per module (shop, school, job, crm) so `user_roles` and `user_groups` can express view/edit/manage rights and be enforced at the HTTP endpoint level.

### Description
- Added module-level role enum values and human labels in `Role` (`ROLE_SHOP_VIEWER/EDITOR/MANAGER`, `ROLE_SCHOOL_VIEWER/EDITOR/MANAGER`, `ROLE_JOB_VIEWER/EDITOR/MANAGER`).
- Extended the Symfony `role_hierarchy` so `EDITOR` inherits `VIEWER`, `MANAGER` inherits `EDITOR`, and `ROLE_ADMIN` includes module manager roles to preserve admin access.
- Added `access_control` rules in `config/packages/security.yaml` to map HTTP methods to module roles for `/api/v1/crm`, `/api/v1/shop`, `/api/v1/school`, and `/api/v1/recruit` (GET -> viewer, POST/PUT/PATCH -> editor/manager, DELETE -> manager/owner).
- Kept existing per-controller `IsGranted`/voter checks intact; these `access_control` entries provide a centralized coarse-grained guard layer.

### Testing
- Ran `php -l src/Role/Domain/Enum/Role.php` which reported no syntax errors and passed.
- Attempted `php bin/console lint:yaml config/packages/security.yaml` but it failed in the current environment due to missing dependencies and requires running `composer install` (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea0f146c4c832b912c8cf1763b51c0)