### PR TITLE
Add Template, CoverPage and CoverLetter entities with migration and fixture seeding

### DIFF
--- a/migrations/Version20260507120000.php
+++ b/migrations/Version20260507120000.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+namespace DoctrineMigrations;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+final class Version20260507120000 extends AbstractMigration {
+public function getDescription(): string { return 'Add template, cover page, cover letter and link template to resume'; }
+public function up(Schema $schema): void {
+$this->addSql("CREATE TABLE recruit_template (id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', name VARCHAR(255) NOT NULL, type VARCHAR(30) NOT NULL, version INT NOT NULL, layout VARCHAR(100) DEFAULT NULL, structure_name VARCHAR(100) DEFAULT NULL, sections JSON DEFAULT NULL, theme JSON DEFAULT NULL, aside_data JSON DEFAULT NULL, photo JSON DEFAULT NULL, decor JSON DEFAULT NULL, layout_options JSON DEFAULT NULL, decor_options JSON DEFAULT NULL, section_title_style JSON DEFAULT NULL, header_type VARCHAR(100) DEFAULT NULL, fake_data JSON DEFAULT NULL, text_styles JSON DEFAULT NULL, typography JSON DEFAULT NULL, section_bar JSON DEFAULT NULL, items JSON DEFAULT NULL, created_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', updated_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+$this->addSql("CREATE TABLE recruit_cover_page (id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', template_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', full_name VARCHAR(255) DEFAULT NULL, role_name VARCHAR(255) DEFAULT NULL, photo VARCHAR(1024) DEFAULT NULL, description LONGTEXT DEFAULT NULL, email VARCHAR(255) DEFAULT NULL, phone VARCHAR(50) DEFAULT NULL, header VARCHAR(255) DEFAULT NULL, profile LONGTEXT DEFAULT NULL, signature VARCHAR(1024) DEFAULT NULL, created_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', updated_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', INDEX IDX_7E02A15A5DA0FB8 (template_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+$this->addSql("CREATE TABLE recruit_cover_letter (id BINARY(16) NOT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', template_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', full_name VARCHAR(255) DEFAULT NULL, role_name VARCHAR(255) DEFAULT NULL, photo VARCHAR(1024) DEFAULT NULL, sender_date DATE DEFAULT NULL COMMENT '(DC2Type:date_immutable)', location VARCHAR(255) DEFAULT NULL, header VARCHAR(255) DEFAULT NULL, description_1 LONGTEXT DEFAULT NULL, description_2 LONGTEXT DEFAULT NULL, created_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', updated_at DATETIME NOT NULL COMMENT '(DC2Type:datetime_immutable)', INDEX IDX_D867F1A85DA0FB8 (template_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB");
+$this->addSql('ALTER TABLE recruit_cover_page ADD CONSTRAINT FK_7E02A15A5DA0FB8 FOREIGN KEY (template_id) REFERENCES recruit_template (id) ON DELETE SET NULL');
+$this->addSql('ALTER TABLE recruit_cover_letter ADD CONSTRAINT FK_D867F1A85DA0FB8 FOREIGN KEY (template_id) REFERENCES recruit_template (id) ON DELETE SET NULL');
+$this->addSql("ALTER TABLE recruit_resume ADD template_id BINARY(16) DEFAULT NULL COMMENT '(DC2Type:uuid_binary_ordered_time)', ADD CONSTRAINT FK_B8B20E35DA0FB8 FOREIGN KEY (template_id) REFERENCES recruit_template (id) ON DELETE SET NULL");
+$this->addSql('CREATE INDEX IDX_B8B20E35DA0FB8 ON recruit_resume (template_id)'); }
+public function down(Schema $schema): void {
+$this->addSql('ALTER TABLE recruit_resume DROP FOREIGN KEY FK_B8B20E35DA0FB8');
+$this->addSql('DROP INDEX IDX_B8B20E35DA0FB8 ON recruit_resume');
+$this->addSql('ALTER TABLE recruit_resume DROP template_id');
+$this->addSql('ALTER TABLE recruit_cover_page DROP FOREIGN KEY FK_7E02A15A5DA0FB8');
+$this->addSql('ALTER TABLE recruit_cover_letter DROP FOREIGN KEY FK_D867F1A85DA0FB8');
+$this->addSql('DROP TABLE recruit_cover_page'); $this->addSql('DROP TABLE recruit_cover_letter'); $this->addSql('DROP TABLE recruit_template'); }}

--- a/src/Recruit/Domain/Entity/CoverLetter.php
+++ b/src/Recruit/Domain/Entity/CoverLetter.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+namespace App\Recruit\Domain\Entity;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_cover_letter')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class CoverLetter implements EntityInterface { use Timestampable; use Uuid;
+#[ORM\Id] #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)] private UuidInterface $id;
+#[ORM\ManyToOne(targetEntity: Template::class)] #[ORM\JoinColumn(name: 'template_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')] private ?Template $template = null;
+#[ORM\Column(name: 'full_name', type: 'string', length: 255, nullable: true)] private ?string $fullName = null;
+#[ORM\Column(name: 'role_name', type: 'string', length: 255, nullable: true)] private ?string $role = null;
+#[ORM\Column(name: 'photo', type: 'string', length: 1024, nullable: true)] private ?string $photo = null;
+#[ORM\Column(name: 'sender_date', type: 'date_immutable', nullable: true)] private ?\DateTimeImmutable $senderDate = null;
+#[ORM\Column(name: 'location', type: 'string', length: 255, nullable: true)] private ?string $location = null;
+#[ORM\Column(name: 'header', type: 'string', length: 255, nullable: true)] private ?string $header = 'Motivation Letter';
+#[ORM\Column(name: 'description_1', type: 'text', nullable: true)] private ?string $description1 = null;
+#[ORM\Column(name: 'description_2', type: 'text', nullable: true)] private ?string $description2 = null;
+public function __construct(){ $this->id=$this->createUuid(); }
+#[Override] public function getId(): string { return $this->id->toString(); }
+public function getTemplate(): ?Template { return $this->template; } public function setTemplate(?Template $template): self { $this->template=$template; return $this; }
+public function getFullName(): ?string { return $this->fullName; } public function setFullName(?string $fullName): self { $this->fullName=$fullName; return $this; }
+public function getRole(): ?string { return $this->role; } public function setRole(?string $role): self { $this->role=$role; return $this; }
+public function getPhoto(): ?string { return $this->photo; } public function setPhoto(?string $photo): self { $this->photo=$photo; return $this; }
+public function getSenderDate(): ?\DateTimeImmutable { return $this->senderDate; } public function setSenderDate(?\DateTimeImmutable $senderDate): self { $this->senderDate=$senderDate; return $this; }
+public function getLocation(): ?string { return $this->location; } public function setLocation(?string $location): self { $this->location=$location; return $this; }
+public function getHeader(): ?string { return $this->header; } public function setHeader(?string $header): self { $this->header=$header; return $this; }
+public function getDescription1(): ?string { return $this->description1; } public function setDescription1(?string $description1): self { $this->description1=$description1; return $this; }
+public function getDescription2(): ?string { return $this->description2; } public function setDescription2(?string $description2): self { $this->description2=$description2; return $this; }
+}

--- a/src/Recruit/Domain/Entity/CoverPage.php
+++ b/src/Recruit/Domain/Entity/CoverPage.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+namespace App\Recruit\Domain\Entity;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_cover_page')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class CoverPage implements EntityInterface { use Timestampable; use Uuid;
+#[ORM\Id] #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)] private UuidInterface $id;
+#[ORM\ManyToOne(targetEntity: Template::class)] #[ORM\JoinColumn(name: 'template_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')] private ?Template $template = null;
+#[ORM\Column(name: 'full_name', type: 'string', length: 255, nullable: true)] private ?string $fullName = null;
+#[ORM\Column(name: 'role_name', type: 'string', length: 255, nullable: true)] private ?string $role = null;
+#[ORM\Column(name: 'photo', type: 'string', length: 1024, nullable: true)] private ?string $photo = null;
+#[ORM\Column(name: 'description', type: 'text', nullable: true)] private ?string $description = null;
+#[ORM\Column(name: 'email', type: 'string', length: 255, nullable: true)] private ?string $email = null;
+#[ORM\Column(name: 'phone', type: 'string', length: 50, nullable: true)] private ?string $phone = null;
+#[ORM\Column(name: 'header', type: 'string', length: 255, nullable: true)] private ?string $header = 'About Me';
+#[ORM\Column(name: 'profile', type: 'text', nullable: true)] private ?string $profile = null;
+#[ORM\Column(name: 'signature', type: 'string', length: 1024, nullable: true)] private ?string $signature = null;
+public function __construct(){ $this->id=$this->createUuid(); }
+#[Override] public function getId(): string { return $this->id->toString(); }
+public function getTemplate(): ?Template { return $this->template; } public function setTemplate(?Template $template): self { $this->template=$template; return $this; }
+public function getFullName(): ?string { return $this->fullName; } public function setFullName(?string $fullName): self { $this->fullName=$fullName; return $this; }
+public function getRole(): ?string { return $this->role; } public function setRole(?string $role): self { $this->role=$role; return $this; }
+public function getPhoto(): ?string { return $this->photo; } public function setPhoto(?string $photo): self { $this->photo=$photo; return $this; }
+public function getDescription(): ?string { return $this->description; } public function setDescription(?string $description): self { $this->description=$description; return $this; }
+public function getEmail(): ?string { return $this->email; } public function setEmail(?string $email): self { $this->email=$email; return $this; }
+public function getPhone(): ?string { return $this->phone; } public function setPhone(?string $phone): self { $this->phone=$phone; return $this; }
+public function getHeader(): ?string { return $this->header; } public function setHeader(?string $header): self { $this->header=$header; return $this; }
+public function getProfile(): ?string { return $this->profile; } public function setProfile(?string $profile): self { $this->profile=$profile; return $this; }
+public function getSignature(): ?string { return $this->signature; } public function setSignature(?string $signature): self { $this->signature=$signature; return $this; }
+}

--- a/src/Recruit/Domain/Entity/Resume.php
+++ b/src/Recruit/Domain/Entity/Resume.php
@@ -37,6 +37,10 @@ class Resume implements EntityInterface
     #[ORM\Column(name: 'document_url', type: 'string', length: 255, nullable: true)]
     private ?string $documentUrl = null;
 
+    #[ORM\ManyToOne(targetEntity: Template::class)]
+    #[ORM\JoinColumn(name: 'template_id', referencedColumnName: 'id', nullable: true, onDelete: 'SET NULL')]
+    private ?Template $template = null;
+
     #[ORM\Column(name: 'information_full_name', type: 'string', length: 255, nullable: true)]
     private ?string $informationFullName = null;
 
@@ -133,6 +137,16 @@ class Resume implements EntityInterface
     public function getApplicant(): ?Applicant
     {
         return $this->applicant;
+    }
+    public function getTemplate(): ?Template
+    {
+        return $this->template;
+    }
+    public function setTemplate(?Template $template): self
+    {
+        $this->template = $template;
+
+        return $this;
     }
     public function getDocumentUrl(): ?string
     {

--- a/src/Recruit/Domain/Entity/Template.php
+++ b/src/Recruit/Domain/Entity/Template.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+namespace App\Recruit\Domain\Entity;
+use App\General\Domain\Entity\Interfaces\EntityInterface;
+use App\General\Domain\Entity\Traits\Timestampable;
+use App\General\Domain\Entity\Traits\Uuid;
+use Doctrine\ORM\Mapping as ORM;
+use Override;
+use Ramsey\Uuid\Doctrine\UuidBinaryOrderedTimeType;
+use Ramsey\Uuid\UuidInterface;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'recruit_template')]
+#[ORM\ChangeTrackingPolicy('DEFERRED_EXPLICIT')]
+class Template implements EntityInterface { use Timestampable; use Uuid;
+#[ORM\Id] #[ORM\Column(name: 'id', type: UuidBinaryOrderedTimeType::NAME, unique: true)] private UuidInterface $id;
+#[ORM\Column(name: 'name', type: 'string', length: 255)] private string $name;
+#[ORM\Column(name: 'type', type: 'string', length: 30)] private string $type;
+#[ORM\Column(name: 'version', type: 'integer')] private int $version = 1;
+#[ORM\Column(name: 'layout', type: 'string', length: 100, nullable: true)] private ?string $layout = null;
+#[ORM\Column(name: 'structure_name', type: 'string', length: 100, nullable: true)] private ?string $structure = null;
+#[ORM\Column(name: 'sections', type: 'json', nullable: true)] private ?array $sections = null;
+#[ORM\Column(name: 'theme', type: 'json', nullable: true)] private ?array $theme = null;
+#[ORM\Column(name: 'aside_data', type: 'json', nullable: true)] private ?array $aside = null;
+#[ORM\Column(name: 'photo', type: 'json', nullable: true)] private ?array $photo = null;
+#[ORM\Column(name: 'decor', type: 'json', nullable: true)] private ?array $decor = null;
+#[ORM\Column(name: 'layout_options', type: 'json', nullable: true)] private ?array $layoutOptions = null;
+#[ORM\Column(name: 'decor_options', type: 'json', nullable: true)] private ?array $decorOptions = null;
+#[ORM\Column(name: 'section_title_style', type: 'json', nullable: true)] private ?array $sectionTitleStyle = null;
+#[ORM\Column(name: 'header_type', type: 'string', length: 100, nullable: true)] private ?string $headerType = null;
+#[ORM\Column(name: 'fake_data', type: 'json', nullable: true)] private ?array $fakeData = null;
+#[ORM\Column(name: 'text_styles', type: 'json', nullable: true)] private ?array $textStyles = null;
+#[ORM\Column(name: 'typography', type: 'json', nullable: true)] private ?array $typography = null;
+#[ORM\Column(name: 'section_bar', type: 'json', nullable: true)] private ?array $sectionBar = null;
+#[ORM\Column(name: 'items', type: 'json', nullable: true)] private ?array $items = null;
+public function __construct(){ $this->id = $this->createUuid(); }
+#[Override] public function getId(): string { return $this->id->toString(); }
+public function getName(): string { return $this->name; } public function setName(string $name): self { $this->name = $name; return $this; }
+public function getType(): string { return $this->type; } public function setType(string $type): self { $this->type = $type; return $this; }
+public function getVersion(): int { return $this->version; } public function setVersion(int $version): self { $this->version = $version; return $this; }
+public function getLayout(): ?string { return $this->layout; } public function setLayout(?string $layout): self { $this->layout = $layout; return $this; }
+public function getStructure(): ?string { return $this->structure; } public function setStructure(?string $structure): self { $this->structure = $structure; return $this; }
+public function getSections(): ?array { return $this->sections; } public function setSections(?array $sections): self { $this->sections = $sections; return $this; }
+public function getTheme(): ?array { return $this->theme; } public function setTheme(?array $theme): self { $this->theme = $theme; return $this; }
+public function getAside(): ?array { return $this->aside; } public function setAside(?array $aside): self { $this->aside = $aside; return $this; }
+public function getPhoto(): ?array { return $this->photo; } public function setPhoto(?array $photo): self { $this->photo = $photo; return $this; }
+public function getDecor(): ?array { return $this->decor; } public function setDecor(?array $decor): self { $this->decor = $decor; return $this; }
+public function getLayoutOptions(): ?array { return $this->layoutOptions; } public function setLayoutOptions(?array $layoutOptions): self { $this->layoutOptions = $layoutOptions; return $this; }
+public function getDecorOptions(): ?array { return $this->decorOptions; } public function setDecorOptions(?array $decorOptions): self { $this->decorOptions = $decorOptions; return $this; }
+public function getSectionTitleStyle(): ?array { return $this->sectionTitleStyle; } public function setSectionTitleStyle(?array $sectionTitleStyle): self { $this->sectionTitleStyle = $sectionTitleStyle; return $this; }
+public function getHeaderType(): ?string { return $this->headerType; } public function setHeaderType(?string $headerType): self { $this->headerType = $headerType; return $this; }
+public function getFakeData(): ?array { return $this->fakeData; } public function setFakeData(?array $fakeData): self { $this->fakeData = $fakeData; return $this; }
+public function getTextStyles(): ?array { return $this->textStyles; } public function setTextStyles(?array $textStyles): self { $this->textStyles = $textStyles; return $this; }
+public function getTypography(): ?array { return $this->typography; } public function setTypography(?array $typography): self { $this->typography = $typography; return $this; }
+public function getSectionBar(): ?array { return $this->sectionBar; } public function setSectionBar(?array $sectionBar): self { $this->sectionBar = $sectionBar; return $this; }
+public function getItems(): ?array { return $this->items; } public function setItems(?array $items): self { $this->items = $items; return $this; }
+}

