### PR TITLE
Support interests alias and robust resume section payload normalization

### DIFF
--- a/src/Recruit/Application/Service/ResumeNormalizerService.php
+++ b/src/Recruit/Application/Service/ResumeNormalizerService.php
@@ -29,6 +29,8 @@ class ResumeNormalizerService
      */
     public function normalize(Resume $resume): array
     {
+        $hobbies = $this->normalizeSections($resume->getHobbies()->toArray());
+
         return [
             'id' => $resume->getId(),
             'documentUrl' => $resume->getDocumentUrl(),
@@ -51,7 +53,8 @@ class ResumeNormalizerService
             'certifications' => $this->normalizeSections($resume->getCertifications()->toArray()),
             'projects' => $this->normalizeSections($resume->getProjects()->toArray()),
             'references' => $this->normalizeSections($resume->getReferences()->toArray()),
-            'hobbies' => $this->normalizeSections($resume->getHobbies()->toArray()),
+            'hobbies' => $hobbies,
+            'interests' => $hobbies,
         ];
     }
 

--- a/src/Recruit/Application/Service/ResumePayloadService.php
+++ b/src/Recruit/Application/Service/ResumePayloadService.php
@@ -30,6 +30,7 @@ use function trim;
 
 class ResumePayloadService
 {
+    private const string INTERESTS_FIELD = 'interests';
     /**
      * @var list<string>
      */
@@ -89,10 +90,15 @@ class ResumePayloadService
                 $payload[$field] = $decoded;
             }
 
+            $this->mapInterestsAlias($payload);
+
             return $payload;
         }
 
-        return $request->toArray();
+        $payload = $request->toArray();
+        $this->mapInterestsAlias($payload);
+
+        return $payload;
     }
 
     /**
@@ -206,9 +212,7 @@ class ResumePayloadService
     private function appendSections(Resume $resume, string $field, array $input): void
     {
         foreach ($input as $index => $item) {
-            if (!is_array($item)) {
-                throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Section at index ' . $index . ' must be an object.');
-            }
+            $item = $this->normalizeSectionItem($field, $item, $index);
 
             $title = $item['title'] ?? null;
             $description = $item['description'] ?? '';
@@ -256,6 +260,55 @@ class ResumePayloadService
 
             $this->addSection($resume, $field, $section);
         }
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private function mapInterestsAlias(array &$payload): void
+    {
+        if (array_key_exists('hobbies', $payload)) {
+            return;
+        }
+
+        if (array_key_exists(self::INTERESTS_FIELD, $payload)) {
+            $payload['hobbies'] = $payload[self::INTERESTS_FIELD];
+        }
+    }
+
+    /**
+     * @param mixed $item
+     * @return array<string, mixed>
+     */
+    private function normalizeSectionItem(string $field, mixed $item, int $index): array
+    {
+        if ($field === 'languages') {
+            if (is_string($item)) {
+                return ['title' => $item, 'description' => '', 'level' => null];
+            }
+
+            if (is_array($item) && is_string($item['name'] ?? null) && !array_key_exists('title', $item)) {
+                return [
+                    'title' => $item['name'],
+                    'description' => '',
+                    'level' => $item['level'] ?? null,
+                ];
+            }
+        }
+
+        if ($field === 'skills' && is_string($item)) {
+            return ['title' => $item, 'description' => '', 'level' => null];
+        }
+
+        if ($field === 'hobbies' && is_string($item)) {
+            return ['title' => $item, 'description' => ''];
+        }
+
+        if (!is_array($item)) {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Section at index ' . $index . ' must be an object.');
+        }
+
+        return $item;
     }
 
     private function clearSections(Resume $resume, string $field): void


### PR DESCRIPTION
### Motivation
- Le frontend souhaite que la section "Interests" ait la même logique que "Skills"/"Languages" et pouvoir afficher la section soit dans l'aside soit en parallèle avec les skills, ce qui nécessite une API acceptant plusieurs formes de payloads pour ces sections.
- Les formulaires côté client envoient parfois des formats différents (strings simples, `{name, level}` pour languages), provoquant des erreurs côté API; il faut rendre l'ingestion plus tolérante.
- Il est utile de renvoyer `interests` dans la réponse normalisée pour que le client puisse choisir d'afficher la même liste que `hobbies` sous le nom `interests` sans transformation supplémentaire.

### Description
- Ajout d'un alias `interests` → `hobbies` lors de l'extraction du payload afin d'accepter côté API la section envoyée sous le nom `interests` (fichier modifié: `src/Recruit/Application/Service/ResumePayloadService.php`).
- Normalisation plus flexible des entrées de sections pour accepter plusieurs formes: `languages` accepte les `string` simples et les objets `{name, level}` (mappés en `{title, level}`), et `skills`/`hobbies` acceptent maintenant des strings simples; validation et mapping centralisés dans `normalizeSectionItem` (modifié: `src/Recruit/Application/Service/ResumePayloadService.php`).
- Ajout de `interests` dans la réponse normalisée du CV en miroir de `hobbies` pour simplifier l'affichage côté client (modifié: `src/Recruit/Application/Service/ResumeNormalizerService.php`).

### Testing
- Exécution de la vérification de syntaxe PHP sur les fichiers modifiés avec `php -l src/Recruit/Application/Service/ResumePayloadService.php` (succès).
- Exécution de la vérification de syntaxe PHP sur `src/Recruit/Application/Service/ResumeNormalizerService.php` (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1474400008326bfb55da00af8e7a3)