### PR TITLE
feat(crm): add GitLab route aliases for CRM GitHub endpoints

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/CrmGithub/GetCrmGithubLatestSyncJobController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CrmGithub/GetCrmGithubLatestSyncJobController.php
@@ -28,6 +28,7 @@ final readonly class GetCrmGithubLatestSyncJobController
     }
 
     #[Route('/v1/crm/github/sync/jobs/latest', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/gitlab/sync/jobs/latest', methods: [Request::METHOD_GET])]
         #[OA\Get(
         summary: 'Get latest CRM GitHub sync job',
         responses: [

--- a/src/Crm/Transport/Controller/Api/V1/CrmGithub/GetCrmGithubSyncJobController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CrmGithub/GetCrmGithubSyncJobController.php
@@ -26,6 +26,7 @@ final readonly class GetCrmGithubSyncJobController
     }
 
     #[Route('/v1/crm/github/sync/jobs/{jobId}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/gitlab/sync/jobs/{jobId}', methods: [Request::METHOD_GET])]
         #[OA\Parameter(name: 'jobId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Get(
         summary: 'Get CRM GitHub sync job status',

--- a/src/Crm/Transport/Controller/Api/V1/CrmGithub/ListCrmGithubSyncJobsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CrmGithub/ListCrmGithubSyncJobsController.php
@@ -31,6 +31,7 @@ final readonly class ListCrmGithubSyncJobsController
     }
 
     #[Route('/v1/crm/github/sync/jobs', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/gitlab/sync/jobs', methods: [Request::METHOD_GET])]
         #[OA\Parameter(name: 'status', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100, default: 20))]
     #[OA\Get(

--- a/src/Crm/Transport/Controller/Api/V1/CrmGithub/PostCrmGithubBootstrapSyncController.php
+++ b/src/Crm/Transport/Controller/Api/V1/CrmGithub/PostCrmGithubBootstrapSyncController.php
@@ -39,6 +39,7 @@ final readonly class PostCrmGithubBootstrapSyncController
      * @throws ExceptionInterface
      */
     #[Route('/v1/crm/github/sync/bootstrap', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/gitlab/sync/bootstrap', methods: [Request::METHOD_POST])]
         #[OA\Post(
         description: 'Synchronise les repositories et issues GitHub vers CRM selon issueTarget.'
             . "\n\nRègles de mapping:"

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubIssueCommentController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubIssueCommentController.php
@@ -32,6 +32,7 @@ final readonly class AddProjectGithubIssueCommentController
     }
 
     #[Route('/v1/crm/projects/{project}/github/issues/{number}/comments', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/projects/{project}/gitlab/issues/{number}/comments', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
     #[OA\Post(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/AddProjectGithubRepositoryController.php
@@ -34,6 +34,7 @@ final readonly class AddProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/projects/{project}/github/repositories', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/projects/{project}/gitlab/repositories', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12')]
     #[OA\Post(
         description: 'Ajoute un repository GitHub existant au projet CRM courant à partir du fullName `owner/name`.',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubBranchController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubBranchController.php
@@ -32,6 +32,7 @@ final readonly class CreateProjectGithubBranchController
     }
 
     #[Route('/v1/crm/projects/{project}/github/branches/create', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/projects/{project}/gitlab/branches/create', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
         summary: 'Create Project GitHub Branch',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubIssueController.php
@@ -32,6 +32,7 @@ final readonly class CreateProjectGithubIssueController
     }
 
     #[Route('/v1/crm/projects/{project}/github/issues', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/projects/{project}/gitlab/issues', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
         summary: 'Create Project GitHub Issue',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubProjectBoardController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubProjectBoardController.php
@@ -32,6 +32,7 @@ final readonly class CreateProjectGithubProjectBoardController
     }
 
     #[Route('/v1/crm/projects/{project}/github/projects', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/projects/{project}/gitlab/projects', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
         summary: 'Create Project GitHub Project Board',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubPullRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubPullRequestController.php
