### PR TITLE
Harden resume AI parsing against noisy PDF extraction artifacts

### DIFF
--- a/src/Recruit/Application/Service/ResumeAiParsingService.php
+++ b/src/Recruit/Application/Service/ResumeAiParsingService.php
@@ -22,6 +22,7 @@ use function count;
 use function file_get_contents;
 use function gzuncompress;
 use function gzinflate;
+use function implode;
 use function is_array;
 use function is_string;
 use function json_decode;
@@ -29,70 +30,132 @@ use function preg_match_all;
 use function preg_replace;
 use function preg_split;
 use function preg_replace_callback;
+use function str_contains;
+use function str_replace;
 use function str_starts_with;
+use function strtolower;
+use function strlen;
+use function substr;
 use function trim;
 
 readonly class ResumeAiParsingService
 {
     private const string AI_URL = 'http://127.0.0.1:11434/api/generate';
     private const string AI_MODEL = 'phi';
+    private const int MAX_PROMPT_RESUME_LENGTH = 12000;
 
     public function __construct(
         private HttpClientInterface $httpClient,
     ) {
     }
 
-    function fixEncoding(string $text): string
-    {
-        // 1. Si présence massive de bytes nuls => UTF-16
-        if (strpos($text, "\x00") !== false) {
-            $text = mb_convert_encoding($text, 'UTF-8', 'UTF-16');
-        }
-
-        // 2. Si texte encore "chinois chelou" => reconversion brute
-        if (preg_match('/[^\x00-\x7F]{3,}/', $text)) {
-            $text = mb_convert_encoding($text, 'UTF-8', 'UTF-16LE');
-        }
-
-        // 3. Nettoyage caractères non imprimables
-        $text = preg_replace('/[^\P{C}\n\r\t]/u', '', $text);
-
-        return trim($text);
-    }
-
     private function cleanResumeText(string $text): string
     {
-        // 1. Fix UTF-16 / UTF-8 proprement
         if (!mb_check_encoding($text, 'UTF-8')) {
             $text = mb_convert_encoding($text, 'UTF-8', 'auto');
         }
 
-        // 2. Supprimer caractères non imprimables
         $text = preg_replace('/[^\P{C}\n\r\t]/u', '', $text);
-
-        // 3. Supprimer les blocs "gibberish" (genre chinois fake)
-        $text = preg_replace('/[^\x00-\x7F]{4,}/u', ' ', $text);
-
-        // 4. Normaliser espaces
-        $text = preg_replace('/\s+/', ' ', $text);
-
-        // 5. Garder lignes utiles (heuristique CV)
-        $lines = preg_split('/\n|\r/', $text);
-
-        $filtered = [];
-        foreach ($lines as $line) {
-            $line = trim($line);
-
-            // ignore lignes trop courtes ou bruit
-            if (strlen($line) < 3) continue;
-
-            // ignore lignes avec trop de caractères non ASCII
-            if (preg_match('/[^\x00-\x7F]/', $line)) continue;
-
-            $filtered[] = $line;
+        if (!is_string($text)) {
+            return '';
         }
 
-        return implode("\n", $filtered);
+        $text = str_replace(["\r\n", "\r"], "\n", $text);
+
+        $text = preg_replace('/\/CIDInit\s+\/ProcSet.*?end\s+end/s', ' ', $text);
+        if (!is_string($text)) {
+            return '';
+        }
+
+        $text = preg_replace('/(?:\bLEBENSLAUF\.DE\b\s*){3,}/ui', ' ', $text);
+        if (!is_string($text)) {
+            return '';
+        }
+
+        $text = preg_replace('/Vorschau\s+mit\s+Wasserzeichen/ui', ' ', $text);
+        if (!is_string($text)) {
+            return '';
+        }
+
+        $text = preg_replace('/\s+/', ' ', $text);
+        if (!is_string($text)) {
+            return '';
+        }
+
+        $text = str_replace('. ', ".\n", $text);
+        $lines = preg_split('/\n+/', $text);
+        if (!is_array($lines)) {
+            return '';
+        }
+
+        $filtered = [];
+        $previousLine = '';
+        foreach ($lines as $line) {
+            if (!is_string($line)) {
+                continue;
+            }
+
+            $line = trim($line);
+            if ($line === '' || strlen($line) < 3) {
+                continue;
+            }
+
+            if (preg_match('/[\p{L}\p{N}]/u', $line) !== 1) {
+                continue;
+            }
+
+            if ($this->isMostlyRepeatedTokenLine($line)) {
+                continue;
+            }
+
+            if ($line === $previousLine) {
+                continue;
+            }
+
+            $filtered[] = $line;
+            $previousLine = $line;
+        }
+
+        $cleaned = trim(implode("\n", $filtered));
+        if ($cleaned === '') {
+            return '';
+        }
+
+        if (strlen($cleaned) > self::MAX_PROMPT_RESUME_LENGTH) {
+            return trim(substr($cleaned, 0, self::MAX_PROMPT_RESUME_LENGTH));
+        }
+
+        return $cleaned;
+    }
+
+    private function isMostlyRepeatedTokenLine(string $line): bool
+    {
+        $tokens = preg_split('/\s+/', strtolower($line));
+        if (!is_array($tokens) || count($tokens) < 8) {
+            return false;
+        }
+
+        $firstToken = (string) preg_replace('/^[\p{P}\s]+|[\p{P}\s]+$/u', '', (string) ($tokens[0] ?? ''));
+        if ($firstToken === '') {
+            return false;
+        }
+
+        foreach ($tokens as $token) {
+            if (!is_string($token)) {
+                return false;
+            }
+
+            $normalized = (string) preg_replace('/^[\p{P}\s]+|[\p{P}\s]+$/u', '', $token);
+            if ($normalized === '') {
+                continue;
+            }
+
+            if (!str_contains($normalized, $firstToken) && !str_contains($firstToken, $normalized)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -110,7 +173,8 @@ readonly class ResumeAiParsingService
             throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'No extractable text found in the provided PDF.');
         }
 
-        $prompt = $this->buildPrompt($rawText);
+        $cleanedText = $this->cleanResumeText($rawText);
+        $prompt = $this->buildPrompt($cleanedText !== '' ? $cleanedText : $rawText);
 
         try {
             $response = $this->httpClient->request('POST', self::AI_URL, [
@@ -123,7 +187,11 @@ readonly class ResumeAiParsingService
             ]);
             $data = $response->toArray(false);
         } catch (TransportExceptionInterface $exception) {
-            throw new HttpException(Response::HTTP_BAD_GATEWAY, 'Unable to reach local AI service.', $exception);
+            throw new HttpException(
+                Response::HTTP_BAD_GATEWAY,
+                'Unable to reach local AI service. Please verify that the local model server is running and reachable.',
+                $exception,
+            );
         }
 
         $content = trim((string) ($data['response'] ?? ''));


### PR DESCRIPTION
### Motivation
- Les extractions textuelles de PDF contenaient beaucoup d'artefacts (CIDInit/ProcSet, watermarks répétés, lignes gibberish) qui polluaient le prompt envoyé au modèle IA et pouvaient provoquer des réponses vides ou des erreurs de service local.

### Description
- Ajout d’un nettoyeur robuste `cleanResumeText` qui retire les blocs `CIDInit/ProcSet`, les occurrences répétées de `LEBENSLAUF.DE`, le texte `Vorschau mit Wasserzeichen`, normalise les espaces et segmente le texte en lignes utiles avant construction du prompt (fichier modifié: `src/Recruit/Application/Service/ResumeAiParsingService.php`).
- Ajout d’une heuristique `isMostlyRepeatedTokenLine` pour ignorer les lignes composées majoritairement de tokens répétés (typique des watermarks/OCR junk) et déduplication des lignes consécutives.
- Limitation de la taille du prompt à `MAX_PROMPT_RESUME_LENGTH = 12000` caractères et fallback sur le texte brut si le nettoyage retourne une chaîne vide.
- Message d’erreur 502 enrichi pour indiquer explicitement de vérifier que le serveur de modèle local est démarré et joignable.

### Testing
- `php -l src/Recruit/Application/Service/ResumeAiParsingService.php` (vérification de syntaxe PHP) a réussi.
- Aucun nouveau test automatisé ajouté dans cette PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec3ce53d54832b9f13449c329b7618)