### PR TITLE
Add per-area Nelmio API docs and routes

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -393,7 +393,30 @@ when@dev: &dev
                 -   Bearer: []
                 -   ApiKey: []
         areas: # to filter documented areas
-            path_patterns:
-                - ^/api(?!/doc$) # Accepts routes under /api except /api/doc
+            default:
+                path_patterns:
+                    - ^/api(?!/doc(?:$|/|\.json$)) # Accepts routes under /api except /api/doc and module docs
+            users:
+                path_patterns:
+                    - ^/api/v1/(?:auth|profile|user(?:s|_group)?|private/stories)(?:/|$)
+            blog:
+                path_patterns:
+                    - ^/api/v1/private/blogs?(?:/|$)
+            crm:
+                path_patterns:
+                    - ^/api/v1/crm(?:/|$)
+            shop:
+                path_patterns:
+                    - ^/api/v1/shop(?:/|$)
+            school:
+                path_patterns:
+                    - ^/api/v1/school(?:/|$)
+            recruit:
+                path_patterns:
+                    - ^/api/v1/recruit(?:/|$)
+            calendar:
+                path_patterns:
+                    - ^/api/v1/calendar(?:/|$)
+
 
 when@test: *dev

--- a/config/routes/nelmio_api_doc.yaml
+++ b/config/routes/nelmio_api_doc.yaml
@@ -3,13 +3,83 @@ when@dev: &dev
     app.swagger:
         path: /api/doc.json
         methods: GET
-        defaults: { _controller: nelmio_api_doc.controller.swagger }
+        defaults: { _controller: nelmio_api_doc.controller.swagger, area: default }
+
+    app.swagger.users:
+        path: /api/doc/users.json
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger, area: users }
+
+    app.swagger.blog:
+        path: /api/doc/blog.json
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger, area: blog }
+
+    app.swagger.crm:
+        path: /api/doc/crm.json
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger, area: crm }
+
+    app.swagger.shop:
+        path: /api/doc/shop.json
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger, area: shop }
+
+    app.swagger.school:
+        path: /api/doc/school.json
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger, area: school }
+
+    app.swagger.recruit:
+        path: /api/doc/recruit.json
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger, area: recruit }
+
+    app.swagger.calendar:
+        path: /api/doc/calendar.json
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger, area: calendar }
 
     ## Requires the Asset component and the Twig bundle
     ## $ composer require twig asset
     app.swagger_ui:
         path: /api/doc
         methods: GET
-        defaults: { _controller: nelmio_api_doc.controller.swagger_ui }
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui, area: default }
+
+    app.swagger_ui.users:
+        path: /api/doc/users
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui, area: users }
+
+    app.swagger_ui.blog:
+        path: /api/doc/blog
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui, area: blog }
+
+    app.swagger_ui.crm:
+        path: /api/doc/crm
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui, area: crm }
+
+    app.swagger_ui.shop:
+        path: /api/doc/shop
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui, area: shop }
+
+    app.swagger_ui.school:
+        path: /api/doc/school
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui, area: school }
+
+    app.swagger_ui.recruit:
+        path: /api/doc/recruit
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui, area: recruit }
+
+    app.swagger_ui.calendar:
+        path: /api/doc/calendar
+        methods: GET
+        defaults: { _controller: nelmio_api_doc.controller.swagger_ui, area: calendar }
 
 when@test: *dev


### PR DESCRIPTION
### Motivation

- Provide segmented API documentation to expose separate Swagger/Swagger-UI endpoints per module/area instead of a single monolithic doc.
- Avoid including module docs under the main `/api/doc` endpoint and allow selective filtering of routes per area.

### Description

- Updated `config/packages/nelmio_api_doc.yaml` to replace the single `path_patterns` entry with a `default` area and explicit `users`, `blog`, `crm`, `shop`, `school`, `recruit`, and `calendar` areas each having their own `path_patterns` regexes. 
- Tightened the exclusion for the main docs path to `^/api(?!/doc(?:$|/|\.json$))` and adjusted the default area to exclude module docs.
- Added per-area routes in `config/routes/nelmio_api_doc.yaml` for both JSON docs and the Swagger UI, by registering `app.swagger.*` and `app.swagger_ui.*` routes and passing the `area` default to the `nelmio_api_doc` controllers.
- Left the original default docs routes in place but wired them to the `default` area so existing behavior remains while enabling per-module docs.

### Testing

- Ran configuration validation and route loading checks, and the Symfony routing configuration validated successfully.
- Executed the project's automated test suite (unit and integration tests) and all tests passed. 
- Verified that the new Swagger JSON endpoints (e.g. `/api/doc/users.json`) and Swagger UI pages (e.g. `/api/doc/users`) resolve and return the expected doc outputs during local checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8309c0a0832b804b6231104b8bd5)