### PR TITLE
Add resume birth/place/profileText and skill levels; update fixtures and migration

### DIFF
--- a/migrations/Version20260428123000.php
+++ b/migrations/Version20260428123000.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260428123000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add resume birth/profile fields and skill level.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE recruit_resume ADD information_birth_date DATE DEFAULT NULL COMMENT "(DC2Type:date_immutable)", ADD information_birth_place VARCHAR(255) DEFAULT NULL, ADD information_profile_text LONGTEXT DEFAULT NULL');
+        $this->addSql('ALTER TABLE recruit_resume_skill ADD level VARCHAR(10) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE recruit_resume DROP information_birth_date, DROP information_birth_place, DROP information_profile_text');
+        $this->addSql('ALTER TABLE recruit_resume_skill DROP level');
+    }
+}

--- a/src/Recruit/Application/Service/ResumeNormalizerService.php
+++ b/src/Recruit/Application/Service/ResumeNormalizerService.php
@@ -10,6 +10,7 @@ use App\Recruit\Domain\Entity\Experience;
 use App\Recruit\Domain\Entity\Language;
 use App\Recruit\Domain\Entity\Project;
 use App\Recruit\Domain\Entity\Resume;
+use App\Recruit\Domain\Entity\Skill;
 
 class ResumeNormalizerService
 {
@@ -38,6 +39,9 @@ class ResumeNormalizerService
                 'homepage' => $resume->getInformationHomepage(),
                 'repo_profile' => $resume->getInformationRepoProfile(),
                 'adresse' => $resume->getInformationAddress(),
+                'birthDate' => $resume->getInformationBirthDate()?->format('Y-m-d'),
+                'birthPlace' => $resume->getInformationBirthPlace(),
+                'profileText' => $resume->getInformationProfileText(),
             ],
             'experiences' => $this->normalizeSections($resume->getExperiences()->toArray()),
             'educations' => $this->normalizeSections($resume->getEducations()->toArray()),
@@ -65,6 +69,9 @@ class ResumeNormalizerService
             ];
 
             if ($section instanceof Language) {
+                $payload['level'] = $section->getLevel();
+            }
+            if ($section instanceof Skill) {
                 $payload['level'] = $section->getLevel();
             }
 

--- a/src/Recruit/Application/Service/ResumePayloadService.php
+++ b/src/Recruit/Application/Service/ResumePayloadService.php
@@ -125,6 +125,9 @@ class ResumePayloadService
         $resume->setInformationHomepage($this->nullableTrimmedString($input['homepage'] ?? null));
         $resume->setInformationRepoProfile($this->nullableTrimmedString($input['repo_profile'] ?? null));
         $resume->setInformationAddress($this->nullableTrimmedString($input['adresse'] ?? null) ?? $profile?->getLocation());
+        $resume->setInformationBirthDate($this->nullableDate($input['birthDate'] ?? null, 'birthDate'));
+        $resume->setInformationBirthPlace($this->nullableTrimmedString($input['birthPlace'] ?? null));
+        $resume->setInformationProfileText($this->nullableTrimmedString($input['profileText'] ?? null));
     }
 
     /**
@@ -154,6 +157,15 @@ class ResumePayloadService
         }
         if (array_key_exists('adresse', $input)) {
             $resume->setInformationAddress($this->nullableTrimmedString($input['adresse']));
+        }
+        if (array_key_exists('birthDate', $input)) {
+            $resume->setInformationBirthDate($this->nullableDate($input['birthDate'], 'birthDate'));
+        }
+        if (array_key_exists('birthPlace', $input)) {
+            $resume->setInformationBirthPlace($this->nullableTrimmedString($input['birthPlace']));
+        }
+        if (array_key_exists('profileText', $input)) {
+            $resume->setInformationProfileText($this->nullableTrimmedString($input['profileText']));
         }
     }
 
@@ -220,6 +232,9 @@ class ResumePayloadService
             if ($field === 'projects' && $section instanceof Project) {
                 $section->setAttachments($this->normalizeStringArray($item['attachments'] ?? null, 'attachments'));
                 $section->setHomePage($this->nullableTrimmedString($item['home_page'] ?? null));
+            }
+            if ($field === 'skills' && $section instanceof Skill) {
+                $section->setLevel($this->nullableTrimmedString($item['level'] ?? null));
             }
 
             if ($field === 'educations' && $section instanceof Education) {

--- a/src/Recruit/Domain/Entity/Resume.php
+++ b/src/Recruit/Domain/Entity/Resume.php
@@ -55,6 +55,15 @@ class Resume implements EntityInterface
     #[ORM\Column(name: 'information_address', type: 'string', length: 255, nullable: true)]
     private ?string $informationAddress = null;
 
+    #[ORM\Column(name: 'information_birth_date', type: 'date_immutable', nullable: true)]
+    private ?\DateTimeImmutable $informationBirthDate = null;
+
+    #[ORM\Column(name: 'information_birth_place', type: 'string', length: 255, nullable: true)]
+    private ?string $informationBirthPlace = null;
+
+    #[ORM\Column(name: 'information_profile_text', type: 'text', nullable: true)]
+    private ?string $informationProfileText = null;
+
     /** @var Collection<int, Experience>|ArrayCollection<int, Experience> */
     #[ORM\OneToMany(targetEntity: Experience::class, mappedBy: 'resume', cascade: ['persist', 'remove'], orphanRemoval: true)]
     private Collection|ArrayCollection $experiences;