@@ -32,6 +32,7 @@ final readonly class CreateProjectGithubPullRequestController
     }
 
     #[Route('/v1/crm/projects/{project}/github/pull-requests', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/projects/{project}/gitlab/pull-requests', methods: [Request::METHOD_POST])]
     public function __invoke(Project $project, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/CreateProjectGithubRepositoryController.php
@@ -32,6 +32,7 @@ final readonly class CreateProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/projects/{project}/github/repositories/create', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/projects/{project}/gitlab/repositories/create', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(
         summary: 'Create Project GitHub Repository',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/DeleteProjectGithubBranchController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/DeleteProjectGithubBranchController.php
@@ -32,6 +32,7 @@ final readonly class DeleteProjectGithubBranchController
     }
 
     #[Route('/v1/crm/projects/{project}/github/branches/delete', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/crm/projects/{project}/gitlab/branches/delete', methods: [Request::METHOD_DELETE])]
     #[OA\Delete(
         summary: 'Delete Project GitHub Branch',
         requestBody: new OA\RequestBody(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/DeleteProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/DeleteProjectGithubRepositoryController.php
@@ -37,6 +37,7 @@ final readonly class DeleteProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/projects/{project}/github/repositories/{repositoryId}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/crm/projects/{project}/gitlab/repositories/{repositoryId}', methods: [Request::METHOD_DELETE])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12')]
     #[OA\Parameter(name: 'repositoryId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: '03463358-2e8f-4f63-a893-69d5313b05d2')]
     #[OA\Parameter(name: 'deleteRemote', in: 'query', required: false, schema: new OA\Schema(type: 'boolean', default: false), example: true)]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubCommitController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubCommitController.php
@@ -21,6 +21,7 @@ final readonly class GetProjectGithubCommitController
     }
 
     #[Route('/v1/crm/projects/{project}/github/commits/{sha}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/commits/{sha}', methods: [Request::METHOD_GET])]
     public function __invoke(Project $project, string $sha, Request $request): JsonResponse
     {
         return new JsonResponse($this->crmGithubService->getCommit(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubDashboardController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubDashboardController.php
@@ -24,6 +24,7 @@ final readonly class GetProjectGithubDashboardController
     }
 
     #[Route('/v1/crm/projects/{project}/github/dashboard', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/dashboard', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Get(
         description: 'Exécute l action metier Get Project Github Dashboard dans le perimetre de l application CRM.',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubIssueController.php
@@ -28,6 +28,7 @@ final readonly class GetProjectGithubIssueController
     }
 
     #[Route('/v1/crm/projects/{project}/github/issues/{number}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/issues/{number}', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
     #[OA\Parameter(name: 'repo', in: 'query', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubPullRequestDetailController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubPullRequestDetailController.php
@@ -24,6 +24,7 @@ final readonly class GetProjectGithubPullRequestDetailController
     }
 
     #[Route('/v1/crm/projects/{project}/github/pull-requests/{number}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/pull-requests/{number}', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Get(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GetProjectGithubRepositoryController.php
@@ -28,6 +28,7 @@ final readonly class GetProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/projects/{project}/github/repositories/{repository}', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/repositories/{repository}', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'repository', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
     #[OA\Get(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/GithubWebhookController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/GithubWebhookController.php
@@ -24,6 +24,7 @@ final readonly class GithubWebhookController
     }
 
     #[Route('/v1/crm/github/webhook', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/gitlab/webhook', methods: [Request::METHOD_POST])]
     #[OA\Post(
         description: 'Use this endpoint as GitHub webhook URL. In /api/doc, click "Try it out", set required headers and paste the raw GitHub payload JSON.',
         summary: 'Handle Project GitHub Webhook',

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListGithubAccountRepositoriesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListGithubAccountRepositoriesController.php
@@ -25,6 +25,7 @@ final readonly class ListGithubAccountRepositoriesController
     }
 
     #[Route('/v1/crm/projects/{project}/github/account/repositories', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/account/repositories', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]
     #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100), example: 20)]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubActionsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubActionsController.php
