### PR TITLE
Add module endpoint docs generator, generate docs, refactor UserStoryService and add GetActiveStories test

### DIFF
--- a/docs/technical-notes/apikey-module-endpoints.md
+++ b/docs/technical-notes/apikey-module-endpoints.md
@@ -1,0 +1,8 @@
+# ApiKey module endpoints
+
+Liste extraite automatiquement des attributs `#[Route(...)]` du module `src/ApiKey/Transport/Controller/Api/V1`.
+Chemin HTTP final exposé par l’API : `/api` + `Path`.
+
+| Method(s) | Path | Controller file |
+|---|---|---|
+| `-` | `/v1/api_key` | `src/ApiKey/Transport/Controller/Api/V1/ApiKey/ApiKeyController.php` |

--- a/docs/technical-notes/blog-module-endpoints.md
+++ b/docs/technical-notes/blog-module-endpoints.md
@@ -1,0 +1,24 @@
+# Blog module endpoints
+
+Liste extraite automatiquement des attributs `#[Route(...)]` du module `src/Blog/Transport/Controller/Api/V1`.
+Chemin HTTP final exposé par l’API : `/api` + `Path`.
+
+| Method(s) | Path | Controller file |
+|---|---|---|
+| `DELETE` | `/v1/private/blog/comments/{commentId}` | `src/Blog/Transport/Controller/Api/V1/Mutation/DeleteBlogCommentController.php` |
+| `DELETE` | `/v1/private/blog/posts/{postId}` | `src/Blog/Transport/Controller/Api/V1/Mutation/DeleteBlogPostController.php` |
+| `DELETE` | `/v1/private/blog/reactions/{reactionId}` | `src/Blog/Transport/Controller/Api/V1/Mutation/DeleteBlogReactionController.php` |
+| `GET` | `/v1/blog/feed` | `src/Blog/Transport/Controller/Api/V1/Read/GetApplicationBlogController.php` |
+| `GET` | `/v1/blog/posts/{slug}` | `src/Blog/Transport/Controller/Api/V1/Read/GetBlogPostBySlugController.php` |
+| `GET` | `/v1/private/blog/posts/mine` | `src/Blog/Transport/Controller/Api/V1/Read/GetMyBlogPostsController.php` |
+| `GET` | `/v1/private/blogs/general` | `src/Blog/Transport/Controller/Api/V1/Read/GetGeneralBlogController.php` |
+| `GET` | `/v1/public/blogs/general` | `src/Blog/Transport/Controller/Api/V1/Read/GetPublicGeneralBlogController.php` |
+| `GET` | `/v1/public/blogs/reactions/types` | `src/Blog/Transport/Controller/Api/V1/Read/GetBlogReactionTypesController.php` |
+| `PATCH` | `/v1/private/blog/comments/{commentId}` | `src/Blog/Transport/Controller/Api/V1/Mutation/PatchBlogCommentController.php` |
+| `PATCH` | `/v1/private/blog/posts/{postId}` | `src/Blog/Transport/Controller/Api/V1/Mutation/PatchBlogPostController.php` |
+| `PATCH` | `/v1/private/blog/reactions/{reactionId}` | `src/Blog/Transport/Controller/Api/V1/Mutation/PatchBlogReactionController.php` |
+| `POST` | `/v1/private/blog/comments/{commentId}/reactions` | `src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogReactionController.php` |
+| `POST` | `/v1/private/blog/posts/{postId}/comments` | `src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogCommentController.php` |
+| `POST` | `/v1/private/blog/posts/{postId}/reactions` | `src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostReactionController.php` |
+| `POST` | `/v1/private/blogs/general` | `src/Blog/Transport/Controller/Api/V1/Mutation/CreateGeneralBlogController.php` |
+| `POST` | `/v1/private/blogs/{blogId}/posts` | `src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostController.php` |

