### PR TITLE
feat(crm): add executive dashboard endpoint and DTO flow

### DIFF
--- a/src/Crm/Application/Dto/Dashboard/CrmDashboardAgendaItemDto.php
+++ b/src/Crm/Application/Dto/Dashboard/CrmDashboardAgendaItemDto.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Dto\Dashboard;
+
+final readonly class CrmDashboardAgendaItemDto
+{
+    public function __construct(
+        public string $time,
+        public string $event,
+        public string $owner,
+    ) {
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function toArray(): array
+    {
+        return [
+            'time' => $this->time,
+            'event' => $this->event,
+            'owner' => $this->owner,
+        ];
+    }
+}

--- a/src/Crm/Application/Dto/Dashboard/CrmDashboardFunnelStageDto.php
+++ b/src/Crm/Application/Dto/Dashboard/CrmDashboardFunnelStageDto.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Dto\Dashboard;
+
+final readonly class CrmDashboardFunnelStageDto
+{
+    public function __construct(
+        public string $label,
+        public int $deals,
+        public string $amount,
+    ) {
+    }
+
+    /**
+     * @return array<string,int|string>
+     */
+    public function toArray(): array
+    {
+        return [
+            'label' => $this->label,
+            'deals' => $this->deals,
+            'amount' => $this->amount,
+        ];
+    }
+}

--- a/src/Crm/Application/Dto/Dashboard/CrmDashboardKpiTileDto.php
+++ b/src/Crm/Application/Dto/Dashboard/CrmDashboardKpiTileDto.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Dto\Dashboard;
+
+final readonly class CrmDashboardKpiTileDto
+{
+    public function __construct(
+        public string $title,
+        public string $value,
+        public string $trend,
+        public string $tone,
+        public string $icon,
+        public string $caption,
+    ) {
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function toArray(): array
+    {
+        return [
+            'title' => $this->title,
+            'value' => $this->value,
+            'trend' => $this->trend,
+            'tone' => $this->tone,
+            'icon' => $this->icon,
+            'caption' => $this->caption,
+        ];
+    }
+}

--- a/src/Crm/Application/Dto/Dashboard/CrmDashboardTeamDto.php
+++ b/src/Crm/Application/Dto/Dashboard/CrmDashboardTeamDto.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Dto\Dashboard;
+
+final readonly class CrmDashboardTeamDto
+{
+    public function __construct(
+        public string $name,
+        public string $owner,
+        public string $velocity,
+        public string $status,
+    ) {
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'owner' => $this->owner,
+            'velocity' => $this->velocity,
+            'status' => $this->status,
+        ];
+    }
+}

--- a/src/Crm/Application/Dto/Dashboard/CrmExecutiveDashboardDto.php
+++ b/src/Crm/Application/Dto/Dashboard/CrmExecutiveDashboardDto.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Dto\Dashboard;
+
+final readonly class CrmExecutiveDashboardDto
+{
+    /**
+     * @param list<CrmDashboardKpiTileDto> $kpiTiles
+     * @param list<CrmDashboardFunnelStageDto> $funnelStages
+     * @param list<CrmDashboardTeamDto> $teams
+     * @param list<CrmDashboardAgendaItemDto> $todayAgenda
+     */
+    public function __construct(
+        public array $kpiTiles,
+        public array $funnelStages,
+        public array $teams,
+        public array $todayAgenda,
+    ) {
+    }
+
+    /**
+     * @return array<string,list<array<string,int|string>>>
+     */
+    public function toArray(): array
+    {
+        return [
+            'kpiTiles' => array_map(static fn (CrmDashboardKpiTileDto $tile) => $tile->toArray(), $this->kpiTiles),
+            'funnelStages' => array_map(static fn (CrmDashboardFunnelStageDto $stage) => $stage->toArray(), $this->funnelStages),
+            'teams' => array_map(static fn (CrmDashboardTeamDto $team) => $team->toArray(), $this->teams),
+            'todayAgenda' => array_map(static fn (CrmDashboardAgendaItemDto $agendaItem) => $agendaItem->toArray(), $this->todayAgenda),
+        ];
+    }
+}

--- a/src/Crm/Application/Service/CrmExecutiveDashboardService.php
+++ b/src/Crm/Application/Service/CrmExecutiveDashboardService.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Application\Dto\Dashboard\CrmDashboardAgendaItemDto;
+use App\Crm\Application\Dto\Dashboard\CrmDashboardFunnelStageDto;
+use App\Crm\Application\Dto\Dashboard\CrmDashboardKpiTileDto;
+use App\Crm\Application\Dto\Dashboard\CrmDashboardTeamDto;
+use App\Crm\Application\Dto\Dashboard\CrmExecutiveDashboardDto;
+
+final readonly class CrmExecutiveDashboardService
+{
+    public function build(): CrmExecutiveDashboardDto
+    {
+        return new CrmExecutiveDashboardDto(
+            kpiTiles: [
+                new CrmDashboardKpiTileDto('MRR', '$284,700', '+12.4%', 'success', 'mdi-cash-multiple', 'vs month dernier'),
+                new CrmDashboardKpiTileDto('Nouveaux leads', '1,482', '+8.1%', 'success', 'mdi-account-multiple-plus-outline', '7 derniers jours'),
+                new CrmDashboardKpiTileDto('Taux de conversion', '34.8%', '-1.7%', 'warning', 'mdi-chart-line-variant', 'pipeline global'),
+                new CrmDashboardKpiTileDto('Tickets SLA en retard', '17', '-6', 'success', 'mdi-timer-alert-outline', 'objectif: < 20'),
+            ],
+            funnelStages: [
+                new CrmDashboardFunnelStageDto('Prospection', 54, '$410k'),
+                new CrmDashboardFunnelStageDto('Qualification', 31, '$295k'),
+                new CrmDashboardFunnelStageDto('Proposition', 19, '$188k'),
+                new CrmDashboardFunnelStageDto('Négociation', 11, '$121k'),
+                new CrmDashboardFunnelStageDto('Closing', 7, '$84k'),
+            ],
+            teams: [
+                new CrmDashboardTeamDto('Sales Ops', 'Amine', '92%', 'Excellent'),
+                new CrmDashboardTeamDto('Customer Success', 'Meriem', '87%', 'Stable'),
+                new CrmDashboardTeamDto('Partnerships', 'Yassir', '73%', 'À surveiller'),
+                new CrmDashboardTeamDto('Finance CRM', 'Lina', '95%', 'Excellent'),
+            ],
+            todayAgenda: [
+                new CrmDashboardAgendaItemDto('09:00', 'QBR - Compte Enterprise Orbitex', 'Account Team A'),
+                new CrmDashboardAgendaItemDto('11:30', 'Validation devis 2026 / segment SaaS', 'Finance CRM'),
+                new CrmDashboardAgendaItemDto('14:00', 'Sprint planning - intégrations API', 'RevOps + Dev'),
+                new CrmDashboardAgendaItemDto('16:30', 'Point risques churn clients premium', 'Customer Success'),
+            ],
+        );
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/Report/GetCrmExecutiveDashboardController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Report/GetCrmExecutiveDashboardController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Report;
+
+use App\Crm\Application\Service\CrmApplicationScopeResolver;
+use App\Crm\Application\Service\CrmExecutiveDashboardService;
+use App\Role\Domain\Enum\Role;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_OWNER->value)]
+final readonly class GetCrmExecutiveDashboardController
+{
+    public function __construct(
+        private CrmExecutiveDashboardService $dashboardService,
+        private CrmApplicationScopeResolver $scopeResolver,
+    ) {
+    }
+
+    #[Route('/v1/crm/dashboard/executive', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        description: 'Retourne les widgets du dashboard exécutif CRM (KPIs, funnel, équipes, agenda).',
+        summary: 'Consulter le dashboard exécutif CRM',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'Dashboard exécutif récupéré avec succès.'),
+            new OA\Response(response: JsonResponse::HTTP_UNAUTHORIZED, description: 'Authentification requise.'),
+            new OA\Response(response: JsonResponse::HTTP_FORBIDDEN, description: 'Accès refusé.'),
+            new OA\Response(response: JsonResponse::HTTP_NOT_FOUND, description: 'Application CRM introuvable.'),
+        ],
+    )]
+    public function __invoke(): JsonResponse
+    {
+        $this->scopeResolver->resolveOrFail('crm-general-core');
+
+        return new JsonResponse($this->dashboardService->build()->toArray());
+    }
+}


