### PR TITLE
Handle stale chat commands without retry storms

### DIFF
--- a/src/Chat/Application/MessageHandler/CreateMessageCommandHandler.php
+++ b/src/Chat/Application/MessageHandler/CreateMessageCommandHandler.php
@@ -16,8 +16,6 @@ use App\General\Application\Service\MercurePublisher;
 use App\User\Domain\Entity\User;
 use App\User\Infrastructure\Repository\UserRepository;
 use DateTimeImmutable;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
@@ -39,14 +37,17 @@ final readonly class CreateMessageCommandHandler
      */
     public function __invoke(CreateMessageCommand $command): string
     {
-        /** @var array{chatId: string, message: ChatMessage} $result */
-        $result = $this->messageRepository->getEntityManager()->getConnection()->transactional(function () use ($command): array {
+        /** @var array{chatId: string, message: ChatMessage}|null $result */
+        $result = $this->messageRepository->getEntityManager()->getConnection()->transactional(function () use ($command): ?array {
             $actor = $this->userRepository->find($command->actorUserId);
             if (!$actor instanceof User) {
-                throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'User not found.');
+                return null;
             }
 
             $conversation = $this->findParticipantConversation($command->conversationId, $actor);
+            if (!$conversation instanceof Conversation) {
+                return null;
+            }
 
             $message = new ChatMessage()
                 ->setConversation($conversation)
@@ -66,6 +67,10 @@ final readonly class CreateMessageCommandHandler
             ];
         });
 
+        if (null === $result) {
+            return '';
+        }
+
         $this->cacheInvalidationService->invalidateConversationCaches($result['chatId'], $command->actorUserId);
 
         $this->mercurePublisher->publish('/conversations/' . $command->conversationId . '/messages', [
@@ -81,15 +86,15 @@ final readonly class CreateMessageCommandHandler
         return $result['message']->getId();
     }
 
-    private function findParticipantConversation(string $conversationId, User $actor): Conversation
+    private function findParticipantConversation(string $conversationId, User $actor): ?Conversation
     {
         $conversation = $this->conversationRepository->find($conversationId);
         if (!$conversation instanceof Conversation) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+            return null;
         }
 
         if (!$this->participantRepository->findOneByConversationAndUser($conversation, $actor) instanceof ConversationParticipant) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+            return null;
         }
 
         return $conversation;

--- a/src/Chat/Application/MessageHandler/MarkConversationMessagesAsReadCommandHandler.php
+++ b/src/Chat/Application/MessageHandler/MarkConversationMessagesAsReadCommandHandler.php
@@ -10,8 +10,6 @@ use App\Chat\Domain\Entity\ConversationParticipant;
 use App\Chat\Infrastructure\Repository\ConversationParticipantRepository;
 use App\Chat\Infrastructure\Repository\ConversationRepository;
 use App\General\Application\Service\CacheInvalidationService;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
@@ -26,7 +24,12 @@ final readonly class MarkConversationMessagesAsReadCommandHandler
 
     public function __invoke(MarkConversationMessagesAsReadCommand $command): void
     {
-        [$conversation, $participant] = $this->findParticipantConversation($command->conversationId, $command->actorUserId);
+        $result = $this->findParticipantConversation($command->conversationId, $command->actorUserId);
+        if (null === $result) {
+            return;
+        }
+
+        [$conversation, $participant] = $result;
 
         $participant->setLastReadMessageAt(new \DateTimeImmutable());
         $this->participantRepository->save($participant);
@@ -34,13 +37,13 @@ final readonly class MarkConversationMessagesAsReadCommandHandler
     }
 
     /**
-     * @return array{Conversation, ConversationParticipant}
+     * @return array{Conversation, ConversationParticipant}|null
      */
-    private function findParticipantConversation(string $conversationId, string $actorUserId): array
+    private function findParticipantConversation(string $conversationId, string $actorUserId): ?array
     {
         $conversation = $this->conversationRepository->find($conversationId);
         if (!$conversation instanceof Conversation) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+            return null;
         }
 
         $participant = $this->participantRepository->findOneBy([
@@ -48,7 +51,7 @@ final readonly class MarkConversationMessagesAsReadCommandHandler
             'user' => $actorUserId,
         ]);
         if (!$participant instanceof ConversationParticipant) {
-            throw new HttpException(JsonResponse::HTTP_NOT_FOUND, 'Conversation not found.');
+            return null;
         }
 
         return [$conversation, $participant];


### PR DESCRIPTION
### Motivation
- Messenger workers were repeatedly retrying chat commands that referenced deleted or inaccessible conversations or users, causing noisy critical logs and failure-transport churn.
- The intent is to treat those stale-state conditions as benign (idempotent) and avoid throwing HTTP 404 exceptions from async handlers so retries are not triggered.

### Description
- `CreateMessageCommandHandler` now treats missing actor or missing conversation/participant as a benign condition by returning `null` from the transactional closure and exiting early with an empty string, instead of throwing `HttpException` (changes in `src/Chat/Application/MessageHandler/CreateMessageCommandHandler.php`).
- `MarkConversationMessagesAsReadCommandHandler` now returns early when the conversation or participant is absent, turning the handler into a no-op for stale commands (changes in `src/Chat/Application/MessageHandler/MarkConversationMessagesAsReadCommandHandler.php`).
- Updated method signatures to return nullable types (`?Conversation` and `?array`) and removed unused `HttpException`/`JsonResponse` imports where applicable.

### Testing
- Ran `php -l src/Chat/Application/MessageHandler/CreateMessageCommandHandler.php` which succeeded with no syntax errors. 
- Ran `php -l src/Chat/Application/MessageHandler/MarkConversationMessagesAsReadCommandHandler.php` which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69effbad43b88326aa4cc960a64f7afe)