### PR TITLE
Accept single `files` field in CRM attachment uploads

### DIFF
--- a/src/Crm/Application/Service/CrmAttachmentUploaderService.php
+++ b/src/Crm/Application/Service/CrmAttachmentUploaderService.php
@@ -35,7 +35,9 @@ final readonly class CrmAttachmentUploaderService
         }
 
         $multiple = $request->files->get('files');
-        if (is_array($multiple)) {
+        if ($multiple instanceof UploadedFile) {
+            $files[] = $multiple;
+        } elseif (is_array($multiple)) {
             foreach ($multiple as $file) {
                 if ($file instanceof UploadedFile) {
                     $files[] = $file;
@@ -54,7 +56,7 @@ final readonly class CrmAttachmentUploaderService
     public function upload(Request $request, array $files, string $relativeDirectory): array
     {
         if ($files === []) {
-            throw new HttpException(Response::HTTP_BAD_REQUEST, 'No file found. Expected "file" or "files[]".');
+            throw new HttpException(Response::HTTP_BAD_REQUEST, 'No file found. Expected "file", "files", or "files[]".');
         }
 
         return $this->mediaUploaderService->upload(


### PR DESCRIPTION
### Motivation
- Multipart uploads parsed by Symfony can expose a repeated `files` field as a single `UploadedFile`, which caused valid uploads to be rejected with a 400 error.
- Make the CRM attachment extractor robust to different client payload shapes so single- and multi-file uploads both work.

### Description
- Update `CrmAttachmentUploaderService::extractFiles()` to accept a single `UploadedFile` under the `files` key in addition to arrays and the existing `file` key by checking `instanceof UploadedFile` before treating `files` as an array. 
- Clarify the bad-request message in `CrmAttachmentUploaderService::upload()` to mention `file`, `files`, and `files[]` as accepted field names.
- Changes are implemented in `src/Crm/Application/Service/CrmAttachmentUploaderService.php` and keep existing behavior for `file` and `files[]` formats.

### Testing
- Ran a PHP syntax check with `php -l src/Crm/Application/Service/CrmAttachmentUploaderService.php`, which returned no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2d43ff54832b993b4ef1580b76e4)