### PR TITLE
Add abonnement news module and user visibility/subscription workflow

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -258,6 +258,9 @@ when@dev:
         App\School\Infrastructure\DataFixtures\:
             resource: '../src/School/Infrastructure/DataFixtures/*'
 
+        App\Abonnement\Infrastructure\DataFixtures\:
+            resource: '../src/Abonnement/Infrastructure/DataFixtures/*'
+
         App\Page\Infrastructure\DataFixtures\:
             resource: '../src/Page/Infrastructure/DataFixtures/*'
 
@@ -309,6 +312,10 @@ when@test:
 
         App\Shop\Infrastructure\DataFixtures\:
             resource: '../src/Shop/Infrastructure/DataFixtures/*'
+
+        App\Abonnement\Infrastructure\DataFixtures\:
+            resource: '../src/Abonnement/Infrastructure/DataFixtures/*'
+
         App\Crm\Infrastructure\DataFixtures\:
             resource: '../src/Crm/Infrastructure/DataFixtures/*'
         App\School\Infrastructure\DataFixtures\:

--- a/migrations/Version20260424110000.php
+++ b/migrations/Version20260424110000.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260424110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'User visibility/subscription flags and abonnement_news table.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE user ADD visible TINYINT(1) NOT NULL DEFAULT 1, ADD abonnement TINYINT(1) NOT NULL DEFAULT 0');
+        $this->addSql('CREATE TABLE abonnement_news (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", title VARCHAR(255) NOT NULL, description LONGTEXT NOT NULL, execute_at DATETIME NOT NULL COMMENT "(DC2Type:datetime_immutable)", executed TINYINT(1) NOT NULL DEFAULT 0, created_at DATETIME NOT NULL COMMENT "(DC2Type:datetime_immutable)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('CREATE INDEX idx_abonnement_news_execute ON abonnement_news (execute_at, executed)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE abonnement_news');
+        $this->addSql('ALTER TABLE user DROP visible, DROP abonnement');
+    }
+}

--- a/src/Abonnement/Application/DTO/News/News.php
+++ b/src/Abonnement/Application/DTO/News/News.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Application\DTO\News;
+
+use App\Abonnement\Domain\Entity\News as Entity;
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\DTO\RestDto;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use DateTimeImmutable;
+use Override;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @method self|RestDtoInterface get(string $id)
+ * @method self|RestDtoInterface patch(RestDtoInterface $dto)
+ * @method Entity|EntityInterface update(EntityInterface $entity)
+ */
+class News extends RestDto
+{
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 2, max: 255)]
+    protected string $title = '';
+
+    #[Assert\NotBlank]
+    protected string $description = '';
+
+    #[Assert\NotNull]
+    protected DateTimeImmutable $executeAt;
+
+    protected bool $executed = false;
+
+    public function __construct()
+    {
+        $this->executeAt = new DateTimeImmutable();
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->setVisited('title');
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->setVisited('description');
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getExecuteAt(): DateTimeImmutable
+    {
+        return $this->executeAt;
+    }
+
+    public function setExecuteAt(DateTimeImmutable $executeAt): self
+    {
+        $this->setVisited('executeAt');
+        $this->executeAt = $executeAt;
+
+        return $this;
+    }
+
+    public function isExecuted(): bool
+    {
+        return $this->executed;
+    }
+
+    public function setExecuted(bool $executed): self
+    {
+        $this->setVisited('executed');
+        $this->executed = $executed;
+
+        return $this;
+    }
+
+    /** @param EntityInterface|Entity $entity */
+    #[Override]
+    public function load(EntityInterface $entity): self
+    {
+        if ($entity instanceof Entity) {
+            $this->id = $entity->getId();
+            $this->title = $entity->getTitle();
+            $this->description = $entity->getDescription();
+            $this->executeAt = $entity->getExecuteAt();
+            $this->executed = $entity->isExecuted();
+        }
+
+        return $this;
+    }
+}

--- a/src/Abonnement/Application/DTO/News/NewsCreate.php
+++ b/src/Abonnement/Application/DTO/News/NewsCreate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Application\DTO\News;
+
+class NewsCreate extends News
+{
+}

--- a/src/Abonnement/Application/DTO/News/NewsPatch.php
+++ b/src/Abonnement/Application/DTO/News/NewsPatch.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Application\DTO\News;
+
+class NewsPatch extends News
+{
+}

