### PR TITLE
Add CRM General conversation bootstrap and application-scoped conversation listing

### DIFF
--- a/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationScopeConversationListController.php
+++ b/src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationScopeConversationListController.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Chat\Transport\Controller\Api\V1\Conversation;
+
+use App\Chat\Application\Service\ConversationListService;
+use App\Chat\Infrastructure\Repository\ChatRepository;
+use App\General\Application\Service\ApplicationScopeResolver;
+use App\User\Domain\Entity\User;
+use JsonException;
+use OpenApi\Attributes as OA;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Chat Conversation')]
+#[OA\Get(
+    path: '/v1/chat/{applicationSlug}/private/applications/conversations',
+    operationId: 'chat_conversation_private_application_scope_list',
+    summary: "Lister les conversations d'une application",
+    tags: ['Chat Conversation'],
+    parameters: [
+        new OA\Parameter(name: 'applicationSlug', in: 'path', required: true, schema: new OA\Schema(type: 'string', example: 'crm-general-core')),
+        new OA\Parameter(name: 'page', in: 'query', schema: new OA\Schema(type: 'integer', default: 1, minimum: 1)),
+        new OA\Parameter(name: 'limit', in: 'query', schema: new OA\Schema(type: 'integer', default: 20, maximum: 100, minimum: 1)),
+        new OA\Parameter(name: 'message', in: 'query', required: false, schema: new OA\Schema(type: 'string', example: 'bonjour')),
+    ],
+    responses: [
+        new OA\Response(response: 200, description: 'Liste paginée des conversations de l\'application'),
+        new OA\Response(response: 404, description: 'Chat introuvable pour cette application'),
+    ]
+)]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class ApplicationScopeConversationListController
+{
+    public function __construct(
+        private ConversationListService $conversationListService,
+        private ChatRepository $chatRepository,
+        private ApplicationScopeResolver $applicationScopeResolver,
+    ) {
+    }
+
+    /**
+     * @throws JsonException
+     * @throws InvalidArgumentException
+     */
+    #[Route(path: '/v1/chat/private/applications/conversations', methods: [Request::METHOD_GET])]
+    public function __invoke(Request $request, User $loggedInUser): JsonResponse
+    {
+        $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);
+        $chat = $this->chatRepository->findOneBy([
+            'applicationSlug' => $applicationSlug,
+        ]);
+        if ($chat === null) {
+            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Chat not found for this application scope.');
+        }
+
+        $page = max(1, $request->query->getInt('page', 1));
+        $limit = max(1, min(100, $request->query->getInt('limit', 20)));
+        $filters = [
+            'message' => trim((string)$request->query->get('message', '')),
+        ];
+
+        return ConversationJsonResponseFactory::create(
+            $this->conversationListService->getByChatIdAndUser($chat->getId(), $loggedInUser, $filters, $page, $limit)
+        );
+    }
+}

--- a/src/Crm/Infrastructure/Repository/EmployeeRepository.php
+++ b/src/Crm/Infrastructure/Repository/EmployeeRepository.php
@@ -6,6 +6,8 @@ namespace App\Crm\Infrastructure\Repository;
 
 use App\Crm\Domain\Entity\Employee as Entity;
 use App\General\Infrastructure\Repository\BaseRepository;
+use App\Platform\Domain\Entity\Application;
+use App\User\Domain\Entity\User;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Doctrine\Persistence\ManagerRegistry;
@@ -57,6 +59,24 @@ class EmployeeRepository extends BaseRepository
             ->andWhere('employee.crm = :crmId')
             ->setParameter('crmId', $crmId, UuidBinaryOrderedTimeType::NAME)
             ->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * @return list<User>
