### PR TITLE
Handle Mercure publish failures gracefully and honor `private` flag

### DIFF
--- a/src/General/Application/Service/MercurePublisher.php
+++ b/src/General/Application/Service/MercurePublisher.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace App\General\Application\Service;
 
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Mercure\HubInterface;
+use Symfony\Component\Mercure\Exception\RuntimeException;
 use Symfony\Component\Mercure\Update;
 
 final readonly class MercurePublisher
 {
     public function __construct(
         private HubInterface $hub,
+        private LoggerInterface $logger,
     ) {
     }
 
@@ -19,9 +22,17 @@ final readonly class MercurePublisher
         $update = new Update(
             $topic,
             json_encode($data, JSON_THROW_ON_ERROR),
-            private: false
+            private: $private
         );
 
-        $this->hub->publish($update);
+        try {
+            $this->hub->publish($update);
+        } catch (RuntimeException $exception) {
+            $this->logger->error('Mercure publish failed.', [
+                'topic' => $topic,
+                'private' => $private,
+                'exception' => $exception->getMessage(),
+            ]);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent uncaught `Symfony\Component\Mercure\Exception\RuntimeException` from bubbling up and turning service calls into HTTP 500 errors. 
- Ensure the `publish` call actually respects the `private` argument when constructing an `Update` so message visibility is correct.

### Description
- Inject `Psr\Log\LoggerInterface` into `MercurePublisher` and use it to report errors. 
- Use the method parameter `private` when constructing `Symfony\Component\Mercure\Update` instead of a hardcoded value. 
- Wrap the hub `publish` call in a `try/catch` for `Symfony\Component\Mercure\Exception\RuntimeException` and log structured context (`topic`, `private`, exception message) on failure.

### Testing
- Ran `php -l src/General/Application/Service/MercurePublisher.php` which reported no syntax errors. (succeeded)
- Verified repository status with `git status --short` and committed the change with a descriptive message. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdadf76dc832bb4cedb941c674e52)