### PR TITLE
feat(blog): add post tags relation and tag-based filtering

### DIFF
--- a/migrations/Version20260424101000.php
+++ b/migrations/Version20260424101000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260424101000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add many-to-many relation between blog posts and blog tags.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE blog_post_tag (post_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", tag_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", PRIMARY KEY(post_id, tag_id), INDEX IDX_6C91CB0A4B89032C (post_id), INDEX IDX_6C91CB0ABAD26311 (tag_id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE blog_post_tag ADD CONSTRAINT FK_6C91CB0A4B89032C FOREIGN KEY (post_id) REFERENCES blog_post (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE blog_post_tag ADD CONSTRAINT FK_6C91CB0ABAD26311 FOREIGN KEY (tag_id) REFERENCES blog_tag (id) ON DELETE CASCADE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE blog_post_tag DROP FOREIGN KEY FK_6C91CB0A4B89032C');
+        $this->addSql('ALTER TABLE blog_post_tag DROP FOREIGN KEY FK_6C91CB0ABAD26311');
+        $this->addSql('DROP TABLE blog_post_tag');
+    }
+}

--- a/src/Blog/Application/Message/CreateBlogPostCommand.php
+++ b/src/Blog/Application/Message/CreateBlogPostCommand.php
@@ -10,6 +10,7 @@ final readonly class CreateBlogPostCommand implements MessageHighInterface
 {
     /**
      * @param list<string> $mediaUrls
+     * @param list<string> $tagIds
      */
     public function __construct(
         public string $operationId,
@@ -20,6 +21,7 @@ final readonly class CreateBlogPostCommand implements MessageHighInterface
         public ?string $content,
         public ?string $filePath,
         public array $mediaUrls,
+        public array $tagIds,
         public ?string $sharedUrl,
         public ?string $parentPostId,
         public bool $isPinned

--- a/src/Blog/Application/Message/PatchBlogPostCommand.php
+++ b/src/Blog/Application/Message/PatchBlogPostCommand.php
@@ -10,6 +10,7 @@ final readonly class PatchBlogPostCommand implements MessageHighInterface
 {
     /**
      * @param list<string>|null $mediaUrls
+     * @param list<string>|null $tagIds
      */
     public function __construct(
         public string $operationId,
@@ -19,6 +20,7 @@ final readonly class PatchBlogPostCommand implements MessageHighInterface
         public ?string $content,
         public ?string $filePath,
         public ?array $mediaUrls,
+        public ?array $tagIds,
         public ?string $sharedUrl,
         public ?bool $isPinned
     ) {

--- a/src/Blog/Application/MessageHandler/CreateBlogPostCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/CreateBlogPostCommandHandler.php
@@ -8,8 +8,10 @@ use App\Blog\Application\Message\CreateBlogPostCommand;
 use App\Blog\Application\Service\BlogNotificationService;
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Entity\BlogPost;
+use App\Blog\Domain\Entity\BlogTag;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
 use App\Blog\Infrastructure\Repository\BlogRepository;
+use App\Blog\Infrastructure\Repository\BlogTagRepository;
 use App\General\Application\Service\CacheInvalidationService;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
@@ -27,6 +29,7 @@ final readonly class CreateBlogPostCommandHandler
     public function __construct(
         private BlogPostRepository $postRepository,
         private BlogRepository $blogRepository,
+        private BlogTagRepository $blogTagRepository,
         private UserRepository $userRepository,
         private BlogNotificationService $blogNotificationService,
         private CacheInvalidationService $cacheInvalidationService,
@@ -71,6 +74,7 @@ final readonly class CreateBlogPostCommandHandler
         }
 
         $post = new BlogPost();
+        $tags = $this->resolveTags($blog, $command->tagIds);
 
         $this->postRepository->save($post
             ->setBlog($blog)
@@ -80,6 +84,7 @@ final readonly class CreateBlogPostCommandHandler
             ->setContent($command->content)
             ->setFilePath($command->filePath)
             ->setMediaUrls($command->mediaUrls)
+            ->setTags($tags)
             ->setSharedUrl($command->sharedUrl)
             ->setParentPost($parentPost)
             ->setIsPinned($command->isPinned));
@@ -92,5 +97,31 @@ final readonly class CreateBlogPostCommandHandler
         $this->cacheInvalidationService->invalidateBlogCaches($blog->getApplication()?->getSlug(), $affectedUserIds);
 
         return $post->getId();
+    }
+
+    /**
+     * @param list<string> $tagIds
+     *
+     * @return list<BlogTag>
+     */
+    private function resolveTags(Blog $blog, array $tagIds): array
+    {
+        if ($tagIds === []) {
+            return [];
+        }
+
+        $tags = $this->blogTagRepository->findBy(['id' => $tagIds]);
+
+        if (count($tags) !== count($tagIds)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'One or more tags are invalid.');
+        }
+
+        foreach ($tags as $tag) {
+            if (!$tag instanceof BlogTag || $tag->getBlog()->getId() !== $blog->getId()) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Tags must belong to the same blog.');
+            }
+        }
+
+        return array_values(array_filter($tags, static fn ($tag): bool => $tag instanceof BlogTag));
     }
 }

--- a/src/Blog/Application/MessageHandler/PatchBlogPostCommandHandler.php
+++ b/src/Blog/Application/MessageHandler/PatchBlogPostCommandHandler.php
@@ -7,7 +7,9 @@ namespace App\Blog\Application\MessageHandler;
 use App\Blog\Application\Message\PatchBlogPostCommand;
 use App\Blog\Application\Service\BlogNotificationService;
 use App\Blog\Domain\Entity\BlogPost;
+use App\Blog\Domain\Entity\BlogTag;
 use App\Blog\Infrastructure\Repository\BlogPostRepository;
+use App\Blog\Infrastructure\Repository\BlogTagRepository;
 use App\General\Application\Service\CacheInvalidationService;
 use Doctrine\ORM\Exception\ORMException;
 use Doctrine\ORM\OptimisticLockException;
@@ -20,6 +22,7 @@ final readonly class PatchBlogPostCommandHandler
 {
     public function __construct(
         private BlogPostRepository $postRepository,
+        private BlogTagRepository $blogTagRepository,
         private BlogNotificationService $blogNotificationService,
         private CacheInvalidationService $cacheInvalidationService
     ) {
@@ -58,6 +61,10 @@ final readonly class PatchBlogPostCommandHandler
             $post->setMediaUrls($command->mediaUrls);
         }
 
+        if ($command->tagIds !== null) {
+            $post->setTags($this->resolveTags($post, $command->tagIds));
+        }
+
         if ($command->isPinned !== null) {
             $post->setIsPinned($command->isPinned);
         }
@@ -68,5 +75,31 @@ final readonly class PatchBlogPostCommandHandler
         ]);
         $affectedUserIds = array_values(array_filter(array_unique([$command->actorUserId, $post->getAuthor()->getId()]), static fn (?string $userId): bool => $userId !== null && $userId !== ''));
         $this->cacheInvalidationService->invalidateBlogCaches($post->getBlog()->getApplication()?->getSlug(), $affectedUserIds);
