### PR TITLE
feat(crm): auto-fill Employee names from linked User on prePersist/preUpdate

### DIFF
--- a/config/packages/event_listeners.yaml
+++ b/config/packages/event_listeners.yaml
@@ -49,3 +49,9 @@ services:
             - { name: doctrine.event_listener, event: onFlush }
             - { name: doctrine.event_listener, event: postFlush }
 
+
+    App\Crm\Transport\EventListener\CrmEmployeeEntityEventListener:
+        tags:
+            - { name: doctrine.event_listener, event: prePersist }
+            - { name: doctrine.event_listener, event: preUpdate }
+

--- a/src/Crm/Transport/EventListener/CrmEmployeeEntityEventListener.php
+++ b/src/Crm/Transport/EventListener/CrmEmployeeEntityEventListener.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\EventListener;
+
+use App\Crm\Domain\Entity\Employee;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+
+use function trim;
+
+final class CrmEmployeeEntityEventListener
+{
+    public function prePersist(LifecycleEventArgs $event): void
+    {
+        $this->hydrateMissingNamesFromUser($event->getObject());
+    }
+
+    public function preUpdate(PreUpdateEventArgs $event): void
+    {
+        $entity = $event->getObject();
+        if (!$entity instanceof Employee) {
+            return;
+        }
+
+        $beforeFirstName = $entity->getFirstName();
+        $beforeLastName = $entity->getLastName();
+
+        $this->hydrateMissingNamesFromUser($entity);
+
+        if ($beforeFirstName === $entity->getFirstName() && $beforeLastName === $entity->getLastName()) {
+            return;
+        }
+
+        $objectManager = $event->getObjectManager();
+        if (!$objectManager instanceof EntityManagerInterface) {
+            return;
+        }
+
+        $unitOfWork = $objectManager->getUnitOfWork();
+        $metadata = $objectManager->getClassMetadata(Employee::class);
+        $unitOfWork->recomputeSingleEntityChangeSet($metadata, $entity);
+    }
+
+    private function hydrateMissingNamesFromUser(object $entity): void
+    {
+        if (!$entity instanceof Employee) {
+            return;
+        }
+
+        $user = $entity->getUser();
+        if (!$user instanceof User) {
+            return;
+        }
+
+        if ($this->isBlank($entity->getFirstName()) && !$this->isBlank($user->getFirstName())) {
+            $entity->setFirstName($user->getFirstName());
+        }
+
+        if ($this->isBlank($entity->getLastName()) && !$this->isBlank($user->getLastName())) {
+            $entity->setLastName($user->getLastName());
+        }
+    }
+
+    private function isBlank(string $value): bool
+    {
+        return trim($value) === '';
+    }
+}