--- a/docs/technical-notes/calendar-module-endpoints.md
+++ b/docs/technical-notes/calendar-module-endpoints.md
@@ -1,0 +1,20 @@
+# Calendar module endpoints
+
+Liste extraite automatiquement des attributs `#[Route(...)]` du module `src/Calendar/Transport/Controller/Api/V1`.
+Chemin HTTP final exposé par l’API : `/api` + `Path`.
+
+| Method(s) | Path | Controller file |
+|---|---|---|
+| `DELETE` | `/v1/calendar/events/{eventId}` | `src/Calendar/Transport/Controller/Api/V1/Event/DeleteApplicationEventController.php` |
+| `DELETE` | `/v1/calendar/private/events/{eventId}` | `src/Calendar/Transport/Controller/Api/V1/Event/DeletePrivateEventController.php` |
+| `GET` | `/v1/calendar/events` | `src/Calendar/Transport/Controller/Api/V1/Event/ApplicationEventListController.php` |
+| `GET` | `/v1/calendar/events/me` | `src/Calendar/Transport/Controller/Api/V1/Event/ApplicationUserEventListController.php` |
+| `GET` | `/v1/calendar/events/upcoming` | `src/Calendar/Transport/Controller/Api/V1/Event/UpcomingEventListController.php` |
+| `GET` | `/v1/calendar/private/events` | `src/Calendar/Transport/Controller/Api/V1/Event/UserEventListController.php` |
+| `PATCH` | `/v1/calendar/events/{eventId}` | `src/Calendar/Transport/Controller/Api/V1/Event/PatchApplicationEventController.php` |
+| `PATCH` | `/v1/calendar/private/events/{eventId}` | `src/Calendar/Transport/Controller/Api/V1/Event/PatchPrivateEventController.php` |
+| `POST` | `/v1/calendar/events` | `src/Calendar/Transport/Controller/Api/V1/Event/CreateApplicationEventController.php` |
+| `POST` | `/v1/calendar/events/{eventId}/cancel` | `src/Calendar/Transport/Controller/Api/V1/Event/CancelApplicationEventController.php` |
+| `POST` | `/v1/calendar/private/events` | `src/Calendar/Transport/Controller/Api/V1/Event/CreatePrivateEventController.php` |
+| `POST` | `/v1/calendar/private/events/google/sync` | `src/Calendar/Transport/Controller/Api/V1/Event/SyncPrivateGoogleEventController.php` |
+| `POST` | `/v1/calendar/private/events/{eventId}/cancel` | `src/Calendar/Transport/Controller/Api/V1/Event/CancelPrivateEventController.php` |

--- a/docs/technical-notes/role-module-endpoints.md
+++ b/docs/technical-notes/role-module-endpoints.md
@@ -1,0 +1,10 @@
+# Role module endpoints
+
+Liste extraite automatiquement des attributs `#[Route(...)]` du module `src/Role/Transport/Controller/Api/V1`.
+Chemin HTTP final exposé par l’API : `/api` + `Path`.
+
+| Method(s) | Path | Controller file |
+|---|---|---|
+| `-` | `/v1/role` | `src/Role/Transport/Controller/Api/V1/Role/RoleController.php` |
+| `GET` | `/v1/role/{role}` | `src/Role/Transport/Controller/Api/V1/Role/FindOneRoleController.php` |
+| `GET` | `/v1/role/{role}/inherited` | `src/Role/Transport/Controller/Api/V1/Role/InheritedRolesController.php` |