+    }
+
+    /**
+     * @param list<string> $tagIds
+     *
+     * @return list<BlogTag>
+     */
+    private function resolveTags(BlogPost $post, array $tagIds): array
+    {
+        if ($tagIds === []) {
+            return [];
+        }
+
+        $tags = $this->blogTagRepository->findBy(['id' => $tagIds]);
+
+        if (count($tags) !== count($tagIds)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'One or more tags are invalid.');
+        }
+
+        foreach ($tags as $tag) {
+            if (!$tag instanceof BlogTag || $tag->getBlog()->getId() !== $post->getBlog()->getId()) {
+                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Tags must belong to the same blog.');
+            }
+        }
+
+        return array_values(array_filter($tags, static fn ($tag): bool => $tag instanceof BlogTag));
     }
 }

--- a/src/Blog/Application/Service/BlogMutationRequestService.php
+++ b/src/Blog/Application/Service/BlogMutationRequestService.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 use function array_filter;
 use function array_map;
+use function array_values;
 use function is_string;
 use function sprintf;
 use function trim;
@@ -127,6 +128,26 @@ final readonly class BlogMutationRequestService
             'content' => $content !== '' ? $content : null,
             'sharedUrl' => $sharedUrl !== '' ? $sharedUrl : null,
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function normalizeTagIds(mixed $rawTagIds): array
+    {
+        if (!is_array($rawTagIds)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(static function ($tagId): ?string {
+            if (!is_string($tagId)) {
+                return null;
+            }
+
+            $normalized = trim($tagId);
+
+            return $normalized !== '' ? $normalized : null;
+        }, $rawTagIds)));
     }
 
     /**

--- a/src/Blog/Application/Service/BlogReadService.php
+++ b/src/Blog/Application/Service/BlogReadService.php
@@ -36,14 +36,15 @@ final readonly class BlogReadService
     /**
      * @throws InvalidArgumentException
      */
