### PR TITLE
feat(api-doc): add dedicated users OpenAPI docs routes

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -393,7 +393,11 @@ when@dev: &dev
                 -   Bearer: []
                 -   ApiKey: []
         areas: # to filter documented areas
-            path_patterns:
-                - ^/api(?!/doc$) # Accepts routes under /api except /api/doc
+            default:
+                path_patterns:
+                    - ^/api(?!/doc(?:$|/|\.json$)) # Accepts routes under /api except /api/doc and module docs
+            users:
+                path_patterns:
+                    - ^/api/v1/(?:auth|profile|user(?:s|_group)?|private/stories)(?:/|$)
 
 when@test: *dev

--- a/config/routes/nelmio_api_doc.yaml
+++ b/config/routes/nelmio_api_doc.yaml
@@ -3,13 +3,23 @@ when@dev: &dev
     app.swagger:
         path: /api/doc.json
         methods: GET
-        defaults: { _controller: nelmio_api_doc.controller.swagger }
+        defaults: { _controller: nelmio_api_doc.controller.swagger, area: default }
+
+    app.swagger.users:
+        path: /api/doc/users.json
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger, area: users }
 
     ## Requires the Asset component and the Twig bundle
     ## $ composer require twig asset
     app.swagger_ui:
         path: /api/doc
         methods: GET
-        defaults: { _controller: nelmio_api_doc.controller.swagger_ui }
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui, area: default }
+
+    app.swagger_ui.users:
+        path: /api/doc/users
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui, area: users }
 
 when@test: *dev


### PR DESCRIPTION
### Motivation
- Provide a separate OpenAPI/Swagger UI for the User module so user/auth/profile/user_group/private stories endpoints can be tested independently via `/api/doc/users` and `/api/doc/users.json`.

### Description
- Update `config/packages/nelmio_api_doc.yaml` to split documentation `areas` into `default` and `users` and add a `users` `path_patterns` that matches user-related routes.
- Tighten the global `default` pattern to exclude the main docs endpoint and module docs by using `^/api(?!/doc(?:$|/|\.json$))`.
- Add routes in `config/routes/nelmio_api_doc.yaml` for `app.swagger.users` (`/api/doc/users.json`) and `app.swagger_ui.users` (`/api/doc/users`) and set `area: users` on them while keeping the global docs at `/api/doc` and `/api/doc.json` with `area: default`.

### Testing
- Ran `php bin/console lint:yaml config/packages/nelmio_api_doc.yaml config/routes/nelmio_api_doc.yaml` which failed in this environment because project dependencies are not installed and the console exits with a `LogicException` advising to run `composer install`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8309c0a0832b804b6231104b8bd5)