### PR TITLE
Add CRM General chat & calendar fixture scenario and update Recruit CRM events

### DIFF
--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace App\Crm\Infrastructure\DataFixtures\ORM;
 
+use App\Calendar\Domain\Entity\Calendar;
+use App\Calendar\Domain\Entity\Event;
+use App\Calendar\Domain\Enum\EventStatus;
+use App\Calendar\Domain\Enum\EventVisibility;
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Domain\Enum\BlogType;
+use App\Chat\Domain\Entity\Chat;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Domain\Enum\ConversationType;
 use App\Crm\Domain\Entity\Billing;
 use App\Crm\Domain\Entity\Company;
 use App\Crm\Domain\Entity\Contact;
@@ -288,6 +296,7 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
 
             // Employees
             $this->generateEmployees($manager, $crm);
+            $this->ensureCrmGeneralChatAndCalendarScenario($manager, $crm, $application);
 
             foreach ($companies as $companyIndex => $company) {
                 // Contacts
@@ -456,6 +465,185 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
 
             $manager->persist($employee);
         }
+    }
+
+    private function ensureCrmGeneralChatAndCalendarScenario(ObjectManager $manager, Crm $crm, Application $application): void
+    {
+        if ($application->getSlug() !== 'crm-general-core') {
+            return;
+        }
+
+        $chat = $this->ensureChat($manager, $application);
+        $conversation = $this->ensureGeneralGroupConversation($manager, $chat);
+        $this->ensureCrmEmployeeParticipants($manager, $crm, $conversation);
+
+        $calendar = $this->ensureCalendar($manager, $application);
+        $this->ensureCrmGeneralCalendarEvents($manager, $crm, $calendar);
+    }
+
+    private function ensureChat(ObjectManager $manager, Application $application): Chat
+    {
+        /** @var Chat|null $chat */
+        $chat = $manager->getRepository(Chat::class)->findOneBy([
+            'application' => $application,
+        ]);
+
+        if ($chat instanceof Chat) {
+            return $chat;
+        }
+
+        $application->ensureGeneratedSlug();
+        $chat = (new Chat())
+            ->setApplication($application)
+            ->setApplicationSlug($application->getSlug());
+
+        $manager->persist($chat);
+
+        return $chat;
+    }
+
+    private function ensureGeneralGroupConversation(ObjectManager $manager, Chat $chat): Conversation
+    {
+        /** @var Conversation|null $conversation */
+        $conversation = $manager->getRepository(Conversation::class)->findOneBy([
+            'chat' => $chat,
+            'type' => ConversationType::GROUP,
+            'title' => 'General Group',
+        ]);
+
+        if ($conversation instanceof Conversation) {
+            return $conversation;
+        }
+
+        $conversation = (new Conversation())
+            ->setChat($chat)
+            ->setType(ConversationType::GROUP)
+            ->setTitle('General Group');
+
+        $manager->persist($conversation);
+
+        return $conversation;
+    }
+
+    private function ensureCrmEmployeeParticipants(ObjectManager $manager, Crm $crm, Conversation $conversation): void
+    {
+        /** @var array<int, Employee> $employees */
+        $employees = $manager->getRepository(Employee::class)->findBy([
+            'crm' => $crm,
+        ]);
+
+        foreach ($employees as $employee) {
+            $user = $employee->getUser();
+            if (!$user instanceof User) {
+                continue;
+            }
+
+            $existing = $manager->getRepository(ConversationParticipant::class)->findOneBy([
+                'conversation' => $conversation,
+                'user' => $user,
+            ]);
+            if ($existing instanceof ConversationParticipant) {
+                continue;
+            }
+
+            $participant = (new ConversationParticipant())
+                ->setConversation($conversation)
+                ->setUser($user);
+
+            $manager->persist($participant);
+        }
+    }
+
+    private function ensureCalendar(ObjectManager $manager, Application $application): Calendar
+    {
+        /** @var Calendar|null $calendar */
+        $calendar = $manager->getRepository(Calendar::class)->findOneBy([
+            'application' => $application,
+        ]);
+
+        if ($calendar instanceof Calendar) {
+            return $calendar;
+        }
+
+        $calendar = (new Calendar())
+            ->setApplication($application)
+            ->setUser($application->getUser())
+            ->setTitle('CRM General Calendar');
+
+        $manager->persist($calendar);
+
+        return $calendar;
+    }
+
+    private function ensureCrmGeneralCalendarEvents(ObjectManager $manager, Crm $crm, Calendar $calendar): void
+    {
+        /** @var User|null $calendarOwner */
+        $calendarOwner = $calendar->getUser();
+        $this->ensureCalendarEvent(
+            $manager,
+            $calendar,
+            'CRM General - Application Creation',
+            'Milestone fixture for CRM General application creation.',
+            $calendarOwner,
+            2,
+        );
+
+        /** @var array<int, Employee> $employees */
+        $employees = $manager->getRepository(Employee::class)->findBy([
+            'crm' => $crm,
+        ]);
+
+        $dayOffset = 3;
+        foreach ($employees as $employee) {
+            $employeeUser = $employee->getUser();
+            if (!$employeeUser instanceof User) {
+                continue;
+            }
+
+            $this->ensureCalendarEvent(
+                $manager,
+                $calendar,
+                sprintf('CRM General - %s %s Employee Start', $employee->getFirstName(), $employee->getLastName()),
+                sprintf('%s %s commencement event as Employee for CRM General.', $employee->getFirstName(), $employee->getLastName()),
+                $employeeUser,
+                $dayOffset,
+            );
+            ++$dayOffset;
+        }
+    }
+
+    private function ensureCalendarEvent(
+        ObjectManager $manager,
+        Calendar $calendar,
+        string $title,
+        string $description,
+        ?User $user,
+        int $dayOffset,
+    ): void {
+        $existing = $manager->getRepository(Event::class)->findOneBy([
+            'calendar' => $calendar,
+            'title' => $title,
+        ]);
+        if ($existing instanceof Event) {
+            return;
+        }
+
+        $startAt = (new DateTimeImmutable(sprintf('+%d day', $dayOffset)))->setTime(9, 0);
+        $event = (new Event())
+            ->setCalendar($calendar)
+            ->setUser($user)
+            ->setTitle($title)
+            ->setDescription($description)
+            ->setStartAt($startAt)
+            ->setEndAt($startAt->modify('+1 hour'))
+            ->setStatus(EventStatus::CONFIRMED)
+            ->setVisibility(EventVisibility::PRIVATE)
+            ->setLocation('CRM General HQ')
+            ->setTimezone('Europe/Paris')
+            ->setOrganizerName('CRM General')
+            ->setOrganizerEmail('crm-general@example.test');
+
+        $manager->persist($event);
     }
 
     private function isBlank(string $value): bool

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -65,6 +65,10 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         foreach ($chatEnabledApplications as $application) {
             $chat = $this->ensureChat($manager, $application);
             $this->ensureApplicationChatScenario($manager, $application, $chat);
+            if ($application->getSlug() === 'crm-general-core') {
+                $crmGeneralCalendar = $this->ensureCalendar($manager, $application);
+                $this->ensureCrmGeneralEmployeeEvents($manager, $application, $crmGeneralCalendar);
+            }
 
             if ($application->getTitle() === 'Recruit Talent Hub') {
                 $calendar = $this->ensureCalendar($manager, $application);
@@ -348,7 +352,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         if ($application->getSlug() === 'crm-general-core') {
             $conversation
                 ->setType(ConversationType::GROUP)
-                ->setTitle('General');
+                ->setTitle('General Group');
         }
 
         $this->ensureParticipant($manager, $conversation, $johnRoot);
@@ -542,26 +546,37 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             return;
         }
 
-        /** @var User $johnRoot */
-        $johnRoot = $this->getReference('User-john-root', User::class);
-
         $this->ensureEvent(
             $manager,
             $calendar,
-            $johnRoot,
-            'CRM General - John Root assigned planning',
+            $application->getUser() ?? $calendar->getUser(),
+            'CRM General - Application created',
             5,
-            'Event fixture assigné à john-root dans CRM General.',
+            'Milestone fixture marking CRM General application creation.',
         );
 
-        $this->ensureEvent(
-            $manager,
-            $calendar,
-            $johnRoot,
-            'CRM General - John Root delivery sync',
-            6,
-            'Event fixture de synchronisation delivery pour john-root.',
-        );
+        $employeeStartEvents = [
+            'User-john-root' => 'John Root',
+            'User-john-admin' => 'John Admin',
+            'User-john-user' => 'John User',
+            'User-john-api' => 'John Api',
+        ];
+
+        $dayOffset = 6;
+        foreach ($employeeStartEvents as $userReference => $employeeName) {
+            /** @var User $employeeUser */
+            $employeeUser = $this->getReference($userReference, User::class);
+
+            $this->ensureEvent(
+                $manager,
+                $calendar,
+                $employeeUser,
+                sprintf('CRM General - %s employee start', $employeeName),
+                $dayOffset,
+                sprintf('%s commencement as Employee in CRM General.', $employeeName),
+            );
+            ++$dayOffset;
+        }
     }
 
     private function ensureStandaloneEvent(


### PR DESCRIPTION
### Motivation

- Provide a consistent "CRM General" demo scenario by ensuring a Chat group and Calendar with events are created for the `crm-general-core` application.
- Seed conversation participants from CRM employees so the chat scenario reflects actual users.
- Align Recruit scenario fixtures with the CRM General changes and make CRM General calendar events more generic and inclusive of deterministic users.

### Description

- Added chat and calendar setup to CRM fixtures by calling `ensureCrmGeneralChatAndCalendarScenario` from `LoadCrmData::load` and implemented the helper methods `ensureChat`, `ensureGeneralGroupConversation`, `ensureCrmEmployeeParticipants`, `ensureCalendar`, `ensureCrmGeneralCalendarEvents`, and `ensureCalendarEvent` in `src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php` to idempotently create `Chat`, `Conversation`, `ConversationParticipant`, `Calendar`, and `Event` entities for `crm-general-core`.
- Imported required calendar, chat and enum classes and added event creation logic that schedules a milestone and per-employee start events tied to user accounts.
- Updated `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php` to set the CRM conversation title to `General Group`, to create/ensure a calendar for `crm-general-core` inside the chat-enabled loop, and to refactor `ensureCrmGeneralEmployeeEvents` to use the application/calendar owner and to generate per-user employee start events for multiple deterministic users.

### Testing

- Ran the project automated test suite with `vendor/bin/phpunit` and the tests passed.
- Executed a fixtures load smoke test with `php bin/console doctrine:fixtures:load --append --env=test` to validate idempotent creation of chat, conversation, participants, calendar and events for `crm-general-core`, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee83de217483268a486401344a7c90)