--- a/src/Abonnement/Application/DTO/News/NewsUpdate.php
+++ b/src/Abonnement/Application/DTO/News/NewsUpdate.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Application\DTO\News;
+
+class NewsUpdate extends News
+{
+}

--- a/src/Abonnement/Application/Resource/NewsResource.php
+++ b/src/Abonnement/Application/Resource/NewsResource.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Application\Resource;
+
+use App\Abonnement\Domain\Entity\News as Entity;
+use App\Abonnement\Domain\Repository\Interfaces\NewsRepositoryInterface as Repository;
+use App\General\Application\DTO\Interfaces\RestDtoInterface;
+use App\General\Application\Rest\RestResource;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+
+/**
+ * @method Entity create(RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity update(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity patch(string $id, RestDtoInterface $dto, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ * @method Entity delete(string $id, ?bool $flush = null, ?string $entityManagerName = null)
+ * @method Entity save(EntityInterface $entity, ?bool $flush = null, ?bool $skipValidation = null, ?string $entityManagerName = null)
+ */
+class NewsResource extends RestResource
+{
+    public function __construct(
+        Repository $repository,
+    ) {
+        parent::__construct($repository);
+    }
+}

--- a/src/Abonnement/Domain/Entity/News.php
+++ b/src/Abonnement/Domain/Entity/News.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Attribute\Groups;
+use Symfony\Component\Validator\Constraints as Assert;
+use Throwable;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'abonnement_news')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class News implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    final public const string SET_NEWS = 'set.News';
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true, nullable: false)]
+    #[Groups(['News', 'News.id', self::SET_NEWS])]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'title', type: Types::STRING, length: 255, nullable: false)]
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 2, max: 255)]
+    #[Groups(['News', 'News.title', self::SET_NEWS])]
+    private string $title = '';
+
+    #[ORM\Column(name: 'description', type: Types::TEXT, nullable: false)]
+    #[Assert\NotBlank]
+    #[Groups(['News', 'News.description', self::SET_NEWS])]
+    private string $description = '';
+
+    #[ORM\Column(name: 'execute_at', type: Types::DATETIME_IMMUTABLE, nullable: false)]
+    #[Assert\NotNull]
+    #[Groups(['News', 'News.executeAt', self::SET_NEWS])]
+    private DateTimeImmutable $executeAt;
+
+    #[ORM\Column(name: 'executed', type: Types::BOOLEAN, nullable: false, options: ['default' => false])]
+    #[Groups(['News', 'News.executed', self::SET_NEWS])]
+    private bool $executed = false;
+
+    /**
+     * @throws Throwable
+     */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->executeAt = new DateTimeImmutable();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function getExecuteAt(): DateTimeImmutable
+    {
+        return $this->executeAt;
+    }
+
+    public function setExecuteAt(DateTimeImmutable $executeAt): self
+    {
+        $this->executeAt = $executeAt;
+
+        return $this;
+    }
+
+    public function isExecuted(): bool
+    {
+        return $this->executed;
+    }
+
+    public function setExecuted(bool $executed): self
+    {
+        $this->executed = $executed;
+
+        return $this;
+    }
+}

--- a/src/Abonnement/Domain/Repository/Interfaces/NewsRepositoryInterface.php
+++ b/src/Abonnement/Domain/Repository/Interfaces/NewsRepositoryInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Domain\Repository\Interfaces;
+
+interface NewsRepositoryInterface
+{
+}

--- a/src/Abonnement/Infrastructure/DataFixtures/ORM/LoadNewsData.php
+++ b/src/Abonnement/Infrastructure/DataFixtures/ORM/LoadNewsData.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Infrastructure\DataFixtures\ORM;
+
+use App\Abonnement\Domain\Entity\News;
+use DateTimeImmutable;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Persistence\ObjectManager;
+use Override;
+
+final class LoadNewsData extends Fixture implements OrderedFixtureInterface
+{
+    #[Override]
+    public function load(ObjectManager $manager): void
+    {
+        $news1 = (new News())
+            ->setTitle('Maintenance plateforme')
+            ->setDescription('<p>Une maintenance est prévue ce soir à 23h00 UTC.</p>')
+            ->setExecuteAt(new DateTimeImmutable('-1 day'))
+            ->setExecuted(false);
+
+        $news2 = (new News())
+            ->setTitle('Nouveautés du mois')
+            ->setDescription('<h2>Release notes</h2><p>Nouvelles fonctionnalités disponibles.</p>')
+            ->setExecuteAt(new DateTimeImmutable('+1 day'))
+            ->setExecuted(false);
+
+        $manager->persist($news1);
+        $manager->persist($news2);
+        $manager->flush();
+    }
+
+    #[Override]
+    public function getOrder(): int
+    {
+        return 100;
+    }
+}

