### PR TITLE
Add Mailjet notification templates sync, API endpoints and send-by-template support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -188,6 +188,7 @@
 		"docker": [
 			"php bin/console scheduler:cleanup-logs",
 			"php bin/console scheduler:cleanup-messenger-messages",
+			"php bin/console scheduler:notification-template-sync",
 			"php bin/console scheduler:recruit-index-similar-jobs",
 			"php bin/console scheduler:elastic-reindex-domains",
 			"php bin/console scheduler:warmup-public-endpoints",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -208,6 +208,13 @@ services:
         arguments:
             $providers: !tagged_iterator { tag: 'app.shop.payment_provider', index_by: 'key' }
 
+    App\Notification\Application\Service\MailjetTemplateService:
+        arguments:
+            $mailjetApiKey: '%env(default::MAILJET_API_KEY)%'
+            $mailjetSecretKey: '%env(default::MAILJET_SECRET_KEY)%'
+            $mailjetSenderEmail: '%env(default::MAILJET_SENDER_EMAIL)%'
+            $mailjetSenderName: '%env(default:Bro World:MAILJET_SENDER_NAME)%'
+
     App\Crm\Application\Service\CrmGithubOwnerResolver:
         arguments:
             $defaultOwner: '%crm.github.default_repository_owner%'

--- a/migrations/Version20260424143000.php
+++ b/migrations/Version20260424143000.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260424143000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create notification_template table to store synchronized Mailjet templates and variables.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE notification_template (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", provider_template_id INT NOT NULL, name VARCHAR(255) NOT NULL, is_active TINYINT(1) NOT NULL DEFAULT 1, variables JSON NOT NULL, created_at DATETIME NOT NULL COMMENT "(DC2Type:datetime_immutable)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", UNIQUE INDEX uniq_notification_template_provider_id (provider_template_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE notification_template');
+    }
+}

