### PR TITLE
Refactor quiz routes to application-scoped endpoints, restrict mutations to ROLE_ROOT, restore public quiz routes

### DIFF
--- a/src/Quiz/Transport/Controller/Api/V1/CreateQuizQuestionController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/CreateQuizQuestionController.php
@@ -19,11 +19,10 @@ use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\Messenger\Exception\ExceptionInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[AsController]
-#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted('ROLE_ROOT')]
 #[OA\Tag(name: 'Quiz')]
 final class CreateQuizQuestionController
 {
@@ -36,7 +35,7 @@ final class CreateQuizQuestionController
      * @throws ExceptionInterface
      * @throws JsonException
      */
-    #[Route('/v1/quiz/questions', methods: [Request::METHOD_POST])]
+    #[Route('/v1/quiz/applications/{applicationSlug}/questions', methods: [Request::METHOD_POST])]
     #[OA\Post(summary: 'POST /v1/quiz/questions', tags: ['Quiz'])]
     public function __invoke(Request $request, MessageBusInterface $messageBus, User $loggedInUser, ApplicationRepository $applicationRepository, QuizRepository $quizRepository, QuizEditorAccessService $accessService): JsonResponse
     {

--- a/src/Quiz/Transport/Controller/Api/V1/GetPublicGeneralQuizCategoriesController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/GetPublicGeneralQuizCategoriesController.php
@@ -15,6 +15,7 @@ use Symfony\Component\Routing\Attribute\Route;
 #[OA\Tag(name: 'Quiz')]
 final readonly class GetPublicGeneralQuizCategoriesController
 {
+    #[Route('/v1/public/quiz/general/categories', methods: [Request::METHOD_GET])]
     #[OA\Get(summary: 'Get quiz categories for general quiz (public)', security: [], tags: ['Quiz'])]
     public function __invoke(QuizReadService $quizReadService): JsonResponse
     {

--- a/src/Quiz/Transport/Controller/Api/V1/GetPublicGeneralQuizLeaderboardController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/GetPublicGeneralQuizLeaderboardController.php
@@ -15,6 +15,7 @@ use Symfony\Component\Routing\Attribute\Route;
 #[OA\Tag(name: 'Quiz')]
 final readonly class GetPublicGeneralQuizLeaderboardController
 {
+    #[Route('/v1/public/quiz/general/leaderboard', methods: [Request::METHOD_GET])]
     #[OA\Get(
         summary: 'Get top 3 users for general quiz weighted score',
         security: [],

--- a/src/Quiz/Transport/Controller/Api/V1/GetPublicGeneralQuizLevelsController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/GetPublicGeneralQuizLevelsController.php
@@ -15,6 +15,7 @@ use Symfony\Component\Routing\Attribute\Route;
 #[OA\Tag(name: 'Quiz')]
 final readonly class GetPublicGeneralQuizLevelsController
 {
+    #[Route('/v1/public/quiz/general/levels', methods: [Request::METHOD_GET])]
     #[OA\Get(summary: 'Get quiz levels (public)', security: [], tags: ['Quiz'])]
     public function __invoke(QuizReadService $quizReadService): JsonResponse
     {

--- a/src/Quiz/Transport/Controller/Api/V1/GetQuizAttemptsByApplicationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/GetQuizAttemptsByApplicationController.php
@@ -30,7 +30,7 @@ final readonly class GetQuizAttemptsByApplicationController
     ) {
     }
 
-    #[Route('/v1/quiz/attempts', methods: [Request::METHOD_GET])]
+    #[Route('/v1/quiz/applications/{applicationSlug}/attempts', methods: [Request::METHOD_GET])]
     #[OA\Get(summary: 'List current user quiz attempts by application', tags: ['Quiz'])]
     public function __invoke(Request $request, User $loggedInUser): JsonResponse
     {

--- a/src/Quiz/Transport/Controller/Api/V1/GetQuizByApplicationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/GetQuizByApplicationController.php
@@ -24,7 +24,7 @@ final class GetQuizByApplicationController
     ) {
     }
 
-    #[Route('/v1/quiz', methods: [Request::METHOD_GET])]
+    #[Route('/v1/quiz/applications/{applicationSlug}', methods: [Request::METHOD_GET])]
     public function __invoke(Request $request, QuizReadService $quizReadService): JsonResponse
     {
         $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);

--- a/src/Quiz/Transport/Controller/Api/V1/GetQuizStatsByApplicationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/GetQuizStatsByApplicationController.php
@@ -24,7 +24,7 @@ final class GetQuizStatsByApplicationController
     ) {
     }
 
-    #[Route('/v1/quiz/stats', methods: [Request::METHOD_GET])]
+    #[Route('/v1/quiz/applications/{applicationSlug}/stats', methods: [Request::METHOD_GET])]
     public function __invoke(Request $request, QuizReadService $quizReadService): JsonResponse
     {
         $applicationSlug = $this->applicationScopeResolver->resolveFromRequest($request);

--- a/src/Quiz/Transport/Controller/Api/V1/QuizMutationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/QuizMutationController.php
@@ -26,7 +26,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Attribute\AsController;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 use function array_values;
@@ -35,7 +34,7 @@ use function is_bool;
 use function is_string;
 
 #[AsController]
-#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+#[IsGranted('ROLE_ROOT')]
 #[OA\Tag(name: 'Quiz')]
 final readonly class QuizMutationController
 {
@@ -57,7 +56,7 @@ final readonly class QuizMutationController
      * @throws ORMException
      * @throws OptimisticLockException
      */
-    #[Route('/v1/quiz', methods: [Request::METHOD_POST])]
+    #[Route('/v1/quiz/applications/{applicationSlug}', methods: [Request::METHOD_POST])]
     #[OA\Post(summary: 'Create quiz for application', tags: ['Quiz'])]
     public function createQuiz(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
     {
@@ -101,7 +100,7 @@ final readonly class QuizMutationController
      * @throws ORMException
      * @throws OptimisticLockException
      */
-    #[Route('/v1/quiz', methods: [Request::METHOD_PUT])]
+    #[Route('/v1/quiz/applications/{applicationSlug}', methods: [Request::METHOD_PUT])]
     #[OA\Put(summary: 'Update quiz metadata', tags: ['Quiz'])]
     public function updateQuiz(string $applicationSlug, Request $request, User $loggedInUser): JsonResponse
     {
@@ -126,7 +125,7 @@ final readonly class QuizMutationController
      * @throws OptimisticLockException
      * @throws ORMException
      */
-    #[Route('/v1/quiz/publish', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/quiz/applications/{applicationSlug}/publish', methods: [Request::METHOD_PATCH])]
     #[OA\Patch(summary: 'Publish quiz', tags: ['Quiz'])]
     public function publishQuiz(string $applicationSlug, User $loggedInUser): JsonResponse
     {
@@ -137,7 +136,7 @@ final readonly class QuizMutationController
      * @throws OptimisticLockException
      * @throws ORMException
      */
-    #[Route('/v1/quiz/unpublish', methods: [Request::METHOD_PATCH])]
+    #[Route('/v1/quiz/applications/{applicationSlug}/unpublish', methods: [Request::METHOD_PATCH])]
     #[OA\Patch(summary: 'Unpublish quiz', tags: ['Quiz'])]
     public function unpublishQuiz(string $applicationSlug, User $loggedInUser): JsonResponse
     {
@@ -160,6 +159,7 @@ final readonly class QuizMutationController
      * @throws OptimisticLockException
      * @throws ORMException
      */
+    #[Route('/v1/quiz/general/publish', methods: [Request::METHOD_PATCH])]
     #[OA\Patch(summary: 'Publish general quiz', tags: ['Quiz'])]
     public function publishGeneralQuiz(User $loggedInUser): JsonResponse
     {
@@ -170,6 +170,7 @@ final readonly class QuizMutationController
      * @throws OptimisticLockException
      * @throws ORMException
      */
+    #[Route('/v1/quiz/general/unpublish', methods: [Request::METHOD_PATCH])]
     #[OA\Patch(summary: 'Unpublish general quiz', tags: ['Quiz'])]
     public function unpublishGeneralQuiz(User $loggedInUser): JsonResponse
     {
@@ -191,7 +192,7 @@ final readonly class QuizMutationController
      * @throws OptimisticLockException
      * @throws ORMException
      */
-    #[Route('/v1/quiz', methods: [Request::METHOD_DELETE])]
+    #[Route('/v1/quiz/applications/{applicationSlug}', methods: [Request::METHOD_DELETE])]
     #[OA\Delete(summary: 'Delete quiz', tags: ['Quiz'])]
     public function deleteQuiz(string $applicationSlug, User $loggedInUser): JsonResponse
     {

--- a/src/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationController.php
+++ b/src/Quiz/Transport/Controller/Api/V1/SubmitQuizByApplicationController.php
@@ -35,7 +35,7 @@ final class SubmitQuizByApplicationController
      * @throws ORMException
      * @throws OptimisticLockException
      */
-    #[Route('/v1/quiz/submit', methods: [Request::METHOD_POST])]
+    #[Route('/v1/quiz/applications/{applicationSlug}/submit', methods: [Request::METHOD_POST])]
     #[OA\Post(summary: 'Submit quiz answers for an application', tags: ['Quiz'])]
     public function __invoke(Request $request, QuizSubmissionService $quizSubmissionService, User $loggedInUser): JsonResponse
     {
@@ -110,6 +110,7 @@ final class SubmitQuizByApplicationController
             new OA\Response(response: 404, description: 'General quiz not found or unpublished.'),
         ]
     )]
+    #[Route('/v1/quiz/general/submit', methods: [Request::METHOD_POST])]
     public function submitGeneral(Request $request, QuizSubmissionService $quizSubmissionService, User $loggedInUser): JsonResponse
     {
         $payload = (array)json_decode((string)$request->getContent(), true, 512, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
### Motivation
- Make Quiz API routes explicit per-application so clients operate on `applicationSlug`-scoped resources. 
- Limit destructive and edit operations to privileged accounts by requiring `ROLE_ROOT` for quiz mutations and question creation. 
- Restore missing public endpoints for categories, levels and leaderboard so public clients can access general quiz metadata and top scores without a token.

### Description
- Changed read/submit/stats/attempts/create-question and mutation routes to use an application scope path prefix `/v1/quiz/applications/{applicationSlug}/...` and kept general-alias endpoints where appropriate. 
- Replaced auth requirement on mutation controllers with role check `#[IsGranted('ROLE_ROOT')]` for `QuizMutationController` and `CreateQuizQuestionController`. 
- Added explicit `Route` attributes for public controllers: `/v1/public/quiz/general/categories`, `/v1/public/quiz/general/levels`, and `/v1/public/quiz/general/leaderboard`. 
- Added explicit route for general quiz submission at `/v1/quiz/general/submit` and adjusted submit endpoint to `/v1/quiz/applications/{applicationSlug}/submit` for scoped submissions.

### Testing
- Ran `php -l` on all modified Quiz controllers and received no syntax errors. 
- Attempted to run the focused PHPUnit test `php bin/phpunit tests/Application/Quiz/Transport/Controller/Api/V1/QuizManagementControllerTest.php` but the command failed in this environment with `Could not open input file: bin/phpunit` so full integration tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee73b923c88326b770854340b8086d)