--- a/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitData.php
+++ b/src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitData.php
@@ -12,6 +12,7 @@ use App\Recruit\Domain\Entity\Job;
 use App\Recruit\Domain\Entity\Recruit;
 use App\Recruit\Domain\Entity\Salary;
 use App\Recruit\Domain\Entity\Tag;
+use App\Recruit\Domain\Entity\Template;
 use App\Recruit\Domain\Enum\ContractType;
 use App\Recruit\Domain\Enum\ExperienceLevel;
 use App\Recruit\Domain\Enum\Schedule;
@@ -86,6 +87,52 @@ final class LoadRecruitData extends Fixture implements OrderedFixtureInterface
         'Remote Friendly',
     ];
 
+
+    /** @var array<int, array<string, mixed>> */
+    private const array TEMPLATES = [
+        [
+            'id' => 'tpl-001','name' => 'aside-structure-1','type' => 'resume','version' => 1,'layout' => 'aside','structure' => 'structure-1',
+            'sections' => ['experience'=>'classic','education'=>'list','skills'=>'classic','languages'=>'dots','languagesLabel'=>'cards','certifications'=>'classic','references'=>'list','projects'=>'dot','interests'=>'dot','contact'=>'icons','profile'=>'classic'],
+            'theme' => ['palette'=>['primary'=>'#1D4ED8','secondary'=>'#93C5FD','text'=>'#0F172A','muted'=>'#64748B','pageBackground'=>'#F8FAFC'],'line'=>'soft','density'=>'comfortable','textStyle'=>'roman','showIcon'=>true],
+            'aside' => ['width'=>'720','height'=>'220px','radius'=>'18px'],
+            'photo' => ['position'=>'left','size'=>'92px','shape'=>'circle','border'=>'2px solid #1F2937','photoType'=>'circle','photoSize'=>'92px','photoBorderRadius'=>'999px','photoBorderColor'=>'#1F2937'],
+            'decor' => ['corners'=>[['shape'=>'circle','size'=>'280px','color'=>'#93C5FD','x'=>'top-right','y'=>'0'],['shape'=>'square','size'=>'220px','color'=>'#1D4ED8','x'=>'bottom-left','y'=>'0']]],
+            'layoutOptions' => ['asideStartsAtTop'=>true],'decorOptions'=>['enabled'=>true,'preset'=>'geo-duo'],'sectionTitleStyle'=>['underline'=>'thin'],'headerType'=>'header-left',
+        ],
+        [
+            'id' => 'tpl-002','name' => 'aside-structure-2','type' => 'resume','version' => 1,'layout' => 'aside','structure' => 'structure-2',
+            'sections' => ['experience'=>'list','education'=>'dot','skills'=>'stars','languages'=>'progress-line','languagesLabel'=>'cards','certifications'=>'list','references'=>'dot','projects'=>'timeline','interests'=>'cards','contact'=>'icons','profile'=>'classic'],
+            'theme' => ['palette'=>['primary'=>'#7C3AED','secondary'=>'#C4B5FD','text'=>'#1F2937','muted'=>'#6B7280','pageBackground'=>'#FAF5FF'],'line'=>'strong','density'=>'compact','textStyle'=>'roman','showIcon'=>true],
+            'aside' => ['width'=>'720','height'=>'220px','radius'=>'18px'],'layoutOptions' => ['asideStartsAtTop'=>true],'decorOptions'=>['enabled'=>true,'preset'=>'abstract-duo'],'sectionTitleStyle'=>['underline'=>'thick'],'headerType'=>'header-right',
+        ],
+        [
+            'id'=>'cpage-001','name'=>'cover-page-hero-01','type'=>'cover_page','version'=>1,'layout'=>'layout-left','structure'=>'cover-structure-1',
+            'theme'=>['palette'=>['primary'=>'#0F4C81','secondary'=>'#5FA8D3','text'=>'#111827','muted'=>'#6B7280','pageBackground'=>'#F8FAFC'],'density'=>'airy','textStyle'=>'sans'],
+            'sections'=>['hero'=>['alignment'=>'left','showPhoto'=>true,'accent'=>'bar','accentIntensity'=>'medium','photoPosition'=>'left']],
+            'layoutOptions'=>['sectionSpacing'=>'normal','titleCase'=>'upper','contentWidth'=>'normal','photoShape'=>'rounded'],
+            'decorOptions'=>['designTokens'=>['borderRadius'=>'sm','shadowDepth'=>'soft','gradientStyle'=>'linear-soft','patternOverlay'=>'dots','typographyScale'=>'balanced']],
+        ],
+        [
+            'id'=>'cpage-002','name'=>'cover-page-editorial-02','type'=>'cover_page','version'=>1,'layout'=>'layout-left','structure'=>'cover-structure-2',
+            'theme'=>['palette'=>['primary'=>'#7C3AED','secondary'=>'#C4B5FD','text'=>'#111827','muted'=>'#6B7280','pageBackground'=>'#FAF5FF'],'density'=>'comfortable','textStyle'=>'roman'],
+            'sections'=>['hero'=>['alignment'=>'center','showPhoto'=>false,'accent'=>'shape','accentIntensity'=>'bold','photoPosition'=>'right']],
+            'layoutOptions'=>['sectionSpacing'=>'relaxed','titleCase'=>'normal','contentWidth'=>'wide','photoShape'=>'square'],
+            'decorOptions'=>['designTokens'=>['borderRadius'=>'md','shadowDepth'=>'medium','gradientStyle'=>'linear-vivid','patternOverlay'=>'grid','typographyScale'=>'spacious']],
+        ],
+        [
+            'id'=>'cletter-001','name'=>'cover-letter-classic-01','type'=>'cover_letter','version'=>1,'layout'=>'layout-left','structure'=>'letter-structure-1',
+            'theme'=>['palette'=>['primary'=>'#BE123C','secondary'=>'#FDA4AF','text'=>'#0F172A','muted'=>'#64748B','pageBackground'=>'#FFF1F2'],'density'=>'comfortable','textStyle'=>'roman'],
+            'sections'=>['header'=>'minimal','body'=>'narrative','signature'=>'simple','calloutStyle'=>'quote','photoPosition'=>'left'],
+            'layoutOptions'=>['paragraphSpacing'=>'normal','showDivider'=>true,'signatureAlign'=>'center','headerAlignment'=>'center'],
+        ],
+        [
+            'id'=>'cletter-002','name'=>'cover-letter-modern-02','type'=>'cover_letter','version'=>1,'layout'=>'layout-left','structure'=>'letter-structure-2',
+            'theme'=>['palette'=>['primary'=>'#065F46','secondary'=>'#6EE7B7','text'=>'#0F172A','muted'=>'#64748B','pageBackground'=>'#ECFDF5'],'density'=>'compact','textStyle'=>'sans'],
+            'sections'=>['header'=>'detailed','body'=>'bullet-mix','signature'=>'formal','calloutStyle'=>'highlight-box','photoPosition'=>'right'],
+            'layoutOptions'=>['paragraphSpacing'=>'wide','showDivider'=>false,'signatureAlign'=>'right','headerAlignment'=>'left'],
+        ],
+    ];
+
     /**
      * @var array<int, string>
      */