--- a/src/Notification/Application/Service/MailjetTemplateService.php
+++ b/src/Notification/Application/Service/MailjetTemplateService.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\Service;
+
+use RuntimeException;
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+use function array_filter;
+use function array_map;
+use function array_merge;
+use function array_unique;
+use function count;
+use function is_array;
+use function is_numeric;
+use function is_string;
+use function max;
+use function preg_match_all;
+use function sort;
+use function sprintf;
+use function trim;
+
+final readonly class MailjetTemplateService
+{
+    private const string MAILJET_TEMPLATE_ENDPOINT = 'https://api.mailjet.com/v3/REST/template';
+    private const string MAILJET_TEMPLATE_DETAIL_ENDPOINT = 'https://api.mailjet.com/v3/REST/template/%d/detailcontent';
+    private const string MAILJET_SEND_ENDPOINT = 'https://api.mailjet.com/v3.1/send';
+
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private string $mailjetApiKey,
+        private string $mailjetSecretKey,
+        private string $mailjetSenderEmail,
+        private string $mailjetSenderName,
+    ) {
+    }
+
+    /**
+     * @return array<int, array{id:int|null,name:string,isActive:bool,createdAt:?string,updatedAt:?string,variables:array<int, string>}>
+     *
+     * @throws ExceptionInterface
+     */
+    public function listTemplates(int $limit = 50, int $offset = 0): array
+    {
+        $payload = $this->request('GET', self::MAILJET_TEMPLATE_ENDPOINT, [
+            'query' => [
+                'Limit' => max(1, $limit),
+                'Offset' => max(0, $offset),
+            ],
+        ]);
+
+        $templates = $payload['Data'] ?? [];
+        if (!is_array($templates)) {
+            return [];
+        }
+
+        return array_map(function (mixed $template): array {
+            if (!is_array($template)) {
+                return [
+                    'id' => null,
+                    'name' => '',
+                    'isActive' => false,
+                    'createdAt' => null,
+                    'updatedAt' => null,
+                    'variables' => [],
+                ];
+            }
+
+            $templateId = is_numeric($template['ID'] ?? null) ? (int)$template['ID'] : null;
+
+            return [
+                'id' => $templateId,
+                'name' => is_string($template['Name'] ?? null) ? $template['Name'] : '',
+                'isActive' => (bool)($template['IsActive'] ?? false),
+                'createdAt' => is_string($template['CreatedAt'] ?? null) ? $template['CreatedAt'] : null,
+                'updatedAt' => is_string($template['EditModeUpdatedAt'] ?? null) ? $template['EditModeUpdatedAt'] : null,
+                'variables' => $templateId !== null ? $this->fetchTemplateVariables($templateId) : [],
+            ];
+        }, $templates);
+    }
+
+    /**
+     * @return array<int, string>
+     *
+     * @throws ExceptionInterface
+     */
+    public function fetchTemplateVariables(int $templateId): array
+    {
+        $payload = $this->request('GET', sprintf(self::MAILJET_TEMPLATE_DETAIL_ENDPOINT, $templateId));
+        $details = $payload['Data'] ?? [];
+        if (!is_array($details) || $details === []) {
+            return [];
+        }
+
+        $detail = is_array($details[0] ?? null) ? $details[0] : [];
+
+        $contentParts = [];
+        foreach (['Html-part', 'Text-part', 'Headers'] as $field) {
+            $value = $detail[$field] ?? null;
+            if (is_string($value) && trim($value) !== '') {
+                $contentParts[] = $value;
+            }
+        }
+
+        return $this->extractVariables(array_merge($contentParts));
+    }
+
+    /**
+     * @param array<string, mixed> $variables
+     *
+     * @return array<string, mixed>
+     * @throws ExceptionInterface
+     */
+    public function sendTemplateEmail(int $templateId, string $toEmail, array $variables = []): array
+    {
+        if (trim($toEmail) === '') {
+            throw new RuntimeException('Recipient email is required.');
+        }
+
+        return $this->request('POST', self::MAILJET_SEND_ENDPOINT, [
+            'json' => [
+                'Messages' => [
+                    [
+                        'From' => [
+                            'Email' => $this->mailjetSenderEmail,
+                            'Name' => $this->mailjetSenderName,
+                        ],
+                        'To' => [
+                            [
+                                'Email' => $toEmail,
+                            ],
+                        ],
+                        'TemplateID' => $templateId,
+                        'TemplateLanguage' => true,
+                        'Variables' => $variables,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    private function hasCredentials(): bool
+    {
+        return trim($this->mailjetApiKey) !== '' && trim($this->mailjetSecretKey) !== '';
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<string, mixed>
+     *
+     * @throws ExceptionInterface
+     */
+    private function request(string $method, string $url, array $options = []): array
+    {
+        if (!$this->hasCredentials()) {
+            throw new RuntimeException('Mailjet credentials are not configured.');
+        }
+
+        $response = $this->httpClient->request($method, $url, [
+            ...$options,
+            'auth_basic' => [$this->mailjetApiKey, $this->mailjetSecretKey],
+            'timeout' => 15,
+        ]);
+
+        $payload = $response->toArray(false);
+        if ($response->getStatusCode() < 200 || $response->getStatusCode() >= 300) {
+            throw new RuntimeException(sprintf('Mailjet API returned status code %d.', $response->getStatusCode()));
+        }
+
+        return is_array($payload) ? $payload : [];
+    }
+
+    /**
+     * @param array<int, string> $contents
+     * @return array<int, string>
+     */
+    private function extractVariables(array $contents): array
+    {
+        $variables = [];
+        foreach ($contents as $content) {
+            preg_match_all('/\{\{\s*var:([a-zA-Z0-9_\.\-]+)(?:[^}]*)\}\}/', $content, $matchesA);
+            preg_match_all('/\[\[\s*var:([a-zA-Z0-9_\.\-]+)(?:[^\]]*)\]\]/', $content, $matchesB);
+
+            $variables = array_merge($variables, $matchesA[1] ?? [], $matchesB[1] ?? []);
+        }
+
+        $variables = array_values(array_unique(array_filter($variables, static fn (mixed $value): bool => is_string($value) && trim($value) !== '')));
+        sort($variables);
+
+        return $variables;
+    }
+}

--- a/src/Notification/Application/Service/NotificationTemplateSyncService.php
+++ b/src/Notification/Application/Service/NotificationTemplateSyncService.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Application\Service;
+
+use App\Notification\Domain\Entity\NotificationTemplate;
+use App\Notification\Infrastructure\Repository\NotificationTemplateRepository;
+use Throwable;
+
+use function is_array;
+use function is_int;
+use function is_string;
+
+final readonly class NotificationTemplateSyncService
+{
+    public function __construct(
+        private MailjetTemplateService $mailjetTemplateService,
+        private NotificationTemplateRepository $notificationTemplateRepository,
+    ) {
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function sync(int $batchSize = 100): int
+    {
+        $offset = 0;
+        $synced = 0;
+
+        do {
+            $items = $this->mailjetTemplateService->listTemplates($batchSize, $offset);
+            foreach ($items as $item) {
+                $providerTemplateId = $item['id'] ?? null;
+                if (!is_int($providerTemplateId)) {
+                    continue;
+                }
+
+                $template = $this->notificationTemplateRepository->findOneByProviderTemplateId($providerTemplateId)
+                    ?? (new NotificationTemplate())->setProviderTemplateId($providerTemplateId);
+
+                $template
+                    ->setName(is_string($item['name'] ?? null) ? $item['name'] : '')
+                    ->setIsActive((bool)($item['isActive'] ?? false))
+                    ->setVariables(is_array($item['variables'] ?? null) ? $item['variables'] : []);
+
+                $this->notificationTemplateRepository->save($template, false);
+                ++$synced;
+            }
+
+            $this->notificationTemplateRepository->getEntityManager()->flush();
+            $offset += $batchSize;
+        } while ($items !== []);
+
+        return $synced;
+    }
+}

--- a/src/Notification/Domain/Entity/NotificationTemplate.php
+++ b/src/Notification/Domain/Entity/NotificationTemplate.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'notification_template')]
+#[ORM\UniqueConstraint(name: 'uniq_notification_template_provider_id', columns: ['provider_template_id'])]
+class NotificationTemplate implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\Column(name: 'provider_template_id', type: Types::INTEGER, unique: true)]
+    private int $providerTemplateId = 0;
+
+    #[ORM\Column(name: 'name', type: Types::STRING, length: 255)]
+    private string $name = '';
+
+    #[ORM\Column(name: 'is_active', type: Types::BOOLEAN, options: ['default' => true])]
+    private bool $isActive = true;
+
+    /**
+     * @var array<int, string>
+     */
+    #[ORM\Column(name: 'variables', type: Types::JSON)]
+    private array $variables = [];
+
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getProviderTemplateId(): int
+    {
+        return $this->providerTemplateId;
+    }
+
+    public function setProviderTemplateId(int $providerTemplateId): self
+    {
+        $this->providerTemplateId = $providerTemplateId;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+
+    public function setIsActive(bool $isActive): self
+    {
+        $this->isActive = $isActive;
+
+        return $this;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function getVariables(): array
+    {
+        return $this->variables;
+    }
+
+    /**
+     * @param array<int, string> $variables
+     */
+    public function setVariables(array $variables): self
+    {
+        $this->variables = $variables;
+
+        return $this;
+    }
+}

--- a/src/Notification/Infrastructure/Repository/NotificationTemplateRepository.php
+++ b/src/Notification/Infrastructure/Repository/NotificationTemplateRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Infrastructure\Repository;
+
+use App\General\Infrastructure\Repository\BaseRepository;
+use App\Notification\Domain\Entity\NotificationTemplate;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @method NotificationTemplate|null find(string $id, $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ */
+class NotificationTemplateRepository extends BaseRepository
+{
+    protected static string $entityName = NotificationTemplate::class;
+    protected static array $searchColumns = ['id', 'name', 'providerTemplateId'];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+
+    /**
+     * @return NotificationTemplate[]
+     */
+    public function findList(int $limit = 50, int $offset = 0): array
+    {
+        $result = $this->createQueryBuilder('nt')
+            ->orderBy('nt.name', 'ASC')
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+
+        return array_values(array_filter($result, static fn ($template): bool => $template instanceof NotificationTemplate));
+    }
+
+    public function findOneByProviderTemplateId(int $providerTemplateId): ?NotificationTemplate
+    {
+        $template = $this->createQueryBuilder('nt')
+            ->andWhere('nt.providerTemplateId = :providerTemplateId')
+            ->setParameter('providerTemplateId', $providerTemplateId)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+
+        return $template instanceof NotificationTemplate ? $template : null;
+    }
+}

--- a/src/Notification/Transport/Command/Scheduler/SyncNotificationTemplatesScheduledCommand.php
+++ b/src/Notification/Transport/Command/Scheduler/SyncNotificationTemplatesScheduledCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Transport\Command\Scheduler;
+
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Notification\Transport\Command\Utils\SyncNotificationTemplatesCommand;
+use App\Tool\Application\Service\Scheduler\Interfaces\ScheduledCommandServiceInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Create cron job for Mailjet notification templates synchronization.',
+)]
+final class SyncNotificationTemplatesScheduledCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'scheduler:notification-template-sync';
+
+    public function __construct(
+        private readonly ScheduledCommandServiceInterface $scheduledCommandService,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = $this->getSymfonyStyle($input, $output);
+        $message = $this->createScheduledCommand();
+
+        if ($input->isInteractive()) {
+            $io->success($message);
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function createScheduledCommand(): string
+    {
+        $entity = $this->scheduledCommandService->findByCommand(SyncNotificationTemplatesCommand::NAME);
+        if ($entity !== null) {
+            return "The job notification-template-sync is already present [id='{$entity->getId()}'] - have a nice day";
+        }
+
+        $this->scheduledCommandService->create(
+            'Sync notification templates from Mailjet',
+            SyncNotificationTemplatesCommand::NAME,
+            '0 * * * *',
+            '/notification-template-sync.log',
+        );
+
+        return 'The job notification-template-sync is created - have a nice day';
+    }
+}

--- a/src/Notification/Transport/Command/Utils/SyncNotificationTemplatesCommand.php
+++ b/src/Notification/Transport/Command/Utils/SyncNotificationTemplatesCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notification\Transport\Command\Utils;
+
+use App\General\Transport\Command\Traits\SymfonyStyleTrait;
+use App\Notification\Application\Service\NotificationTemplateSyncService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+use function sprintf;
+
+#[AsCommand(
+    name: self::NAME,
+    description: 'Synchronize notification templates from Mailjet.',
+)]
+final class SyncNotificationTemplatesCommand extends Command
+{
+    use SymfonyStyleTrait;
+
+    final public const string NAME = 'notification:templates:sync';
+
+    public function __construct(
+        private readonly NotificationTemplateSyncService $notificationTemplateSyncService,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = $this->getSymfonyStyle($input, $output);
+        $synced = $this->notificationTemplateSyncService->sync();
+
+        if ($input->isInteractive()) {
+            $io->success(sprintf('%d notification templates synchronized.', $synced));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Notification/Transport/Controller/Api/V1/NotificationController.php
+++ b/src/Notification/Transport/Controller/Api/V1/NotificationController.php
@@ -7,9 +7,11 @@ namespace App\Notification\Transport\Controller\Api\V1;
 use App\General\Domain\Service\Interfaces\MessageServiceInterface;
 use App\Notification\Application\Message\CreateNotificationCommand;
 use App\Notification\Application\Message\MarkAllNotificationsAsReadCommand;
+use App\Notification\Application\Service\MailjetTemplateService;
 use App\Notification\Application\Service\NotificationReadService;
 use App\Notification\Domain\Entity\Notification;
 use App\Notification\Infrastructure\Repository\NotificationRepository;
+use App\Notification\Infrastructure\Repository\NotificationTemplateRepository;
 use App\User\Domain\Entity\User;
 use OpenApi\Attributes as OA;
 use Ramsey\Uuid\Uuid;
@@ -22,6 +24,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 use Throwable;
+use function is_array;
+use function is_int;
 use function is_string;
 use function trim;
 
@@ -32,7 +36,9 @@ final readonly class NotificationController
 {
     public function __construct(
         private NotificationRepository $notificationRepository,
+        private NotificationTemplateRepository $notificationTemplateRepository,
         private NotificationReadService $notificationReadService,
+        private MailjetTemplateService $mailjetTemplateService,
         private MessageServiceInterface $messageService,
     ) {
     }
@@ -112,6 +118,104 @@ final readonly class NotificationController
             'items' => $this->notificationReadService->normalizeList($notifications),
             'unreadCount' => $this->notificationRepository->countUnreadByRecipient($loggedInUser),
         ]);
+    }
+
+    #[Route('/v1/notifications/templates', methods: [Request::METHOD_GET])]
+    #[OA\Get(summary: 'List synchronized notification templates with their variables.')]
+    #[OA\Parameter(name: 'limit', description: 'Max number of templates to return (default: 50).', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 1, example: 20))]
+    #[OA\Parameter(name: 'offset', description: 'Pagination offset (default: 0).', in: 'query', required: false, schema: new OA\Schema(type: 'integer', minimum: 0, example: 0))]
+    #[OA\Response(
+        response: 200,
+        description: 'Notification templates list.',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(
+                    property: 'items',
+                    type: 'array',
+                    items: new OA\Items(
+                        properties: [
+                            new OA\Property(property: 'id', type: 'string', format: 'uuid'),
+                            new OA\Property(property: 'templateId', type: 'integer', nullable: false, example: 123456789),
+                            new OA\Property(property: 'name', type: 'string', example: 'Welcome Email'),
+                            new OA\Property(property: 'isActive', type: 'boolean', example: true),
+                            new OA\Property(property: 'variables', type: 'array', items: new OA\Items(type: 'string', example: 'firstName')),
+                        ],
+                        type: 'object',
+                    ),
+                ),
+            ],
+            type: 'object',
+        ),
+    )]
+    #[OA\Response(response: 401, description: 'Authentication required.')]
+    #[OA\Response(response: 403, description: 'Access denied.')]
+    public function listTemplates(Request $request): JsonResponse
+    {
+        $limit = max(1, (int)$request->query->get('limit', 50));
+        $offset = max(0, (int)$request->query->get('offset', 0));
+
+        $templates = $this->notificationTemplateRepository->findList($limit, $offset);
+
+        return new JsonResponse([
+            'items' => array_map(static fn ($template): array => [
+                'id' => $template->getId(),
+                'templateId' => $template->getProviderTemplateId(),
+                'name' => $template->getName(),
+                'isActive' => $template->isActive(),
+                'variables' => $template->getVariables(),
+            ], $templates),
+        ]);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[Route('/v1/notifications/templates/send', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Send an email using a Mailjet template and request variables.')]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['templateId', 'to'],
+            properties: [
+                new OA\Property(property: 'templateId', type: 'integer', example: 123456789),
+                new OA\Property(property: 'to', type: 'string', format: 'email', example: 'user@example.com'),
+                new OA\Property(property: 'variables', type: 'object', additionalProperties: new OA\AdditionalProperties(type: 'string')),
+            ],
+        ),
+    )]
+    #[OA\Response(response: 202, description: 'Mailjet send request accepted.')]
+    #[OA\Response(response: 400, description: 'Validation error.')]
+    #[OA\Response(response: 401, description: 'Authentication required.')]
+    #[OA\Response(response: 403, description: 'Access denied.')]
+    #[OA\Response(response: 502, description: 'Mailjet upstream error.')]
+    public function sendTemplateEmail(Request $request): JsonResponse
+    {
+        $payload = $request->toArray();
+        $templateId = $payload['templateId'] ?? null;
+        $to = $payload['to'] ?? null;
+        $variables = $payload['variables'] ?? [];
+
+        if (!is_int($templateId)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "templateId" must be an integer.');
+        }
+        if (!is_string($to) || trim($to) === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "to" must be a non-empty email string.');
+        }
+        if (!is_array($variables)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "variables" must be an object.');
+        }
+
+        try {
+            $response = $this->mailjetTemplateService->sendTemplateEmail($templateId, $to, $variables);
+        } catch (Throwable $exception) {
+            throw new HttpException(JsonResponse::HTTP_BAD_GATEWAY, 'Unable to send template email through Mailjet.', $exception);
+        }
+
+        return new JsonResponse([
+            'status' => 'accepted',
+            'provider' => 'mailjet',
+            'response' => $response,
+        ], JsonResponse::HTTP_ACCEPTED);
     }
 
     /**

--- a/tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php
+++ b/tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest.php
@@ -33,6 +33,56 @@ class NotificationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
+    #[TestDox('Test that `GET /v1/notifications/templates` requires authentication.')]
+    public function testThatTemplateListRequiresAuthentication(): void
+    {
+        $client = $this->getTestClient();
+
+        $client->request('GET', $this->baseUrl . '/templates');
+
+        self::assertSame(Response::HTTP_UNAUTHORIZED, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `GET /v1/notifications/templates` returns a normalized list.')]
+    public function testThatTemplateListReturnsNormalizedPayload(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('GET', $this->baseUrl . '/templates');
+
+        $response = $client->getResponse();
+        $content = $response->getContent();
+        self::assertNotFalse($content);
+        self::assertSame(Response::HTTP_OK, $response->getStatusCode(), "Response:\n" . $response);
+
+        $payload = JSON::decode($content, true);
+        self::assertIsArray($payload);
+        self::assertArrayHasKey('items', $payload);
+        self::assertIsArray($payload['items']);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    #[TestDox('Test that `POST /v1/notifications/templates/send` validates required payload.')]
+    public function testThatSendTemplateEmailValidatesPayload(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+
+        $client->request('POST', $this->baseUrl . '/templates/send', [], [], [], JSON::encode([
+            'templateId' => 'invalid',
+            'to' => '',
+        ]));
+
+        self::assertSame(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
     #[TestDox('Test that `GET /v1/notifications` returns only notifications for the authenticated user.')]
     public function testThatListReturnsOnlyCurrentUserNotifications(): void
     {


### PR DESCRIPTION
### Motivation

- Introduce Mailjet template synchronization so notification templates and their variables can be stored locally and used by the application. 
- Expose API endpoints to list synchronized templates and to send email using a Mailjet template with variables. 
- Provide a scheduled job to create the periodic synchronization task and a command to execute the sync. 

### Description

- Added a `MailjetTemplateService` to interact with Mailjet APIs for listing templates, extracting template variables, and sending template emails with `TemplateLanguage` and `Variables` support. 
- Added domain model and persistence for templates with `NotificationTemplate` entity, `NotificationTemplateRepository`, and a migration `Version20260424143000` to create the `notification_template` table. 
- Implemented `NotificationTemplateSyncService` to import/synchronize templates in batches and commands `notification:templates:sync` and `scheduler:notification-template-sync` to perform synchronization and to create the scheduled job respectively. 
- Registered the new service in `config/services.yaml`, added the scheduler command to the `docker` script in `composer.json`, and extended `NotificationController` with `listTemplates` and `sendTemplateEmail` endpoints and OpenAPI annotations. 
- Updated `NotificationControllerTest` to include authentication and payload validation tests for the new template endpoints. 

### Testing

- Updated and executed the notification controller tests class `tests/Application/Notification/Transport/Controller/Api/V1/NotificationControllerTest`, which includes tests for `GET /v1/notifications/templates` authentication and payload validation for `POST /v1/notifications/templates/send`, and they passed. 
- Ran the relevant PHPUnit suite for notification API endpoints using `php bin/phpunit` and confirmed the new assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebfb9448f0832b9ab9f21823107f4d)