--- a/src/Abonnement/Infrastructure/Repository/NewsRepository.php
+++ b/src/Abonnement/Infrastructure/Repository/NewsRepository.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Infrastructure\Repository;
+
+use App\Abonnement\Domain\Entity\News as Entity;
+use App\Abonnement\Domain\Repository\Interfaces\NewsRepositoryInterface;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity|null findOneBy(array $criteria, ?array $orderBy = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class NewsRepository extends BaseRepository implements NewsRepositoryInterface
+{
+    protected static string $entityName = Entity::class;
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+}

--- a/src/Abonnement/Transport/Command/ExecutePendingNewsCommand.php
+++ b/src/Abonnement/Transport/Command/ExecutePendingNewsCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Transport\Command;
+
+use App\Abonnement\Domain\Entity\News;
+use App\General\Domain\Service\Interfaces\MailerServiceInterface;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Execute pending News and send email notifications to subscribed users.',
+)]
+final class ExecutePendingNewsCommand extends Command
+{
+    final public const string NAME = 'app:abonnement:execute-news';
+
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+        private readonly MailerServiceInterface $mailerService,
+        #[Autowire('%env(resolve:APP_SENDER_EMAIL)%')]
+        private readonly string $senderEmail,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $pendingNews = $this->entityManager->getRepository(News::class)
+            ->createQueryBuilder('news')
+            ->where('news.executed = :executed')
+            ->andWhere('news.executeAt <= :now')
+            ->setParameter('executed', false)
+            ->setParameter('now', new DateTimeImmutable())
+            ->orderBy('news.executeAt', 'ASC')
+            ->getQuery()
+            ->getResult();
+
+        if ($pendingNews === []) {
+            $io->success('No pending news to execute.');
+
+            return Command::SUCCESS;
+        }
+
+        $subscribedUsers = $this->entityManager->getRepository(User::class)
+            ->createQueryBuilder('user')
+            ->where('user.abonnement = :abonnement')
+            ->setParameter('abonnement', true)
+            ->getQuery()
+            ->getResult();
+
+        foreach ($pendingNews as $news) {
+            if (!$news instanceof News) {
+                continue;
+            }
+
+            foreach ($subscribedUsers as $user) {
+                if (!$user instanceof User) {
+                    continue;
+                }
+
+                $this->mailerService->sendMail(
+                    $news->getTitle(),
+                    $this->senderEmail,
+                    $user->getEmail(),
+                    $news->getDescription(),
+                );
+            }
+
+            $news->setExecuted(true);
+            $this->entityManager->persist($news);
+        }
+
+        $this->entityManager->flush();
+
+        $io->success('Pending news executed and emails sent.');
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Abonnement/Transport/Command/Scheduler/ExecutePendingNewsScheduledCommand.php
+++ b/src/Abonnement/Transport/Command/Scheduler/ExecutePendingNewsScheduledCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Transport\Command\Scheduler;
+
+use App\Abonnement\Transport\Command\ExecutePendingNewsCommand;
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Tool\Application\Service\Scheduler\Interfaces\ScheduledCommandServiceInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Create a cron job for abonnement news execution every minute.',
+)]
+final class ExecutePendingNewsScheduledCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'scheduler:abonnement-execute-news';
+
+    public function __construct(
+        private readonly ScheduledCommandServiceInterface $scheduledCommandService,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $message = $this->createScheduledCommand();
+
+        if ($input->isInteractive()) {
+            $this->getSymfonyStyle($input, $output)->success($message);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function createScheduledCommand(): string
+    {
+        $entity = $this->scheduledCommandService->findByCommand(ExecutePendingNewsCommand::NAME);
+
+        if ($entity !== null) {
+            return "The job AbonnementExecuteNews is already present [id='{$entity->getId()}']";
+        }
+
+        $this->scheduledCommandService->create(
+            'Execute abonnement news and send emails',
+            ExecutePendingNewsCommand::NAME,
+            '* * * * *',
+            '/abonnement-execute-news.log',
+        );
+
+        return 'The job AbonnementExecuteNews is created';
+    }
+}

--- a/src/Abonnement/Transport/Controller/Api/V1/News/NewsController.php
+++ b/src/Abonnement/Transport/Controller/Api/V1/News/NewsController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Abonnement\Transport\Controller\Api\V1\News;
+
+use App\Abonnement\Application\DTO\News\NewsCreate;
+use App\Abonnement\Application\DTO\News\NewsPatch;
+use App\Abonnement\Application\DTO\News\NewsUpdate;
+use App\Abonnement\Application\Resource\NewsResource;
+use App\General\Transport\Rest\Controller;
+use App\General\Transport\Rest\ResponseHandler;
+use App\General\Transport\Rest\Traits\Actions;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+/**
+ * @method NewsResource getResource()
+ * @method ResponseHandler getResponseHandler()
+ */
+#[AsController]
+#[Route(path: '/v1/admin/abonnement/news')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[OA\Tag(name: 'Abonnement News')]
+class NewsController extends Controller
+{
+    use Actions\Admin\CountAction;
+    use Actions\Admin\FindAction;
+    use Actions\Admin\FindOneAction;
+    use Actions\Admin\IdsAction;
+    use Actions\Root\CreateAction;
+    use Actions\Root\DeleteAction;
+    use Actions\Root\PatchAction;
+    use Actions\Root\UpdateAction;
+
+    protected static array $dtoClasses = [
+        Controller::METHOD_CREATE => NewsCreate::class,
+        Controller::METHOD_UPDATE => NewsUpdate::class,
+        Controller::METHOD_PATCH => NewsPatch::class,
+    ];
+
+    public function __construct(NewsResource $resource)
+    {
+        parent::__construct($resource);
+    }
+}

--- a/src/User/Application/DTO/User/User.php
+++ b/src/User/Application/DTO/User/User.php
@@ -79,6 +79,11 @@ class User extends RestDto
     #[Assert\LessThanOrEqual(value: Entity::COINS_MAX)]
     protected int $coins = Entity::COINS_DEFAULT;
 
+
+    protected bool $visible = true;
+
+    protected bool $abonnement = false;
+
     /**
      * @var UserGroupEntity[]|array<int, UserGroupEntity>
      */
@@ -216,6 +221,33 @@ class User extends RestDto
         return $this;
     }
 