@@ -21,6 +21,7 @@ final readonly class ListProjectGithubActionsController
     }
 
     #[Route('/v1/crm/projects/{project}/github/actions/workflows', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/actions/workflows', methods: [Request::METHOD_GET])]
     public function workflows(Project $project, Request $request): JsonResponse
     {
         return new JsonResponse($this->crmGithubService->listWorkflows(
@@ -32,6 +33,7 @@ final readonly class ListProjectGithubActionsController
     }
 
     #[Route('/v1/crm/projects/{project}/github/actions/runs', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/actions/runs', methods: [Request::METHOD_GET])]
     public function runs(Project $project, Request $request): JsonResponse
     {
         $workflowId = $request->query->get('workflowId');

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubBranchesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubBranchesController.php
@@ -24,6 +24,7 @@ final readonly class ListProjectGithubBranchesController
     }
 
     #[Route('/v1/crm/projects/{project}/github/branches', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/branches', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(ref: '#/components/parameters/page')]
     #[OA\Parameter(ref: '#/components/parameters/limit')]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCollaboratorsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCollaboratorsController.php
@@ -21,6 +21,7 @@ final readonly class ListProjectGithubCollaboratorsController
     }
 
     #[Route('/v1/crm/projects/{project}/github/collaborators', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/collaborators', methods: [Request::METHOD_GET])]
     public function __invoke(Project $project, Request $request): JsonResponse
     {
         return new JsonResponse($this->crmGithubService->listCollaborators(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCommitsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubCommitsController.php
@@ -21,6 +21,7 @@ final readonly class ListProjectGithubCommitsController
     }
 
     #[Route('/v1/crm/projects/{project}/github/commits', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/commits', methods: [Request::METHOD_GET])]
     public function __invoke(Project $project, Request $request): JsonResponse
     {
         return new JsonResponse($this->crmGithubService->listCommits(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubIssuesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubIssuesController.php
@@ -28,6 +28,7 @@ final readonly class ListProjectGithubIssuesController
     }
 
     #[Route('/v1/crm/projects/{project}/github/issues', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/issues', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'repo', in: 'query', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
     #[OA\Parameter(ref: '#/components/parameters/status')]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectItemsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectItemsController.php
@@ -28,6 +28,7 @@ final readonly class ListProjectGithubProjectItemsController
     }
 
     #[Route('/v1/crm/projects/{project}/github/projects/{projectId}/items', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/projects/{projectId}/items', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'projectId', in: 'path', required: true, schema: new OA\Schema(type: 'string'), example: 'PVT_kwDOBfke3c4A9v0F')]
     #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubProjectsController.php
@@ -28,6 +28,7 @@ final readonly class ListProjectGithubProjectsController
     }
 
     #[Route('/v1/crm/projects/{project}/github/projects', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/projects', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'repo', in: 'query', required: true, schema: new OA\Schema(type: 'string'), example: 'rami-aouinti/bro-world-api')]
     #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestCommitsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestCommitsController.php
@@ -21,6 +21,7 @@ final readonly class ListProjectGithubPullRequestCommitsController
     }
 
     #[Route('/v1/crm/projects/{project}/github/pull-requests/{number}/commits', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/pull-requests/{number}/commits', methods: [Request::METHOD_GET])]
     public function __invoke(Project $project, int $number, Request $request): JsonResponse
     {
         return new JsonResponse($this->crmGithubService->listPullRequestCommits(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubPullRequestsController.php
@@ -24,6 +24,7 @@ final readonly class ListProjectGithubPullRequestsController
     }
 
     #[Route('/v1/crm/projects/{project}/github/pull-requests', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/pull-requests', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1), example: 1)]
     #[OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 100), example: 20)]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubRepositoriesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ListProjectGithubRepositoriesController.php
@@ -24,6 +24,7 @@ final readonly class ListProjectGithubRepositoriesController
     }
 
     #[Route('/v1/crm/projects/{project}/github/repositories', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/projects/{project}/gitlab/repositories', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(ref: '#/components/parameters/page')]
     #[OA\Parameter(ref: '#/components/parameters/limit')]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/MoveProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/MoveProjectGithubIssueController.php
@@ -32,6 +32,7 @@ final readonly class MoveProjectGithubIssueController
     }
 
     #[Route('/v1/crm/projects/{project}/github/projects/{projectId}/items/{itemId}/move', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/projects/{project}/gitlab/projects/{projectId}/items/{itemId}/move', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'projectId', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'itemId', in: 'path', required: true, schema: new OA\Schema(type: 'string'))]

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubIssueController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubIssueController.php
@@ -32,6 +32,7 @@ final readonly class PatchProjectGithubIssueController
     }
 
     #[Route('/v1/crm/projects/{project}/github/issues/{number}/patch', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/crm/projects/{project}/gitlab/issues/{number}/patch', methods: [Request::METHOD_PATCH])]
     public function __invoke(Project $project, int $number, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubPullRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubPullRequestController.php
@@ -32,6 +32,7 @@ final readonly class PatchProjectGithubPullRequestController
     }
 
     #[Route('/v1/crm/projects/{project}/github/pull-requests/{number}', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/crm/projects/{project}/gitlab/pull-requests/{number}', methods: [Request::METHOD_PATCH])]
     public function __invoke(Project $project, int $number, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/PatchProjectGithubRepositoryController.php
@@ -32,6 +32,7 @@ final readonly class PatchProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/projects/{project}/github/repositories/patch', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/crm/projects/{project}/gitlab/repositories/patch', methods: [Request::METHOD_PATCH])]
     public function __invoke(Project $project, Request $request): JsonResponse
     {
         $payload = $this->crmRequestHandler->decodeJson($request);

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/ProjectGithubPullRequestActionController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/ProjectGithubPullRequestActionController.php
@@ -29,6 +29,7 @@ final readonly class ProjectGithubPullRequestActionController
      * @throws JsonException
      */
     #[Route('/v1/crm/projects/{project}/github/pull-requests/{number}/action', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/projects/{project}/gitlab/pull-requests/{number}/action', methods: [Request::METHOD_POST])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Post(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubIssueStateController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubIssueStateController.php
@@ -32,6 +32,7 @@ final readonly class UpdateProjectGithubIssueStateController
     }
 
     #[Route('/v1/crm/projects/{project}/github/issues/{number}', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/crm/projects/{project}/gitlab/issues/{number}', methods: [Request::METHOD_PATCH])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'))]
     #[OA\Parameter(name: 'number', in: 'path', required: true, schema: new OA\Schema(type: 'integer'), example: 42)]
     #[OA\Patch(