-    public function getGeneralBlogWithTree(?User $currentUser = null, int $page = 1, int $limit = 20): array
+    public function getGeneralBlogWithTree(?User $currentUser = null, int $page = 1, int $limit = 20, ?string $tag = null): array
     {
         $page = max(1, $page);
         $limit = max(1, min(100, $limit));
 
-        $cacheKey = $this->buildBlogCacheKey(sprintf('general?page=%d&limit=%d', $page, $limit), $currentUser);
+        $tagScope = $tag !== null ? sprintf('&tag=%s', $tag) : '';
+        $cacheKey = $this->buildBlogCacheKey(sprintf('general?page=%d&limit=%d%s', $page, $limit, $tagScope), $currentUser);
 
-        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($currentUser, $page, $limit): array {
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($currentUser, $page, $limit, $tag): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->tagPublicBlog());
@@ -58,18 +59,21 @@ final readonly class BlogReadService
                 return [];
             }
 
-            return $this->normalizeBlog($blog, $currentUser, $page, $limit);
+            return $this->normalizeBlog($blog, $currentUser, $page, $limit, $tag);
         });
     }
 
     /**
      * @throws InvalidArgumentException
      */
-    public function getByApplicationSlug(string $applicationSlug, ?User $currentUser = null): array
+    public function getByApplicationSlug(string $applicationSlug, ?User $currentUser = null, int $page = 1, int $limit = 20, ?string $tag = null): array
     {
-        $cacheKey = $this->buildBlogCacheKey('app/' . $applicationSlug, $currentUser);
+        $page = max(1, $page);
+        $limit = max(1, min(100, $limit));
+        $tagScope = $tag !== null ? sprintf('&tag=%s', $tag) : '';
+        $cacheKey = $this->buildBlogCacheKey(sprintf('app/%s?page=%d&limit=%d%s', $applicationSlug, $page, $limit, $tagScope), $currentUser);
 
-        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $currentUser): array {
+        return $this->cache->get($cacheKey, function (ItemInterface $item) use ($applicationSlug, $currentUser, $page, $limit, $tag): array {
             $item->expiresAfter(120);
             if (method_exists($item, 'tag') && $this->cache instanceof TagAwareCacheInterface) {
                 $item->tag($this->cacheKeyConventionService->tagPublicBlog());
@@ -84,7 +88,7 @@ final readonly class BlogReadService
                 return [];
             }
 
-            return $this->normalizeBlog($blog, $currentUser);
+            return $this->normalizeBlog($blog, $currentUser, $page, $limit, $tag);
         });
     }
 
@@ -132,10 +136,10 @@ final readonly class BlogReadService
         ];
     }
 
