### PR TITLE
feat(recruit): normalize resume languages with country code and flag

### DIFF
--- a/src/Recruit/Application/Service/ResumeNormalizerService.php
+++ b/src/Recruit/Application/Service/ResumeNormalizerService.php
@@ -47,12 +47,50 @@ class ResumeNormalizerService
             'experiences' => $this->normalizeSections($resume->getExperiences()->toArray()),
             'educations' => $this->normalizeSections($resume->getEducations()->toArray()),
             'skills' => $this->normalizeSections($resume->getSkills()->toArray()),
-            'languages' => $this->normalizeSections($resume->getLanguages()->toArray()),
+            'languages' => $this->normalizeLanguages($resume->getLanguages()->toArray()),
             'certifications' => $this->normalizeSections($resume->getCertifications()->toArray()),
             'projects' => $this->normalizeSections($resume->getProjects()->toArray()),
             'references' => $this->normalizeSections($resume->getReferences()->toArray()),
             'hobbies' => $this->normalizeSections($resume->getHobbies()->toArray()),
         ];
+    }
+
+
+    /**
+     * @param array<int, Language> $languages
+     *
+     * @return array<int, array<string, string|null>>
+     */
+    private function normalizeLanguages(array $languages): array
+    {
+        return array_map(function (Language $language): array {
+            $countryCode = strtoupper(trim($language->getDescription()));
+            if ($countryCode === '') {
+                $countryCode = null;
+            }
+
+            return [
+                'name' => $language->getTitle(),
+                'countryCode' => $countryCode,
+                'flag' => $this->countryCodeToFlag($countryCode),
+            ];
+        }, $languages);
+    }
+
+    private function countryCodeToFlag(?string $countryCode): ?string
+    {
+        if ($countryCode === null || strlen($countryCode) !== 2) {
+            return null;
+        }
+
+        $first = ord($countryCode[0]);
+        $second = ord($countryCode[1]);
+
+        if ($first < 65 || $first > 90 || $second < 65 || $second > 90) {
+            return null;
+        }
+
+        return mb_chr(0x1F1E6 + ($first - 65), 'UTF-8') . mb_chr(0x1F1E6 + ($second - 65), 'UTF-8');
     }
 
     /**


### PR DESCRIPTION
### Motivation
- The resume `languages` output must follow the new API shape `[{ "name": "French", "countryCode": "FR", "flag": "🇫🇷" }, ...]` instead of the previous `title/description` shape. 
- This change ensures the public recruit endpoints return a stable language object with an ISO country code and a derived emoji flag.

### Description
- Replaced the languages serialization in `ResumeNormalizerService` to use a new `normalizeLanguages()` method and adjusted the `normalize()` output to call `normalizeLanguages()` for `languages` instead of `normalizeSections()`.
- Implemented `normalizeLanguages()` to map `title` -> `name` and `description` -> `countryCode` (uppercased and normalized), and to include a `flag` field derived from the ISO-2 `countryCode` when valid. 
- Added `countryCodeToFlag()` helper which converts a valid 2-letter uppercase ISO code into the corresponding Unicode regional indicator emoji, returning `null` for invalid or absent codes.
- Kept all other resume section normalizations unchanged and preserved backward-safe behavior when `countryCode` is missing or invalid.

### Testing
- Ran PHP linting on the modified file with `php -l src/Recruit/Application/Service/ResumeNormalizerService.php` which completed with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f241e0333883269943d9b1af9ad5f3)