### PR DESCRIPTION
### Motivation

- Exposer un endpoint structuré pour le dashboard exécutif CRM afin de pouvoir retourner les widgets `kpiTiles`, `funnelStages`, `teams` et `todayAgenda` dans une forme JSON prête à l'affichage.
- Centraliser la construction du payload dans un service pour séparer la logique de présentation des contrôleurs.

### Description

- Ajout de DTOs de réponse sous `src/Crm/Application/Dto/Dashboard/` : `CrmDashboardKpiTileDto`, `CrmDashboardFunnelStageDto`, `CrmDashboardTeamDto`, `CrmDashboardAgendaItemDto` et `CrmExecutiveDashboardDto` pour représenter la structure demandée.
- Ajout du service `CrmExecutiveDashboardService` qui assemble un `CrmExecutiveDashboardDto` avec les KPI, funnel, équipes et agenda (valeurs statiques pour la première implémentation).
- Ajout du contrôleur `GetCrmExecutiveDashboardController` exposant `GET /v1/crm/dashboard/executive`, qui résout le scope CRM (`crm-general-core`), applique la sécurité `IsGranted(Role::CRM_OWNER)` et retourne la réponse JSON via `toArray()`.

### Testing

- Exécution de `php -l` sur les nouveaux fichiers DTO, service et contrôleur a réussi (aucune erreur de syntaxe détectée).
- Tentative d'exécuter `php bin/console debug:router` a échoué automatiquement parce que les dépendances Composer ne sont pas installées (`Try running "composer install"`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed273ad3c4832baabdd57b8a113069)