### PR TITLE
fixtures(crm): define deterministic base projects in LoadCrmData

### DIFF
--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -90,6 +90,39 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
     ];
 
     /**
+     * @var array<int, array{
+     *     name: non-empty-string,
+     *     code: non-empty-string,
+     *     slug: non-empty-string,
+     *     status: ProjectStatus,
+     *     assignees: array<int, non-empty-string>
+     * }>
+     */
+    private const array BASE_PROJECTS = [
+        [
+            'name' => 'Bro World',
+            'code' => 'PRJ-BRO',
+            'slug' => 'bro-world',
+            'status' => ProjectStatus::ACTIVE,
+            'assignees' => ['User-john-root', 'User-john-admin', 'User-john-user'],
+        ],
+        [
+            'name' => 'Shopware World',
+            'code' => 'PRJ-SHOP',
+            'slug' => 'shopware-world',
+            'status' => ProjectStatus::PLANNED,
+            'assignees' => ['User-john-root', 'User-john-admin', 'User-john-api'],
+        ],
+        [
+            'name' => 'Oro World',
+            'code' => 'PRJ-ORO',
+            'slug' => 'oro-world',
+            'status' => ProjectStatus::ON_HOLD,
+            'assignees' => ['User-john-root', 'User-john-user', 'User-john-api'],
+        ],
+    ];
+
+    /**
      * @var array<non-empty-string, array<int, non-empty-string>>
      */
     private const array APPLICATION_KEYS_BY_PLATFORM = [
@@ -355,34 +388,53 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
         int $wikiPageCount,
     ): array {
         $projects = [];
+        $useBaseProjects = $application->getSlug() === 'crm-general-core' && $companyIndex === 0;
+        $effectiveProjectCount = $useBaseProjects ? max($projectCount, count(self::BASE_PROJECTS)) : $projectCount;
 
-        for ($index = 0; $index < $projectCount; $index++) {
+        for ($index = 0; $index < $effectiveProjectCount; $index++) {
             $startedAt = $faker->dateTimeBetween('-3 months', '-2 weeks');
             $dueAt = $faker->dateTimeBetween($startedAt, '+4 months');
             $projectSlug = trim(strtolower((string)preg_replace('/[^a-z0-9]+/i', '-', $faker->words(2, true))), '-');
             if ($projectSlug === '') {
                 $projectSlug = sprintf('project-%d-%d', $companyIndex + 1, $index + 1);
             }
+            $projectName = sprintf('%s - %s', $application->getTitle(), ucfirst($faker->words(3, true)));
+            $projectCode = sprintf('PRJ-%d-%02d', $companyIndex + 1, $index + 1);
+            $projectStatus = $faker->randomElement(ProjectStatus::cases());
+            $projectAssignees = [];
+
+            if ($useBaseProjects && isset(self::BASE_PROJECTS[$index])) {
+                $baseProject = self::BASE_PROJECTS[$index];
+                $projectSlug = $baseProject['slug'];
+                $projectName = $baseProject['name'];
+                $projectCode = $baseProject['code'];
+                $projectStatus = $baseProject['status'];
+                $projectAssignees = $baseProject['assignees'];
+            }
 
             $project = (new Project())
                 ->setCompany($company)
-                ->setName(sprintf('%s - %s', $application->getTitle(), ucfirst($faker->words(3, true))))
-                ->setCode(sprintf('PRJ-%d-%02d', $companyIndex + 1, $index + 1))
+                ->setName($projectName)
+                ->setCode($projectCode)
                 ->setDescription($faker->paragraph(2))
-                ->setStatus($faker->randomElement(ProjectStatus::cases()))
+                ->setStatus($projectStatus)
                 ->setStartedAt(DateTimeImmutable::createFromMutable($startedAt))
                 ->setDueAt(DateTimeImmutable::createFromMutable($dueAt))
                 ->setGithubToken('ghp_john_root_fake_token')
                 ->setGithubRepositories([
                     [
-                        'fullName' => sprintf('rami-aouinti/%s-api', $projectSlug),
+                        'fullName' => sprintf('john-root/%s-api', $projectSlug),
                         'defaultBranch' => 'main',
                     ],
                     [
-                        'fullName' => sprintf('rami-aouinti/%s-web', $projectSlug),
+                        'fullName' => sprintf('john-root/%s-web', $projectSlug),
                         'defaultBranch' => 'develop',
                     ],
                 ]);
+
+            foreach ($projectAssignees as $projectAssigneeReference) {
+                $project->addAssignee($this->getReference($projectAssigneeReference, User::class));
+            }
 
             for ($attachmentIndex = 0; $attachmentIndex < $attachmentCount; $attachmentIndex++) {
                 $project->addAttachment($this->generateAttachment($faker, '/uploads/crm/projects/', $project->getId()));


### PR DESCRIPTION
### Motivation

- Provide three deterministic CRM projects for the main CRM scope to avoid random names and to have predictable fixtures for `crm-general-core` first company.
- Ensure those base entries have statuses aligned with the enum `ProjectStatus` and start with concrete members from fixture users.

### Description

- Add `BASE_PROJECTS` constant with definitions for `Bro World`, `Shopware World`, and `Oro World` including `name`, `code`, `slug`, `status` (enum), and `assignees` references.
- Make `generateProjects` produce the base projects deterministically when the application slug is `crm-general-core` and `companyIndex === 0` by using `max($projectCount, count(self::BASE_PROJECTS))` and overriding generated name/code/slug/status for those indices.
- Use `john-root` as GitHub repository owner for generated repositories (`john-root/<slug>-api` and `john-root/<slug>-web`) instead of the previous owner, and add initial members by calling `addAssignee(...)` with the fixture user references.
- Preserve existing random project generation for additional projects beyond the three base entries.

### Testing

- Ran `php -l src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php` and it reported no syntax errors.
- Verified repository state with `git status --short` and committed the change with the message `fixtures(crm): define base projects and assignees`.
- PR metadata was prepared via the `make_pr` tool with the commit applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2d04466c832bbe616697ec88ad00)