--- a/docs/technical-notes/school-module-endpoints.md
+++ b/docs/technical-notes/school-module-endpoints.md
@@ -1,0 +1,29 @@
+# School module endpoints
+
+Liste extraite automatiquement des attributs `#[Route(...)]` du module `src/School/Transport/Controller/Api/V1`.
+Chemin HTTP final exposé par l’API : `/api` + `Path`.
+
+| Method(s) | Path | Controller file |
+|---|---|---|
+| `DELETE` | `/v1/school/classes/{id}` | `src/School/Transport/Controller/Api/V1/Class/DeleteClassController.php` |
+| `DELETE` | `/v1/school/classes/{id}/teachers/{teacherId}` | `src/School/Transport/Controller/Api/V1/Class/UnassignClassTeacherController.php` |
+| `DELETE` | `/v1/school/exams/{id}` | `src/School/Transport/Controller/Api/V1/Exam/DeleteExamController.php` |
+| `DELETE` | `/v1/school/grades/{id}` | `src/School/Transport/Controller/Api/V1/Grade/DeleteGradeController.php` |
+| `DELETE` | `/v1/school/students/{id}` | `src/School/Transport/Controller/Api/V1/Student/DeleteStudentController.php` |
+| `DELETE` | `/v1/school/teachers/{id}` | `src/School/Transport/Controller/Api/V1/Teacher/DeleteTeacherController.php` |
+| `GET` | `/v1/school/classes` | `src/School/Transport/Controller/Api/V1/Class/ListClassesByApplicationController.php` |
+| `GET` | `/v1/school/exams` | `src/School/Transport/Controller/Api/V1/Exam/ListExamsController.php` |
+| `GET` | `/v1/school/grades` | `src/School/Transport/Controller/Api/V1/Grade/ListGradesController.php` |
+| `GET` | `/v1/school/students` | `src/School/Transport/Controller/Api/V1/Student/ListStudentsController.php` |
+| `GET` | `/v1/school/teachers` | `src/School/Transport/Controller/Api/V1/Teacher/ListTeachersController.php` |
+| `GET` | `/v1/school/{resource}` | `src/School/Transport/Controller/Api/V1/SchoolApplicationResourceListController.php` |
+| `GET` | `/v1/school/{resource}/{id}` | `src/School/Transport/Controller/Api/V1/Application/GetSchoolApplicationResourceController.php` |
+| `GET` | `/v1/school/{resource}/{id}` | `src/School/Transport/Controller/Api/V1/General/GetGeneralSchoolResourceController.php` |
+| `PATCH|PUT` | `/v1/school/{resource}/{id}` | `src/School/Transport/Controller/Api/V1/Application/PatchSchoolApplicationResourceController.php` |
+| `POST` | `/v1/school/classes` | `src/School/Transport/Controller/Api/V1/Class/CreateClassByApplicationController.php` |
+| `POST` | `/v1/school/classes/{id}/teachers/{teacherId}` | `src/School/Transport/Controller/Api/V1/Class/AssignClassTeacherController.php` |
+| `POST` | `/v1/school/courses` | `src/School/Transport/Controller/Api/V1/Course/CreateCourseController.php` |
+| `POST` | `/v1/school/exams` | `src/School/Transport/Controller/Api/V1/Exam/CreateExamController.php` |
+| `POST` | `/v1/school/grades` | `src/School/Transport/Controller/Api/V1/Grade/CreateGradeController.php` |
+| `POST` | `/v1/school/students` | `src/School/Transport/Controller/Api/V1/Student/CreateStudentController.php` |
+| `POST` | `/v1/school/teachers` | `src/School/Transport/Controller/Api/V1/Teacher/CreateTeacherController.php` |

