### PR TITLE
Add welcome and social-login notification emails for social authentication

### DIFF
--- a/src/User/Transport/Controller/Api/V1/Auth/SocialLoginController.php
+++ b/src/User/Transport/Controller/Api/V1/Auth/SocialLoginController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\User\Transport\Controller\Api\V1\Auth;
 
+use App\General\Domain\Service\Interfaces\MailerServiceInterface;
 use App\General\Domain\Utils\JSON;
 use App\Role\Application\Security\Interfaces\RolesServiceInterface;
 use App\User\Application\Security\SecurityUser;
@@ -14,6 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use JsonException;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use OpenApi\Attributes as OA;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,6 +26,7 @@ use Throwable;
 
 use function in_array;
 use function bin2hex;
+use function ucfirst;
 use function explode;
 use function random_bytes;
 use function sprintf;
@@ -41,8 +44,12 @@ class SocialLoginController
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly JWTTokenManagerInterface $jwtTokenManager,
+        private readonly MailerServiceInterface $mailerService,
+        private readonly \Twig\Environment $twig,
         private readonly UserRepositoryInterface $userRepository,
         private readonly RolesServiceInterface $rolesService,
+        #[Autowire('%env(resolve:APP_SENDER_EMAIL)%')]
+        private readonly string $appSenderEmail,
     ) {
     }
 
@@ -59,7 +66,7 @@ class SocialLoginController
                 required: ['email', 'provider', 'providerId'],
                 properties: [
                     new OA\Property(property: 'email', type: 'string', format: 'email', example: 'social.user@bro-world.com'),
-                    new OA\Property(property: 'provider', type: 'string', enum: ['github', 'instagram', 'facebook', 'google'], example: 'google'),
+                    new OA\Property(property: 'provider', type: 'string', enum: ['github', 'gitlab', 'instagram', 'facebook', 'google'], example: 'google'),
                     new OA\Property(property: 'providerId', type: 'string', example: 'google-oauth2|1134889988776655'),
                 ],
                 example: [
@@ -90,7 +97,7 @@ class SocialLoginController
         }
 
         if (!in_array($provider, self::ALLOWED_PROVIDERS, true)) {
-            throw new BadRequestHttpException('provider must be one of: github, instagram, facebook, google');
+            throw new BadRequestHttpException('provider must be one of: github, gitlab, instagram, facebook, google');
         }
 
         $social = $this->entityManager
@@ -105,7 +112,10 @@ class SocialLoginController
             ->getQuery()
             ->getOneOrNullResult();
 
+        $isFirstAuthenticationWithProvider = false;
+
         if (!($social instanceof Social)) {
+            $isFirstAuthenticationWithProvider = true;
             $user = $this->userRepository->loadUserByIdentifier($email, false);
 
             if (!($user instanceof User)) {
@@ -128,6 +138,31 @@ class SocialLoginController
 
             $this->entityManager->persist($social);
             $this->entityManager->flush();
+        }
+
+        if ($isFirstAuthenticationWithProvider) {
+            $body = $this->twig->render('Emails/welcome.html.twig', [
+                'email' => $email,
+            ]);
+
+            $this->mailerService->sendMail(
+                'Welcome to Bro World',
+                $this->appSenderEmail,
+                $email,
+                $body,
+            );
+        } else {
+            $body = $this->twig->render('Emails/social_login_notification.html.twig', [
+                'provider' => ucfirst($provider),
+                'email' => $email,
+            ]);
+
+            $this->mailerService->sendMail(
+                sprintf('Connexion via %s sur Bro World', ucfirst($provider)),
+                $this->appSenderEmail,
+                $email,
+                $body,
+            );
         }
 
         $securityUser = new SecurityUser(

--- a/templates/Emails/social_login_notification.html.twig
+++ b/templates/Emails/social_login_notification.html.twig
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Social login notification</title>
+</head>
+<body style="margin:0;padding:0;background-color:#f4f6f8;font-family:Arial,sans-serif;color:#1f2937;">
+<table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="background-color:#f4f6f8;padding:24px 0;">
+    <tr>
+        <td align="center">
+            <table role="presentation" width="600" cellspacing="0" cellpadding="0" style="max-width:600px;background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 6px 18px rgba(0,0,0,0.08);">
+                <tr>
+                    <td style="padding:24px 32px;background-color:#111827;color:#ffffff;">
+                        <h1 style="margin:0;font-size:24px;line-height:1.3;">Nouvelle connexion détectée</h1>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:32px;">
+                        <p style="margin:0 0 16px;font-size:16px;line-height:1.6;">
+                            Bonjour,
+                        </p>
+                        <p style="margin:0 0 16px;font-size:16px;line-height:1.6;">
+                            Vous venez de vous connecter à votre compte Bro World avec <strong>{{ provider }}</strong>.
+                        </p>
+                        <p style="margin:0 0 24px;font-size:16px;line-height:1.6;">
+                            Compte concerné : <strong>{{ email }}</strong>
+                        </p>
+                        <p style="margin:0;font-size:14px;line-height:1.6;color:#6b7280;">
+                            Si cette connexion ne vient pas de vous, merci de sécuriser votre compte immédiatement.
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="padding:16px 32px;background:#f9fafb;color:#6b7280;font-size:12px;line-height:1.5;">
+                        Cet email est envoyé automatiquement par Bro World.
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Ensure users receive a proper onboarding email when they sign in via a social provider for the first time and receive a connection notification on subsequent social sign-ins.
- Cover common social providers consistently and reflect supported providers in API validation.

### Description
- Inject `MailerServiceInterface` and `Twig` into `SocialLoginController` and use `APP_SENDER_EMAIL` for outgoing mails.
- Send the existing welcome email (`Emails/welcome.html.twig`) when a new `Social` link is created for a user (first social authentication), otherwise send a connection notification email using a new template `templates/Emails/social_login_notification.html.twig` that includes the provider and account email.
- Add `gitlab` to the OpenAPI enum and validation error message for the `provider` field in `SocialLoginController`.
- Files changed: `src/User/Transport/Controller/Api/V1/Auth/SocialLoginController.php` and added `templates/Emails/social_login_notification.html.twig`.

### Testing
- Ran a PHP syntax check with `php -l src/User/Transport/Controller/Api/V1/Auth/SocialLoginController.php` which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebb9288d94832b9d27ac0533baaa2e)