### PR TITLE
Add AI endpoints for resume review and structuring from text

### DIFF
--- a/src/Recruit/Application/Service/ResumeAiParsingService.php
+++ b/src/Recruit/Application/Service/ResumeAiParsingService.php
@@ -26,6 +26,7 @@ use function implode;
 use function is_array;
 use function is_string;
 use function json_decode;
+use function json_encode;
 use function preg_match;
 use function preg_match_all;
 use function preg_replace;
@@ -48,6 +49,35 @@ readonly class ResumeAiParsingService
     public function __construct(
         private HttpClientInterface $httpClient,
     ) {
+    }
+
+    /**
+     * @param array<string, mixed> $resumeData
+     */
+    public function reviewResume(array $resumeData): string
+    {
+        $jsonPayload = json_encode($resumeData, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        if (!is_string($jsonPayload) || trim($jsonPayload) === '') {
+            throw new HttpException(Response::HTTP_BAD_REQUEST, 'Invalid review payload.');
+        }
+
+        return $this->generateTextResponse($this->buildResumeReviewPrompt($jsonPayload));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function structureResumeFromText(string $resumeText): array
+    {
+        $cleanedText = $this->cleanResumeText($resumeText);
+        $promptInput = $cleanedText !== '' ? $cleanedText : trim($resumeText);
+        if ($promptInput === '') {
+            throw new HttpException(Response::HTTP_BAD_REQUEST, 'Field "resumeText" must not be empty.');
+        }
+
+        $content = $this->generateTextResponse($this->buildStructuredResumePrompt($promptInput));
+
+        return $this->normalizeAiStructuredResumePayload($content);
     }
 
     private function cleanResumeText(string $text): string
@@ -277,28 +307,7 @@ readonly class ResumeAiParsingService
         $cleanedText = $this->cleanResumeText($rawText);
         $prompt = $this->buildPrompt($cleanedText !== '' ? $cleanedText : $rawText);
 
-        try {
-            $response = $this->httpClient->request('POST', self::AI_URL, [
-                'timeout' => 120,
-                'json' => [
-                    'model' => self::AI_MODEL,
-                    'prompt' => $prompt,
-                    'stream' => false,
-                ],
-            ]);
-            $data = $response->toArray(false);
-        } catch (TransportExceptionInterface $exception) {
-            throw new HttpException(
-                Response::HTTP_BAD_GATEWAY,
-                'Unable to reach local AI service. Please verify that the local model server is running and reachable.',
-                $exception,
-            );
-        }
-
-        $content = trim((string) ($data['response'] ?? ''));
-        if ($content === '') {
-            throw new HttpException(Response::HTTP_BAD_GATEWAY, 'AI service returned an empty response.');
-        }
+        $content = $this->generateTextResponse($prompt);
 
         return $this->normalizeAiPayload($content);
     }
@@ -467,6 +476,84 @@ PROMPT
             . "\n" . $rawText;
     }
 
+    private function buildResumeReviewPrompt(string $resumeJson): string
+    {
+        return <<<'PROMPT'
+You are a senior recruiter and CV reviewer.
+Analyse the provided resume payload and answer ONLY as plain text (no markdown).
+Your answer must include:
+1) Overall quality verdict (good / needs improvement).
+2) Major issues found (if any).
+3) Concrete improvements section with bullet-style lines starting by "- ".
+Keep answer concise and actionable.
+
+Resume payload:
+PROMPT
+            . "\n" . $resumeJson;
+    }
+
+    private function buildStructuredResumePrompt(string $rawText): string
+    {
+        return <<<'PROMPT'
+You are a CV parser.
+Read the resume text and return ONLY valid minified JSON with this exact schema:
+{
+  "user": {
+    "fullName": "",
+    "email": "",
+    "phone": "",
+    "address": "",
+    "summary": "",
+    "links": []
+  },
+  "experiences": [{"title":"","company":"","startDate":"","endDate":"","description":""}],
+  "educations": [{"title":"","school":"","startDate":"","endDate":"","description":""}],
+  "skills": ["", ""],
+  "languages": [{"name":"","level":""}],
+  "certifications": [{"title":"","issuer":"","date":"","description":""}],
+  "projects": [{"title":"","description":"","link":""}],
+  "references": [{"name":"","contact":"","description":""}],
+  "hobbies": ["", ""]
+}
+Rules:
+- Never include markdown.
+- Always include every key.
+- Missing values must stay empty strings/arrays.
+- Keep output strictly as JSON object.
+
+Resume text:
+PROMPT
+            . "\n" . $rawText;
+    }
+
+    private function generateTextResponse(string $prompt): string
+    {
+        try {
+            $response = $this->httpClient->request('POST', self::AI_URL, [
+                'timeout' => 120,
+                'json' => [
+                    'model' => self::AI_MODEL,
+                    'prompt' => $prompt,
+                    'stream' => false,
+                ],
+            ]);
+            $data = $response->toArray(false);
+        } catch (TransportExceptionInterface $exception) {
+            throw new HttpException(
+                Response::HTTP_BAD_GATEWAY,
+                'Unable to reach local AI service. Please verify that the local model server is running and reachable.',
+                $exception,
+            );
+        }
+
+        $content = trim((string) ($data['response'] ?? ''));
+        if ($content === '') {
+            throw new HttpException(Response::HTTP_BAD_GATEWAY, 'AI service returned an empty response.');
+        }
+
+        return $content;
+    }
+
     /**
      * @return array<string, mixed>
      */
