### PR TITLE
Fix active User stories fallback and add exhaustive User endpoints inventory

### DIFF
--- a/docs/technical-notes/user-module-endpoints.md
+++ b/docs/technical-notes/user-module-endpoints.md
@@ -1,0 +1,54 @@
+# User module endpoints
+
+Liste extraite automatiquement des attributs `#[Route(...)]` du module `src/User/Transport/Controller/Api/V1`.
+
+| Method(s) | Path | Controller file |
+|---|---|---|
+| `-` | `/v1/user` | `src/User/Transport/Controller/Api/V1/User/UserController.php` |
+| `-` | `/v1/user_group` | `src/User/Transport/Controller/Api/V1/UserGroup/UserGroupController.php` |
+| `DELETE` | `/v1/private/stories/{id}` | `src/User/Transport/Controller/Api/V1/UserStory/DeleteUserStoryController.php` |
+| `DELETE` | `/v1/user/{user}` | `src/User/Transport/Controller/Api/V1/User/DeleteUserController.php` |
+| `DELETE` | `/v1/user/{user}/group/{userGroup}` | `src/User/Transport/Controller/Api/V1/User/DetachUserGroupController.php` |
+| `DELETE` | `/v1/user_group/{userGroup}/user/{user}` | `src/User/Transport/Controller/Api/V1/UserGroup/DetachUserController.php` |
+| `DELETE` | `/v1/users/me` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `DELETE` | `/v1/users/{user}/block` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `GET` | `/v1/private/stories` | `src/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesController.php` |
+| `GET` | `/v1/profile` | `src/User/Transport/Controller/Api/V1/Profile/IndexController.php` |
+| `GET` | `/v1/profile/configuration/{configurationKey}` | `src/User/Transport/Controller/Api/V1/Profile/ConfigurationController.php` |
+| `GET` | `/v1/profile/groups` | `src/User/Transport/Controller/Api/V1/Profile/GroupsController.php` |
+| `GET` | `/v1/profile/roles` | `src/User/Transport/Controller/Api/V1/Profile/RolesController.php` |
+| `GET` | `/v1/public/user/{username}` | `src/User/Transport/Controller/Api/V1/User/PublicUserController.php` |
+| `GET` | `/v1/public/users` | `src/User/Transport/Controller/Api/V1/User/PublicUserListController.php` |
+| `GET` | `/v1/user/{user}/groups` | `src/User/Transport/Controller/Api/V1/User/UserGroupsController.php` |
+| `GET` | `/v1/user/{user}/roles` | `src/User/Transport/Controller/Api/V1/User/UserRolesController.php` |
+| `GET` | `/v1/user_group/{userGroup}/users` | `src/User/Transport/Controller/Api/V1/UserGroup/UsersController.php` |
+| `GET` | `/v1/users/me` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `GET` | `/v1/users/me/applications` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `GET` | `/v1/users/me/applications/latest` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `GET` | `/v1/users/me/friends` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `GET` | `/v1/users/me/friends/blocked` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `GET` | `/v1/users/me/friends/requests` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `GET` | `/v1/users/me/friends/requests/sent` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `GET` | `/v1/users/me/profile` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `GET` | `/v1/users/me/sessions` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `PATCH` | `/v1/profile` | `src/User/Transport/Controller/Api/V1/Profile/PatchController.php` |
+| `PATCH` | `/v1/profile/configuration/{configurationKey}` | `src/User/Transport/Controller/Api/V1/Profile/ConfigurationPatchController.php` |
+| `PATCH` | `/v1/users/me/password` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `PATCH` | `/v1/users/me/profile` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `POST` | `/v1/auth/get_token` | `src/User/Transport/Controller/Api/V1/Auth/GetTokenController.php` |
+| `POST` | `/v1/auth/register` | `src/User/Transport/Controller/Api/V1/Auth/RegisterController.php` |
+| `POST` | `/v1/auth/social_login` | `src/User/Transport/Controller/Api/V1/Auth/SocialLoginController.php` |
+| `POST` | `/v1/private/stories` | `src/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryController.php` |
+| `POST` | `/v1/profile/applications` | `src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php` |
+| `POST` | `/v1/profile/applications/{application}/photo` | `src/User/Transport/Controller/Api/V1/Profile/ApplicationUploadPhotoController.php` |
+| `POST` | `/v1/profile/configuration` | `src/User/Transport/Controller/Api/V1/Profile/ConfigurationCreateController.php` |
+| `POST` | `/v1/profile/photo` | `src/User/Transport/Controller/Api/V1/Profile/UploadPhotoController.php` |
+| `POST` | `/v1/profile/platforms/{platform}/photo` | `src/User/Transport/Controller/Api/V1/Profile/PlatformUploadPhotoController.php` |
+| `POST` | `/v1/profile/plugins/{plugin}/photo` | `src/User/Transport/Controller/Api/V1/Profile/PluginUploadPhotoController.php` |
+| `POST` | `/v1/user/{user}/group/{userGroup}` | `src/User/Transport/Controller/Api/V1/User/AttachUserGroupController.php` |
+| `POST` | `/v1/user_group/{userGroup}/user/{user}` | `src/User/Transport/Controller/Api/V1/UserGroup/AttachUserController.php` |
+| `POST` | `/v1/users/{user}/block` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `POST` | `/v1/users/{user}/friends/accept` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `POST` | `/v1/users/{user}/friends/cancel` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `POST` | `/v1/users/{user}/friends/reject` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `POST` | `/v1/users/{user}/friends/request` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |

