### PR TITLE
feat(crm): add task-level planned/consumed/remaining hour aggregates

### DIFF
--- a/src/Crm/Application/Service/CrmApiNormalizer.php
+++ b/src/Crm/Application/Service/CrmApiNormalizer.php
@@ -11,6 +11,7 @@ use App\User\Domain\Entity\User;
 use DateTimeInterface;
 
 use function array_map;
+use function array_reduce;
 use function array_values;
 use function is_array;
 use function is_string;
@@ -54,6 +55,16 @@ final readonly class CrmApiNormalizer
             $taskRequests,
         ));
         $consumedHoursByTaskRequestId = $this->taskRequestWorklogReadService->getConsumedHoursByTaskRequestIds($taskRequestIds);
+        $taskPlannedHours = array_reduce(
+            $taskRequests,
+            static fn (float $sum, TaskRequest $taskRequest): float => $sum + $taskRequest->getPlannedHours(),
+            0.0,
+        );
+        $taskConsumedHours = array_reduce(
+            $taskRequests,
+            static fn (float $sum, TaskRequest $taskRequest): float => $sum + ($consumedHoursByTaskRequestId[$taskRequest->getId()] ?? 0.0),
+            0.0,
+        );
 
         $payload = [
             'id' => $task->getId(),
@@ -67,6 +78,10 @@ final readonly class CrmApiNormalizer
             'parentTaskId' => $task->getParentTask()?->getId(),
             'dueAt' => $this->normalizeDate($task->getDueAt()),
             'estimatedHours' => $task->getEstimatedHours(),
+            'plannedHoursFromRequests' => $taskPlannedHours,
+            'taskPlannedHours' => $taskPlannedHours,
+            'taskConsumedHours' => $taskConsumedHours,
+            'taskRemainingHours' => max(0.0, $taskPlannedHours - $taskConsumedHours),
             'updatedAt' => $this->normalizeDate($task->getUpdatedAt()),
             'attachments' => $task->getAttachments(),
             'blogId' => $task->getBlog()?->getId(),

--- a/src/Crm/Domain/Entity/Task.php
+++ b/src/Crm/Domain/Entity/Task.php
@@ -77,6 +77,10 @@ class Task implements EntityInterface
     #[ORM\Column(name: 'due_at', type: Types::DATETIME_IMMUTABLE, nullable: true)]
     private ?DateTimeImmutable $dueAt = null;
 
+    /**
+     * User-provided estimate for the task itself.
+     * This value is independent from TaskRequest planned-hours aggregates.
+     */
     #[ORM\Column(name: 'estimated_hours', type: Types::FLOAT, nullable: true)]
     private ?float $estimatedHours = null;
 


### PR DESCRIPTION
### Motivation

- Surface task-level hour aggregates computed from all linked `TaskRequest` entries so list/detail task payloads can display consolidated planned/consumed/remaining hours. 
- Avoid ambiguity between `Task::estimatedHours` and the sum of child requests by providing an explicit aggregate field. 

### Description

- Compute `taskPlannedHours` and `taskConsumedHours` in `CrmApiNormalizer::normalizeTaskWithOptions` using `array_reduce` and derive `taskRemainingHours` as `max(0.0, taskPlannedHours - taskConsumedHours)`. 
- Expose the following fields on the task payload returned by the normalizer: `plannedHoursFromRequests`, `taskPlannedHours`, `taskConsumedHours`, and `taskRemainingHours`. 
- Add a PHPDoc comment to `Task::$estimatedHours` clarifying that `estimatedHours` is a user-provided estimate and is independent from the `TaskRequest` planned-hours aggregates. 

### Testing

- Ran `php -l src/Crm/Application/Service/CrmApiNormalizer.php` which passed without syntax errors. 
- Ran `php -l src/Crm/Domain/Entity/Task.php` which passed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3b635c64832b85ccc14fb424e7d1)