--- a/tests/Unit/Crm/Transport/EventListener/CrmEmployeeEntityEventListenerTest.php
+++ b/tests/Unit/Crm/Transport/EventListener/CrmEmployeeEntityEventListenerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Crm\Transport\EventListener;
+
+use App\Crm\Domain\Entity\Employee;
+use App\Crm\Transport\EventListener\CrmEmployeeEntityEventListener;
+use App\User\Domain\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\UnitOfWork;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use PHPUnit\Framework\TestCase;
+
+final class CrmEmployeeEntityEventListenerTest extends TestCase
+{
+    public function testPrePersistCopiesMissingNamesFromLinkedUser(): void
+    {
+        $listener = new CrmEmployeeEntityEventListener();
+
+        $user = (new User())
+            ->setFirstName('John')
+            ->setLastName('Doe');
+
+        $employee = (new Employee())
+            ->setFirstName('')
+            ->setLastName('   ')
+            ->setUser($user);
+
+        $event = $this->createMock(LifecycleEventArgs::class);
+        $event->method('getObject')->willReturn($employee);
+
+        $listener->prePersist($event);
+
+        self::assertSame('John', $employee->getFirstName());
+        self::assertSame('Doe', $employee->getLastName());
+    }
+
+    public function testPrePersistDoesNotOverwriteExistingNames(): void
+    {
+        $listener = new CrmEmployeeEntityEventListener();
+
+        $user = (new User())
+            ->setFirstName('John')
+            ->setLastName('Doe');
+
+        $employee = (new Employee())
+            ->setFirstName('Jane')
+            ->setLastName('Smith')
+            ->setUser($user);
+
+        $event = $this->createMock(LifecycleEventArgs::class);
+        $event->method('getObject')->willReturn($employee);
+
+        $listener->prePersist($event);
+
+        self::assertSame('Jane', $employee->getFirstName());
+        self::assertSame('Smith', $employee->getLastName());
+    }
+
+    public function testPreUpdateSkipsWhenUserIsMissing(): void
+    {
+        $listener = new CrmEmployeeEntityEventListener();
+
+        $employee = (new Employee())
+            ->setFirstName('')
+            ->setLastName('');
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('getUnitOfWork');
+
+        $event = new PreUpdateEventArgs($employee, $entityManager, []);
+
+        $listener->preUpdate($event);
+
+        self::assertSame('', $employee->getFirstName());
+        self::assertSame('', $employee->getLastName());
+    }
+
+    public function testPreUpdateCopiesMissingNamesAndRecomputesChangeSet(): void
+    {
+        $listener = new CrmEmployeeEntityEventListener();
+
+        $user = (new User())
+            ->setFirstName('John')
+            ->setLastName('Doe');
+
+        $employee = (new Employee())
+            ->setFirstName('')
+            ->setLastName('')
+            ->setUser($user);
+
+        $unitOfWork = $this->createMock(UnitOfWork::class);
+        $unitOfWork
+            ->expects(self::once())
+            ->method('recomputeSingleEntityChangeSet')
+            ->with(
+                self::isInstanceOf(ClassMetadata::class),
+                self::identicalTo($employee),
+            );
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getUnitOfWork')->willReturn($unitOfWork);
+        $entityManager->method('getClassMetadata')->with(Employee::class)->willReturn(new ClassMetadata(Employee::class));
+
+        $event = new PreUpdateEventArgs($employee, $entityManager, []);
+
+        $listener->preUpdate($event);
+
+        self::assertSame('John', $employee->getFirstName());
+        self::assertSame('Doe', $employee->getLastName());
+    }
+}


### PR DESCRIPTION
### Motivation
- Centraliser la règle de fallback pour les noms d’Employee afin qu’elle s’applique partout où l’entité est persistée (fixtures, création métier, endpoints PUT/PATCH). 
- Éviter les données incomplètes quand un `Employee` est lié à un `User` ayant des `firstName`/`lastName` renseignés.

### Description
- Ajout d’un listener Doctrine `App\Crm\Transport\EventListener\CrmEmployeeEntityEventListener` qui s’exécute en `prePersist` et `preUpdate` et copie `firstName`/`lastName` depuis `Employee.user` si les champs Employee sont vides ou blancs et si les valeurs User sont présentes, sans jamais écraser une valeur existante.
- En `preUpdate` la mutation des champs déclenche un `recomputeSingleEntityChangeSet` pour garantir la persistance correcte uniquement si une modification a eu lieu.
- Enregistrement du listener dans `config/packages/event_listeners.yaml` et ajout de tests unitaires ciblés `tests/Unit/Crm/Transport/EventListener/CrmEmployeeEntityEventListenerTest.php` pour couvrir les cas de copy, non-écrasement, absence de user et recompute du change set.
- Aucun changement aux controllers ou handlers existants; la logique s’applique de façon transversale (fixtures via `LoadCrmData`, création via `CreateEmployeeCommandHandler`, update via `PutEmployeeController`/`PatchEmployeeController`).

### Testing
- `php -l src/Crm/Transport/EventListener/CrmEmployeeEntityEventListener.php` a été exécuté et a réussi (pas d’erreur de syntaxe).
- `php -l tests/Unit/Crm/Transport/EventListener/CrmEmployeeEntityEventListenerTest.php` a été exécuté et a réussi (pas d’erreur de syntaxe).
- Exécution de `./vendor/bin/phpunit tests/Unit/Crm/Transport/EventListener/CrmEmployeeEntityEventListenerTest.php` a échoué dans cet environnement car le binaire `phpunit` n’est pas présent (`./vendor/bin/phpunit: No such file or directory`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2b87a0c4832ba7782cc88b2a64e6)