--- a/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubRepositoryController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Project/Github/UpdateProjectGithubRepositoryController.php
@@ -35,6 +35,7 @@ final readonly class UpdateProjectGithubRepositoryController
     }
 
     #[Route('/v1/crm/projects/{project}/github/repositories/{repositoryId}', methods: [Request::METHOD_PUT])]
+    #[Route('/v1/crm/projects/{project}/gitlab/repositories/{repositoryId}', methods: [Request::METHOD_PUT])]
     #[OA\Parameter(name: 'project', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: 'ebf77366-d60c-4ac4-b204-9f91a7f7ee12')]
     #[OA\Parameter(name: 'repositoryId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: '03463358-2e8f-4f63-a893-69d5313b05d2')]
     #[OA\Put(

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestGithubBranchController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestGithubBranchController.php
@@ -49,6 +49,7 @@ final readonly class CreateTaskRequestGithubBranchController
     }
 
     #[Route('/v1/crm/task-requests/{taskRequest}/github/branches', methods: [Request::METHOD_POST])]
+    #[Route('/v1/crm/task-requests/{taskRequest}/gitlab/branches', methods: [Request::METHOD_POST])]
     #[OA\Parameter(
         name: 'taskRequest',
         description: 'TaskRequest UUID. Future alias: body.taskRequestId on project/github equivalent endpoint.',

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/DeleteTaskRequestGithubBranchController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/DeleteTaskRequestGithubBranchController.php
@@ -41,6 +41,7 @@ final readonly class DeleteTaskRequestGithubBranchController
     }
 
     #[Route('/v1/crm/task-requests/{taskRequest}/github/branches/{branchId}', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/crm/task-requests/{taskRequest}/gitlab/branches/{branchId}', methods: [Request::METHOD_DELETE])]
         #[OA\Parameter(name: 'taskRequest', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: 'a8f2140e-322e-49e5-94dc-dd86126fef3a')]
     #[OA\Parameter(name: 'branchId', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: '5d6c6190-c986-4c78-a08b-90eb29de6316')]
     #[OA\Parameter(name: 'deleteRemote', in: 'query', required: false, schema: new OA\Schema(type: 'boolean', default: false), example: true)]

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestGithubBranchesController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListTaskRequestGithubBranchesController.php
@@ -31,6 +31,7 @@ final readonly class ListTaskRequestGithubBranchesController
     }
 
     #[Route('/v1/crm/task-requests/{taskRequest}/github/branches', methods: [Request::METHOD_GET])]
+    #[Route('/v1/crm/task-requests/{taskRequest}/gitlab/branches', methods: [Request::METHOD_GET])]
     #[OA\Parameter(name: 'taskRequest', in: 'path', required: true, schema: new OA\Schema(type: 'string', format: 'uuid'), example: 'a8f2140e-322e-49e5-94dc-dd86126fef3a')]
     #[OA\Get(
         summary: 'List Task Request GitHub Branches',


### PR DESCRIPTION
### Motivation
- Permettre l'accès aux mêmes contrôleurs CRM exposant aujourd'hui des endpoints GitHub via des chemins alternatifs en `/gitlab/...` pour supporter des usages GitLab sans modifier la logique métier existante.
- Éviter de dupliquer la logique backend en exposant simplement des aliases de route vers les handlers/services actuels.

### Description
- Ajout de routes alternatives en remplaçant les segments `/github/...` par `/gitlab/...` dans les contrôleurs CRM concernés (sync/webhook, project repositories/issues/branches/PRs/actions, task-request branch endpoints, etc.).
- Les handlers, services et la logique interne des contrôleurs n'ont pas été modifiés, seules des annotations `#[Route(...)]` supplémentaires ont été ajoutées pour chaque endpoint pertinent.
- Les annotations OpenAPI/`OA` sont préservées pour conserver la documentation existante et permettre l'exposition des mêmes schémas via les nouvelles routes.
- Changements appliqués à une trentaine/une quarantaine de fichiers de contrôleur dans `src/Crm/Transport/Controller/Api/V1`.

### Testing
- Exécution de vérifications de syntaxe PHP via `php -l` sur les fichiers modifiés, qui n'ont retourné aucune erreur.
- Tentative de validation des routes avec `php bin/console debug:router` impossible dans cet environnement à cause de dépendances manquantes, `composer install` est nécessaire pour valider l'intégration complète et la génération du routing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebaa9e01dc832b878a113afd1aeef6)