### PR TITLE
feat(notification): add Mailjet templates endpoint

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -208,6 +208,11 @@ services:
         arguments:
             $providers: !tagged_iterator { tag: 'app.shop.payment_provider', index_by: 'key' }
 
+    App\Notification\Application\Service\MailjetTemplateService:
+        arguments:
+            $mailjetApiKey: '%env(default::MAILJET_API_KEY)%'
+            $mailjetSecretKey: '%env(default::MAILJET_SECRET_KEY)%'
+
     App\Crm\Application\Service\CrmGithubOwnerResolver:
         arguments:
             $defaultOwner: '%crm.github.default_repository_owner%'

--- a/src/Notification/Application/Service/MailjetTemplateService.php
+++ b/src/Notification/Application/Service/MailjetTemplateService.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\Service;
+
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+use function array_map;
+use function is_array;
+use function is_numeric;
+use function is_string;
+use function sprintf;
+use function trim;
+
+final readonly class MailjetTemplateService
+{
+    private const string MAILJET_TEMPLATE_ENDPOINT = 'https://api.mailjet.com/v3/REST/template';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private string $mailjetApiKey,
+        private string $mailjetSecretKey,
+    ) {
+    }
+
+    /**
+     * @return array<int, array{id:int|null,name:string,isActive:bool,createdAt:?string,updatedAt:?string}>
+     *
+     * @throws ExceptionInterface
+     */
+    public function listTemplates(int $limit = 50, int $offset = 0): array
+    {
+        if (trim($this->mailjetApiKey) === '' || trim($this->mailjetSecretKey) === '') {
+            return [];
+        }
+
+        $response = $this->httpClient->request('GET', self::MAILJET_TEMPLATE_ENDPOINT, [
+            'auth_basic' => [$this->mailjetApiKey, $this->mailjetSecretKey],
+            'query' => [
+                'Limit' => max(1, $limit),
+                'Offset' => max(0, $offset),
+            ],
+            'timeout' => 10,
+        ]);
+
+        $payload = $response->toArray(false);
+
+        if ($response->getStatusCode() < 200 || $response->getStatusCode() >= 300) {
+            throw new \RuntimeException(sprintf('Mailjet API returned status code %d.', $response->getStatusCode()));
+        }
+
+        $templates = $payload['Data'] ?? [];
+        if (!is_array($templates)) {
+            return [];
+        }
+
+        return array_map(static function (mixed $template): array {
+            if (!is_array($template)) {
+                return [
+                    'id' => null,
+                    'name' => '',
+                    'isActive' => false,
+                    'createdAt' => null,
+                    'updatedAt' => null,
+                ];
+            }
+
+            return [
+                'id' => is_numeric($template['ID'] ?? null) ? (int)$template['ID'] : null,
+                'name' => is_string($template['Name'] ?? null) ? $template['Name'] : '',
+                'isActive' => (bool)($template['IsActive'] ?? false),
+                'createdAt' => is_string($template['CreatedAt'] ?? null) ? $template['CreatedAt'] : null,
+                'updatedAt' => is_string($template['EditModeUpdatedAt'] ?? null) ? $template['EditModeUpdatedAt'] : null,
+            ];
+        }, $templates);
+    }
+}

--- a/src/Notification/Transport/Controller/Api/V1/NotificationController.php
+++ b/src/Notification/Transport/Controller/Api/V1/NotificationController.php
@@ -7,6 +7,7 @@ namespace App\Notification\Transport\Controller\Api\V1;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\Notification\Application\Message\CreateNotificationCommand;
 use App\Notification\Application\Message\MarkAllNotificationsAsReadCommand;
+use App\Notification\Application\Service\MailjetTemplateService;
 use App\Notification\Application\Service\NotificationReadService;
 use App\Notification\Domain\Entity\Notification;
 use App\Notification\Infrastructure\Repository\NotificationRepository;
@@ -33,6 +34,7 @@ final readonly class NotificationController
     public function __construct(
         private NotificationRepository $notificationRepository,
         private NotificationReadService $notificationReadService,
+        private MailjetTemplateService $mailjetTemplateService,
         private MessageServiceInterface $messageService,
     ) {
     }
@@ -112,6 +114,50 @@ final readonly class NotificationController
             'items' => $this->notificationReadService->normalizeList($notifications),
             'unreadCount' => $this->notificationRepository->countUnreadByRecipient($loggedInUser),
         ]);
