### PR TITLE
Fix /v1/notifications/read-all recipient id handling in NotificationRepository

### DIFF
--- a/src/Notification/Infrastructure/Repository/NotificationRepository.php
+++ b/src/Notification/Infrastructure/Repository/NotificationRepository.php
@@ -54,10 +54,10 @@ class NotificationRepository extends BaseRepository
 
     public function markAllAsReadByRecipient(User $user): int
     {
-        return $this->markAllAsReadByRecipientId($user);
+        return $this->markAllAsReadByRecipientId($user->getId());
     }
 
-    public function markAllAsReadByRecipientId(User $user): int
+    public function markAllAsReadByRecipientId(string $recipientId): int
     {
         return $this->createQueryBuilder('n')
             ->update()
@@ -66,7 +66,7 @@ class NotificationRepository extends BaseRepository
             ->andWhere('n.isRead = :currentState')
             ->setParameter('isRead', true)
             ->setParameter('currentState', false)
-            ->setParameter('recipient', $user->getId(), UuidBinaryOrderedTimeType::NAME)
+            ->setParameter('recipient', $recipientId, UuidBinaryOrderedTimeType::NAME)
             ->getQuery()
             ->execute();
     }


### PR DESCRIPTION
### Motivation
- Fix a type mismatch between the message handler (which provides `actorUserId` as a string) and the repository method, which prevented `/v1/notifications/read-all` from marking notifications as read.

### Description
- Change `NotificationRepository::markAllAsReadByRecipientId` to accept `string $recipientId`, and update `markAllAsReadByRecipient` to forward `$user->getId()`, and use the new `$recipientId` in the update query.

### Testing
- Ran `php -l src/Notification/Infrastructure/Repository/NotificationRepository.php` for a syntax check and `rg "markAllAsReadByRecipientId\(" -n src` to verify usages, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb75827ac0832b97f7617d6584d00a)