@@ -505,6 +592,46 @@ PROMPT
             'experiences' => $this->normalizeEntries($experiences, ['title', 'company', 'startDate', 'endDate', 'description']),
             'educations' => $this->normalizeEntries($educations, ['title', 'school', 'startDate', 'endDate', 'description']),
             'skills' => $this->stringArray($skills),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeAiStructuredResumePayload(string $raw): array
+    {
+        $normalizedRaw = $this->stripCodeFence($raw);
+
+        try {
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode($normalizedRaw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new HttpException(Response::HTTP_BAD_GATEWAY, 'AI service returned invalid JSON.', $exception);
+        }
+
+        if (!is_array($decoded)) {
+            throw new HttpException(Response::HTTP_BAD_GATEWAY, 'AI service JSON must be an object.');
+        }
+
+        $user = $decoded['user'] ?? [];
+
+        return [
+            'user' => [
+                'fullName' => $this->stringValue(is_array($user) ? ($user['fullName'] ?? '') : ''),
+                'email' => $this->stringValue(is_array($user) ? ($user['email'] ?? '') : ''),
+                'phone' => $this->stringValue(is_array($user) ? ($user['phone'] ?? '') : ''),
+                'address' => $this->stringValue(is_array($user) ? ($user['address'] ?? '') : ''),
+                'summary' => $this->stringValue(is_array($user) ? ($user['summary'] ?? '') : ''),
+                'links' => $this->stringArray(is_array($user) ? ($user['links'] ?? []) : []),
+            ],
+            'experiences' => $this->normalizeEntries(is_array($decoded['experiences'] ?? null) ? $decoded['experiences'] : [], ['title', 'company', 'startDate', 'endDate', 'description']),
+            'educations' => $this->normalizeEntries(is_array($decoded['educations'] ?? null) ? $decoded['educations'] : [], ['title', 'school', 'startDate', 'endDate', 'description']),
+            'skills' => $this->stringArray($decoded['skills'] ?? []),
+            'languages' => $this->normalizeEntries(is_array($decoded['languages'] ?? null) ? $decoded['languages'] : [], ['name', 'level']),
+            'certifications' => $this->normalizeEntries(is_array($decoded['certifications'] ?? null) ? $decoded['certifications'] : [], ['title', 'issuer', 'date', 'description']),
+            'projects' => $this->normalizeEntries(is_array($decoded['projects'] ?? null) ? $decoded['projects'] : [], ['title', 'description', 'link']),
+            'references' => $this->normalizeEntries(is_array($decoded['references'] ?? null) ? $decoded['references'] : [], ['name', 'contact', 'description']),
+            'hobbies' => $this->stringArray($decoded['hobbies'] ?? []),
         ];
     }
 

--- a/src/Recruit/Transport/Controller/Api/V1/Resume/ResumeReviewController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/ResumeReviewController.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Resume;
+
+use App\Recruit\Application\Service\ResumeAiParsingService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_array;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Resume')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class ResumeReviewController
+{
+    public function __construct(
+        private ResumeAiParsingService $resumeAiParsingService,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/resumes/review', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Analyse un payload CV et retourne une review textuelle avec améliorations possibles.')]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['resumeData'],
+            properties: [
+                new OA\Property(
+                    property: 'resumeData',
+                    description: 'Données du CV à analyser (informations personnelles, expériences, formations, skills, etc.).',
+                    type: 'object',
+                    additionalProperties: true,
+                ),
+            ],
+        ),
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'Review textuelle retournée par l\'IA.',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'review', type: 'string'),
+            ],
+            type: 'object',
+            example: [
+                'review' => 'needs improvement\nMissing quantified achievements in experiences.\n- Add metrics for each role.\n- Clarify education dates.',
+            ],
+        ),
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+        $resumeData = $payload['resumeData'] ?? null;
+
+        if (!is_array($resumeData) || $resumeData === []) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "resumeData" is required and must be a non-empty object.');
+        }
+
+        return new JsonResponse([
+            'review' => $this->resumeAiParsingService->reviewResume($resumeData),
+        ]);
+    }
+}