+    }
+
+    #[Route('/v1/notifications/mailjet/templates', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'List email templates available in Mailjet.')]
+    #[OA\Parameter(name: 'limit', description: 'Max number of templates to return (default: 50).', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, example: 20))]
+    #[OA\Parameter(name: 'offset', description: 'Pagination offset (default: 0).', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 0, example: 0))]
+    #[OA\Response(
+        response: 200,
+        description: 'Mailjet templates list.',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'items',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'id', type: 'integer', nullable: true, example: 123456789),
+                            new OA\Property(property: 'name', type: 'string', example: 'Welcome Email'),
+                            new OA\Property(property: 'isActive', type: 'boolean', example: true),
+                            new OA\Property(property: 'createdAt', type: 'string', nullable: true, example: '2026-04-24T10:00:00Z'),
+                            new OA\Property(property: 'updatedAt', type: 'string', nullable: true, example: '2026-04-24T10:30:00Z'),
+                        ],
+                        type: 'object',
+                    ),
+                ),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[OA\Response(response: 401, description: 'Authentication required.')]
+    #[OA\Response(response: 403, description: 'Access denied.')]
+    #[OA\Response(response: 502, description: 'Failed to fetch templates from Mailjet.')]
+    public function listMailjetTemplates(Request $request): JsonResponse
+    {
+        $limit = max(1, (int)$request->query->get('limit', 50));
+        $offset = max(0, (int)$request->query->get('offset', 0));
+
+        try {
+            return new JsonResponse([
+                'items' => $this->mailjetTemplateService->listTemplates($limit, $offset),
+            ]);
+        } catch (Throwable $exception) {
+            throw new HttpException(JsonResponse::HTTP_BAD_GATEWAY, 'Unable to fetch Mailjet templates.', $exception);
+        }
     }
 
     /**

--- a/tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php
+++ b/tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php
@@ -33,6 +33,40 @@ class NotificationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
+    #[TestDox('Test that `GET /v1/notifications/mailjet/templates` requires authentication.')]
+    public function testThatMailjetTemplateListRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', $this->baseUrl . '/mailjet/templates');
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/notifications/mailjet/templates` returns a normalized list.')]
+    public function testThatMailjetTemplateListReturnsNormalizedPayload(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', $this->baseUrl . '/mailjet/templates');
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('items', $payload);
+        self::assertIsArray($payload['items']);
+    }
+
+    /**
+     * @throws Throwable
+     */
     #[TestDox('Test that `GET /v1/notifications` returns only notifications for the authenticated user.')]
     public function testThatListReturnsOnlyCurrentUserNotifications(): void
     {


### PR DESCRIPTION
### Motivation
- Expose Mailjet email templates to the Notification module so the app can list and reuse available Mailjet templates. 
- Provide a simple, authenticated HTTP API to fetch templates with pagination (`limit`/`offset`) and surface upstream errors as an HTTP `502`.

### Description
- Add `MailjetTemplateService` (`src/Notification/Application/Service/MailjetTemplateService.php`) which calls Mailjet REST API (`https://api.mailjet.com/v3/REST/template`) using `HttpClientInterface` and Basic Auth and normalizes items to `{id, name, isActive, createdAt, updatedAt}`; it returns an empty array when Mailjet credentials are not configured.
- Add controller endpoint `GET /v1/notifications/mailjet/templates` in `NotificationController` with OpenAPI documentation and error handling that converts Mailjet failures into `502` responses.
- Wire Mailjet credentials into DI via `config/services.yaml` (`MAILJET_API_KEY` / `MAILJET_SECRET_KEY`).
- Add controller tests in `tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php` covering authentication requirement and the normalized payload contract.

### Testing
- Ran syntax checks: `php -l` for `src/Notification/Application/Service/MailjetTemplateService.php`, `src/Notification/Transport/Controller/Api/V1/NotificationController.php`, and `tests/.../NotificationControllerTest.php`, all passed.
- Attempted to run PHPUnit for the new controller tests but the PHPUnit binary was not available in the environment, so automated test execution could not be completed here. 
- Changes committed with message `feat(notification): add Mailjet templates endpoint`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebfb9448f0832b9ab9f21823107f4d)