@@ -152,6 +199,8 @@ final class LoadRecruitData extends Fixture implements OrderedFixtureInterface
         if ($badges !== []) {
             $this->addReference('Recruit-Badge-1', $badges[0]);
         }
+
+        $this->createTemplates($manager);
 
         $recruitApplications = $manager->getRepository(Application::class)
             ->createQueryBuilder('application')
@@ -275,6 +324,31 @@ final class LoadRecruitData extends Fixture implements OrderedFixtureInterface
         }
 
         $manager->flush();
+    }
+
+
+    private function createTemplates(ObjectManager $manager): void
+    {
+        foreach (self::TEMPLATES as $item) {
+            $template = (new Template())
+                ->setName($item['name'])
+                ->setType($item['type'])
+                ->setVersion($item['version'])
+                ->setLayout($item['layout'])
+                ->setStructure($item['structure'])
+                ->setSections($item['sections'] ?? null)
+                ->setTheme($item['theme'] ?? null)
+                ->setAside($item['aside'] ?? null)
+                ->setPhoto($item['photo'] ?? null)
+                ->setDecor($item['decor'] ?? null)
+                ->setLayoutOptions($item['layoutOptions'] ?? null)
+                ->setDecorOptions($item['decorOptions'] ?? null)
+                ->setSectionTitleStyle($item['sectionTitleStyle'] ?? null)
+                ->setHeaderType($item['headerType'] ?? null);
+
+            $manager->persist($template);
+            $this->addReference('Recruit-Template-' . $item['id'], $template);
+        }
     }
 
     #[Override]


### PR DESCRIPTION
### Motivation
- Introduce a reusable `Template` model and attachable templates for resumes, cover pages and cover letters to support multiple document layouts and theming. 
- Provide persistent storage and default seeded templates so the application can render and manage different resume/cover layouts.

### Description
- Add a new Doctrine migration `migrations/Version20260507120000.php` which creates `recruit_template`, `recruit_cover_page`, and `recruit_cover_letter` tables and adds a `template_id` FK/index to `recruit_resume` with proper `ON DELETE SET NULL` behavior. 
- Add domain entities `Template`, `CoverPage`, and `CoverLetter` in `src/Recruit/Domain/Entity/` with UUID ids, timestamp traits, appropriate fields and relationships to support template metadata and content. 
- Update `Resume` entity to include a nullable many-to-one `template` relation and corresponding getter/setter methods. 
- Extend fixtures in `src/Recruit/Infrastructure/DataFixtures/ORM/LoadRecruitData.php` by adding a `TEMPLATES` constant and a `createTemplates` method to persist several example templates and add references for tests and local development. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbf63aab1083268b374d20bf2017a0)