### PR TITLE
Add CRM TaskRequest worklogs and hour tracking

### DIFF
--- a/migrations/Version20260425110000.php
+++ b/migrations/Version20260425110000.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260425110000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add planned hours on task requests and introduce task request worklogs.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_task_request ADD planned_hours DOUBLE PRECISION NOT NULL DEFAULT 0');
+        $this->addSql('CREATE TABLE crm_task_request_worklog (id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", task_request_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", employee_id BINARY(16) NOT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", logged_by_user_id BINARY(16) DEFAULT NULL COMMENT "(DC2Type:uuid_binary_ordered_time)", hours DOUBLE PRECISION NOT NULL, logged_at DATETIME NOT NULL COMMENT "(DC2Type:datetime_immutable)", comment LONGTEXT DEFAULT NULL, created_at DATETIME NOT NULL COMMENT "(DC2Type:datetime_immutable)", updated_at DATETIME DEFAULT NULL COMMENT "(DC2Type:datetime_immutable)", INDEX idx_crm_task_request_worklog_task_request_id (task_request_id), INDEX idx_crm_task_request_worklog_employee_id (employee_id), INDEX idx_crm_task_request_worklog_logged_at (logged_at), INDEX IDX_E3A39295F8C3BF8E (logged_by_user_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE crm_task_request_worklog ADD CONSTRAINT FK_48A8BE753D7470A8 FOREIGN KEY (task_request_id) REFERENCES crm_task_request (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE crm_task_request_worklog ADD CONSTRAINT FK_48A8BE758C03F15C FOREIGN KEY (employee_id) REFERENCES crm_employee (id) ON DELETE CASCADE');
+        $this->addSql('ALTER TABLE crm_task_request_worklog ADD CONSTRAINT FK_E3A39295F8C3BF8E FOREIGN KEY (logged_by_user_id) REFERENCES user (id) ON DELETE SET NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE crm_task_request_worklog DROP FOREIGN KEY FK_48A8BE753D7470A8');
+        $this->addSql('ALTER TABLE crm_task_request_worklog DROP FOREIGN KEY FK_48A8BE758C03F15C');
+        $this->addSql('ALTER TABLE crm_task_request_worklog DROP FOREIGN KEY FK_E3A39295F8C3BF8E');
+        $this->addSql('DROP TABLE crm_task_request_worklog');
+        $this->addSql('ALTER TABLE crm_task_request DROP planned_hours');
+    }
+}

--- a/src/Crm/Application/Service/CrmApiNormalizer.php
+++ b/src/Crm/Application/Service/CrmApiNormalizer.php
@@ -11,13 +11,16 @@ use App\User\Domain\Entity\User;
 use DateTimeInterface;
 
 use function array_map;
+use function array_values;
 use function is_array;
 use function is_string;
