### PR TITLE
feat(crm): add endpoints for current user's assigned tasks and task requests

### DIFF
--- a/src/Crm/Transport/Controller/Api/V1/Task/ListMyAssignedTasksController.php
+++ b/src/Crm/Transport/Controller/Api/V1/Task/ListMyAssignedTasksController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\Task;
+
+use App\Crm\Application\Service\TaskBoardService;
+use App\Role\Domain\Enum\Role;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm')]
+#[IsGranted(Role::CRM_VIEWER->value)]
+final readonly class ListMyAssignedTasksController
+{
+    public function __construct(
+        private TaskBoardService $taskBoardService,
+    ) {
+    }
+
+    #[Route('/v1/crm/me/assigned-tasks', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'List My Assigned Tasks',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'List of tasks assigned to the current user.'),
+        ],
+    )]
+    public function __invoke(User $loggedInUser): JsonResponse
+    {
+        $mine = $this->taskBoardService->listMine('crm-general-core', $loggedInUser);
+
+        return new JsonResponse([
+            'items' => $mine['items']['tasks'] ?? [],
+        ]);
+    }
+}

--- a/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListMyAssignedTaskRequestsController.php
+++ b/src/Crm/Transport/Controller/Api/V1/TaskRequest/ListMyAssignedTaskRequestsController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Crm\Transport\Controller\Api\V1\TaskRequest;
+
+use App\Crm\Application\Service\TaskBoardService;
+use App\Role\Domain\Enum\Role;
+use App\User\Domain\Entity\User;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Crm TaskRequest')]
+#[IsGranted(Role::CRM_VIEWER->value)]
+final readonly class ListMyAssignedTaskRequestsController
+{
+    public function __construct(
+        private TaskBoardService $taskBoardService,
+    ) {
+    }
+
+    #[Route('/v1/crm/me/assigned-task-requests', methods: [Request::METHOD_GET])]
+    #[OA\Get(
+        summary: 'List My Assigned Task Requests',
+        responses: [
+            new OA\Response(response: JsonResponse::HTTP_OK, description: 'List of task requests assigned to the current user.'),
+        ],
+    )]
+    public function __invoke(User $loggedInUser): JsonResponse
+    {
+        $mine = $this->taskBoardService->listMine('crm-general-core', $loggedInUser);
+
+        return new JsonResponse([
+            'items' => $mine['items']['taskRequests'] ?? [],
+        ]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Fournir des endpoints dédiés pour récupérer uniquement les tasks et les task requests auxquelles l’utilisateur connecté est assigné afin de simplifier les appels clients.

### Description
- Ajout de `ListMyAssignedTasksController` exposant `GET /v1/crm/me/assigned-tasks` qui réutilise `TaskBoardService::listMine()` et retourne les tasks sous la clé `items`.
- Ajout de `ListMyAssignedTaskRequestsController` exposant `GET /v1/crm/me/assigned-task-requests` qui réutilise `TaskBoardService::listMine()` et retourne les task requests sous la clé `items`.
- Les deux controllers sont protégés par le rôle `CRM_VIEWER` via `#[IsGranted(Role::CRM_VIEWER->value)]` et comportent des annotations OpenAPI pour la documentation.
- Le format et la normalisation des éléments sont délégués à `TaskBoardService`/normalizer pour rester cohérent avec `GET /api/v1/crm/me/tasks`.

### Testing
- Exécution de `php -l src/Crm/Transport/Controller/Api/V1/Task/ListMyAssignedTasksController.php` qui a renvoyé « No syntax errors detected ». 
- Exécution de `php -l src/Crm/Transport/Controller/Api/V1/TaskRequest/ListMyAssignedTaskRequestsController.php` qui a renvoyé « No syntax errors detected ».

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eeb241e624832689e9ae772dd693da)