### PR TITLE
Create CRM General chat & calendar scenario and add employee events/participants in fixtures

### DIFF
--- a/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
+++ b/src/Crm/Infrastructure/DataFixtures/ORM/LoadCrmData.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace App\Crm\Infrastructure\DataFixtures\ORM;
 
+use App\Calendar\Domain\Entity\Calendar;
+use App\Calendar\Domain\Entity\Event;
+use App\Calendar\Domain\Enum\EventStatus;
+use App\Calendar\Domain\Enum\EventVisibility;
 use App\Blog\Domain\Entity\Blog;
 use App\Blog\Domain\Entity\BlogComment;
 use App\Blog\Domain\Entity\BlogPost;
 use App\Blog\Domain\Enum\BlogType;
+use App\Chat\Domain\Entity\Chat;
+use App\Chat\Domain\Entity\Conversation;
+use App\Chat\Domain\Entity\ConversationParticipant;
+use App\Chat\Domain\Enum\ConversationType;
 use App\Crm\Domain\Entity\Billing;
 use App\Crm\Domain\Entity\Company;
 use App\Crm\Domain\Entity\Contact;
@@ -287,7 +295,8 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
             }
 
             // Employees
-            $this->generateEmployees($manager, $crm);
+            $employees = $this->generateEmployees($manager, $crm);
+            $this->ensureCrmGeneralChatAndCalendarScenario($manager, $crm, $application, $employees);
 
             foreach ($companies as $companyIndex => $company) {
                 // Contacts
@@ -432,8 +441,12 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
         }
     }
 
