### PR TITLE
feat(recruit): add AI text generation endpoints for cover page and cover letter

### DIFF
--- a/src/Recruit/Application/Service/ResumeAiParsingService.php
+++ b/src/Recruit/Application/Service/ResumeAiParsingService.php
@@ -75,6 +75,26 @@ readonly class ResumeAiParsingService
         return $this->normalizeAiStructuredResumePayload($content);
     }
 
+    public function generateAboutMeForCoverPage(string $inputText): string
+    {
+        $normalizedInput = trim($inputText);
+        if ($normalizedInput === '') {
+            throw new HttpException(Response::HTTP_BAD_REQUEST, 'Field "text" must not be empty.');
+        }
+
+        return $this->generateTextResponse($this->buildAboutMePrompt($normalizedInput));
+    }
+
+    public function generateCoverLetterFromJobText(string $inputText): string
+    {
+        $normalizedInput = trim($inputText);
+        if ($normalizedInput === '') {
+            throw new HttpException(Response::HTTP_BAD_REQUEST, 'Field "text" must not be empty.');
+        }
+
+        return $this->generateTextResponse($this->buildCoverLetterPrompt($normalizedInput));
+    }
+
     private function cleanResumeText(string $text): string
     {
         if ($text === '') {
@@ -379,6 +399,53 @@ Rules:
 Resume text:
 PROMPT
             . "\n" . $rawText;
+    }
+
+    private function buildAboutMePrompt(string $inputText): string
+    {
+        return <<<'PROMPT'
+You are an expert career writer.
+
+Generate ONLY one polished "About Me" paragraph for a cover page.
+Return plain text only (no markdown, no title, no JSON, no bullet points).
+
+Rules:
+- Input can be either a user profile or a job description.
+- If it is a job description, infer the ideal candidate voice and adapt it.
+- Keep it concise (90 to 140 words).
+- Professional, confident, concrete, and human tone.
+- Avoid placeholders and avoid hallucinated facts that are not implied by the input.
+
+Input text:
+PROMPT
+            . "\n" . $inputText;
+    }
+
+    private function buildCoverLetterPrompt(string $inputText): string
+    {
+        return <<<'PROMPT'
+You are an expert recruiter and cover letter writer.
+
+Task:
+1) Detect the company context and its likely needs from the input text.
+2) Write a tailored cover letter text area in plain text.
+
+Output format:
+- Return plain text only.
+- No markdown, no JSON, no labels.
+- 3 short paragraphs max.
+- 160 to 260 words.
+
+Writing rules:
+- Mention the company naturally when possible.
+- Explicitly connect candidate strengths to inferred company needs.
+- Keep a professional and persuasive tone.
+- End with a short call to action.
+- Do not invent precise facts that are not supported by input.
+
+Input text:
+PROMPT
+            . "\n" . $inputText;
     }
 
     private function generateTextResponse(string $prompt): string

--- a/src/Recruit/Transport/Controller/Api/V1/CoverLetter/AiCoverWritingController.php
+++ b/src/Recruit/Transport/Controller/Api/V1/CoverLetter/AiCoverWritingController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Recruit\Transport\Controller\Api\V1\CoverLetter;
+
+use App\Recruit\Application\Service\ResumeAiParsingService;
+use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Attribute\AsController;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[AsController]
+#[OA\Tag(name: 'Recruit Cover AI')]
+#[IsGranted(AuthenticatedVoter::IS_AUTHENTICATED_FULLY)]
+readonly class AiCoverWritingController
+{
+    public function __construct(
+        private ResumeAiParsingService $resumeAiParsingService,
+    ) {
+    }
+
+    #[Route(path: '/v1/recruit/cover-pages/about-me/generate', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Génère un texte About Me pour cover page à partir d\'un profil utilisateur ou d\'une description de poste.')]
+    public function generateAboutMe(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+        $inputText = isset($payload['text']) ? trim((string) $payload['text']) : '';
+
+        if ($inputText === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "text" is required and must be a non-empty string.');
+        }
+
+        return new JsonResponse([
+            'textArea' => $this->resumeAiParsingService->generateAboutMeForCoverPage($inputText),
+        ]);
+    }
+
+    #[Route(path: '/v1/recruit/cover-letters/generate', methods: [Request::METHOD_POST])]
+    #[OA\Post(summary: 'Détecte la company et ses besoins depuis un texte, puis génère un cover letter adapté.')]
+    public function generateCoverLetter(Request $request): JsonResponse
+    {
+        /** @var array<string, mixed> $payload */
+        $payload = $request->toArray();
+        $inputText = isset($payload['text']) ? trim((string) $payload['text']) : '';
+
+        if ($inputText === '') {
+            throw new HttpException(JsonResponse::HTTP_BAD_REQUEST, 'Field "text" is required and must be a non-empty string.');
+        }
+
+        return new JsonResponse([
+            'textArea' => $this->resumeAiParsingService->generateCoverLetterFromJobText($inputText),
+        ]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide recruiters and applicants with fast AI-generated copy for cover pages and cover letters by reusing the existing local AI infra in the Recruit module. 
- Allow generating a concise "About Me" paragraph from either a user profile or a job description and produce a tailored cover letter by detecting company context and needs.

### Description
- Added a new authenticated controller `AiCoverWritingController` exposing two POST endpoints: `POST /v1/recruit/cover-pages/about-me/generate` and `POST /v1/recruit/cover-letters/generate`, both accepting a `text` field and returning a `textArea` value.  
- Extended `ResumeAiParsingService` with `generateAboutMeForCoverPage(string $inputText): string` and `generateCoverLetterFromJobText(string $inputText): string` which invoke the shared `generateTextResponse` method. 
- Implemented prompt builders `buildAboutMePrompt` and `buildCoverLetterPrompt` to steer the AI output format and constraints (length, tone, no markdown/JSON). 
- Added input validation that returns HTTP 400 for missing/empty `text` payloads and consistent error handling when the AI is unreachable or returns empty responses.

### Testing
- Ran PHP syntax checks with `php -l src/Recruit/Transport/Controller/Api/V1/CoverLetter/AiCoverWritingController.php` which succeeded.  
- Ran PHP syntax checks with `php -l src/Recruit/Application/Service/ResumeAiParsingService.php` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fced09457483269632fbf902eec024)