@@ -186,6 +195,36 @@ class Resume implements EntityInterface
     public function setInformationAddress(?string $informationAddress): self
     {
         $this->informationAddress = $informationAddress;
+
+        return $this;
+    }
+    public function getInformationBirthDate(): ?\DateTimeImmutable
+    {
+        return $this->informationBirthDate;
+    }
+    public function setInformationBirthDate(?\DateTimeImmutable $informationBirthDate): self
+    {
+        $this->informationBirthDate = $informationBirthDate;
+
+        return $this;
+    }
+    public function getInformationBirthPlace(): ?string
+    {
+        return $this->informationBirthPlace;
+    }
+    public function setInformationBirthPlace(?string $informationBirthPlace): self
+    {
+        $this->informationBirthPlace = $informationBirthPlace;
+
+        return $this;
+    }
+    public function getInformationProfileText(): ?string
+    {
+        return $this->informationProfileText;
+    }
+    public function setInformationProfileText(?string $informationProfileText): self
+    {
+        $this->informationProfileText = $informationProfileText;
 
         return $this;
     }

--- a/src/Recruit/Domain/Entity/Skill.php
+++ b/src/Recruit/Domain/Entity/Skill.php
@@ -39,6 +39,9 @@ class Skill implements EntityInterface
     ])]
     private string $description = '';
 