-    private function generateEmployees(ObjectManager $manager, Crm $crm): void
+    /**
+     * @return array<int, Employee>
+     */
+    private function generateEmployees(ObjectManager $manager, Crm $crm): array
     {
+        $employees = [];
         foreach (self::DETERMINISTIC_EMPLOYEES as $employeeData) {
             $user = $this->getReference($employeeData['userReference'], User::class);
             $firstName = $employeeData['firstName'];
@@ -455,7 +468,203 @@ final class LoadCrmData extends Fixture implements OrderedFixtureInterface
                 ->setRoleName($employeeData['roleName']);
 
             $manager->persist($employee);
+            $employees[] = $employee;
         }
+
+        return $employees;
+    }
+
+    /**
+     * @param array<int, Employee> $employees
+     */
+    private function ensureCrmGeneralChatAndCalendarScenario(ObjectManager $manager, Crm $crm, Application $application, array $employees): void
+    {
+        $application->ensureGeneratedSlug();
+        if ($application->getSlug() !== 'crm-general-core' && $application->getTitle() !== 'CRM General Core') {
+            return;
+        }
+
+        $chat = $this->ensureChat($manager, $application);
+        $conversation = $this->ensureGeneralGroupConversation($manager, $chat);
+        $this->ensureCrmEmployeeParticipants($manager, $crm, $conversation, $employees);
+
+        $calendar = $this->ensureCalendar($manager, $application);
+        $this->ensureCrmGeneralCalendarEvents($manager, $crm, $calendar, $employees);
+    }
+
+    private function ensureChat(ObjectManager $manager, Application $application): Chat
+    {
+        /** @var Chat|null $chat */
+        $chat = $manager->getRepository(Chat::class)->findOneBy([
+            'application' => $application,
+        ]);
+
+        if ($chat instanceof Chat) {
+            return $chat;
+        }
+
+        $application->ensureGeneratedSlug();
+        $chat = (new Chat())
+            ->setApplication($application)
+            ->setApplicationSlug($application->getSlug());
+
+        $manager->persist($chat);
+
+        return $chat;
+    }
+
+    private function ensureGeneralGroupConversation(ObjectManager $manager, Chat $chat): Conversation
+    {
+        /** @var Conversation|null $conversation */
+        $conversation = $manager->getRepository(Conversation::class)->findOneBy([
+            'chat' => $chat,
+            'type' => ConversationType::GROUP,
+            'title' => 'General Group',
+        ]);
+
+        if ($conversation instanceof Conversation) {
+            return $conversation;
+        }
+
+        $conversation = (new Conversation())
+            ->setChat($chat)
+            ->setType(ConversationType::GROUP)
+            ->setTitle('General Group');
+
+        $manager->persist($conversation);
+
+        return $conversation;
+    }
+
+    /**
+     * @param array<int, Employee> $employees
+     */
+    private function ensureCrmEmployeeParticipants(ObjectManager $manager, Crm $crm, Conversation $conversation, array $employees): void
+    {
+        if ($employees === []) {
+            /** @var array<int, Employee> $employees */
+            $employees = $manager->getRepository(Employee::class)->findBy([
+                'crm' => $crm,
+            ]);
+        }
+
+        foreach ($employees as $employee) {
+            $user = $employee->getUser();
+            if (!$user instanceof User) {
+                continue;
+            }
+
+            $existing = $manager->getRepository(ConversationParticipant::class)->findOneBy([
+                'conversation' => $conversation,
+                'user' => $user,
+            ]);
+            if ($existing instanceof ConversationParticipant) {
+                continue;
+            }
+
+            $participant = (new ConversationParticipant())
+                ->setConversation($conversation)
+                ->setUser($user);
+
+            $manager->persist($participant);
+        }
+    }
+
+    private function ensureCalendar(ObjectManager $manager, Application $application): Calendar
+    {
+        /** @var Calendar|null $calendar */
+        $calendar = $manager->getRepository(Calendar::class)->findOneBy([
+            'application' => $application,
+        ]);
+
+        if ($calendar instanceof Calendar) {
+            return $calendar;
+        }
+
+        $calendar = (new Calendar())
+            ->setApplication($application)
+            ->setUser($application->getUser())
+            ->setTitle('CRM General Calendar');
+
+        $manager->persist($calendar);
+
+        return $calendar;
+    }
+
+    /**
+     * @param array<int, Employee> $employees
+     */
+    private function ensureCrmGeneralCalendarEvents(ObjectManager $manager, Crm $crm, Calendar $calendar, array $employees): void
+    {
+        /** @var User|null $calendarOwner */
+        $calendarOwner = $calendar->getUser();
+        $this->ensureCalendarEvent(
+            $manager,
+            $calendar,
+            'CRM General - Application Creation',
+            'Milestone fixture for CRM General application creation.',
+            $calendarOwner,
+            2,
+        );
+
+        if ($employees === []) {
+            /** @var array<int, Employee> $employees */
+            $employees = $manager->getRepository(Employee::class)->findBy([
+                'crm' => $crm,
+            ]);
+        }
+
+        $dayOffset = 3;
+        foreach ($employees as $employee) {
+            $employeeUser = $employee->getUser();
+            if (!$employeeUser instanceof User) {
+                continue;
+            }
+
+            $this->ensureCalendarEvent(
+                $manager,
+                $calendar,
+                sprintf('CRM General - %s %s Employee Start', $employee->getFirstName(), $employee->getLastName()),
+                sprintf('%s %s commencement event as Employee for CRM General.', $employee->getFirstName(), $employee->getLastName()),
+                $employeeUser,
+                $dayOffset,
+            );
+            ++$dayOffset;
+        }
+    }
+
+    private function ensureCalendarEvent(
+        ObjectManager $manager,
+        Calendar $calendar,
+        string $title,
+        string $description,
+        ?User $user,
+        int $dayOffset,
+    ): void {
+        $existing = $manager->getRepository(Event::class)->findOneBy([
+            'calendar' => $calendar,
+            'title' => $title,
+        ]);
+        if ($existing instanceof Event) {
+            return;
+        }
+
+        $startAt = (new DateTimeImmutable(sprintf('+%d day', $dayOffset)))->setTime(9, 0);
+        $event = (new Event())
+            ->setCalendar($calendar)
+            ->setUser($user)
+            ->setTitle($title)
+            ->setDescription($description)
+            ->setStartAt($startAt)
+            ->setEndAt($startAt->modify('+1 hour'))
+            ->setStatus(EventStatus::CONFIRMED)
+            ->setVisibility(EventVisibility::PRIVATE)
+            ->setLocation('CRM General HQ')
+            ->setTimezone('Europe/Paris')
+            ->setOrganizerName('CRM General')
+            ->setOrganizerEmail('crm-general@example.test');
+
+        $manager->persist($event);
     }
 
     private function isBlank(string $value): bool

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitChatCalendarScenarioData.php
@@ -65,6 +65,10 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         foreach ($chatEnabledApplications as $application) {
             $chat = $this->ensureChat($manager, $application);
             $this->ensureApplicationChatScenario($manager, $application, $chat);
+            if ($application->getSlug() === 'crm-general-core') {
+                $crmGeneralCalendar = $this->ensureCalendar($manager, $application);
+                $this->ensureCrmGeneralEmployeeEvents($manager, $application, $crmGeneralCalendar);
+            }
 
             if ($application->getTitle() === 'Recruit Talent Hub') {
                 $calendar = $this->ensureCalendar($manager, $application);
@@ -348,7 +352,7 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
         if ($application->getSlug() === 'crm-general-core') {
             $conversation
                 ->setType(ConversationType::GROUP)
-                ->setTitle('General');
+                ->setTitle('General Group');
         }
 
         $this->ensureParticipant($manager, $conversation, $johnRoot);
@@ -542,26 +546,37 @@ final class LoadRecruitChatCalendarScenarioData extends Fixture implements Order
             return;
         }
 
-        /** @var User $johnRoot */
-        $johnRoot = $this->getReference('User-john-root', User::class);
-
         $this->ensureEvent(
             $manager,
             $calendar,
-            $johnRoot,
-            'CRM General - John Root assigned planning',
+            $application->getUser() ?? $calendar->getUser(),
+            'CRM General - Application created',
             5,
-            'Event fixture assigné à john-root dans CRM General.',
+            'Milestone fixture marking CRM General application creation.',
         );
 
-        $this->ensureEvent(
-            $manager,
-            $calendar,
-            $johnRoot,
-            'CRM General - John Root delivery sync',
-            6,
-            'Event fixture de synchronisation delivery pour john-root.',
-        );
+        $employeeStartEvents = [
+            'User-john-root' => 'John Root',
+            'User-john-admin' => 'John Admin',
+            'User-john-user' => 'John User',
+            'User-john-api' => 'John Api',
+        ];
+
+        $dayOffset = 6;
+        foreach ($employeeStartEvents as $userReference => $employeeName) {
+            /** @var User $employeeUser */
+            $employeeUser = $this->getReference($userReference, User::class);
+
+            $this->ensureEvent(
+                $manager,
+                $calendar,
+                $employeeUser,
+                sprintf('CRM General - %s employee start', $employeeName),
+                $dayOffset,
+                sprintf('%s commencement as Employee in CRM General.', $employeeName),
+            );
+            ++$dayOffset;
+        }
     }
 
     private function ensureStandaloneEvent(


### PR DESCRIPTION
### Motivation
- Ensure the "CRM General" application gets a seeded chat and calendar scenario so functional/demo environments include a prepopulated group conversation and onboarding events. 
- Add deterministic employee participants to the CRM General group conversation and create calendar milestones and per-employee start events for a realistic scenario. 
- Harmonize titles/ownership for the group conversation and CRM General events across CRM and Recruit fixtures. 

### Description
- Modified `LoadCrmData` to return generated employees from `generateEmployees` and call a new `ensureCrmGeneralChatAndCalendarScenario` helper for `crm-general-core` applications. 
- Added helpers in `LoadCrmData`: `ensureChat`, `ensureGeneralGroupConversation`, `ensureCrmEmployeeParticipants`, `ensureCalendar`, `ensureCrmGeneralCalendarEvents`, and `ensureCalendarEvent` to create or reuse `Chat`, `Conversation`, `ConversationParticipant`, `Calendar`, and `Event` entities. 
- Updated `LoadRecruitChatCalendarScenarioData` to set the CRM General conversation title to `General Group`, to create CRM General calendar when applicable, and to create per-employee CRM General start events using the application calendar owner when appropriate. 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee83de217483268a486401344a7c90)