--- a/docs/technical-notes/shop-module-endpoints.md
+++ b/docs/technical-notes/shop-module-endpoints.md
@@ -1,0 +1,30 @@
+# Shop module endpoints
+
+Liste extraite automatiquement des attributs `#[Route(...)]` du module `src/Shop/Transport/Controller/Api/V1`.
+Chemin HTTP final exposé par l’API : `/api` + `Path`.
+
+| Method(s) | Path | Controller file |
+|---|---|---|
+| `DELETE` | `/v1/shop/carts/{shopId}/items/{itemId}` | `src/Shop/Transport/Controller/Api/V1/Cart/DeleteCartItemController.php` |
+| `DELETE` | `/v1/shop/categories/{id}` | `src/Shop/Transport/Controller/Api/V1/Category/DeleteCategoryController.php` |
+| `DELETE` | `/v1/shop/products/{id}` | `src/Shop/Transport/Controller/Api/V1/Product/DeleteProductController.php` |
+| `DELETE` | `/v1/shop/tags/{id}` | `src/Shop/Transport/Controller/Api/V1/Tag/DeleteTagController.php` |
+| `GET` | `/v1/shop/applcations/products` | `src/Shop/Transport/Controller/Api/V1/ApplicationProduct/ListApplicationProductsController.php` |
+| `GET` | `/v1/shop/carts/{shopId}` | `src/Shop/Transport/Controller/Api/V1/Cart/GetCartController.php` |
+| `GET` | `/v1/shop/categories` | `src/Shop/Transport/Controller/Api/V1/Category/ListCategoriesController.php` |
+| `GET` | `/v1/shop/general` | `src/Shop/Transport/Controller/Api/V1/General/GetGeneralShopController.php` |
+| `GET` | `/v1/shop/legacy/products` | `src/Shop/Transport/Controller/Api/V1/Product/ListProductsController.php` |
+| `GET` | `/v1/shop/products` | `src/Shop/Transport/Controller/Api/V1/General/ListGeneralProductsController.php` |
+| `GET` | `/v1/shop/products/{id}` | `src/Shop/Transport/Controller/Api/V1/Product/GetProductController.php` |
+| `GET` | `/v1/shop/tags` | `src/Shop/Transport/Controller/Api/V1/Tag/ListTagsController.php` |
+| `PATCH` | `/v1/shop/carts/{shopId}/items/{itemId}` | `src/Shop/Transport/Controller/Api/V1/Cart/PatchCartItemController.php` |
+| `PATCH` | `/v1/shop/products/{id}` | `src/Shop/Transport/Controller/Api/V1/Product/PatchProductController.php` |
+| `POST` | `/v1/shop/carts/{shopId}/items` | `src/Shop/Transport/Controller/Api/V1/Cart/AddCartItemController.php` |
+| `POST` | `/v1/shop/categories` | `src/Shop/Transport/Controller/Api/V1/Category/CreateCategoryController.php` |
+| `POST` | `/v1/shop/checkout/{shopId}` | `src/Shop/Transport/Controller/Api/V1/Checkout/CheckoutController.php` |
+| `POST` | `/v1/shop/legacy/products` | `src/Shop/Transport/Controller/Api/V1/Product/CreateProductController.php` |
+| `POST` | `/v1/shop/orders/{orderId}/payment-confirm` | `src/Shop/Transport/Controller/Api/V1/Payment/ConfirmPaymentController.php` |
+| `POST` | `/v1/shop/orders/{orderId}/payment-intent` | `src/Shop/Transport/Controller/Api/V1/Payment/CreatePaymentIntentController.php` |
+| `POST` | `/v1/shop/payments/webhook` | `src/Shop/Transport/Controller/Api/V1/Payment/PaymentWebhookController.php` |
+| `POST` | `/v1/shop/products` | `src/Shop/Transport/Controller/Api/V1/ApplicationProduct/CreateApplicationProductController.php` |
+| `POST` | `/v1/shop/tags` | `src/Shop/Transport/Controller/Api/V1/Tag/CreateTagController.php` |

--- a/docs/technical-notes/tool-module-endpoints.md
+++ b/docs/technical-notes/tool-module-endpoints.md
@@ -1,0 +1,11 @@
+# Tool module endpoints
+
+Liste extraite automatiquement des attributs `#[Route(...)]` du module `src/Tool/Transport/Controller/Api/V1`.
+Chemin HTTP final exposé par l’API : `/api` + `Path`.
+
+| Method(s) | Path | Controller file |
+|---|---|---|
+| `GET` | `/v1/localization/language` | `src/Tool/Transport/Controller/Api/V1/Localization/LanguageController.php` |
+| `GET` | `/v1/localization/locale` | `src/Tool/Transport/Controller/Api/V1/Localization/LocaleController.php` |
+| `GET` | `/v1/localization/timezone` | `src/Tool/Transport/Controller/Api/V1/Localization/TimeZoneController.php` |
+| `GET` | `/v1/statistics` | `src/Tool/Transport/Controller/Api/V1/StatisticsController.php` |