+use function max;
 
 final readonly class CrmApiNormalizer
 {
     public function __construct(
         private CrmBlogNormalizer $crmBlogNormalizer,
+        private TaskRequestWorklogReadService $taskRequestWorklogReadService,
     ) {
     }
 
@@ -45,6 +48,12 @@ final readonly class CrmApiNormalizer
     private function normalizeTaskWithOptions(Task $task, bool $includeBlog): array
     {
         $assignees = $this->mapUserAssignees($task->getAssignees());
+        $taskRequests = $task->getTaskRequests()->toArray();
+        $taskRequestIds = array_values(array_map(
+            static fn (TaskRequest $taskRequest): string => $taskRequest->getId(),
+            $taskRequests,
+        ));
+        $consumedHoursByTaskRequestId = $this->taskRequestWorklogReadService->getConsumedHoursByTaskRequestIds($taskRequestIds);
 
         $payload = [
             'id' => $task->getId(),
@@ -88,13 +97,20 @@ final readonly class CrmApiNormalizer
                 $task->getSubTasks()->toArray()
             ),
             'children' => array_map(
-                static fn (TaskRequest $taskRequest) => [
-                    'id' => $taskRequest->getId(),
-                    'title' => $taskRequest->getTitle(),
-                    'description' => $taskRequest->getDescription(),
-                    'status' => $taskRequest->getStatus(),
-                ],
-                $task->getTaskRequests()->toArray()
+                function (TaskRequest $taskRequest) use ($consumedHoursByTaskRequestId): array {
+                    $consumedHours = $consumedHoursByTaskRequestId[$taskRequest->getId()] ?? 0.0;
+
+                    return [
+                        'id' => $taskRequest->getId(),
+                        'title' => $taskRequest->getTitle(),
+                        'description' => $taskRequest->getDescription(),
+                        'status' => $taskRequest->getStatus(),
+                        'plannedHours' => $taskRequest->getPlannedHours(),
+                        'consumedHours' => $consumedHours,
+                        'remainingHours' => $this->taskRequestWorklogReadService->getRemainingHours($taskRequest->getPlannedHours(), $consumedHours),
+                    ];
+                },
+                $taskRequests
             ),
         ];
 
@@ -111,6 +127,7 @@ final readonly class CrmApiNormalizer
     public function normalizeTaskRequest(TaskRequest $taskRequest): array
     {
         $assignees = $this->mapUserAssignees($taskRequest->getAssignees());
+        $consumedHours = $this->taskRequestWorklogReadService->getConsumedHours($taskRequest->getId());
 
         return [
             'id' => $taskRequest->getId(),
@@ -123,6 +140,9 @@ final readonly class CrmApiNormalizer
             'attachments' => $taskRequest->getAttachments(),
             'blogId' => $taskRequest->getBlog()?->getId(),
             'assignees' => $assignees,
+            'plannedHours' => $taskRequest->getPlannedHours(),
+            'consumedHours' => $consumedHours,
+            'remainingHours' => $this->taskRequestWorklogReadService->getRemainingHours($taskRequest->getPlannedHours(), $consumedHours),
             'githubIssue' => $taskRequest->getGithubIssue()?->toArray(),
             'githubBranches' => array_map(static fn (TaskRequestGithubBranch $branch): array => $branch->toArray(), $taskRequest->getGithubBranches()->toArray()),
             'blog' => $this->crmBlogNormalizer->normalizeBlog($taskRequest->getBlog()),
@@ -172,12 +192,18 @@ final readonly class CrmApiNormalizer
      */
     public function normalizeTaskRequestProjection(array $item): array
     {
+        $plannedHours = (float)($item['plannedHours'] ?? 0);
+        $consumedHours = (float)($item['consumedHours'] ?? 0);
+
         return [
             'id' => (string)($item['id'] ?? ''),
             'title' => (string)($item['title'] ?? ''),
             'status' => ($item['status'] ?? ''),
             'requestedAt' => $this->normalizeDateValue($item['requestedAt'] ?? null),
             'resolvedAt' => $this->normalizeDateValue($item['resolvedAt'] ?? null),
+            'plannedHours' => $plannedHours,
+            'consumedHours' => $consumedHours,
+            'remainingHours' => max(0.0, $plannedHours - $consumedHours),
             'assignees' => $this->mapTaskRequestAssigneesProjection((array)($item['assignees'] ?? [])),
             'githubIssue' => [
                 'provider' => $item['githubIssueProvider'] ?? null,

--- a/src/Crm/Application/Service/TaskRequestWorklogReadService.php
+++ b/src/Crm/Application/Service/TaskRequestWorklogReadService.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Application\Service;
+
+use App\Crm\Infrastructure\Repository\TaskRequestWorklogRepository;
+
+use function max;
+
+final readonly class TaskRequestWorklogReadService
+{
+    public function __construct(
+        private TaskRequestWorklogRepository $worklogRepository,
+    ) {
+    }
+
+    public function getConsumedHours(string $taskRequestId): float
+    {
+        return $this->worklogRepository->sumConsumedHoursByTaskRequestId($taskRequestId);
+    }
+
+    /**
+     * @param list<string> $taskRequestIds
+     * @return array<string,float>
+     */
+    public function getConsumedHoursByTaskRequestIds(array $taskRequestIds): array
+    {
+        return $this->worklogRepository->sumConsumedHoursByTaskRequestIds($taskRequestIds);
+    }
+
+    public function getRemainingHours(float $plannedHours, float $consumedHours): float
+    {
+        return max(0.0, $plannedHours - $consumedHours);
+    }
+}

--- a/src/Crm/Domain/Entity/TaskRequest.php
+++ b/src/Crm/Domain/Entity/TaskRequest.php
@@ -21,6 +21,10 @@ use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 use Throwable;
 
+use function array_map;
+use function array_reduce;
+use function max;
+
 #[ORM\Entity]
 #[ORM\Table(
     name: 'crm_task_request',
@@ -87,6 +91,13 @@ class TaskRequest implements EntityInterface
     #[ORM\InverseJoinColumn(name: 'user_id', referencedColumnName: 'id', onDelete: 'CASCADE')]
     private Collection|ArrayCollection $assignees;
 
+    #[ORM\Column(name: 'planned_hours', type: Types::FLOAT, options: ['default' => 0])]
+    private float $plannedHours = 0.0;
+
+    /** @var Collection<int, TaskRequestWorklog>|ArrayCollection<int, TaskRequestWorklog> */
+    #[ORM\OneToMany(mappedBy: 'taskRequest', targetEntity: TaskRequestWorklog::class, cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection|ArrayCollection $worklogs;
+
     /**
      * @throws Throwable
      */
@@ -96,6 +107,7 @@ class TaskRequest implements EntityInterface
         $this->requestedAt = new DateTimeImmutable();
         $this->assignees = new ArrayCollection();
         $this->githubBranches = new ArrayCollection();
+        $this->worklogs = new ArrayCollection();
     }
 
     #[Override]
@@ -298,6 +310,62 @@ class TaskRequest implements EntityInterface
         return $this;
     }
 
+    public function getPlannedHours(): float
+    {
+        return $this->plannedHours;
+    }
+
+    public function setPlannedHours(float $plannedHours): self
+    {
+        $this->plannedHours = max(0.0, $plannedHours);
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, TaskRequestWorklog>|ArrayCollection<int, TaskRequestWorklog>
+     */
+    public function getWorklogs(): Collection|ArrayCollection
+    {
+        return $this->worklogs;
+    }
+
+    public function addWorklog(TaskRequestWorklog $worklog): self
+    {
+        if (!$this->worklogs->contains($worklog)) {
+            $this->worklogs->add($worklog);
+        }
+
+        if ($worklog->getTaskRequest() !== $this) {
+            $worklog->setTaskRequest($this);
+        }
+
+        return $this;
+    }
+
+    public function removeWorklog(TaskRequestWorklog $worklog): self
+    {
+        if ($this->worklogs->removeElement($worklog) && $worklog->getTaskRequest() === $this) {
+            $worklog->setTaskRequest(null);
+        }
+
+        return $this;
+    }
+
+    public function getConsumedHours(): float
+    {
+        return array_reduce(
+            $this->worklogs->toArray(),
+            static fn (float $sum, TaskRequestWorklog $worklog): float => $sum + $worklog->getHours(),
+            0.0,
+        );
+    }
+
+    public function getRemainingHours(): float
+    {
+        return max(0.0, $this->plannedHours - $this->getConsumedHours());
+    }
+
     public function toArray(): array
     {
         return [
@@ -311,6 +379,9 @@ class TaskRequest implements EntityInterface
             'assignees' => $this->getAssignees()->toArray(),
             'github_issue' => $this->getGithubIssue()?->toArray(),
             'github_branches' => array_map(static fn (TaskRequestGithubBranch $branch): array => $branch->toArray(), $this->getGithubBranches()->toArray()),
+            'planned_hours' => $this->getPlannedHours(),
+            'consumed_hours' => $this->getConsumedHours(),
+            'remaining_hours' => $this->getRemainingHours(),
         ];
     }
 }

--- a/src/Crm/Domain/Entity/TaskRequestWorklog.php
+++ b/src/Crm/Domain/Entity/TaskRequestWorklog.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Domain\Entity;
+
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use App\User\Domain\Entity\User;
+use DateTimeImmutable;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Throwable;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'crm_task_request_worklog')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class TaskRequestWorklog implements EntityInterface
+{
+    use Timestampable;
+    use Uuid;
+
+    #[ORM\Id]
+    #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)]
+    private UuidInterface $id;
+
+    #[ORM\ManyToOne(targetEntity: TaskRequest::class, inversedBy: 'worklogs')]
+    #[ORM\JoinColumn(name: 'task_request_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    private ?TaskRequest $taskRequest = null;
+
+    #[ORM\ManyToOne(targetEntity: Employee::class)]
+    #[ORM\JoinColumn(name: 'employee_id', referencedColumnName: 'id', nullable: false, onDelete: 'CASCADE')]
+    #[Assert\NotNull]
+    private ?Employee $employee = null;
+
+    #[ORM\ManyToOne(targetEntity: User::class)]
+    #[ORM\JoinColumn(name: 'logged_by_user_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?User $loggedByUser = null;
+
+    #[ORM\Column(name: 'hours', type: Types::FLOAT)]
+    #[Assert\Positive]
+    private float $hours = 0.0;
+
+    #[ORM\Column(name: 'logged_at', type: Types::DATETIME_IMMUTABLE)]
+    private DateTimeImmutable $loggedAt;
+
+    #[ORM\Column(name: 'comment', type: Types::TEXT, nullable: true)]
+    private ?string $comment = null;
+
+    /**
+     * @throws Throwable
+     */
+    public function __construct()
+    {
+        $this->id = $this->createUuid();
+        $this->loggedAt = new DateTimeImmutable();
+    }
+
+    #[Override]
+    public function getId(): string
+    {
+        return $this->id->toString();
+    }
+
+    public function getTaskRequest(): ?TaskRequest
+    {
+        return $this->taskRequest;
+    }
+
+    public function setTaskRequest(?TaskRequest $taskRequest): self
+    {
+        $this->taskRequest = $taskRequest;
+
+        return $this;
+    }
+
+    public function getEmployee(): ?Employee
+    {
+        return $this->employee;
+    }
+
+    public function setEmployee(?Employee $employee): self
+    {
+        $this->employee = $employee;
+
+        return $this;
+    }
+
+    public function getLoggedByUser(): ?User
+    {
+        return $this->loggedByUser;
+    }
+
+    public function setLoggedByUser(?User $loggedByUser): self
+    {
+        $this->loggedByUser = $loggedByUser;
+
+        return $this;
+    }
+
+    public function getHours(): float
+    {
+        return $this->hours;
+    }
+
+    public function setHours(float $hours): self
+    {
+        $this->hours = $hours;
+
+        return $this;
+    }
+
+    public function getLoggedAt(): DateTimeImmutable
+    {
+        return $this->loggedAt;
+    }
+
+    public function setLoggedAt(DateTimeImmutable $loggedAt): self
+    {
+        $this->loggedAt = $loggedAt;
+
+        return $this;
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->comment;
+    }
+
+    public function setComment(?string $comment): self
+    {
+        $this->comment = $comment;
+
+        return $this;
+    }
+}

--- a/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
+++ b/src/Crm/Infrastructure/Repository/TaskRequestRepository.php
@@ -147,9 +147,12 @@ class TaskRequestRepository extends BaseRepository
         }
 
         $itemsQb = $this->createQueryBuilder('taskRequest')
-            ->select('taskRequest.id, taskRequest.title, taskRequest.status, taskRequest.requestedAt, taskRequest.resolvedAt, IDENTITY(taskRequest.blog) AS blogId, IDENTITY(taskRequest.task) AS taskId, IDENTITY(taskRequest.repository) AS repositoryId')
+            ->select('taskRequest.id, taskRequest.title, taskRequest.status, taskRequest.requestedAt, taskRequest.resolvedAt, taskRequest.plannedHours, IDENTITY(taskRequest.blog) AS blogId, IDENTITY(taskRequest.task) AS taskId, IDENTITY(taskRequest.repository) AS repositoryId')
+            ->addSelect('COALESCE(SUM(worklog.hours), 0) AS consumedHours')
             ->addSelect('githubIssue.provider AS githubIssueProvider, githubIssue.repositoryFullName AS githubIssueRepositoryFullName, githubIssue.issueNumber AS githubIssueIssueNumber, githubIssue.issueNodeId AS githubIssueIssueNodeId, githubIssue.issueUrl AS githubIssueIssueUrl, githubIssue.syncStatus AS githubIssueSyncStatus, githubIssue.lastSyncedAt AS githubIssueLastSyncedAt')
-            ->leftJoin('taskRequest.githubIssue', 'githubIssue');
+            ->leftJoin('taskRequest.githubIssue', 'githubIssue')
+            ->leftJoin('taskRequest.worklogs', 'worklog')
+            ->groupBy('taskRequest.id, githubIssue.provider, githubIssue.repositoryFullName, githubIssue.issueNumber, githubIssue.issueNodeId, githubIssue.issueUrl, githubIssue.syncStatus, githubIssue.lastSyncedAt');
 
         $this->applyBinaryUuidIdsFilter($itemsQb, 'taskRequest.id', $taskRequestIds, 'task_request_id_');
 

--- a/src/Crm/Infrastructure/Repository/TaskRequestWorklogRepository.php
+++ b/src/Crm/Infrastructure/Repository/TaskRequestWorklogRepository.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Infrastructure\Repository;
+
+use App\Crm\Domain\Entity\TaskRequestWorklog as Entity;
+use App\General\Infrastructure\Repository\BaseRepository;
+use Doctrine\DBAL\LockMode;
+use Doctrine\Persistence\ManagerRegistry;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+
+use function array_values;
+
+/**
+ * @method Entity|null find(string $id, LockMode|int|null $lockMode = null, ?int $lockVersion = null, ?string $entityManagerName = null)
+ * @method Entity[] findBy(array $criteria, ?array $orderBy = null, ?int $limit = null, ?int $offset = null, ?string $entityManagerName = null)
+ */
+class TaskRequestWorklogRepository extends BaseRepository
+{
+    protected static string $entityName = Entity::class;
+
+    protected static array $searchColumns = [
+        'id',
+    ];
+
+    public function __construct(
+        protected ManagerRegistry $managerRegistry,
+    ) {
+    }
+
+    public function sumConsumedHoursByTaskRequestId(string $taskRequestId): float
+    {
+        return $this->sumConsumedHoursByTaskRequestIds([$taskRequestId])[$taskRequestId] ?? 0.0;
+    }
+
+    /**
+     * @param list<string> $taskRequestIds
+     * @return array<string,float>
+     */
+    public function sumConsumedHoursByTaskRequestIds(array $taskRequestIds): array
+    {
+        if ($taskRequestIds === []) {
+            return [];
+        }
+
+        $qb = $this->createQueryBuilder('worklog')
+            ->select('IDENTITY(worklog.taskRequest) AS taskRequestId, COALESCE(SUM(worklog.hours), 0) AS consumedHours')
+            ->groupBy('worklog.taskRequest');
+
+        $orConditions = [];
+        foreach (array_values($taskRequestIds) as $index => $taskRequestId) {
+            $paramName = 'taskRequestId_' . $index;
+            $orConditions[] = 'IDENTITY(worklog.taskRequest) = :' . $paramName;
+            $qb->setParameter($paramName, $taskRequestId, UuidBinaryOrderedTimeType::NAME);
+        }
+
+        $qb->andWhere('(' . implode(' OR ', $orConditions) . ')');
+
+        /** @var list<array{taskRequestId:string,consumedHours:numeric-string|float|int}> $rows */
+        $rows = $qb->getQuery()->getArrayResult();
+
+        $consumedHoursByTaskRequest = [];
+        foreach ($rows as $row) {
+            $consumedHoursByTaskRequest[(string)$row['taskRequestId']] = (float)$row['consumedHours'];
+        }
+
+        return $consumedHoursByTaskRequest;
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/CreateTaskRequestController.php
@@ -111,7 +111,8 @@ final readonly class CreateTaskRequestController
         $taskRequest->setTitle((string)$input->title)
             ->setDescription($input->description)
             ->setStatus(TaskRequestStatus::tryFrom((string)$input->status) ?? TaskRequestStatus::PENDING)
-            ->setResolvedAt($resolvedAt);
+            ->setResolvedAt($resolvedAt)
+            ->setPlannedHours(is_numeric($input->plannedHours) ? (float)$input->plannedHours : 0.0);
 
         if (is_string($input->taskId)) {
             $task = $this->taskRepository->findOneScopedById($input->taskId, $crm->getId());

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/PatchTaskRequestController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/PatchTaskRequestController.php
@@ -95,6 +95,9 @@ final readonly class PatchTaskRequestController
 
             $taskRequest->setRepository($repository);
         }
+        if (array_key_exists('plannedHours', $payload) && is_numeric($payload['plannedHours'])) {
+            $taskRequest->setPlannedHours((float)$payload['plannedHours']);
+        }
 
         $this->taskRequestRepository->save($taskRequest);
 

--- a/src/Crm/Transport/Request/CreateTaskRequestEntryRequest.php
+++ b/src/Crm/Transport/Request/CreateTaskRequestEntryRequest.php
@@ -38,6 +38,10 @@ final class CreateTaskRequestEntryRequest
     ])]
     public ?array $assigneeIds = null;
 
+    #[Assert\Type(type: 'numeric')]
+    #[Assert\GreaterThanOrEqual(0)]
+    public null|int|float|string $plannedHours = null;
+
     public static function fromArray(array $payload): self
     {
         $request = new self();
@@ -48,6 +52,7 @@ final class CreateTaskRequestEntryRequest
         $request->taskId = isset($payload['taskId']) ? (string)$payload['taskId'] : null;
         $request->repositoryId = isset($payload['repositoryId']) ? (string)$payload['repositoryId'] : null;
         $request->assigneeIds = isset($payload['assigneeIds']) && is_array($payload['assigneeIds']) ? $payload['assigneeIds'] : $payload['assigneeIds'] ?? null;
+        $request->plannedHours = $payload['plannedHours'] ?? null;
 
         return $request;
     }


### PR DESCRIPTION
### Motivation

- Support time tracking on CRM task requests by persisting planned hours and recording worklogs so consumed/remaining hours can be computed and surfaced in the API.

### Description

- Persist `plannedHours` on `TaskRequest` and add derived helpers `getConsumedHours()` and `getRemainingHours()` (bounded at 0) and expose them in `toArray()`.
- Add new entity `TaskRequestWorklog` with `ManyToOne` to `TaskRequest`, `ManyToOne` to `Employee`, optional `loggedByUser`, `hours`, `loggedAt`, and `comment`.
- Add `TaskRequestWorklogRepository` with `sumConsumedHoursByTaskRequestId(s)` to aggregate `SUM(hours)` and `TaskRequestWorklogReadService` to expose consumed/remaining hours logic.
- Update `TaskRequestRepository` projection to include `plannedHours` and `COALESCE(SUM(worklog.hours), 0) AS consumedHours` and adapt grouping to return aggregated values.
- Update API normalization in `CrmApiNormalizer` to expose `plannedHours`, `consumedHours`, and `remainingHours` for `normalizeTaskRequest`, children projections in `normalizeTask`, and in `normalizeTaskRequestProjection`.
- Allow `plannedHours` in request DTO `CreateTaskRequestEntryRequest` and wire it through create and patch controllers (`CreateTaskRequestController`, `PatchTaskRequestController`).
- Add Doctrine migration `Version20260425110000` to add `planned_hours` column and create `crm_task_request_worklog` table with indexes on `task_request_id`, `employee_id`, and `logged_at` and appropriate foreign keys.

### Testing

- Ran `php -l` (syntax check) on all modified/added PHP files including entities, repositories, services, controllers, request DTO and migration; all files reported `No syntax errors detected`.
- No additional automated unit/integration tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed38998608832bb0a3451a13bc120d)