+     */
+    public function findUsersByApplication(Application $application): array
+    {
+        /** @var list<User> $users */
+        $users = $this->createQueryBuilder('employee')
+            ->select('DISTINCT user')
+            ->innerJoin('employee.crm', 'crm')
+            ->innerJoin('employee.user', 'user')
+            ->andWhere('crm.application = :application')
+            ->setParameter('application', $application)
+            ->getQuery()
+            ->getResult();
+
+        return $users;
     }
 
     /**

--- a/src/Platform/Application/Service/PluginProvisioning/ChatPluginProvisioner.php
+++ b/src/Platform/Application/Service/PluginProvisioning/ChatPluginProvisioner.php
@@ -6,8 +6,12 @@ namespace App\Platform\Application\Service\PluginProvisioning;
 
 use App\Chat\Domain\Entity\Chat;
 use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Domain\Enum\ConversationParticipantRole;
+use App\Chat\Domain\Enum\ConversationType;
 use App\Chat\Infrastructure\Repository\ChatRepository;
 use App\Chat\Infrastructure\Repository\ConversationRepository;
+use App\Crm\Infrastructure\Repository\EmployeeRepository;
 use App\Platform\Domain\Entity\Application;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -16,6 +20,7 @@ final readonly class ChatPluginProvisioner
     public function __construct(
         private ChatRepository $chatRepository,
         private ConversationRepository $conversationRepository,
+        private EmployeeRepository $employeeRepository,
         private EntityManagerInterface $entityManager,
     ) {
     }
@@ -38,8 +43,20 @@ final readonly class ChatPluginProvisioner
         }
 
         $conversation = (new Conversation())
-            ->setChat($chat);
+            ->setChat($chat)
+            ->setType(ConversationType::GROUP)
+            ->setTitle('General');
 
         $this->entityManager->persist($conversation);
+
+        $users = $this->employeeRepository->findUsersByApplication($application);
+        foreach ($users as $user) {
+            $participant = (new ConversationParticipant())
+                ->setConversation($conversation)
+                ->setUser($user)
+                ->setRole(ConversationParticipantRole::MEMBER);
+
+            $this->entityManager->persist($participant);
+        }
     }
 }

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -14,6 +14,7 @@ use App\Chat\Domain\Entity\ChatMessageReaction;
 use App\Chat\Domain\Entity\Conversation;
 use App\Chat\Domain\Entity\ConversationParticipant;
 use App\Chat\Domain\Enum\ChatReactionType;
+use App\Chat\Domain\Enum\ConversationType;
 use App\General\Domain\Rest\UuidHelper;
 use App\Platform\Domain\Entity\Application as PlatformApplication;
 use App\Platform\Domain\Entity\Plugin;
@@ -343,11 +344,17 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         $johnAdmin = $this->getReference('User-john-admin', User::class);
 
         $conversation = $this->ensureConversation($manager, $chat);
+        if ($application->getSlug() === 'crm-general-core') {
+            $conversation
+                ->setType(ConversationType::GROUP)
+                ->setTitle('General');
+        }
 
         $this->ensureParticipant($manager, $conversation, $johnRoot);
         if ($johnRoot->getId() !== $johnAdmin->getId()) {
             $this->ensureParticipant($manager, $conversation, $johnAdmin);
         }
+        $this->ensureCrmGeneralParticipants($application, $manager, $conversation);
 
         $introMessage = $this->ensureMessage(
             $manager,
@@ -367,6 +374,19 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
 
         $this->ensureReaction($manager, $introMessage, $johnAdmin, 'like');
         $this->ensureReaction($manager, $replyMessage, $johnRoot, 'love');
+    }
+
+    private function ensureCrmGeneralParticipants(PlatformApplication $application, ObjectManager $manager, Conversation $conversation): void
+    {
+        if ($application->getSlug() !== 'crm-general-core') {
+            return;
+        }
+
+        foreach (['User-john-root', 'User-john-admin', 'User-john-user', 'User-john-api'] as $userReference) {
+            /** @var User $user */
+            $user = $this->getReference($userReference, User::class);
+            $this->ensureParticipant($manager, $conversation, $user);
+        }
     }
 
     /**

--- a/tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php
+++ b/tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php
@@ -167,6 +167,26 @@ final class UserConversationControllerTest extends WebTestCase
     /**
      * @throws Throwable
      */
+    #[TestDox('GET application scoped conversations returns CRM General conversation with all CRM employees')]
+    public function testListByApplicationScopeReturnsCrmGeneralConversation(): void
+    {
+        $client = $this->getTestClient('john-root', 'password-root');
+        $client->request('GET', self::API_URL_PREFIX . '/v1/chat/crm-general-core/private/applications/conversations');
+
+        self::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $content = $client->getResponse()->getContent();
+        self::assertNotFalse($content);
+        $payload = JSON::decode($content, true);
+
+        self::assertNotEmpty($payload['items']);
+        self::assertSame('General', $payload['items'][0]['title'] ?? null);
+        self::assertGreaterThanOrEqual(4, count($payload['items'][0]['participants'] ?? []));
+    }
+
+    /**
+     * @throws Throwable
+     */
     #[TestDox('PATCH and DELETE conversation endpoints accept for participant and hide unauthorized conversation')]
     public function testPatchDeleteAndUnauthorizedFindOrCreate(): void
     {


### PR DESCRIPTION
### Motivation
- Ensure that when the Chat plugin is provisioned for a CRM application a dedicated, application-scoped group conversation named `General` is created and includes all CRM employees as participants. 
- Provide an authenticated endpoint to list conversations for a given application scope so clients can fetch application-wide conversations (e.g. CRM General) without manually resolving chat ids. 

### Description
- Added `EmployeeRepository::findUsersByApplication(Application $application)` to resolve `User` entities for CRM employees. (`src/Crm/Infrastructure/Repository/EmployeeRepository.php`).
- Updated `ChatPluginProvisioner::provision()` to create a `Conversation` of type `group` titled `General` for the application chat and to create `ConversationParticipant` entries for each CRM employee returned by `findUsersByApplication`. (`src/Platform/Application/Service/PluginProvisioning/ChatPluginProvisioner.php`).
- Introduced a new controller `ApplicationScopeConversationListController` exposing `GET /v1/chat/{applicationSlug}/private/applications/conversations` which resolves the application slug, finds the related chat and returns paginated conversations for the application using `ConversationListService::getByChatIdAndUser`. (`src/Chat/Transport/Controller/Api/V1/Conversation/ApplicationScopeConversationListController.php`).
- Adjusted recruitment/CRM fixtures so that `crm-general-core` conversation is typed as `group`, titled `General`, and includes deterministic CRM employees; added helper to ensure those participants in fixtures. (`src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php`).
- Added an integration test asserting the application-scoped endpoint returns the `General` conversation and that it contains the CRM employees. (`tests/Application/Chat/Transport/Controller/Api/V1/Conversation/UserConversationControllerTest.php`).

### Testing
- Ran PHP syntax checks: `php -l` for the modified files succeeded for `ChatPluginProvisioner`, `EmployeeRepository`, `ApplicationScopeConversationListController`, fixtures and the updated test file. 
- Attempted to run the PHPUnit scenario for the conversation test (`./vendor/bin/phpunit ...`) but the test runner is unavailable in this environment (`vendor/bin/phpunit` not present), so full automated test execution could not be performed here. 
- No other automated test failures were produced by local static checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee67380e0c8326a00d214457868190)