### PR TITLE
feat(fixtures): seed CRM General group chat and calendar onboarding events

### DIFF
--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -65,6 +65,10 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         foreach ($chatEnabledApplications as $application) {
             $chat = $this->ensureChat($manager, $application);
             $this->ensureApplicationChatScenario($manager, $application, $chat);
+            if ($application->getSlug() === 'crm-general-core') {
+                $crmGeneralCalendar = $this->ensureCalendar($manager, $application);
+                $this->ensureCrmGeneralEmployeeEvents($manager, $application, $crmGeneralCalendar);
+            }
 
             if ($application->getTitle() === 'Recruit Talent Hub') {
                 $calendar = $this->ensureCalendar($manager, $application);
@@ -348,7 +352,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         if ($application->getSlug() === 'crm-general-core') {
             $conversation
                 ->setType(ConversationType::GROUP)
-                ->setTitle('General');
+                ->setTitle('General Group');
         }
 
         $this->ensureParticipant($manager, $conversation, $johnRoot);
@@ -542,26 +546,37 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             return;
         }
 
-        /** @var User $johnRoot */
-        $johnRoot = $this->getReference('User-john-root', User::class);
-
         $this->ensureEvent(
             $manager,
             $calendar,
-            $johnRoot,
-            'CRM General - John Root assigned planning',
+            $application->getUser() ?? $calendar->getUser(),
+            'CRM General - Application created',
             5,
-            'Event fixture assigné à john-root dans CRM General.',
+            'Milestone fixture marking CRM General application creation.',
         );
 
-        $this->ensureEvent(
-            $manager,
-            $calendar,
-            $johnRoot,
-            'CRM General - John Root delivery sync',
-            6,
-            'Event fixture de synchronisation delivery pour john-root.',
-        );
+        $employeeStartEvents = [
+            'User-john-root' => 'John Root',
+            'User-john-admin' => 'John Admin',
+            'User-john-user' => 'John User',
+            'User-john-api' => 'John Api',
+        ];
+
+        $dayOffset = 6;
+        foreach ($employeeStartEvents as $userReference => $employeeName) {
+            /** @var User $employeeUser */
+            $employeeUser = $this->getReference($userReference, User::class);
+
+            $this->ensureEvent(
+                $manager,
+                $calendar,
+                $employeeUser,
+                sprintf('CRM General - %s employee start', $employeeName),
+                $dayOffset,
+                sprintf('%s commencement as Employee in CRM General.', $employeeName),
+            );
+            ++$dayOffset;
+        }
     }
 
     private function ensureStandaloneEvent(


### PR DESCRIPTION
### Motivation
- Provide deterministic fixtures for CRM General so there is a visible group conversation and an associated calendar with onboarding events for employees.

### Description
- Rename the seeded CRM General conversation title from `General` to `General Group` while keeping it a group conversation in `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php`.
- Ensure a `Calendar` is created for the `crm-general-core` application during chat fixture processing and call `ensureCrmGeneralEmployeeEvents` early for that calendar.
- Implement `ensureCrmGeneralEmployeeEvents` to add a calendar milestone event (`CRM General - Application created`) attached to the application/calendar owner and create one onboarding event per deterministic employee (`john-root`, `john-admin`, `john-user`, `john-api`) named `CRM General - <Name> employee start`.
- Changes are confined to `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php`.

### Testing
- Ran `php -l src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` and it reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee83de217483268a486401344a7c90)