-    private function normalizeBlog(Blog $blog, ?User $currentUser, int $page = 1, int $limit = 20): array
+    private function normalizeBlog(Blog $blog, ?User $currentUser, int $page = 1, int $limit = 20, ?string $tag = null): array
     {
-        $rootPosts = $this->blogPostRepository->findRootPostsByBlogPaginated($blog, $page, $limit);
-        $totalItems = $this->blogPostRepository->countRootPostsByBlog($blog);
+        $rootPosts = $this->blogPostRepository->findRootPostsByBlogPaginated($blog, $page, $limit, $tag);
+        $totalItems = $this->blogPostRepository->countRootPostsByBlog($blog, $tag);
         $childrenSummaryByParent = $this->blogPostRepository->findChildrenSharesSummaryByParentIds(
             array_map(static fn (BlogPost $post): string => $post->getId(), $rootPosts),
         );
@@ -150,6 +154,9 @@ final readonly class BlogReadService
             'commentStatus' => $blog->getCommentStatus()->value,
             'visibility' => $blog->getVisibility()->value,
             'applicationSlug' => $blog->getApplication()?->getSlug(),
+            'filter' => [
+                'tag' => $tag,
+            ],
             'posts' => array_map(
                 fn (BlogPost $post): array => $this->normalizePost($post, $currentUser, $childrenSummaryByParent),
                 $rootPosts,
@@ -186,6 +193,10 @@ final readonly class BlogReadService
             'isPinned' => $post->isPinned(),
             'filePath' => $post->getFilePath(),
             'mediaUrls' => $post->getMediaUrls(),
+            'tags' => array_map(static fn ($tag): array => [
+                'id' => $tag->getId(),
+                'label' => $tag->getLabel(),
+            ], $post->getTags()->toArray()),
             'parent' => $includeParent && $post->getParentPost() instanceof BlogPost
                 ? $this->normalizePost($post->getParentPost(), $currentUser, $childrenSummaryByParent, false)
                 : null,

--- a/src/Blog/Domain/Entity/BlogPost.php
+++ b/src/Blog/Domain/Entity/BlogPost.php
@@ -84,6 +84,13 @@ class BlogPost implements EntityInterface
     private Collection $reactions;
 
     /**
+     * @var Collection<int, BlogTag>
+     */
+    #[ORM\ManyToMany(targetEntity: BlogTag::class, inversedBy: 'posts')]
+    #[ORM\JoinTable(name: 'blog_post_tag')]
+    private Collection $tags;
+
+    /**
      * @throws Throwable
      */
     public function __construct()
@@ -92,6 +99,7 @@ class BlogPost implements EntityInterface
         $this->comments = new ArrayCollection();
         $this->reactions = new ArrayCollection();
         $this->childrenPosts = new ArrayCollection();
+        $this->tags = new ArrayCollection();
     }
     #[Override] public function getId(): string
     {
@@ -224,5 +232,36 @@ class BlogPost implements EntityInterface
     public function getReactions(): Collection
     {
         return $this->reactions;
+    }
+
+    /**
+     * @return Collection<int, BlogTag>
+     */
+    public function getTags(): Collection
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @param list<BlogTag> $tags
+     */
+    public function setTags(array $tags): self
+    {
+        $this->tags->clear();
+
+        foreach ($tags as $tag) {
+            $this->addTag($tag);
+        }
+
+        return $this;
+    }
+
+    public function addTag(BlogTag $tag): self
+    {
+        if (!$this->tags->contains($tag)) {
+            $this->tags->add($tag);
+        }
+
+        return $this;
     }
 }

--- a/src/Blog/Domain/Entity/BlogTag.php
+++ b/src/Blog/Domain/Entity/BlogTag.php
@@ -7,6 +7,8 @@ namespace App\Blog\Domain\Entity;
 use App\General\Domain\Entity\Interfaces\EntityInterface;
 use App\General\Domain\Entity\Traits\Timestampable;
 use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Override;
 use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
@@ -30,9 +32,16 @@ class BlogTag implements EntityInterface
     #[ORM\Column(name: 'label', type: 'string', length: 100)]
     private string $label = '';
 
+    /**
+     * @var Collection<int, BlogPost>
+     */
+    #[ORM\ManyToMany(targetEntity: BlogPost::class, mappedBy: 'tags')]
+    private Collection $posts;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
+        $this->posts = new ArrayCollection();
     }
     #[Override] public function getId(): string
     {
@@ -57,5 +66,13 @@ class BlogTag implements EntityInterface
         $this->label = $label;
 
         return $this;
+    }
+
+    /**
+     * @return Collection<int, BlogPost>
+     */
+    public function getPosts(): Collection
+    {
+        return $this->posts;
     }
 }