--- a/src/User/Application/Service/UserStoryService.php
+++ b/src/User/Application/Service/UserStoryService.php
@@ -24,9 +24,12 @@ use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Throwable;
 
 use function array_filter;
+use function array_flip;
 use function array_map;
 use function array_values;
 use function count;
+use function method_exists;
+use function usort;
 
 readonly class UserStoryService
 {
@@ -48,22 +51,16 @@ readonly class UserStoryService
     public function getActiveStories(User $loggedInUser, int $limit): array
     {
         $visibleUsers = $this->findVisibleUsers($loggedInUser);
-        $visibleUserIds = array_map(static fn (User $user): string => $user->getId(), $visibleUsers);
         $cacheKey = $this->cacheKeyConventionService->buildPrivateStoryListKey($loggedInUser->getId(), $limit);
 
         /** @var array<int, array<string, mixed>> $stories */
-        $stories = $this->cache->get($cacheKey, function (ItemInterface $item) use ($loggedInUser, $visibleUserIds, $limit): array {
+        $stories = $this->cache->get($cacheKey, function (ItemInterface $item) use ($loggedInUser, $visibleUsers, $limit): array {
             $item->expiresAfter(60);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->tagPrivateStoryList());
             }
 
-            $esIds = $this->searchActiveStoryIdsFromElastic($visibleUserIds, $limit);
-            if ($esIds === []) {
-                return [];
-            }
-
-            return $this->findActiveStories($loggedInUser, $visibleUserIds, $limit, $esIds);
+            return $this->getActiveStoriesFromSources($loggedInUser, $visibleUsers, $limit);
         });
 
         return $stories;
@@ -113,12 +110,26 @@ readonly class UserStoryService
     }
 
     /**
-     * @param array<int, string> $visibleUserIds
+     * @param array<int, User> $visibleUsers
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function getActiveStoriesFromSources(User $loggedInUser, array $visibleUsers, int $limit): array
+    {
+        $visibleUserIds = array_map(static fn (User $user): string => $user->getId(), $visibleUsers);
+        $esIds = $this->searchActiveStoryIdsFromElastic($visibleUserIds, $limit);
+
+        // If Elasticsearch does not have the index/documents yet, fall back to DB query.
+        return $this->findActiveStories($loggedInUser, $visibleUsers, $limit, $esIds === [] ? null : $esIds);
+    }
+
+    /**
+     * @param array<int, User> $visibleUsers
      * @param array<int, string>|null $esIds
      *
      * @return array<int, array<string, mixed>>
      */
-    private function findActiveStories(User $loggedInUser, array $visibleUserIds, int $limit, ?array $esIds): array
+    private function findActiveStories(User $loggedInUser, array $visibleUsers, int $limit, ?array $esIds): array
     {
         $since = new DateTimeImmutable('-24 hours');
 
@@ -126,9 +137,11 @@ readonly class UserStoryService
             ->select('story', 'user')
             ->innerJoin('story.user', 'user')
             ->andWhere('story.createdAt >= :since')
-            ->andWhere('user.id IN (:visibleUserIds)')
+            ->andWhere('story.expiresAt >= :now')
+            ->andWhere('story.user IN (:visibleUsers)')
             ->setParameter('since', $since)
-            ->setParameter('visibleUserIds', $visibleUserIds)
+            ->setParameter('now', new DateTimeImmutable())
+            ->setParameter('visibleUsers', $visibleUsers)
             ->orderBy('story.createdAt', 'DESC')
             ->setMaxResults($limit);
 

--- a/tests/Application/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\UserStory;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class GetActiveStoriesControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/private/stories';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/private/stories` requires authentication.')]
+    public function testThatGetActiveStoriesRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', $this->baseUrl);
+        $response = $client->getResponse();
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that authenticated user can get visible active stories (mine + friends).')]
+    public function testThatAuthenticatedUserCanGetVisibleStories(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', $this->baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertArrayHasKey('stories', $responseData);
+        self::assertIsArray($responseData['stories']);
+        self::assertNotEmpty($responseData['stories']);
+
+        $firstGroup = $responseData['stories'][0] ?? null;
+        self::assertIsArray($firstGroup);
+        self::assertSame(true, $firstGroup['owner'] ?? null);
+        self::assertArrayHasKey('stories', $firstGroup);
+        self::assertIsArray($firstGroup['stories']);
+        self::assertNotEmpty($firstGroup['stories']);
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent returning an empty list of stories when Elasticsearch is missing or not yet populated by falling back to the DB query; provide a robust story retrieval for private story feeds.
- Provide a complete, easy-to-consume inventory of all endpoints in the User module so callers have “all endpoints, no exceptions.”

### Description
- Refactor `UserStoryService::getActiveStories` by extracting `getActiveStoriesFromSources` and perform orchestration between Elasticsearch and DB fallback, so an empty ES result no longer yields `[]` prematurely and DB is used instead when appropriate (`src/User/Application/Service/UserStoryService.php`).
- Make the DB query for stories stricter and safer by adding `expiresAt >= now` and filtering with entity parameter `story.user IN (:visibleUsers)` instead of string-ID matching, while preserving ES-based ordering when available (`src/User/Application/Service/UserStoryService.php`).
- Add an integration test for `GET /api/v1/private/stories` that verifies authentication and that visible stories (owner + friends) are returned (`tests/Application/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesControllerTest.php`).
- Add `docs/technical-notes/user-module-endpoints.md` containing an exhaustive endpoint inventory discovered from route attributes in `src/User/Transport/Controller/Api/V1`.

### Testing
- Ran `php -l src/User/Application/Service/UserStoryService.php` and `php -l tests/Application/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesControllerTest.php`, both reported no syntax errors (success).
- Added functional PHPUnit test at `tests/Application/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesControllerTest.php` (test created and syntax-checked), and attempted to run it with `php bin/phpunit tests/Application/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesControllerTest.php` but the environment lacks the test bootstrap/dependencies so `phpunit` could not be executed (failure due to missing runtime dependencies).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea303b17e4832b866f648cefa7cfad)