+
+    public function isVisible(): bool
+    {
+        return $this->visible;
+    }
+
+    public function setVisible(bool $visible): self
+    {
+        $this->setVisited('visible');
+        $this->visible = $visible;
+
+        return $this;
+    }
+
+    public function hasAbonnement(): bool
+    {
+        return $this->abonnement;
+    }
+
+    public function setAbonnement(bool $abonnement): self
+    {
+        $this->setVisited('abonnement');
+        $this->abonnement = $abonnement;
+
+        return $this;
+    }
+
     /**
      * @return array<int, UserGroupEntity>
      */
@@ -269,6 +301,8 @@ class User extends RestDto
             $this->timezone = $entity->getTimezone();
             $this->photo = $entity->getPhoto();
             $this->coins = $entity->getCoins();
+            $this->visible = $entity->isVisible();
+            $this->abonnement = $entity->hasAbonnement();
             /** @var array<int, UserGroupEntity> $groups */
             $groups = $entity->getUserGroups()->toArray();
             $this->userGroups = $groups;

--- a/src/User/Application/Service/UserPublicListService.php
+++ b/src/User/Application/Service/UserPublicListService.php
@@ -125,6 +125,8 @@ readonly class UserPublicListService
     {
         $qb = $this->userRepository->createQueryBuilder('user')
             ->select('user')
+            ->andWhere('user.visible = :visible')
+            ->setParameter('visible', true)
             ->orderBy('user.createdAt', 'DESC');
 
         if ($esIds !== null) {

--- a/src/User/Domain/Entity/User.php
+++ b/src/User/Domain/Entity/User.php
@@ -260,6 +260,41 @@ class User implements EntityInterface, UserInterface, UserGroupAwareInterface
     #[Assert\LessThanOrEqual(value: self::COINS_MAX)]
     private int $coins = self::COINS_DEFAULT;
 
+
+    #[ORM\Column(
+        name: 'visible',
+        type: Types::BOOLEAN,
+        nullable: false,
+        options: [
+            'default' => true,
+        ],
+    )]
+    #[Groups([
+        'User',
+        'User.visible',
+
+        self::SET_USER_PROFILE,
+        self::SET_USER_BASIC,
+    ])]
+    private bool $visible = true;
+
+    #[ORM\Column(
+        name: 'abonnement',
+        type: Types::BOOLEAN,
+        nullable: false,
+        options: [
+            'default' => false,
+        ],
+    )]
+    #[Groups([
+        'User',
+        'User.abonnement',
+
+        self::SET_USER_PROFILE,
+        self::SET_USER_BASIC,
+    ])]
+    private bool $abonnement = false;
+
     #[ORM\Column(
         name: 'password',
         type: Types::STRING,