+    #[ORM\Column(name: 'level', type: Types::STRING, length: 10, nullable: true)]
+    private ?string $level = null;
+
     public function __construct()
     {
         $this->id = $this->createUuid();
@@ -76,6 +79,16 @@ class Skill implements EntityInterface
     public function setDescription(string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+    public function getLevel(): ?string
+    {
+        return $this->level;
+    }
+    public function setLevel(?string $level): self
+    {
+        $this->level = $level;
 
         return $this;
     }

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitApplicationData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitApplicationData.php
@@ -225,7 +225,12 @@ final class LoadRecruitApplicationData extends Fixture implements OrderedFixture
                 ->setInformationFullName('Rami Aouinti')
                 ->setInformationEmail('rami.aouinti@gmail.com')
                 ->setInformationPhone('0049 176/35587613')
-                ->setInformationAddress("25.08.1989 in Tunesien\nWiddersdorfer Landstr.11\n50589 Köln Germany");
+                ->setInformationHomepage('https://www.ramy-aouinti.com')
+                ->setInformationRepoProfile('https://github.com/rami-aouinti')
+                ->setInformationAddress("Widdersdorfer Landstr.11\n50589 Köln Germany")
+                ->setInformationBirthDate(new \DateTimeImmutable('1989-08-25'))
+                ->setInformationBirthPlace('Tunesien')
+                ->setInformationProfileText("Softwareentwickler mit Schwerpunkt PHP/Web und Symfony, spezialisiert auf die Entwicklung robuster, skalierbarer und wartbarer Webanwendungen.\nIch arbeite hauptsächlich an der Erstellung von APIs, Backend-Architekturen, Service-Integrationen und Performance-Optimierung.\nStrukturiert, selbstständig und qualitätsorientiert entwickle ich zuverlässige Lösungen, die auf fachliche Anforderungen zugeschnitten sind.");
         } else {
             $resume
                 ->setInformationFullName($owner->getFirstName() . ' ' . $owner->getLastName())
@@ -262,15 +267,16 @@ final class LoadRecruitApplicationData extends Fixture implements OrderedFixture
                 ->addLanguage((new Language())->setTitle('Deutsch')->setDescription('fließend')->setLevel('c1'))
                 ->addLanguage((new Language())->setTitle('Englisch')->setDescription('fließend')->setLevel('c1'))
                 ->addLanguage((new Language())->setTitle('Französisch')->setDescription('Muttersprache')->setLevel('native'))
-                ->addSkill((new Skill())->setTitle('PHP 8')->setDescription('Backend-Entwicklung'))
-                ->addSkill((new Skill())->setTitle('JavaScript, jQuery, TypeScript')->setDescription('Webentwicklung und Frontend-Integration'))
-                ->addSkill((new Skill())->setTitle('Vue.js, Vuetify 3')->setDescription('Frontend-Frameworks'))
-                ->addSkill((new Skill())->setTitle('HTML5, XML, CSS3')->setDescription('Frontend-Basics und Markup'))
-                ->addSkill((new Skill())->setTitle('Symfony 6')->setDescription('Framework'))
-                ->addSkill((new Skill())->setTitle('Laravel 6 & 8')->setDescription('Framework'))
-                ->addSkill((new Skill())->setTitle('ZendFramework 2')->setDescription('Framework'))
-                ->addSkill((new Skill())->setTitle('Oxid eSales Shop 6, Shopware 5.6 & 6, Drupal, Typo3, WordPress')->setDescription('CMS'))
-                ->addSkill((new Skill())->setTitle('SQL, DQL, MongoDB, Redis')->setDescription('Database'));
+                ->addSkill((new Skill())->setTitle('PHP 8')->setDescription('Backend-Entwicklung')->setLevel('5/5'))
+                ->addSkill((new Skill())->setTitle('JavaScript, jQuery, TypeScript')->setDescription('Webentwicklung und Frontend-Integration')->setLevel('4/5'))
+                ->addSkill((new Skill())->setTitle('Vue.js, Vuetify 3')->setDescription('Frontend-Frameworks')->setLevel('4/5'))
+                ->addSkill((new Skill())->setTitle('HTML5, XML, CSS3')->setDescription('Frontend-Basics und Markup')->setLevel('5/5'))
+                ->addSkill((new Skill())->setTitle('Symfony 6')->setDescription('Framework')->setLevel('5/5'))
+                ->addSkill((new Skill())->setTitle('Laravel 6 & 8')->setDescription('Framework')->setLevel('4/5'))
+                ->addSkill((new Skill())->setTitle('ZendFramework 2')->setDescription('Framework')->setLevel('4/5'))
+                ->addSkill((new Skill())->setTitle('Oxid eSales Shop 6, Shopware 5.6 & 6, Drupal, Typo3, WordPress')->setDescription('CMS')->setLevel('4/5'))
+                ->addSkill((new Skill())->setTitle('SQL, DQL, MongoDB, Redis')->setDescription('Database')->setLevel('5/5'))
+                ->addProject((new Project())->setTitle('Bro World Space')->setDescription('Community and collaboration platform project.')->setHomePage('https://github.com/rami-aouinti/bro-world-api')->setAttachments(['https://bro-world.org/img/social-bro-world.png']));
         }
 
         $applicant = (new Applicant())


### PR DESCRIPTION
### Motivation
- Separate birth date/place and profile text from the address so the private resume endpoint returns structured personal info and a textual profile.
- Add a `level` for skills so fixtures and responses can express proficiency (e.g. `4/5`, `5/5`).
- Ensure fixtures for `john-root` reflect corrected address, homepage, repo, birth info, profile text, skill levels and a project with an image/repo link.

### Description
- Added `information_birth_date`, `information_birth_place` and `information_profile_text` to the `Resume` entity with getters/setters and mapping to `recruit_resume` columns.
- Added `level` column to `Skill` entity with getters/setters and support in DTOs/hydration.
- Extended `ResumeNormalizerService` to include `resumeInformation.birthDate`, `resumeInformation.birthPlace`, `resumeInformation.profileText` and to return `skills[].level`.
- Updated `ResumePayloadService` to accept and persist `birthDate`, `birthPlace`, `profileText` on create/patch and to read/write `skills[].level` when hydrating resume sections.
- Updated fixtures (`LoadRecruitApplicationData`) for `john-root` to correct the address, add `homepage` and `repo_profile`, set `birthDate` (`1989-08-25`) and `birthPlace` (`Tunesien`), add the provided German `profileText`, set skill `level` values (4/5–5/5), and add project `Bro World Space` with image and repository links.
- Added Doctrine migration `Version20260428123000` to add the new resume columns and the `level` column on `recruit_resume_skill`.

### Testing
- Ran PHP syntax checks: `php -l src/Recruit/Domain/Entity/Resume.php` (ok).
- Ran PHP syntax checks: `php -l src/Recruit/Domain/Entity/Skill.php` (ok).
- Ran PHP syntax checks: `php -l src/Recruit/Application/Service/ResumeNormalizerService.php` (ok).
- Ran PHP syntax checks: `php -l src/Recruit/Application/Service/ResumePayloadService.php` (ok).
- Ran PHP syntax checks: `php -l src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitApplicationData.php` (ok).
- Ran PHP syntax checks: `php -l migrations/Version20260428123000.php` (ok).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12f3f89348326af509a16c7aada7a)