### PR TITLE
Fix AI post tag creation to always set blog

### DIFF
--- a/src/Blog/Transport/Command/GenerateAiPostsCommand.php
+++ b/src/Blog/Transport/Command/GenerateAiPostsCommand.php
@@ -122,7 +122,7 @@ final class GenerateAiPostsCommand extends Command
             $tags = $this->extractTags($content);
 
             foreach ($tags as $tagName) {
-                $tag = $this->resolveTag($tagName);
+                $tag = $this->resolveTag($blog, $tagName);
                 $post->addTag($tag);
             }
 
@@ -235,15 +235,16 @@ Do NOT use quotes.";
     /**
      * 🔥 Get or create tag
      */
-    private function resolveTag(string $name): BlogTag
+    private function resolveTag(Blog $blog, string $name): BlogTag
     {
         $name = strtolower(trim($name));
 
-        $tag = $this->tagRepository->findOneBy(['label' => $name]);
+        $tag = $this->tagRepository->findOneBy(['blog' => $blog, 'label' => $name]);
 
         if (!$tag) {
             $tag = new BlogTag();
-            $tag->setLabel($name);
+            $tag->setBlog($blog)
+                ->setLabel($name);
 
             $this->em->persist($tag);
         }

--- a/src/Blog/Transport/Command/GenerateAiPostsSampleFiveCommand.php
+++ b/src/Blog/Transport/Command/GenerateAiPostsSampleFiveCommand.php
@@ -121,7 +121,7 @@ final class GenerateAiPostsSampleFiveCommand extends Command
             $tags = $this->extractTags($content);
 
             foreach ($tags as $tagName) {
-                $tag = $this->resolveTag($tagName);
+                $tag = $this->resolveTag($blog, $tagName);
                 $post->addTag($tag);
             }
 
@@ -234,15 +234,16 @@ Do NOT use quotes.";
     /**
      * 🔥 Get or create tag
      */
-    private function resolveTag(string $name): BlogTag
+    private function resolveTag(Blog $blog, string $name): BlogTag
     {
         $name = strtolower(trim($name));
 
-        $tag = $this->tagRepository->findOneBy(['label' => $name]);
+        $tag = $this->tagRepository->findOneBy(['blog' => $blog, 'label' => $name]);
 
         if (!$tag) {
             $tag = new BlogTag();
-            $tag->setLabel($name);
+            $tag->setBlog($blog)
+                ->setLabel($name);
 
             $this->em->persist($tag);
         }

--- a/src/Blog/Transport/Command/GenerateAiPostsSampleFourCommand.php
+++ b/src/Blog/Transport/Command/GenerateAiPostsSampleFourCommand.php
@@ -119,7 +119,7 @@ final class GenerateAiPostsSampleFourCommand extends Command
             $tags = $this->extractTags($content);
 
             foreach ($tags as $tagName) {
-                $tag = $this->resolveTag($tagName);
+                $tag = $this->resolveTag($blog, $tagName);
                 $post->addTag($tag);
             }
 
@@ -232,15 +232,16 @@ Do NOT use quotes.";
     /**
      * 🔥 Get or create tag
      */
-    private function resolveTag(string $name): BlogTag
+    private function resolveTag(Blog $blog, string $name): BlogTag
     {
         $name = strtolower(trim($name));
 
-        $tag = $this->tagRepository->findOneBy(['label' => $name]);
+        $tag = $this->tagRepository->findOneBy(['blog' => $blog, 'label' => $name]);
 
         if (!$tag) {
             $tag = new BlogTag();
-            $tag->setLabel($name);
+            $tag->setBlog($blog)
+                ->setLabel($name);
 
             $this->em->persist($tag);
         }

--- a/src/Blog/Transport/Command/GenerateAiPostsSampleOneCommand.php
+++ b/src/Blog/Transport/Command/GenerateAiPostsSampleOneCommand.php
@@ -118,7 +118,7 @@ final class GenerateAiPostsSampleOneCommand extends Command
             $tags = $this->extractTags($content);
 
             foreach ($tags as $tagName) {
-                $tag = $this->resolveTag($tagName);
+                $tag = $this->resolveTag($blog, $tagName);
                 $post->addTag($tag);
             }
 
@@ -231,15 +231,16 @@ Do NOT use quotes.";
     /**
      * 🔥 Get or create tag
      */
-    private function resolveTag(string $name): BlogTag
+    private function resolveTag(Blog $blog, string $name): BlogTag
     {
         $name = strtolower(trim($name));
 
-        $tag = $this->tagRepository->findOneBy(['label' => $name]);
+        $tag = $this->tagRepository->findOneBy(['blog' => $blog, 'label' => $name]);
 
         if (!$tag) {
             $tag = new BlogTag();
-            $tag->setLabel($name);
+            $tag->setBlog($blog)
+                ->setLabel($name);
 
             $this->em->persist($tag);
         }

--- a/src/Blog/Transport/Command/GenerateAiPostsSampleThreeCommand.php
+++ b/src/Blog/Transport/Command/GenerateAiPostsSampleThreeCommand.php
@@ -126,7 +126,7 @@ final class GenerateAiPostsSampleThreeCommand extends Command
             $tags = $this->extractTags($content);
 
             foreach ($tags as $tagName) {
-                $tag = $this->resolveTag($tagName);
+                $tag = $this->resolveTag($blog, $tagName);
                 $post->addTag($tag);
             }
 
@@ -239,15 +239,16 @@ Do NOT use quotes.";
     /**
      * 🔥 Get or create tag
      */
-    private function resolveTag(string $name): BlogTag
+    private function resolveTag(Blog $blog, string $name): BlogTag
     {
         $name = strtolower(trim($name));
 
-        $tag = $this->tagRepository->findOneBy(['label' => $name]);
+        $tag = $this->tagRepository->findOneBy(['blog' => $blog, 'label' => $name]);
 
         if (!$tag) {
             $tag = new BlogTag();
-            $tag->setLabel($name);
+            $tag->setBlog($blog)
+                ->setLabel($name);
 
             $this->em->persist($tag);
         }

--- a/src/Blog/Transport/Command/GenerateAiPostsSampleTwoCommand.php
+++ b/src/Blog/Transport/Command/GenerateAiPostsSampleTwoCommand.php
@@ -118,7 +118,7 @@ final class GenerateAiPostsSampleTwoCommand extends Command
             $tags = $this->extractTags($content);
 
             foreach ($tags as $tagName) {
-                $tag = $this->resolveTag($tagName);
+                $tag = $this->resolveTag($blog, $tagName);
                 $post->addTag($tag);
             }
 
@@ -231,15 +231,16 @@ Do NOT use quotes.";
     /**
      * 🔥 Get or create tag
      */
-    private function resolveTag(string $name): BlogTag
+    private function resolveTag(Blog $blog, string $name): BlogTag
     {
         $name = strtolower(trim($name));
 
-        $tag = $this->tagRepository->findOneBy(['label' => $name]);
+        $tag = $this->tagRepository->findOneBy(['blog' => $blog, 'label' => $name]);
 
         if (!$tag) {
             $tag = new BlogTag();
-            $tag->setLabel($name);
+            $tag->setBlog($blog)
+                ->setLabel($name);
 
             $this->em->persist($tag);
         }


### PR DESCRIPTION
### Motivation
- AI-generated posts could fail with `SQLSTATE[23000]: Column 'blog_id' cannot be null` because new `BlogTag` entities were persisted without an associated `blog`.
- Tags should be scoped to the `Blog` they belong to to avoid creating orphan tags when generating posts for a specific blog.
- The change ensures tag creation and lookup always use the correct blog context.

### Description
- Updated all `app:generate-ai-posts*` console commands to pass the resolved `Blog` into `resolveTag(...)` when attaching tags to posts.
- Changed `resolveTag` signature to `resolveTag(Blog $blog, string $name)` and perform lookup with `findOneBy(['blog' => $blog, 'label' => $name])`.
- When a tag does not exist, the code now calls `setBlog($blog)->setLabel($name)` on the new `BlogTag` before calling `persist`.
- Changes applied to the six command files under `src/Blog/Transport/Command/GenerateAiPosts*.php`.

### Testing
- Ran `php -l` for each modified file (`GenerateAiPostsCommand.php` and the five `GenerateAiPostsSample*Command.php`) and all files reported `No syntax errors detected`.
- No automated unit tests were modified or added as part of this change; only syntax checks were executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd44a15c8832bb58ab1852d1ca4f8)