--- a/docs/technical-notes/user-module-endpoints.md
+++ b/docs/technical-notes/user-module-endpoints.md
@@ -1,0 +1,55 @@
+# User module endpoints
+
+Liste extraite automatiquement des attributs `#[Route(...)]` du module `src/User/Transport/Controller/Api/V1`.
+Chemin HTTP final exposé par l’API : `/api` + `Path`.
+
+| Method(s) | Path | Controller file |
+|---|---|---|
+| `-` | `/v1/user` | `src/User/Transport/Controller/Api/V1/User/UserController.php` |
+| `-` | `/v1/user_group` | `src/User/Transport/Controller/Api/V1/UserGroup/UserGroupController.php` |
+| `DELETE` | `/v1/private/stories/{id}` | `src/User/Transport/Controller/Api/V1/UserStory/DeleteUserStoryController.php` |
+| `DELETE` | `/v1/user/{user}` | `src/User/Transport/Controller/Api/V1/User/DeleteUserController.php` |
+| `DELETE` | `/v1/user/{user}/group/{userGroup}` | `src/User/Transport/Controller/Api/V1/User/DetachUserGroupController.php` |
+| `DELETE` | `/v1/user_group/{userGroup}/user/{user}` | `src/User/Transport/Controller/Api/V1/UserGroup/DetachUserController.php` |
+| `DELETE` | `/v1/users/me` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `DELETE` | `/v1/users/{user}/block` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `GET` | `/v1/private/stories` | `src/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesController.php` |
+| `GET` | `/v1/profile` | `src/User/Transport/Controller/Api/V1/Profile/IndexController.php` |
+| `GET` | `/v1/profile/configuration/{configurationKey}` | `src/User/Transport/Controller/Api/V1/Profile/ConfigurationController.php` |
+| `GET` | `/v1/profile/groups` | `src/User/Transport/Controller/Api/V1/Profile/GroupsController.php` |
+| `GET` | `/v1/profile/roles` | `src/User/Transport/Controller/Api/V1/Profile/RolesController.php` |
+| `GET` | `/v1/public/user/{username}` | `src/User/Transport/Controller/Api/V1/User/PublicUserController.php` |
+| `GET` | `/v1/public/users` | `src/User/Transport/Controller/Api/V1/User/PublicUserListController.php` |
+| `GET` | `/v1/user/{user}/groups` | `src/User/Transport/Controller/Api/V1/User/UserGroupsController.php` |
+| `GET` | `/v1/user/{user}/roles` | `src/User/Transport/Controller/Api/V1/User/UserRolesController.php` |
+| `GET` | `/v1/user_group/{userGroup}/users` | `src/User/Transport/Controller/Api/V1/UserGroup/UsersController.php` |
+| `GET` | `/v1/users/me` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `GET` | `/v1/users/me/applications` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `GET` | `/v1/users/me/applications/latest` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `GET` | `/v1/users/me/friends` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `GET` | `/v1/users/me/friends/blocked` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `GET` | `/v1/users/me/friends/requests` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `GET` | `/v1/users/me/friends/requests/sent` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `GET` | `/v1/users/me/profile` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `GET` | `/v1/users/me/sessions` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `PATCH` | `/v1/profile` | `src/User/Transport/Controller/Api/V1/Profile/PatchController.php` |
+| `PATCH` | `/v1/profile/configuration/{configurationKey}` | `src/User/Transport/Controller/Api/V1/Profile/ConfigurationPatchController.php` |
+| `PATCH` | `/v1/users/me/password` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `PATCH` | `/v1/users/me/profile` | `src/User/Transport/Controller/Api/V1/User/UserMeController.php` |
+| `POST` | `/v1/auth/get_token` | `src/User/Transport/Controller/Api/V1/Auth/GetTokenController.php` |
+| `POST` | `/v1/auth/register` | `src/User/Transport/Controller/Api/V1/Auth/RegisterController.php` |
+| `POST` | `/v1/auth/social_login` | `src/User/Transport/Controller/Api/V1/Auth/SocialLoginController.php` |
+| `POST` | `/v1/private/stories` | `src/User/Transport/Controller/Api/V1/UserStory/CreateUserStoryController.php` |
+| `POST` | `/v1/profile/applications` | `src/User/Transport/Controller/Api/V1/Profile/ApplicationCreateController.php` |
+| `POST` | `/v1/profile/applications/{application}/photo` | `src/User/Transport/Controller/Api/V1/Profile/ApplicationUploadPhotoController.php` |
+| `POST` | `/v1/profile/configuration` | `src/User/Transport/Controller/Api/V1/Profile/ConfigurationCreateController.php` |
+| `POST` | `/v1/profile/photo` | `src/User/Transport/Controller/Api/V1/Profile/UploadPhotoController.php` |
+| `POST` | `/v1/profile/platforms/{platform}/photo` | `src/User/Transport/Controller/Api/V1/Profile/PlatformUploadPhotoController.php` |
+| `POST` | `/v1/profile/plugins/{plugin}/photo` | `src/User/Transport/Controller/Api/V1/Profile/PluginUploadPhotoController.php` |
+| `POST` | `/v1/user/{user}/group/{userGroup}` | `src/User/Transport/Controller/Api/V1/User/AttachUserGroupController.php` |
+| `POST` | `/v1/user_group/{userGroup}/user/{user}` | `src/User/Transport/Controller/Api/V1/UserGroup/AttachUserController.php` |
+| `POST` | `/v1/users/{user}/block` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `POST` | `/v1/users/{user}/friends/accept` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `POST` | `/v1/users/{user}/friends/cancel` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `POST` | `/v1/users/{user}/friends/reject` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |
+| `POST` | `/v1/users/{user}/friends/request` | `src/User/Transport/Controller/Api/V1/User/UserFriendController.php` |