--- a/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
+++ b/src/Blog/Infrastructure/DataFixtures/ORM/LoadBlogData.php
@@ -116,6 +116,16 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
                     ]);
                 }
 
+                $postTags = [];
+                for ($tagIndex = 1; $tagIndex <= 2; $tagIndex++) {
+                    $tag = (new BlogTag())
+                        ->setBlog($blog)
+                        ->setLabel(sprintf('tag-%d-%d-%d', $blogIndex + 1, $postIndex, $tagIndex));
+                    $manager->persist($tag);
+                    $postTags[] = $tag;
+                }
+
+                $post->setTags($postTags);
                 $manager->persist($post);
 
                 if ($postIndex <= 2) {
@@ -131,12 +141,6 @@ final class LoadBlogData extends Fixture implements OrderedFixtureInterface
                             sprintf('https://cdn.example.com/blog/%d/%d-child-image.webp', $blogIndex + 1, $postIndex),
                         ]);
                     $manager->persist($sharedChild);
-                }
-
-                for ($tagIndex = 1; $tagIndex <= 2; $tagIndex++) {
-                    $manager->persist((new BlogTag())
-                        ->setBlog($blog)
-                        ->setLabel(sprintf('tag-%d-%d-%d', $blogIndex + 1, $postIndex, $tagIndex)));
                 }
 
                 $parent = (new BlogComment())

--- a/src/Blog/Infrastructure/Repository/BlogPostRepository.php
+++ b/src/Blog/Infrastructure/Repository/BlogPostRepository.php
@@ -33,20 +33,27 @@ class BlogPostRepository extends BaseRepository
     /**
      * @return list<BlogPost>
      */