--- a/src/Recruit/Transport/Controller/Api/V1/Resume/ResumeStructureFromTextController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/Resume/ResumeStructureFromTextController.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\Resume;
+
+use App\Recruit\Application\Service\ResumeAiParsingService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+use function is_string;
+use function trim;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Resume')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class ResumeStructureFromTextController
+{
+    public function __construct(
+        private ResumeAiParsingService $resumeAiParsingService,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/resumes/structure-from-text', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Transforme un texte brut de CV en CV structuré complet via IA locale.')]
+    #[OA\RequestBody(
+        required: true,
+        content: new OA\JsonContent(
+            required: ['resumeText'],
+            properties: [
+                new OA\Property(property: 'resumeText', type: 'string', description: 'Texte brut contenant un CV.'),
+            ],
+        ),
+    )]
+    #[OA\Response(
+        response: 200,
+        description: 'CV structuré généré depuis le texte.',
+        content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: 'data', type: 'object'),
+            ],
+            type: 'object',
+        ),
+    )]
+    public function __invoke(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+        $resumeText = $payload['resumeText'] ?? null;
+
+        if (!is_string($resumeText) || trim($resumeText) === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "resumeText" is required and must be a non-empty string.');
+        }
+
+        return new JsonResponse([
+            'data' => $this->resumeAiParsingService->structureResumeFromText($resumeText),
+        ]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Exposer deux nouveaux endpoints pour tirer parti du moteur IA local: un pour reviewer un payload de CV et renvoyer un verdict + améliorations, et un autre pour convertir un texte brut de CV en JSON structuré complet.
- Centraliser et réutiliser l'appel HTTP vers le service IA afin d'unifier le comportement entre l'extraction PDF existante et les nouveaux flux textuels.

### Description
- Ajout de deux contrôleurs API: `src/Recruit/Transport/Controller/Api/V1/Resume/ResumeReviewController.php` qui publie `POST /v1/recruit/resumes/review` et `src/Recruit/Transport/Controller/Api/V1/Resume/ResumeStructureFromTextController.php` qui publie `POST /v1/recruit/resumes/structure-from-text` avec validation de payload et annotations OpenAPI.
- Extension de `src/Recruit/Application/Service/ResumeAiParsingService.php` avec les méthodes `reviewResume(array)`, `structureResumeFromText(string)`, `generateTextResponse(string)`, `buildResumeReviewPrompt()`, `buildStructuredResumePrompt()` et `normalizeAiStructuredResumePayload()` pour gérer prompts, appel IA et normalisation des réponses.
- Refactor de `parsePdf()` pour réutiliser la méthode `generateTextResponse()` (même comportement fonctionnel, moins de duplication) et ajout d'une normalisation dédiée pour la structure complète de CV.
- Les nouveaux endpoints retournent respectivement un champ `review` (texte) et `data` (CV structuré JSON) et sont protégés par l'authentification existante.

### Testing
- Exécution de validation de syntaxe PHP réussie avec `php -l src/Recruit/Application/Service/ResumeAiParsingService.php`.
- Exécution de validation de syntaxe PHP réussie avec `php -l src/Recruit/Transport/Controller/Api/V1/Resume/ResumeReviewController.php` et `php -l src/Recruit/Transport/Controller/Api/V1/Resume/ResumeStructureFromTextController.php`.
- Tentative d'afficher les routes via `php bin/console debug:router | rg "recruit/resumes/(parse-pdf|review|structure-from-text)"` échouée dans cet environnement car les dépendances ne sont pas installées (exige `composer install`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec46ce4c6c832baff099cd16270fe2)