--- a/src/User/Application/Service/UserStoryService.php
+++ b/src/User/Application/Service/UserStoryService.php
@@ -24,9 +24,12 @@ use Symfony\Contracts\Cache\TagAwareCacheInterface;
 use Throwable;
 
 use function array_filter;
+use function array_flip;
 use function array_map;
 use function array_values;
 use function count;
+use function method_exists;
+use function usort;
 
 readonly class UserStoryService
 {
@@ -48,22 +51,16 @@ readonly class UserStoryService
     public function getActiveStories(User $loggedInUser, int $limit): array
     {
         $visibleUsers = $this->findVisibleUsers($loggedInUser);
-        $visibleUserIds = array_map(static fn (User $user): string => $user->getId(), $visibleUsers);
         $cacheKey = $this->cacheKeyConventionService->buildPrivateStoryListKey($loggedInUser->getId(), $limit);
 
         /** @var array<int, array<string, mixed>> $stories */
-        $stories = $this->cache->get($cacheKey, function (ItemInterface $item) use ($loggedInUser, $visibleUserIds, $limit): array {
+        $stories = $this->cache->get($cacheKey, function (ItemInterface $item) use ($loggedInUser, $visibleUsers, $limit): array {
             $item->expiresAfter(60);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->tagPrivateStoryList());
             }
 
-            $esIds = $this->searchActiveStoryIdsFromElastic($visibleUserIds, $limit);
-            if ($esIds === []) {
-                return [];
-            }
-
-            return $this->findActiveStories($loggedInUser, $visibleUserIds, $limit, $esIds);
+            return $this->getActiveStoriesFromSources($loggedInUser, $visibleUsers, $limit);
         });
 
         return $stories;
@@ -113,12 +110,26 @@ readonly class UserStoryService
     }
 
     /**
-     * @param array<int, string> $visibleUserIds
+     * @param array<int, User> $visibleUsers
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function getActiveStoriesFromSources(User $loggedInUser, array $visibleUsers, int $limit): array
+    {
+        $visibleUserIds = array_map(static fn (User $user): string => $user->getId(), $visibleUsers);
+        $esIds = $this->searchActiveStoryIdsFromElastic($visibleUserIds, $limit);
+
+        // If Elasticsearch does not have the index/documents yet, fall back to DB query.
+        return $this->findActiveStories($loggedInUser, $visibleUsers, $limit, $esIds === [] ? null : $esIds);
+    }
+
+    /**
+     * @param array<int, User> $visibleUsers
      * @param array<int, string>|null $esIds
      *
      * @return array<int, array<string, mixed>>
      */
-    private function findActiveStories(User $loggedInUser, array $visibleUserIds, int $limit, ?array $esIds): array
+    private function findActiveStories(User $loggedInUser, array $visibleUsers, int $limit, ?array $esIds): array
     {
         $since = new DateTimeImmutable('-24 hours');
 
@@ -126,9 +137,11 @@ readonly class UserStoryService
             ->select('story', 'user')
             ->innerJoin('story.user', 'user')
             ->andWhere('story.createdAt >= :since')
-            ->andWhere('user.id IN (:visibleUserIds)')
+            ->andWhere('story.expiresAt >= :now')
+            ->andWhere('story.user IN (:visibleUsers)')
             ->setParameter('since', $since)
-            ->setParameter('visibleUserIds', $visibleUserIds)
+            ->setParameter('now', new DateTimeImmutable())
+            ->setParameter('visibleUsers', $visibleUsers)
             ->orderBy('story.createdAt', 'DESC')
             ->setMaxResults($limit);
 

--- a/tests/Application/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesControllerTest.php
+++ b/tests/Application/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesControllerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Application\User\Transport\Controller\Api\V1\UserStory;
+
+use App\General\Domain\Utils\JSON;
+use App\Tests\TestCase\WebTestCase;
+use PHPUnit\Framework\Attributes\TestDox;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+class GetActiveStoriesControllerTest extends WebTestCase
+{
+    private string $baseUrl = self::API_URL_PREFIX . '/v1/private/stories';
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/private/stories` requires authentication.')]
+    public function testThatGetActiveStoriesRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', $this->baseUrl);
+        $response = $client->getResponse();
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode(), "Response:\n" . $response);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that authenticated user can get visible active stories (mine + friends).')]
+    public function testThatAuthenticatedUserCanGetVisibleStories(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', $this->baseUrl);
+        $response = $client->getResponse();
+        $content = $response->getContent();
+
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $responseData = JSON::decode($content, true);
+        self::assertIsArray($responseData);
+        self::assertArrayHasKey('stories', $responseData);
+        self::assertIsArray($responseData['stories']);
+        self::assertNotEmpty($responseData['stories']);
+
+        $firstGroup = $responseData['stories'][0] ?? null;
+        self::assertIsArray($firstGroup);
+        self::assertSame(true, $firstGroup['owner'] ?? null);
+        self::assertArrayHasKey('stories', $firstGroup);
+        self::assertIsArray($firstGroup['stories']);
+        self::assertNotEmpty($firstGroup['stories']);
+    }
+}

--- a/tools/scripts/generate_module_endpoints_docs.py
+++ b/tools/scripts/generate_module_endpoints_docs.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Generate endpoint inventory markdown from Symfony Route attributes."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Iterable
+
+ROUTE_BLOCK = re.compile(r"#\[Route\((.*?)\)\]", re.S)
+PATH_NAMED = re.compile(r"path:\s*'([^']+)'")
+PATH_POSITIONAL = re.compile(r"^\s*'([^']+)'")
+METHODS = re.compile(r"methods:\s*\[(.*?)\]", re.S)
+METHOD_TOKEN = re.compile(r"Request::METHOD_([A-Z]+)")
+
+
+def extract_entries(root: Path) -> list[tuple[str, str, str]]:
+    entries: list[tuple[str, str, str]] = []
+
+    for file_path in sorted(root.rglob("*.php")):
+        content = file_path.read_text(encoding="utf-8")
+
+        for match in ROUTE_BLOCK.finditer(content):
+            block = match.group(1)
+            path_match = PATH_NAMED.search(block) or PATH_POSITIONAL.search(block)
+            path = path_match.group(1) if path_match else "(class-prefix)"
+
+            methods_match = METHODS.search(block)
+            methods = "-"
+            if methods_match:
+                parsed_methods = METHOD_TOKEN.findall(methods_match.group(1))
+                methods = "|".join(parsed_methods) if parsed_methods else "-"
+
+            entries.append((methods, path, file_path.as_posix()))
+
+    return sorted(entries, key=lambda item: (item[0], item[1], item[2]))
+
+
+def build_markdown(module: str, source_root: Path, entries: Iterable[tuple[str, str, str]]) -> str:
+    lines = [
+        f"# {module} module endpoints",
+        "",
+        f"Liste extraite automatiquement des attributs `#[Route(...)]` du module `{source_root.as_posix()}`.",
+        "Chemin HTTP final exposé par l’API : `/api` + `Path`.",
+        "",
+        "| Method(s) | Path | Controller file |",
+        "|---|---|---|",
+    ]
+
+    for methods, path, file_path in entries:
+        lines.append(f"| `{methods}` | `{path}` | `{file_path}` |")
+
+    return "\n".join(lines) + "\n"
+
+
+def parse_module_arg(value: str) -> tuple[str, Path, Path]:
+    try:
+        name, src, out = value.split(":", maxsplit=2)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "Expected format: ModuleName:source_dir:output_file"
+        ) from exc
+
+    return name, Path(src), Path(out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--module",
+        action="append",
+        required=True,
+        type=parse_module_arg,
+        help="ModuleName:source_dir:output_file",
+    )
+    args = parser.parse_args()
+
+    for module_name, source_root, output_file in args.module:
+        entries = extract_entries(source_root)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text(build_markdown(module_name, source_root, entries), encoding="utf-8")
+        print(f"{module_name}: {len(entries)} routes -> {output_file}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide an automated way to export Symfony `#[Route(...)]` attributes into human-readable module endpoint inventories. 
- Improve robustness of the user story listing flow to gracefully fall back to the database when Elasticsearch has no results. 
- Add a functional test to verify `GET /v1/private/stories` authentication and basic response contents.

### Description
- Add a new script `tools/scripts/generate_module_endpoints_docs.py` that parses `#[Route(...)]` attributes and writes module markdown files listing method, path and controller file. 
- Generate and add multiple module endpoint markdown files under `docs/technical-notes/` for modules such as `ApiKey`, `Blog`, `Calendar`, `Role`, `School`, `Shop`, `Tool`, and `User`. 
- Refactor `src/User/Application/Service/UserStoryService.php` to extract `getActiveStoriesFromSources()` and update `findActiveStories()` to accept `User` objects instead of raw ids, add fallback to DB when Elasticsearch returns no ids, enforce `expiresAt` and preserve Elasticsearch ordering when present. 
- Add small improvements to the service such as using `method_exists` for cache tagging and importing `array_flip`/`usort` utilities for ordering logic. 
- Add a functional test `tests/Application/User/Transport/Controller/Api/V1/UserStory/GetActiveStoriesControllerTest.php` that asserts authentication is required and that an authenticated user receives grouped stories including their own.

### Testing
- Ran the test suite via `phpunit`, including the new `GetActiveStoriesControllerTest`, and all tests passed.
- Executed the generator script against the codebase to produce the `docs/technical-notes/*-module-endpoints.md` files and verified the outputs were written successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea303b17e4832b866f648cefa7cfad)