-    public function findRootPostsByBlogPaginated(Blog $blog, int $page, int $limit): array
+    public function findRootPostsByBlogPaginated(Blog $blog, int $page, int $limit, ?string $tag = null): array
     {
         $offset = ($page - 1) * $limit;
 
-        $idRows = $this->createQueryBuilder('post')
+        $qb = $this->createQueryBuilder('post')
             ->select('post.id AS id')
             ->where('post.blog = :blog')
             ->andWhere('post.parentPost IS NULL')
             ->orderBy('post.createdAt', 'DESC')
             ->setFirstResult($offset)
             ->setMaxResults($limit)
-            ->setParameter('blog', $blog->getId(), UuidBinaryOrderedTimeType::NAME)
-            ->getQuery()
-            ->getArrayResult();
+            ->setParameter('blog', $blog->getId(), UuidBinaryOrderedTimeType::NAME);
+
+        if ($tag !== null) {
+            $qb
+                ->innerJoin('post.tags', 'tag')
+                ->andWhere('tag.label = :tagLabel')
+                ->setParameter('tagLabel', $tag);
+        }
+
+        $idRows = $qb->getQuery()->getArrayResult();
 
         /** @var list<string> $ids */
         $ids = array_values(
@@ -59,15 +66,22 @@ class BlogPostRepository extends BaseRepository
         return $this->findPostsWithDisplayRelationsByIds($ids);
     }
 
-    public function countRootPostsByBlog(Blog $blog): int
+    public function countRootPostsByBlog(Blog $blog, ?string $tag = null): int
     {
-        return (int)$this->createQueryBuilder('post')
+        $qb = $this->createQueryBuilder('post')
             ->select('COUNT(post.id)')
             ->where('post.blog = :blog')
             ->andWhere('post.parentPost IS NULL')
-            ->setParameter('blog', $blog->getId(), UuidBinaryOrderedTimeType::NAME)
-            ->getQuery()
-            ->getSingleScalarResult();
+            ->setParameter('blog', $blog->getId(), UuidBinaryOrderedTimeType::NAME);
+
+        if ($tag !== null) {
+            $qb
+                ->innerJoin('post.tags', 'tag')
+                ->andWhere('tag.label = :tagLabel')
+                ->setParameter('tagLabel', $tag);
+        }
+
+        return (int)$qb->getQuery()->getSingleScalarResult();
     }
 
     /**
@@ -114,6 +128,7 @@ class BlogPostRepository extends BaseRepository
         $posts = $this->createQueryBuilder('post')
             ->leftJoin('post.author', 'author')->addSelect('author')
             ->leftJoin('post.parentPost', 'parent')->addSelect('parent')
+            ->leftJoin('post.tags', 'tags')->addSelect('tags')
             ->where('post.slug = :slug')
             ->setParameter('slug', $slug)
             ->setMaxResults(1)
@@ -204,7 +219,8 @@ class BlogPostRepository extends BaseRepository
         $qb = $this->createQueryBuilder('post')
             ->distinct()
             ->leftJoin('post.author', 'author')->addSelect('author')
-            ->leftJoin('post.parentPost', 'parent')->addSelect('parent');
+            ->leftJoin('post.parentPost', 'parent')->addSelect('parent')
+            ->leftJoin('post.tags', 'tags')->addSelect('tags');
 
         $orX = $qb->expr()->orX();
 

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/CreateBlogPostController.php
@@ -48,6 +48,7 @@ final readonly class CreateBlogPostController
         $payload['filePath'] = $this->requestService->resolveUploadedFileUrl($request, (string)($payload['filePath'] ?? ''));
         $contentData = $this->requestService->normalizePostContent($payload);
         $slug = $this->slugify((string)($payload['slug'] ?? $payload['title'] ?? 'post'));
+        $tagIds = $this->requestService->normalizeTagIds($payload['tagIds'] ?? null);
 
         $entityId = $this->handler->__invoke(new CreateBlogPostCommand(
             (string)uniqid('op_', true),
@@ -58,6 +59,7 @@ final readonly class CreateBlogPostController
             $contentData['content'],
             $payload['filePath'] ?: null,
             [],
+            $tagIds,
             $contentData['sharedUrl'],
             isset($payload['parentPostId']) ? (string)$payload['parentPostId'] : null,
             (bool)($payload['isPinned'] ?? false)

--- a/src/Blog/Transport/Controller/Api/V1/Mutation/PatchBlogPostController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Mutation/PatchBlogPostController.php
@@ -40,6 +40,7 @@ final readonly class PatchBlogPostController
         $payload['filePath'] = $this->requestService->resolveUploadedFileUrl($request, (string)($payload['filePath'] ?? ''));
         $contentData = $this->requestService->normalizePostContent($payload);
         $mediaUrls = $this->requestService->resolveUploadedFileUrls($request);
+        $tagIds = $this->requestService->normalizeTagIds($payload['tagIds'] ?? null);
 
         $this->messageBus->dispatch(new PatchBlogPostCommand(
             (string)uniqid('op_', true),
@@ -49,6 +50,7 @@ final readonly class PatchBlogPostController
             $contentData['content'],
             $payload['filePath'] ?: null,
             $mediaUrls !== [] ? $mediaUrls : null,
+            array_key_exists('tagIds', $payload) ? $tagIds : null,
             $contentData['sharedUrl'],
             isset($payload['isPinned']) ? (bool)$payload['isPinned'] : null
         ));

--- a/src/Blog/Transport/Controller/Api/V1/Read/GetApplicationBlogController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Read/GetApplicationBlogController.php
@@ -26,11 +26,27 @@ final readonly class GetApplicationBlogController
     }
 
     #[Route('/v1/blog/feed', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        parameters: [
+            new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 1, minimum: 1)),
+            new OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 20, maximum: 100, minimum: 1)),
+            new OA\Parameter(name: 'tag', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
+        ]
+    )]
     public function __invoke(Request $request): JsonResponse
     {
         $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
         $user = $this->security->getUser();
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $tag = trim((string)$request->query->get('tag', ''));
 
-        return new JsonResponse($this->blogReadService->getByApplicationSlug($applicationSlug, $user instanceof User ? $user : null));
+        return new JsonResponse($this->blogReadService->getByApplicationSlug(
+            $applicationSlug,
+            $user instanceof User ? $user : null,
+            $page,
+            $limit,
+            $tag !== '' ? $tag : null,
+        ));
     }
 }

--- a/src/Blog/Transport/Controller/Api/V1/Read/GetGeneralBlogController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Read/GetGeneralBlogController.php
@@ -32,6 +32,7 @@ final readonly class GetGeneralBlogController
         parameters: [
             new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 1, minimum: 1)),
             new OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 20, maximum: 100, minimum: 1)),
+            new OA\Parameter(name: 'tag', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
         ]
     )]
     #[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
@@ -39,7 +40,8 @@ final readonly class GetGeneralBlogController
     {
         $page = max(1, $request->query->getInt('page', 1));
         $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $tag = trim((string)$request->query->get('tag', ''));
 
-        return new JsonResponse($this->blogReadService->getGeneralBlogWithTree($loggedInUser, $page, $limit));
+        return new JsonResponse($this->blogReadService->getGeneralBlogWithTree($loggedInUser, $page, $limit, $tag !== '' ? $tag : null));
     }
 }

--- a/src/Blog/Transport/Controller/Api/V1/Read/GetPublicGeneralBlogController.php
+++ b/src/Blog/Transport/Controller/Api/V1/Read/GetPublicGeneralBlogController.php
@@ -30,13 +30,15 @@ final readonly class GetPublicGeneralBlogController
         parameters: [
             new OA\Parameter(name: 'page', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 1, minimum: 1)),
             new OA\Parameter(name: 'limit', in: 'query', required: false, schema: new OA\Schema(type: 'integer', default: 20, minimum: 1, maximum: 100)),
+            new OA\Parameter(name: 'tag', in: 'query', required: false, schema: new OA\Schema(type: 'string')),
         ]
     )]
     public function __invoke(Request $request): JsonResponse
     {
         $page = max(1, $request->query->getInt('page', 1));
         $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $tag = trim((string)$request->query->get('tag', ''));
 
-        return new JsonResponse($this->blogReadService->getGeneralBlogWithTree(null, $page, $limit));
+        return new JsonResponse($this->blogReadService->getGeneralBlogWithTree(null, $page, $limit, $tag !== '' ? $tag : null));
     }
 }


### PR DESCRIPTION
### Motivation
- Enable associating tags with blog posts (0..n) and allow clients to filter feeds by tag so users can view posts for a given tag.

### Description
- Add a many-to-many relation between `BlogPost` and `BlogTag` with join table `blog_post_tag` and entity helpers (`getTags`, `setTags`, `addTag`) and update fixtures to attach tags to posts.
- Expose `tags: [{id,label}]` in normalized post responses and include a `filter.tag` field in blog list payloads.
- Implement tag filtering on general (public/private) and application feed endpoints via optional `?tag=<label>` query parameter and wire filtering into `BlogPostRepository` queries.
- Extend create/patch post flows to accept `tagIds`, normalize/validate them, ensure tags belong to the same blog, and assign/clear tags accordingly; add migration file `migrations/Version20260424101000.php`.

### Testing
- Ran `php -l` on all modified PHP files and there were no syntax errors (success).
- Verified repository and working tree with `git status --short` and `git diff --name-only` to confirm expected files changed (success).
- Lightweight validation performed: migration file added and fixtures updated to reflect relation (observed in diff, no runtime tests executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebbed3b5e4832bb853395b79746dbd)