@@ -423,6 +458,31 @@ class User implements EntityInterface, UserInterface, UserGroupAwareInterface
         }
 
         $this->coins = $coins;
+
+        return $this;
+    }
+
+
+    public function isVisible(): bool
+    {
+        return $this->visible;
+    }
+
+    public function setVisible(bool $visible): self
+    {
+        $this->visible = $visible;
+
+        return $this;
+    }
+
+    public function hasAbonnement(): bool
+    {
+        return $this->abonnement;
+    }
+
+    public function setAbonnement(bool $abonnement): self
+    {
+        $this->abonnement = $abonnement;
 
         return $this;
     }

--- a/src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php
+++ b/src/User/Infrastructure/DataFixtures/ORM/LoadUserData.php
@@ -150,6 +150,7 @@ final class LoadUserData extends Fixture implements OrderedFixtureInterface
                 /** @var UserGroup $crmOwnerGroup */
                 $crmOwnerGroup = $this->getReference('UserGroup-crm_owner', UserGroup::class);
                 $entity->addUserGroup($crmOwnerGroup);
+                $entity->setAbonnement(true);
             }
         }
 

--- a/src/User/Transport/Controller/Api/V1/Profile/PatchController.php
+++ b/src/User/Transport/Controller/Api/V1/Profile/PatchController.php
@@ -38,6 +38,8 @@ class PatchController
         'email',
         'language',
         'locale',
+        'visible',
+        'abonnement',
     ];
 
     public function __construct(
@@ -103,6 +105,22 @@ class PatchController
 
     private function applyPatch(User $loggedInUser, string $field, mixed $value): void
     {
+        if ($field === 'visible' || $field === 'abonnement') {
+            if (!is_bool($value)) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" must be a boolean.');
+            }
+
+            if ($field === 'visible') {
+                $loggedInUser->setVisible($value);
+
+                return;
+            }
+
+            $loggedInUser->setAbonnement($value);
+
+            return;
+        }
+
         if (!is_string($value)) {
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "' . $field . '" must be a string.');
         }
@@ -127,4 +145,5 @@ class PatchController
             default => throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Unsupported field "' . $field . '".'),
         };
     }
+
 }


### PR DESCRIPTION
### Motivation
- Allow users to opt-in to a newsletter-like flow and control whether they appear in public user listings. 
- Provide an admin-managed News entity to schedule HTML content to be sent to subscribed users. 

### Description
- Add two flags to `User`: `visible` (`bool`, default `true`) and `abonnement` (`bool`, default `false`) with Doctrine mapping, DTO fields, getters/setters and propagation in `User::load`.
- Extend profile patch (`/v1/profile`) to accept `visible` and `abonnement` (boolean validation) and update `UserPublicListService` to return only users with `visible = true`.
- New `Abonnement` module with `News` entity (`title`, HTML `description`, `executeAt`, `executed`), admin CRUD controller at `/v1/admin/abonnement/news`, resource, repository, DTOs and fixtures for two sample news items.
- Add command `app:abonnement:execute-news` to execute due unprocessed news and email all users with `abonnement = true`, plus `scheduler:abonnement-execute-news` to register a cron entry; include Doctrine migration to add the user columns and `abonnement_news` table.

### Testing
- Ran PHP syntax checks with `php -l` on modified and new files (including `User` entity/DTO, profile controller, public list service, `Abonnement` files, `config/services.yaml`, migration) and they all reported no syntax errors.
- Attempted container validation with `php bin/console lint:container` which failed in this environment due to missing project dependencies and requires `composer install` to run. 
- All new PHP files were linted and the project changes were verified to be syntactically consistent in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9d0e9ca8832ba4abe037df12c881)